### PR TITLE
Multi-target ScottPlot.csproj

### DIFF
--- a/src/ScottPlot/ScottPlot.csproj
+++ b/src/ScottPlot/ScottPlot.csproj
@@ -42,13 +42,14 @@ Release demo: https://swharden.com/scottplot/demo</PackageReleaseNotes>
   </ItemGroup>
 
   <!-- MacOS requires a special DLL to use System.Drawing -->
-  <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'" >
+  <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.8.64" />
   </ItemGroup>
 
-  <!-- .NET 4.6.1 requires a package to support value tuples -->
+  <!-- .NET 4.6.1 requires a package to support value tuples and OS information -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ScottPlot/ScottPlot.csproj
+++ b/src/ScottPlot/ScottPlot.csproj
@@ -46,10 +46,15 @@ Release demo: https://swharden.com/scottplot/demo</PackageReleaseNotes>
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.8.64" />
   </ItemGroup>
 
-  <!-- .NET 4.6.1 requires a package to support value tuples and OS information -->
+  <!-- .NET Framework 4.6.1 requires packages to support C# 7 features -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
+
+  <!-- .NET Framework builds may not use language features newer than C# 7.3 -->
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
 
 </Project>

--- a/src/ScottPlot/ScottPlot.csproj
+++ b/src/ScottPlot/ScottPlot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <PackageIcon>icon.png</PackageIcon>

--- a/src/ScottPlot/ScottPlot.csproj
+++ b/src/ScottPlot/ScottPlot.csproj
@@ -25,7 +25,7 @@ Release demo: https://swharden.com/scottplot/demo</PackageReleaseNotes>
     <Version>4.1.3-beta</Version>
     <AssemblyVersion>4.1.3.0</AssemblyVersion>
     <FileVersion>4.1.3.0</FileVersion>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>

--- a/src/ScottPlot/ScottPlot.csproj
+++ b/src/ScottPlot/ScottPlot.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -39,7 +39,16 @@ Release demo: https://swharden.com/scottplot/demo</PackageReleaseNotes>
     <None Include="icon.png" Pack="true" PackagePath="\" />
     <None Include="icon.ico" Pack="true" PackagePath="\" />
     <None Include="README.txt" Pack="true" PackagePath="\" />
-    <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.8.64" Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'" />
+  </ItemGroup>
+
+  <!-- MacOS requires a special DLL to use System.Drawing -->
+  <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'" >
+    <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.8.64" />
+  </ItemGroup>
+
+  <!-- .NET 4.6.1 requires a package to support value tuples -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/sandbox/WinFormsFrameworkApp/WinFormsFrameworkApp.csproj
+++ b/src/sandbox/WinFormsFrameworkApp/WinFormsFrameworkApp.csproj
@@ -38,6 +38,7 @@
     <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Drawing.Common.5.0.0\lib\net461\System.Drawing.Common.dll</HintPath>
     </Reference>
+    <Reference Include="System.ValueTuple" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
This PR modifies the ScottPlot project to specifically target multiple platforms:
* .NET Framework 4.6.1
* .NET Standard 2.0
* .NET 5.0

Special packages are required for .NET Framework 4.6.1 and for MacOS so the csproj file has been modified to conditionally install those.

These topics are discussed in #691