### PR TITLE
Fix SMA() and SMStDev() calculation

### DIFF
--- a/src/ScottPlot/Statistics/Finance.cs
+++ b/src/ScottPlot/Statistics/Finance.cs
@@ -31,7 +31,7 @@ namespace ScottPlot.Statistics
                     // TODO: could optimize this for perforance by not copying
                     // to do this create a Common.Mean overload
                     var periodValues = new double[period];
-                    Array.Copy(values, i - period, periodValues, 0, period);
+                    Array.Copy(values, i - period + 1, periodValues, 0, period);
                     sma[i] = Common.Mean(periodValues);
                 }
             }
@@ -62,7 +62,7 @@ namespace ScottPlot.Statistics
                 else
                 {
                     var periodValues = new double[period];
-                    Array.Copy(values, i - period, periodValues, 0, period);
+                    Array.Copy(values, i - period + 1, periodValues, 0, period);
                     stDev[i] = Common.StDev(periodValues);
                 }
             }

--- a/src/tests/Finance/TechnicalIndicators.cs
+++ b/src/tests/Finance/TechnicalIndicators.cs
@@ -12,6 +12,16 @@ namespace ScottPlotTests.Finance
     class TechnicalIndicators
     {
         [Test]
+        public void Test_SMA_ProducesExpectedOutput()
+        {
+            double[] values = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            double[] sma = ScottPlot.Statistics.Finance.SMA(values, 3, trimNan: false);
+            double[] expected = { double.NaN, double.NaN, double.NaN, 3, 4, 5, 6, 7, 8, 9 };
+
+            Assert.That(sma, Is.EquivalentTo(expected));
+        }
+
+        [Test]
         public void Test_SMA_DoubleArray()
         {
             Random rand = new Random(0);

--- a/src/tests/Finance/TechnicalIndicators.cs
+++ b/src/tests/Finance/TechnicalIndicators.cs
@@ -25,9 +25,9 @@ namespace ScottPlotTests.Finance
             double[] sma50xs = xs.Skip(50).ToArray();
 
             var plt = new ScottPlot.Plot(600, 400);
-            plt.PlotScatter(xs, prices, lineWidth: 0, label: "Price");
-            plt.PlotScatter(sma20xs, sma20, label: "20 day SMA", markerSize: 0, lineWidth: 2);
-            plt.PlotScatter(sma50xs, sma50, label: "50 day SMA", markerSize: 0, lineWidth: 2);
+            plt.AddScatter(xs, prices, lineWidth: 0, label: "Price");
+            plt.AddScatter(sma20xs, sma20, label: "20 day SMA", markerSize: 0, lineWidth: 2);
+            plt.AddScatter(sma50xs, sma50, label: "50 day SMA", markerSize: 0, lineWidth: 2);
 
             plt.YLabel("Price");
             plt.XLabel("Days");
@@ -53,10 +53,10 @@ namespace ScottPlotTests.Finance
                 ohlcs[i].time = i;
 
             var plt = new ScottPlot.Plot(600, 400);
-            plt.PlotCandlestick(ohlcs);
-            plt.PlotScatter(sma20xs, sma20, label: "20 day SMA",
+            plt.AddCandlesticks(ohlcs);
+            plt.AddScatter(sma20xs, sma20, label: "20 day SMA",
                 color: Color.Blue, markerSize: 0, lineWidth: 2);
-            plt.PlotScatter(sma50xs, sma50, label: "50 day SMA",
+            plt.AddScatter(sma50xs, sma50, label: "50 day SMA",
                 color: Color.Maroon, markerSize: 0, lineWidth: 2);
 
             plt.Title("Simple Moving Average (SMA)");
@@ -83,11 +83,11 @@ namespace ScottPlotTests.Finance
                 ohlcs[i].time = i;
 
             var plt = new ScottPlot.Plot(600, 400);
-            plt.PlotCandlestick(ohlcs);
-            plt.PlotFill(xs2, bolL, xs2, bolU, fillColor: Color.Blue, fillAlpha: .05);
-            plt.PlotScatter(xs2, bolL, color: Color.Navy, markerSize: 0, label: "Bollinger Bands");
-            plt.PlotScatter(xs2, bolU, color: Color.Navy, markerSize: 0);
-            plt.PlotScatter(xs2, sma, color: Color.Navy, markerSize: 0, lineStyle: LineStyle.Dash, label: "SMA 20");
+            plt.AddCandlesticks(ohlcs);
+            plt.AddFill(xs2, bolL, xs2, bolU, color: Color.FromArgb(10, Color.Blue));
+            plt.AddScatter(xs2, bolL, color: Color.Navy, markerSize: 0, label: "Bollinger Bands");
+            plt.AddScatter(xs2, bolU, color: Color.Navy, markerSize: 0);
+            plt.AddScatter(xs2, sma, color: Color.Navy, markerSize: 0, lineStyle: LineStyle.Dash, label: "SMA 20");
 
             plt.Title("Moving Average and Standard Deviation");
             plt.YLabel("Price");


### PR DESCRIPTION
The calculation must include the current period `values[i]`.

 If `period` have a value of 3, it's copying `values[i-3]`,`values[i-2]`,`values[i-1]` to `periodValues[]`
  but it should copy `values[i-2]`,`values[i-1]`,`values[i-0]`