### PR TITLE
Used QuickSelect to add a NthOrderStatistic method

### DIFF
--- a/src/ScottPlot/Statistics/Common.cs
+++ b/src/ScottPlot/Statistics/Common.cs
@@ -61,6 +61,20 @@ namespace ScottPlot.Statistics
             return Quantile(values, i, 100);
         }
 
+        public static double Median(double[] values)
+        {
+            // Note, this is one of many definitions of a median. It is the most common.
+
+            if (values.Length % 2 == 1)
+            {
+                return NthOrderStatistic(values, values.Length / 2 + 1);
+            }
+            else
+            {
+                return (NthOrderStatistic(values, values.Length / 2) + NthOrderStatistic(values, values.Length / 2 + 1)) / 2;
+            }
+        }
+
         private static double QuickSelect(double[] values, int begin, int end, int i)
         {
             // QuickSelect (aka Hoare's Algorithm) is a selection algorithm (i.e. given an integer i it returns the ith smallest element in a sequence) with O(n) expected time.

--- a/src/ScottPlot/Statistics/Common.cs
+++ b/src/ScottPlot/Statistics/Common.cs
@@ -51,6 +51,34 @@ namespace ScottPlot.Statistics
                 return values[begin];
             }
 
+            if(i == 0)
+			{
+                double min = values[begin];
+                for(int j = begin; j <= end; j++)
+				{
+                    if(values[j] < min)
+					{
+                        min = values[j];
+					}
+				}
+
+                return min;
+			}
+
+            if(i == end - begin)
+			{
+                double max = values[begin];
+                for (int j = begin; j <= end; j++)
+                {
+                    if (values[j] > max)
+                    {
+                        max = values[j];
+                    }
+                }
+
+                return max;
+            }
+
             int pivot_index = Partition(values, begin, end);
             int k = pivot_index - begin;
 

--- a/src/ScottPlot/Statistics/Common.cs
+++ b/src/ScottPlot/Statistics/Common.cs
@@ -36,7 +36,7 @@ namespace ScottPlot.Statistics
             double[] copied_values = new double[values.Length];
             Array.Copy(values, copied_values, values.Length); // QuickSelect mutates the array
 
-            return QuickSelect(copied_values, 0, values.Length - 1, n);
+            return QuickSelect(copied_values, 0, values.Length - 1, n - 1);
         }
 
         private static double QuickSelect(double[] values, int begin, int end, int i)

--- a/src/ScottPlot/Statistics/Common.cs
+++ b/src/ScottPlot/Statistics/Common.cs
@@ -33,7 +33,10 @@ namespace ScottPlot.Statistics
 
         public static double NthOrderStatistic(double[] values, int n)
         {
-            return QuickSelect(values, 0, values.Length - 1, n);
+            double[] copied_values = new double[values.Length];
+            Array.Copy(values, copied_values, values.Length); // QuickSelect mutates the array
+
+            return QuickSelect(copied_values, 0, values.Length - 1, n);
         }
 
         private static double QuickSelect(double[] values, int begin, int end, int i)

--- a/src/ScottPlot/Statistics/Common.cs
+++ b/src/ScottPlot/Statistics/Common.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace ScottPlot.Statistics
@@ -28,6 +29,76 @@ namespace ScottPlot.Statistics
                 sum += values[i];
             double mean = sum / values.Length;
             return mean;
+        }
+
+        public static double NthOrderStatistic(double[] values, int n)
+        {
+            return QuickSelect(values, 0, values.Length - 1, n);
+        }
+
+        private static double QuickSelect(double[] values, int begin, int end, int i)
+        {
+            // QuickSelect (aka Hoare's Algorithm) is a selection algorithm (i.e. given an integer i it returns the ith smallest element in a sequence) with O(n) expected time.
+            // In the worst case it is O(n^2), i.e. when the chosen pivot is always the max or min at each call. It is very similar to QuickSort and developed by the same man.
+            // The use of a random pivot virtually assures linear time performance.
+            // There is a guaranteed linear time algorithm which uses median of medians to choose a pivot but the overhead is often not worth it.
+
+            if (begin == end)
+            {
+                return values[begin];
+            }
+
+            int pivot_index = Partition(values, begin, end);
+            int k = pivot_index - begin;
+
+            if (i == k)
+            {
+                return values[pivot_index];
+            }
+            else if (i < k)
+            {
+                return QuickSelect(values, begin, pivot_index - 1, i);
+            }
+            else
+            {
+                return QuickSelect(values, pivot_index + 1, end, i - k - 1);
+            }
+        }
+
+        private static RNGCryptoServiceProvider rand = new RNGCryptoServiceProvider(); // In principle QuickSelect could have its performance degraded through timing attacks, hence the CSPRNG
+        private static int Partition(double[] values, int begin, int end)
+        {
+            byte[] random_bytes = new byte[sizeof(int)];
+            rand.GetBytes(random_bytes);
+            int pivot_index = Math.Abs(BitConverter.ToInt32(random_bytes, 0) % (end - begin)) + begin; // Modulo can return negative numbers in C# if the dividend is negative
+
+
+            // Moving the pivot to the end is far easier than handling it where it is
+            // This also allows you to turn this into the non-randomized Partition
+            double swap = values[pivot_index];
+            values[pivot_index] = values[end];
+            values[end] = swap;
+
+            double pivot = values[end];
+
+            int i = begin - 1;
+            for (int j = begin; j < end; j++)
+            {
+                if (values[j] <= pivot)
+                {
+                    i++;
+                    double tmp1 = values[j];
+                    values[j] = values[i];
+                    values[i] = tmp1;
+                }
+            }
+
+            i++;
+            double tmp2 = values[end];
+            values[end] = values[i];
+            values[i] = tmp2;
+
+            return i;
         }
     }
 }

--- a/src/ScottPlot/Statistics/Common.cs
+++ b/src/ScottPlot/Statistics/Common.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -39,6 +40,27 @@ namespace ScottPlot.Statistics
             return QuickSelect(copied_values, 0, values.Length - 1, n - 1);
         }
 
+        public static double Quantile(double[] values, int i, int numQuantiles)
+        {
+            // Not everyone uses the 0th and qth quantile, for completeness sake they are defined below.
+            if (i == 0)
+            {
+                return values.Min();
+            }
+
+            if (i == numQuantiles)
+            {
+                return values.Max();
+            }
+
+            return NthOrderStatistic(values, i * values.Length / numQuantiles);
+        }
+
+        public static double Percentile(double[] values, int i)
+        {
+            return Quantile(values, i, 100);
+        }
+
         private static double QuickSelect(double[] values, int begin, int end, int i)
         {
             // QuickSelect (aka Hoare's Algorithm) is a selection algorithm (i.e. given an integer i it returns the ith smallest element in a sequence) with O(n) expected time.
@@ -51,22 +73,22 @@ namespace ScottPlot.Statistics
                 return values[begin];
             }
 
-            if(i == 0)
-			{
+            if (i == 0)
+            {
                 double min = values[begin];
-                for(int j = begin; j <= end; j++)
-				{
-                    if(values[j] < min)
-					{
+                for (int j = begin; j <= end; j++)
+                {
+                    if (values[j] < min)
+                    {
                         min = values[j];
-					}
-				}
+                    }
+                }
 
                 return min;
-			}
+            }
 
-            if(i == end - begin)
-			{
+            if (i == end - begin)
+            {
                 double max = values[begin];
                 for (int j = begin; j <= end; j++)
                 {

--- a/src/ScottPlot/Statistics/Common.cs
+++ b/src/ScottPlot/Statistics/Common.cs
@@ -99,10 +99,9 @@ namespace ScottPlot.Statistics
                 return values.Max();
             int percentileIndex = (int)(percentile / 100.0 * (values.Length - 1));
 
-            double[] sortedValues = new double[values.Length];
-            Array.Copy(values, sortedValues, values.Length);
-            Array.Sort(values);
-            return values[percentileIndex];
+            double[] copiedValues = new double[values.Length];
+            Array.Copy(values, copiedValues, values.Length);
+            return NthOrderStatistic(values, percentileIndex + 1);
         }
 
         /// <summary>
@@ -125,7 +124,7 @@ namespace ScottPlot.Statistics
 
         /// <summary>
         /// Return the kth smallest value from a range of the given array.
-        /// WARNING: values will be sorted in place.
+        /// WARNING: values will be mutated.
         /// </summary>
         /// <param name="values"></param>
         /// <param name="leftIndex">inclusive lower bound</param>
@@ -195,11 +194,11 @@ namespace ScottPlot.Statistics
             byte[] randomBytes = new byte[sizeof(int)];
             Rand.GetBytes(randomBytes);
             int randomInt = BitConverter.ToInt32(randomBytes, 0);
-            return Math.Abs(randomInt % (max - min)) + min;
+            return Math.Abs(randomInt % (max - min + 1)) + min;
         }
 
         /// <summary>
-        /// Sort the array between the defined bounds according to a randomly chosen pivot value
+        /// Partition the array between the defined bounds according to elements above and below a randomly chosen pivot value
         /// </summary>
         /// <param name="values"></param>
         /// <param name="leftIndex"></param>

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Misc.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Misc.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Text;
 
 namespace ScottPlot.Cookbook.Recipes
@@ -184,6 +185,32 @@ namespace ScottPlot.Cookbook.Recipes
 
             // zoom in on the interesting area
             plt.SetAxisLimits(40, 60);
+        }
+    }
+
+    class OrderStatistics : IRecipe
+    {
+        public string Category => "Misc";
+        public string ID => "misc_orderStatistics";
+        public string Title => "Kth Order Statistics";
+        public string Description =>
+            "The kth order statistic of a set is the kth smallest value of the set (in this case, indexed from zero).";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            Random rand = new Random(0);
+
+            const int n = 500;
+
+            double[] ys = DataGen.Random(rand, n);
+
+            int k = 10 * n / 100;
+
+            double tenth_percentile = ScottPlot.Statistics.Common.NthOrderStatistic(ys, k); // Note that the 10th percentile is different from 10% lows, which are the average of the bottom 10%
+
+            plt.AddSignal(ys);
+            plt.AddHorizontalLine(tenth_percentile);
+
         }
     }
 }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Misc.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Misc.cs
@@ -194,7 +194,7 @@ namespace ScottPlot.Cookbook.Recipes
         public string ID => "misc_orderStatistics";
         public string Title => "Kth Order Statistics";
         public string Description =>
-            "The kth order statistic of a set is the kth smallest value of the set (in this case, indexed from zero).";
+            "The kth order statistic of a set is the kth smallest value of the set (indexed from 1).";
 
         public void ExecuteRecipe(Plot plt)
         {
@@ -204,12 +204,64 @@ namespace ScottPlot.Cookbook.Recipes
 
             double[] ys = DataGen.Random(rand, n);
 
-            int k = 10 * n / 100;
+            int k = 200;
 
-            double tenth_percentile = ScottPlot.Statistics.Common.NthOrderStatistic(ys, k); // Note that the 10th percentile is different from 10% lows, which are the average of the bottom 10%
+            double y = ScottPlot.Statistics.Common.NthOrderStatistic(ys, k);
+
+            plt.AddSignal(ys, label: "Random Data");
+            plt.AddHorizontalLine(y, label: $"{k}th Order Statistic");
+
+            plt.Legend();
+
+        }
+    }
+
+    class Percentiles : IRecipe
+    {
+        public string Category => "Misc";
+        public string ID => "misc_percentiles";
+        public string Title => "Percentiles";
+        public string Description =>
+            "Percentiles are a good tool to analyze the distribution of your data and filter out extreme values.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            Random rand = new Random(0);
+
+            const int n = 500;
+
+            double[] ys = DataGen.Random(rand, n);
+
+            double tenth_percentile = ScottPlot.Statistics.Common.Percentile(ys, 10); // Note that the 10th percentile is different from 10% lows, which is the average of the bottom 10%
 
             plt.AddSignal(ys, label: "Random Data");
             plt.AddHorizontalLine(tenth_percentile, label: "10th Percentile");
+
+            plt.Legend();
+
+        }
+    }
+
+    class Quantiles : IRecipe
+    {
+        public string Category => "Misc";
+        public string ID => "misc_quantiles";
+        public string Title => "Quantiles";
+        public string Description =>
+            "A q-Quantile is a generalization of quartiles and percentiles to any number of buckets.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            Random rand = new Random(0);
+
+            const int n = 500;
+
+            double[] ys = DataGen.Random(rand, n);
+
+            double second_septile = ScottPlot.Statistics.Common.Quantile(ys, 2, 7); // A septile is a 7-quantile
+
+            plt.AddSignal(ys, label: "Random Data");
+            plt.AddHorizontalLine(second_septile, label: "2nd Septile");
 
             plt.Legend();
 

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Misc.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Misc.cs
@@ -208,8 +208,10 @@ namespace ScottPlot.Cookbook.Recipes
 
             double tenth_percentile = ScottPlot.Statistics.Common.NthOrderStatistic(ys, k); // Note that the 10th percentile is different from 10% lows, which are the average of the bottom 10%
 
-            plt.AddSignal(ys);
-            plt.AddHorizontalLine(tenth_percentile);
+            plt.AddSignal(ys, label: "Random Data");
+            plt.AddHorizontalLine(tenth_percentile, label: "10th Percentile");
+
+            plt.Legend();
 
         }
     }

--- a/src/tests/Statistics/OrderStatistics.cs
+++ b/src/tests/Statistics/OrderStatistics.cs
@@ -48,5 +48,23 @@ namespace ScottPlotTests.Statistics
             double maxValue = SortedValues.Last();
             Assert.AreEqual(maxValue, nthValue);
         }
+
+        [Test]
+        public void Test_0thPercentileIsMin()
+        {
+            int n = 0;
+            double nthValue = ScottPlot.Statistics.Common.Percentile(RandomValues, n);
+            double minValue = SortedValues.First();
+            Assert.AreEqual(minValue, nthValue);
+        }
+
+        [Test]
+        public void Test_100thPercentileIsMax()
+        {
+            int n = 100;
+            double nthValue = ScottPlot.Statistics.Common.Percentile(RandomValues, n);
+            double maxValue = SortedValues.Last();
+            Assert.AreEqual(maxValue, nthValue);
+        }
     }
 }

--- a/src/tests/Statistics/OrderStatistics.cs
+++ b/src/tests/Statistics/OrderStatistics.cs
@@ -34,19 +34,21 @@ namespace ScottPlotTests.Statistics
         [Test]
         public void Test_NthOrderStatistic_MinValue()
         {
-            int n = 1;
-            double nthValue = ScottPlot.Statistics.Common.NthOrderStatistic(RandomValues, n);
+            int smallestValidN = 1;
+            double nthValue = ScottPlot.Statistics.Common.NthOrderStatistic(RandomValues, smallestValidN);
             double minValue = SortedValues.First();
             Assert.AreEqual(minValue, nthValue);
+            Assert.Throws<ArgumentException>(() => ScottPlot.Statistics.Common.NthOrderStatistic(RandomValues, smallestValidN - 1));
         }
 
         [Test]
         public void Test_NthOrderStatistic_MaxValue()
         {
-            int n = RandomValues.Length;
-            double nthValue = ScottPlot.Statistics.Common.NthOrderStatistic(RandomValues, n);
+            int largestValidN = RandomValues.Length;
+            double nthValue = ScottPlot.Statistics.Common.NthOrderStatistic(RandomValues, largestValidN);
             double maxValue = SortedValues.Last();
             Assert.AreEqual(maxValue, nthValue);
+            Assert.Throws<ArgumentException>(() => ScottPlot.Statistics.Common.NthOrderStatistic(RandomValues, largestValidN + 1));
         }
 
         [Test]
@@ -85,6 +87,18 @@ namespace ScottPlotTests.Statistics
             double[] valuesSorted = values.OrderBy(x => x).ToArray();
 
             Assert.AreEqual(ScottPlot.Statistics.Common.Median(values), (valuesSorted[n / 2] + valuesSorted[n / 2 - 1]) / 2);
+        }
+
+        //[Test]
+        public void Test_RandomIntGenerator_IncludesLowerAndExcludesUpper()
+        {
+            int replicates = 1000;
+            int[] randomInts = new int[replicates];
+            for (int i = 0; i < randomInts.Length; i++)
+                randomInts[i] = ScottPlot.Statistics.Common.GetRandomInt(0, 5);
+
+            Assert.AreEqual(0, randomInts.Min());
+            Assert.AreEqual(4, randomInts.Max());
         }
     }
 }

--- a/src/tests/Statistics/OrderStatistics.cs
+++ b/src/tests/Statistics/OrderStatistics.cs
@@ -1,29 +1,52 @@
 ﻿using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
-using System.Text;
 
 namespace ScottPlotTests.Statistics
 {
-    class NthOrderStatistics
+    class OrderStatistics
     {
-        [Test]
-        public void MatchesSortedOrder()
+        double[] RandomValues;
+        double[] SortedValues;
+
+        [OneTimeSetUp]
+        public void SetUp()
         {
             Random rand = new Random(0);
+            RandomValues = ScottPlot.DataGen.Random(rand, pointCount: 5000);
+            SortedValues = RandomValues.OrderBy(x => x).ToArray();
+        }
 
-            const int n = 5000;
-            double[] values = Enumerable.Range(0, n).Select(_ => rand.NextDouble()).ToArray();
-            double[] sorted_values = new double[n];
-            values.CopyTo(sorted_values, 0);
-            Array.Sort(sorted_values);
+        [Test]
+        public void Test_NthOrderStatistic_ReturnsNthElementForRandomNs()
+        {
+            Random rand = new Random(0);
+            var randomNs = Enumerable.Range(0, 100).Select(x => rand.Next(1, RandomValues.Length - 1));
 
-            for (int i = 0; i < n; i++)
+            foreach (int n in randomNs)
             {
-                Assert.AreEqual(sorted_values[i], ScottPlot.Statistics.Common.NthOrderStatistic(values, i));
+                double nthValue = ScottPlot.Statistics.Common.NthOrderStatistic(RandomValues, n);
+                double expectedNthValue = SortedValues[n];
+                Assert.AreEqual(expectedNthValue, nthValue);
             }
+        }
+
+        [Test]
+        public void Test_NthOrderStatistic_MinValue()
+        {
+            int n = 0;
+            double nthValue = ScottPlot.Statistics.Common.NthOrderStatistic(RandomValues, n);
+            double minValue = SortedValues.First();
+            Assert.AreEqual(minValue, nthValue);
+        }
+
+        [Test]
+        public void Test_NthOrderStatistic_MaxValue()
+        {
+            int n = RandomValues.Length - 1;
+            double nthValue = ScottPlot.Statistics.Common.NthOrderStatistic(RandomValues, n);
+            double maxValue = SortedValues.Last();
+            Assert.AreEqual(maxValue, nthValue);
         }
     }
 }

--- a/src/tests/Statistics/OrderStatistics.cs
+++ b/src/tests/Statistics/OrderStatistics.cs
@@ -26,7 +26,7 @@ namespace ScottPlotTests.Statistics
             foreach (int n in randomNs)
             {
                 double nthValue = ScottPlot.Statistics.Common.NthOrderStatistic(RandomValues, n);
-                double expectedNthValue = SortedValues[n];
+                double expectedNthValue = SortedValues[n - 1];
                 Assert.AreEqual(expectedNthValue, nthValue);
             }
         }
@@ -34,7 +34,7 @@ namespace ScottPlotTests.Statistics
         [Test]
         public void Test_NthOrderStatistic_MinValue()
         {
-            int n = 0;
+            int n = 1;
             double nthValue = ScottPlot.Statistics.Common.NthOrderStatistic(RandomValues, n);
             double minValue = SortedValues.First();
             Assert.AreEqual(minValue, nthValue);
@@ -43,7 +43,7 @@ namespace ScottPlotTests.Statistics
         [Test]
         public void Test_NthOrderStatistic_MaxValue()
         {
-            int n = RandomValues.Length - 1;
+            int n = RandomValues.Length;
             double nthValue = ScottPlot.Statistics.Common.NthOrderStatistic(RandomValues, n);
             double maxValue = SortedValues.Last();
             Assert.AreEqual(maxValue, nthValue);

--- a/src/tests/Statistics/OrderStatistics.cs
+++ b/src/tests/Statistics/OrderStatistics.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+
+namespace ScottPlotTests.Statistics
+{
+    class NthOrderStatistics
+    {
+        [Test]
+        public void MatchesSortedOrder()
+        {
+            Random rand = new Random(0);
+
+            const int n = 5000;
+            double[] values = Enumerable.Range(0, n).Select(_ => rand.NextDouble()).ToArray();
+            double[] sorted_values = new double[n];
+            values.CopyTo(sorted_values, 0);
+            Array.Sort(sorted_values);
+
+            for (int i = 0; i < n; i++)
+            {
+                Assert.AreEqual(sorted_values[i], ScottPlot.Statistics.Common.NthOrderStatistic(values, i));
+            }
+        }
+    }
+}

--- a/src/tests/Statistics/OrderStatistics.cs
+++ b/src/tests/Statistics/OrderStatistics.cs
@@ -66,5 +66,25 @@ namespace ScottPlotTests.Statistics
             double maxValue = SortedValues.Last();
             Assert.AreEqual(maxValue, nthValue);
         }
+
+        [Test]
+        public void Test_MedianOdd()
+        {
+            int n = 101;
+            double[] values = ScottPlot.DataGen.Random(new Random(0), n);
+            double[] valuesSorted = values.OrderBy(x => x).ToArray();
+
+            Assert.AreEqual(ScottPlot.Statistics.Common.Median(values), valuesSorted[n / 2]);
+        }
+
+        [Test]
+        public void Test_MedianEven()
+        {
+            int n = 100;
+            double[] values = ScottPlot.DataGen.Random(new Random(0), n);
+            double[] valuesSorted = values.OrderBy(x => x).ToArray();
+
+            Assert.AreEqual(ScottPlot.Statistics.Common.Median(values), (valuesSorted[n / 2] + valuesSorted[n / 2 - 1]) / 2);
+        }
     }
 }

--- a/src/tests/Statistics/OrderStatistics.cs
+++ b/src/tests/Statistics/OrderStatistics.cs
@@ -89,6 +89,21 @@ namespace ScottPlotTests.Statistics
             Assert.AreEqual(ScottPlot.Statistics.Common.Median(values), (valuesSorted[n / 2] + valuesSorted[n / 2 - 1]) / 2);
         }
 
+        [Test]
+        [TestCase(100)]
+        [TestCase(50)]
+        [TestCase(256)]
+        [TestCase(77)]
+        [TestCase(123)]
+        public void Test_FloatPercentile(int n)
+        {
+            Random rand = new Random(0);
+            double[] values = ScottPlot.DataGen.Random(rand, pointCount: n);
+            Assert.AreEqual(ScottPlot.Statistics.Common.Percentile(values, 25), ScottPlot.Statistics.Common.Quartile(values, 1));
+            Assert.AreEqual(ScottPlot.Statistics.Common.Percentile(values, 50), ScottPlot.Statistics.Common.Quartile(values, 2));
+            Assert.AreEqual(ScottPlot.Statistics.Common.Percentile(values, 75), ScottPlot.Statistics.Common.Quartile(values, 3));
+        }
+
         //[Test]
         public void Test_RandomIntGenerator_IncludesLowerAndExcludesUpper()
         {


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
An ith order statistic is an element of an array that is the ith smallest value. It is a generalization of the min (the 0th order statistic*), the max (the last order statistic), the median (the n/2 th order statistic), as well as all quantiles.

I also added a test for the selection algorithm. It validates the algorithm against naïve algorithm (sorting and then indexing) for a large array of doubles.

*it is the 1st order statistic if you index from one. The algorithm I implemented indexes from zero.

**New Functionality:**
Describe what this pull request does using code and/or images.

```cs
double nthOrderStatistic = ScottPlot.Statistics.Common.NthOrderStatistic(values, n);
```

This is implemented using QuickSelect, the younger brother of QuickSort. It gives O(n) expected time, but O(n^2) worst case. The worst case time complexity (like in QuickSort) is exceedingly unlikely when using a randomized algorithm. 

The naïve algorithm is O(n log n), where one sorts the array first and then indexes into it. C# uses IntroSort on `Array.Sort()`, which is essentially QuickSort but which switches to another sorting algorithm to maintain O(n log n) at all times (QuickSort has a O(n^2) worst case). [Array.Sort Remarks](https://docs.microsoft.com/en-us/dotnet/api/system.array.sort?redirectedfrom=MSDN&view=net-5.0#System_Array_Sort_System_Array_ ), [Wikipedia on Introsort](https://en.wikipedia.org/wiki/Introsort)

The official IntroSelect uses a hybrid of QuickSelect and Median of Medians (an algorithm which approximates a median to choose a better pivot). Median of Medians always yields O(n) time complexity, but has higher overhead. There are other "IntroSelects" which can promise O(n) expected and O(n log n) worst case (by using sorting). If it becomes appropriate I can take a look at implementing an IntroSelect algorithm. There is also Floyd-Rivest which is a more complicated algorithm which may be more appropriate than either type of IntroSelect