### PR TITLE
improve signal rendering when using maxRenderIndex (Fix #744)

### DIFF
--- a/src/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot/Plottable/SignalPlotBase.cs
@@ -217,7 +217,7 @@ namespace ScottPlot.Plottable
             List<PointF> linePoints = new List<PointF>(visibleIndex2 - visibleIndex1 + 2);
             if (visibleIndex2 > _Ys.Length - 2)
                 visibleIndex2 = _Ys.Length - 2;
-            if (visibleIndex2 > MaxRenderIndex)
+            if (visibleIndex2 > MaxRenderIndex - 1)
                 visibleIndex2 = MaxRenderIndex - 1;
             if (visibleIndex1 < 0)
                 visibleIndex1 = 0;


### PR DESCRIPTION
**Purpose:**
Fix for incorrect `PlottableSignal` rendering when using `MaxRenderIndex`. #744