### PR TITLE
Don't mix Length and LengthSquared in VectorField

### DIFF
--- a/src/ScottPlot/Plottable/VectorField.cs
+++ b/src/ScottPlot/Plottable/VectorField.cs
@@ -23,8 +23,8 @@ namespace ScottPlot.Plottable
 
         public VectorField(Vector2[,] vectors, double[] xs, double[] ys, Colormap colormap, double scaleFactor, Color defaultColor)
         {
-            double minMagnitudeSquared = vectors[0, 0].Length();
-            double maxMagnitudeSquared = vectors[0, 0].Length();
+            double minMagnitudeSquared = vectors[0, 0].LengthSquared();
+            double maxMagnitudeSquared = vectors[0, 0].LengthSquared();
             for (int i = 0; i < xs.Length; i++)
             {
                 for (int j = 0; j < ys.Length; j++)


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
In [this block](https://github.com/ScottPlot/ScottPlot/blob/master/src/ScottPlot/Plottable/VectorField.cs#L26-L39) we compute the min and max length of all the vectors. However, it mixes `Length` and `LengthSquared`, which means it can get incorrect min or max values. I changed line 26 and 27 to remove this concern.

In this case, it would only happen if the first vector was the min or the max, and it would give an incorrect min for magnitudes > 1, and an incorrect max for magnitudes < 1. (Because x^2 < x for x < 1)

**New Functionality:**
N/A