### PR TITLE
Add CoordinatedHeatmap

### DIFF
--- a/src/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot/Plot/Plot.Add.cs
@@ -16,7 +16,6 @@ using ScottPlot.Plottable;
 using ScottPlot.Statistics;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 
@@ -268,6 +267,62 @@ namespace ScottPlot
                 AxisScaleLock(true);
 
             var plottable = new Heatmap();
+            plottable.Update(intensities, colormap);
+            Add(plottable);
+
+            return plottable;
+        }
+
+        /// <summary>
+        /// Add coordinated heatmap to the plot
+        /// </summary>
+        public CoordinatedHeatmap AddHeatMapCoordinated(double[,] intensities, double? xMin = null, double? xMax = null, double? yMin = null, double? yMax = null, Drawing.Colormap colormap = null)
+        {
+            var plottable = new CoordinatedHeatmap();
+
+            // Solve all possible null combinations, if the boundaries are only partially provided use Step = 1;
+            if (xMin == null && xMax == null)
+            {
+                plottable.XMin = 0;
+                plottable.XMax = 0 + intensities.GetLength(0);
+            }
+            else if (xMin == null)
+            {
+                plottable.XMax = xMax.Value;
+                plottable.XMin = xMax.Value - intensities.GetLength(0);
+            }
+            else if (xMax == null)
+            {
+                plottable.XMin = xMin.Value;
+                plottable.XMax = xMin.Value + intensities.GetLength(0);
+            }
+            else
+            {
+                plottable.XMin = xMin.Value;
+                plottable.XMax = xMax.Value;
+            }
+
+            if (yMin == null && yMax == null)
+            {
+                plottable.YMin = 0;
+                plottable.YMax = 0 + intensities.GetLength(1);
+            }
+            else if (yMin == null)
+            {
+                plottable.YMax = yMax.Value;
+                plottable.YMin = yMax.Value - intensities.GetLength(1);
+            }
+            else if (yMax == null)
+            {
+                plottable.YMin = yMin.Value;
+                plottable.YMax = yMin.Value + intensities.GetLength(1);
+            }
+            else
+            {
+                plottable.YMin = yMin.Value;
+                plottable.YMax = yMax.Value;
+            }
+
             plottable.Update(intensities, colormap);
             Add(plottable);
 

--- a/src/ScottPlot/Plottable/Colorbar.cs
+++ b/src/ScottPlot/Plottable/Colorbar.cs
@@ -60,7 +60,7 @@ namespace ScottPlot.Plottable
 
         public LegendItem[] GetLegendItems() => null;
 
-        public AxisLimits GetAxisLimits() => new AxisLimits();
+        public AxisLimits GetAxisLimits() => new AxisLimits(double.NaN, double.NaN, double.NaN, double.NaN);
 
         public void ValidateData(bool deep = false)
         {

--- a/src/ScottPlot/Plottable/CoordinatedHeatmap.cs
+++ b/src/ScottPlot/Plottable/CoordinatedHeatmap.cs
@@ -6,6 +6,10 @@ using System.Drawing.Imaging;
 
 namespace ScottPlot.Plottable
 {
+    /// <summary>
+    /// This variation of the Heatmap renders intensity data as a rectangle 
+    /// sized to fit user-defined axis limits
+    /// </summary>
     public class CoordinatedHeatmap : Heatmap
     {
         public double XMin { get; set; }

--- a/src/ScottPlot/Plottable/CoordinatedHeatmap.cs
+++ b/src/ScottPlot/Plottable/CoordinatedHeatmap.cs
@@ -1,6 +1,8 @@
 ﻿using ScottPlot.Drawing;
+using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
 
 namespace ScottPlot.Plottable
 {
@@ -17,19 +19,23 @@ namespace ScottPlot.Plottable
             using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
             {
                 gfx.InterpolationMode = Interpolation;
+                gfx.PixelOffsetMode = PixelOffsetMode.Half;
 
-                float drawFrom = dims.GetPixelX(XMin);
-                float drawTo = dims.GetPixelY(YMax);
-                float drawWidth = (float)(dims.PxPerUnitX * (XMax - XMin));
-                float drawHeight = (float)(dims.PxPerUnitY * (YMax - YMin));
+                int drawFromX = (int)Math.Round(dims.GetPixelX(XMin));
+                int drawFromY = (int)Math.Round(dims.GetPixelY(YMax));
+                int drawWidth = (int)Math.Round(dims.GetPixelX(XMax) - drawFromX);
+                int drawHeight = (int)Math.Round(dims.GetPixelY(YMin) - drawFromY);
+                Rectangle destRect = new Rectangle(drawFromX, drawFromY, drawWidth, drawHeight);
+                ImageAttributes attr = new ImageAttributes();
+                attr.SetWrapMode(WrapMode.TileFlipXY);
 
                 if (BackgroundImage != null && !DisplayImageAbove)
-                    gfx.DrawImage(BackgroundImage, drawFrom, drawTo, drawWidth, drawHeight);
+                    gfx.DrawImage(BackgroundImage, destRect, 0, 0, BackgroundImage.Width, BackgroundImage.Height, GraphicsUnit.Pixel, attr);
 
-                gfx.DrawImage(BmpHeatmap, drawFrom, drawTo, drawWidth, drawHeight);
+                gfx.DrawImage(BmpHeatmap, destRect, 0, 0, BmpHeatmap.Width, BmpHeatmap.Height, GraphicsUnit.Pixel, attr);
 
                 if (BackgroundImage != null && DisplayImageAbove)
-                    gfx.DrawImage(BackgroundImage, drawFrom, drawTo, drawWidth, drawHeight);
+                    gfx.DrawImage(BackgroundImage, destRect, 0, 0, BackgroundImage.Width, BackgroundImage.Height, GraphicsUnit.Pixel, attr);
             }
         }
 

--- a/src/ScottPlot/Plottable/CoordinatedHeatmap.cs
+++ b/src/ScottPlot/Plottable/CoordinatedHeatmap.cs
@@ -1,0 +1,41 @@
+﻿using ScottPlot.Drawing;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+
+namespace ScottPlot.Plottable
+{
+    public class CoordinatedHeatmap : Heatmap
+    {
+        public double XMin { get; set; }
+        public double XMax { get; set; }
+        public double YMin { get; set; }
+        public double YMax { get; set; }
+        public InterpolationMode Interpolation { get; set; } = InterpolationMode.NearestNeighbor;
+
+        protected override void RenderHeatmap(PlotDimensions dims, Bitmap bmp, bool lowQuality)
+        {
+            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            {
+                gfx.InterpolationMode = Interpolation;
+
+                float drawFrom = dims.GetPixelX(XMin);
+                float drawTo = dims.GetPixelY(YMax);
+                float drawWidth = (float)(dims.PxPerUnitX * (XMax - XMin));
+                float drawHeight = (float)(dims.PxPerUnitY * (YMax - YMin));
+
+                if (BackgroundImage != null && !DisplayImageAbove)
+                    gfx.DrawImage(BackgroundImage, drawFrom, drawTo, drawWidth, drawHeight);
+
+                gfx.DrawImage(BmpHeatmap, drawFrom, drawTo, drawWidth, drawHeight);
+
+                if (BackgroundImage != null && DisplayImageAbove)
+                    gfx.DrawImage(BackgroundImage, drawFrom, drawTo, drawWidth, drawHeight);
+            }
+        }
+
+        public override AxisLimits GetAxisLimits()
+        {
+            return new AxisLimits(XMin, XMax, YMin, YMax);
+        }
+    }
+}

--- a/src/ScottPlot/Plottable/Heatmap.cs
+++ b/src/ScottPlot/Plottable/Heatmap.cs
@@ -14,7 +14,7 @@ namespace ScottPlot.Plottable
         private double Max;
         private int Width;
         private int Height;
-        private Bitmap BmpHeatmap;
+        protected Bitmap BmpHeatmap;
 
         // these fields are customized by the user
         public string Label;
@@ -152,7 +152,7 @@ namespace ScottPlot.Plottable
             return new LegendItem[] { singleLegendItem };
         }
 
-        public AxisLimits GetAxisLimits()
+        public virtual AxisLimits GetAxisLimits()
         {
             if (BmpHeatmap is null)
                 return new AxisLimits();
@@ -175,7 +175,7 @@ namespace ScottPlot.Plottable
                 RenderAxis(dims, bmp, lowQuality);
         }
 
-        private void RenderHeatmap(PlotDimensions dims, Bitmap bmp, bool lowQuality)
+        protected virtual void RenderHeatmap(PlotDimensions dims, Bitmap bmp, bool lowQuality)
         {
             using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
             {

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace ScottPlot.Cookbook.Recipes.Plottable
 {
@@ -163,6 +161,29 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
 
             var hm = plt.AddHeatmap(intensities);
             var cb = plt.AddColorbar(hm);
+        }
+    }
+
+    public class HeatmapCoordinated : IRecipe
+    {
+        public string Category => "Plottable: Heatmap";
+        public string ID => "heatmap_coordinated";
+        public string Title => "Coordinated Heatmap";
+        public string Description =>
+            "CoordinatedHeatmap is Heatmap stretched to provided boundaries" +
+            "Coordinatedheatmap used to display two-dimensional distributions on a rectangular surface";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            Random rand = new Random(0);
+            int[] xs = DataGen.RandomNormal(rand, 10000, 25, 10).Select(x => (int)x).ToArray();
+            int[] ys = DataGen.RandomNormal(rand, 10000, 25, 10).Select(y => (int)y).ToArray();
+
+            double[,] intensities = Tools.XYToIntensities(mode: IntensityMode.Gaussian,
+                xs: xs, ys: ys, width: 50, height: 50, sampleWidth: 4);
+
+            var hmc = plt.AddHeatMapCoordinated(intensities, -100, 500, 200, 201);
+            var cb = plt.AddColorbar(hmc);
         }
     }
 }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
@@ -170,8 +170,8 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string ID => "heatmap_coordinated";
         public string Title => "Coordinated Heatmap";
         public string Description =>
-            "CoordinatedHeatmap is Heatmap stretched to provided boundaries" +
-            "Coordinatedheatmap used to display two-dimensional distributions on a rectangular surface";
+            "CoordinatedHeatmap is type of Heatmap stretched to fit user-defined boundaries in coordinate space. " +
+            "This plot type displays two-dimensional intensities on a rectangular surface according to a colormap.";
 
         public void ExecuteRecipe(Plot plt)
         {
@@ -182,7 +182,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             double[,] intensities = Tools.XYToIntensities(mode: IntensityMode.Gaussian,
                 xs: xs, ys: ys, width: 50, height: 50, sampleWidth: 4);
 
-            var hmc = plt.AddHeatMapCoordinated(intensities, -100, 500, 200, 201);
+            var hmc = plt.AddHeatMapCoordinated(intensities, xMin: -100, xMax: 500, yMin: 200, yMax: 201);
             var cb = plt.AddColorbar(hmc);
         }
     }


### PR DESCRIPTION
**Purpose:**
Allows to use an existing coordinate system to get additional coordinate information about `HeatMap`. #701

Additionaly Fix `ColorBar`, with this PR it will not affect AxisLimits calculation.

**New Functionality:**
User can provide coordinated boundaries for provided rectangular distribution.
Missing bounds are calculated based on the size of the `intensities` array.


```cs
double[,] intensities = ....; 

var hmc = plt.AddHeatmapCoordinated(intensities, -100, 500, 200, 201);

var hmc1 = plt.AddHeatmapCoordinated(intensities, xMin: -100, yMax: 50);
```

![image](https://user-images.githubusercontent.com/53831487/105596258-b2c1d800-5da4-11eb-97b4-ff12c6378076.png)
