### PR TITLE
Improve support for rotated tick labels

### DIFF
--- a/src/ScottPlot/Renderable/Axis.cs
+++ b/src/ScottPlot/Renderable/Axis.cs
@@ -374,26 +374,21 @@ namespace ScottPlot.Renderable
 
                 if (AxisTicks.TickLabelVisible)
                 {
+                    // determine how many pixels the largest tick label occupies
                     float maxHeight = AxisTicks.TickCollection.maxLabelHeight;
                     float maxWidth = AxisTicks.TickCollection.maxLabelWidth * 1.2f;
-                    float sizeNeeded = IsHorizontal ? maxHeight : maxWidth;
-                    float diff = Math.Max(maxWidth, maxHeight) - Math.Min(maxWidth, maxHeight);
 
-                    switch (Edge)
-                    {
-                        case Edge.Top:
-                        case Edge.Bottom:
-                            sizeNeeded = Math.Min(maxWidth, maxHeight) + diff * (float)Math.Sin(AxisTicks.TickLabelRotation * Math.PI / 180);
-                            break;
+                    // calculate the width and height of the rotated label
+                    float largerEdgeLength = Math.Max(maxWidth, maxHeight);
+                    float shorterEdgeLength = Math.Min(maxWidth, maxHeight);
+                    float differenceInEdgeLengths = largerEdgeLength - shorterEdgeLength;
+                    float sinRotation = IsHorizontal ?
+                        (float)Math.Sin(AxisTicks.TickLabelRotation * Math.PI / 180) :
+                        (float)Math.Cos(AxisTicks.TickLabelRotation * Math.PI / 180);
+                    float rotatedLabelSize = shorterEdgeLength + differenceInEdgeLengths * sinRotation;
 
-                        case Edge.Left:
-                        case Edge.Right:
-                            sizeNeeded = Math.Min(maxWidth, maxHeight) + diff * (float)Math.Cos(AxisTicks.TickLabelRotation * Math.PI / 180);
-                            break;
-
-
-                    }
-                    PixelSize += sizeNeeded;
+                    // add the rotated label size to the size of this axis
+                    PixelSize += rotatedLabelSize;
                 }
 
                 if (AxisTicks.MajorTickVisible)

--- a/src/ScottPlot/Renderable/Axis.cs
+++ b/src/ScottPlot/Renderable/Axis.cs
@@ -378,7 +378,21 @@ namespace ScottPlot.Renderable
                     float maxWidth = AxisTicks.TickCollection.maxLabelWidth * 1.2f;
                     float sizeNeeded = IsHorizontal ? maxHeight : maxWidth;
                     float diff = Math.Max(maxWidth, maxHeight) - Math.Min(maxWidth, maxHeight);
-                    sizeNeeded = Math.Min(maxWidth, maxHeight) + diff * (float)Math.Sin(AxisTicks.TickLabelRotation * Math.PI / 180);
+
+                    switch (Edge)
+                    {
+                        case Edge.Top:
+                        case Edge.Bottom:
+                            sizeNeeded = Math.Min(maxWidth, maxHeight) + diff * (float)Math.Sin(AxisTicks.TickLabelRotation * Math.PI / 180);
+                            break;
+
+                        case Edge.Left:
+                        case Edge.Right:
+                            sizeNeeded = Math.Min(maxWidth, maxHeight) + diff * (float)Math.Cos(AxisTicks.TickLabelRotation * Math.PI / 180);
+                            break;
+
+
+                    }
                     PixelSize += sizeNeeded;
                 }
 

--- a/src/ScottPlot/Renderable/Axis.cs
+++ b/src/ScottPlot/Renderable/Axis.cs
@@ -382,13 +382,12 @@ namespace ScottPlot.Renderable
                     float largerEdgeLength = Math.Max(maxWidth, maxHeight);
                     float shorterEdgeLength = Math.Min(maxWidth, maxHeight);
                     float differenceInEdgeLengths = largerEdgeLength - shorterEdgeLength;
-                    float sinRotation = IsHorizontal ?
-                        (float)Math.Sin(AxisTicks.TickLabelRotation * Math.PI / 180) :
-                        (float)Math.Cos(AxisTicks.TickLabelRotation * Math.PI / 180);
-                    float rotatedLabelSize = shorterEdgeLength + differenceInEdgeLengths * sinRotation;
+                    double radians = AxisTicks.TickLabelRotation * Math.PI / 180;
+                    double fraction = IsHorizontal ? Math.Sin(radians) : Math.Cos(radians);
+                    double rotatedSize = shorterEdgeLength + differenceInEdgeLengths * fraction;
 
                     // add the rotated label size to the size of this axis
-                    PixelSize += rotatedLabelSize;
+                    PixelSize += (float)rotatedSize;
                 }
 
                 if (AxisTicks.MajorTickVisible)

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Axis.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Axis.cs
@@ -129,7 +129,6 @@ namespace ScottPlot.Cookbook.Recipes.Ticks
         }
     }
 
-
     class TicksRotatedY : IRecipe
     {
         public string Category => "Axis and Ticks";

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Axis.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Axis.cs
@@ -113,17 +113,40 @@ namespace ScottPlot.Cookbook.Recipes.Ticks
     {
         public string Category => "Axis and Ticks";
         public string ID => "ticks_rotated";
-        public string Title => "Rotated Ticks";
-        public string Description => "Tick labels can be rotated as desired.";
+        public string Title => "Rotated X Ticks";
+        public string Description => "Horizontal tick labels can be rotated as desired.";
 
         public void ExecuteRecipe(Plot plt)
         {
             // plot sample data
             plt.AddSignal(DataGen.Sin(51));
             plt.AddSignal(DataGen.Cos(51));
+            plt.XAxis.Label("Horizontal Axis");
+            plt.YAxis.Label("Vertical Axis");
 
             // rotate horizontal axis tick labels
             plt.XAxis.TickLabelStyle(rotation: 45);
+        }
+    }
+
+
+    class TicksRotatedY : IRecipe
+    {
+        public string Category => "Axis and Ticks";
+        public string ID => "ticks_rotatedY";
+        public string Title => "Rotated Y Ticks";
+        public string Description => "Vertical tick labels can be rotated as desired.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            // plot sample data
+            plt.AddSignal(DataGen.Sin(51));
+            plt.AddSignal(DataGen.Cos(51));
+            plt.XAxis.Label("Horizontal Axis");
+            plt.YAxis.Label("Vertical Axis");
+
+            // rotate horizontal axis tick labels
+            plt.YAxis.TickLabelStyle(rotation: 45);
         }
     }
 


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
This is #706 but cherry-picked to remove the collapsing of invisible axes.

**New Functionality:**
ditto