### PR TITLE
Heatmap edges fix

### DIFF
--- a/src/ScottPlot/Plottable/Heatmap.cs
+++ b/src/ScottPlot/Plottable/Heatmap.cs
@@ -194,20 +194,20 @@ namespace ScottPlot.Plottable
 
                 if (BackgroundImage != null && !DisplayImageAbove)
                     gfx.DrawImage(
-                            BackgroundImage,
-                            destRect,
-                            0,
-                            0,
-                            BackgroundImage.Width,
-                            BackgroundImage.Height,
-                            GraphicsUnit.Pixel,
-                            attr);
+                            image: BackgroundImage,
+                            destRect: destRect,
+                            srcX: 0,
+                            srcY: 0,
+                            srcWidth: BackgroundImage.Width,
+                            srcHeight: BackgroundImage.Height,
+                            srcUnit: GraphicsUnit.Pixel,
+                            imageAttr: attr);
 
                 gfx.DrawImage(
-                        BmpHeatmap,
-                        destRect,
-                        0,
-                        0,
+                        image: BmpHeatmap,
+                        destRect: destRect,
+                        srcX: 0,
+                        srcY: 0,
                         BmpHeatmap.Width,
                         BmpHeatmap.Height,
                         GraphicsUnit.Pixel,
@@ -215,14 +215,14 @@ namespace ScottPlot.Plottable
 
                 if (BackgroundImage != null && DisplayImageAbove)
                     gfx.DrawImage(
-                            BackgroundImage,
-                            destRect,
-                            0,
-                            0,
-                            BackgroundImage.Width,
-                            BackgroundImage.Height,
-                            GraphicsUnit.Pixel,
-                            attr);
+                            image: BackgroundImage,
+                            destRect: destRect,
+                            srcX: 0,
+                            srcY: 0,
+                            srcWidth: BackgroundImage.Width,
+                            srcHeight: BackgroundImage.Height,
+                            srcUnit: GraphicsUnit.Pixel,
+                            imageAttr: attr);
             }
         }
 

--- a/src/ScottPlot/Plottable/Heatmap.cs
+++ b/src/ScottPlot/Plottable/Heatmap.cs
@@ -198,8 +198,8 @@ namespace ScottPlot.Plottable
                             destRect,
                             0,
                             0,
-                            BmpHeatmap.Width,
-                            BmpHeatmap.Height,
+                            BackgroundImage.Width,
+                            BackgroundImage.Height,
                             GraphicsUnit.Pixel,
                             attr);
 
@@ -219,8 +219,8 @@ namespace ScottPlot.Plottable
                             destRect,
                             0,
                             0,
-                            BmpHeatmap.Width,
-                            BmpHeatmap.Height,
+                            BackgroundImage.Width,
+                            BackgroundImage.Height,
                             GraphicsUnit.Pixel,
                             attr);
             }

--- a/src/ScottPlot/Plottable/Heatmap.cs
+++ b/src/ScottPlot/Plottable/Heatmap.cs
@@ -1,6 +1,7 @@
 ﻿using ScottPlot.Drawing;
 using System;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -180,29 +181,48 @@ namespace ScottPlot.Plottable
             using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
             {
                 gfx.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.NearestNeighbor;
+                gfx.PixelOffsetMode = PixelOffsetMode.Half;
 
-                double minScale = Math.Min(dims.PxPerUnitX, dims.PxPerUnitY);
+                int fromX = (int)Math.Round(dims.GetPixelX(0));
+                int fromY = (int)Math.Round(dims.GetPixelY(Height));
+                int width = (int)Math.Round(dims.GetPixelX(Width) - fromX);
+                int height = (int)Math.Round(dims.GetPixelY(0) - fromY);
+                Rectangle destRect = new Rectangle(fromX, fromY, width, height);
+
+                ImageAttributes attr = new ImageAttributes();
+                attr.SetWrapMode(WrapMode.TileFlipXY);
 
                 if (BackgroundImage != null && !DisplayImageAbove)
                     gfx.DrawImage(
-                        BackgroundImage,
-                        dims.GetPixelX(0),
-                        dims.GetPixelY(0) - (float)(Height * minScale),
-                        (float)(Width * minScale), (float)(Height * minScale));
+                            BackgroundImage,
+                            destRect,
+                            0,
+                            0,
+                            BmpHeatmap.Width,
+                            BmpHeatmap.Height,
+                            GraphicsUnit.Pixel,
+                            attr);
 
                 gfx.DrawImage(
-                    BmpHeatmap,
-                    dims.GetPixelX(0),
-                    dims.GetPixelY(0) - (float)(Height * minScale),
-                    (float)(Width * minScale),
-                    (float)(Height * minScale));
+                        BmpHeatmap,
+                        destRect,
+                        0,
+                        0,
+                        BmpHeatmap.Width,
+                        BmpHeatmap.Height,
+                        GraphicsUnit.Pixel,
+                        attr);
 
                 if (BackgroundImage != null && DisplayImageAbove)
-                    gfx.DrawImage(BackgroundImage,
-                        dims.GetPixelX(0),
-                        dims.GetPixelY(0) - (float)(Height * minScale),
-                        (float)(Width * minScale),
-                        (float)(Height * minScale));
+                    gfx.DrawImage(
+                            BackgroundImage,
+                            destRect,
+                            0,
+                            0,
+                            BmpHeatmap.Width,
+                            BmpHeatmap.Height,
+                            GraphicsUnit.Pixel,
+                            attr);
             }
         }
 


### PR DESCRIPTION
**Purpose:**
Current `Heatmap` implementation render wrong on the edges, This is especially noticeable at small `Heatmaps`.
This PR setup additional params for Graphics.DrawImage() to make correct edges render.
Also more accurate pixel calculation were done, as result `Heatmap` perfect align with axis grid.

Negative side: I remove minScale calculation, as result `Heatmap` cells may be not square if `EqualAxis` will be disabled.
All Demo already have equal axis scales, and additional math not needed.

**New Functionality:**
Old version (incorrect)  3x2 HeatMap from cookbook:
![image](https://user-images.githubusercontent.com/53831487/105750836-44247c00-5f56-11eb-9ab3-766682850cc7.png)

The same demo with this PR:
![image](https://user-images.githubusercontent.com/53831487/105750979-77670b00-5f56-11eb-96bd-112b2b919113.png)

