### PR TITLE
Extend Colormap API

### DIFF
--- a/dev/devops/azure-pipelines.yml
+++ b/dev/devops/azure-pipelines.yml
@@ -53,7 +53,7 @@ steps:
   inputs:
     command: 'custom'
     custom: 'format'
-    arguments: '-w src/ScottPlot.sln --dry-run --check'
+    arguments: '-w src/ScottPlot.sln --check'
 
 ### INSTALL NUGET AND RESTORE PACKAGES
 

--- a/src/ScottPlot/Drawing/Colormap.cs
+++ b/src/ScottPlot/Drawing/Colormap.cs
@@ -56,26 +56,30 @@ namespace ScottPlot.Drawing
         }
 
         public static Colormap[] GetColormaps() =>
-            Assembly
-                .GetExecutingAssembly()
-                .GetTypes()
-                .Where(type => type.Namespace == "ScottPlot.Drawing.Colormaps")
-                .Select(colormapType => (IColormap)Activator.CreateInstance(colormapType))
-                .Select(colormapInstance => new Colormap(colormapInstance))
+                typeof(Colormap)
+                .GetProperties()
+                .Where(x => x.PropertyType == typeof(Colormap))
+                .Select(x => (Colormap)x.GetValue(x))
                 .ToArray();
 
-        [Obsolete("https://github.com/ScottPlot/ScottPlot/issues/767")]
-        public static Colormap[] GetColormapsOld()
-        {
-            IColormap[] ics = AppDomain.CurrentDomain.GetAssemblies()
-                                .SelectMany(s => s.GetTypes())
-                                .Where(p => p.IsInterface == false)
-                                .Where(p => p.ToString().StartsWith("ScottPlot.Drawing.Colormaps."))
-                                .Select(x => x.ToString())
-                                .Select(path => (IColormap)Activator.CreateInstance(Type.GetType(path)))
-                                .ToArray();
+        public static string[] GetColormapNames() =>
+            typeof(Colormap)
+            .GetProperties()
+            .Where(x => x.PropertyType == typeof(Colormap))
+            .Select(x => x.Name)
+            .ToArray();
 
-            return ics.Select(x => new Colormap(x)).ToArray();
+        public static Colormap GetColormapByName(string name)
+        {
+            var matchingCmaps = typeof(Colormap)
+                                .GetProperties()
+                                .Where(x => x.PropertyType == typeof(Colormap))
+                                .Where(x => x.Name == name)
+                                .Select(x => (Colormap)x.GetValue(x));
+
+            return matchingCmaps.Any()
+                ? matchingCmaps.First()
+                : throw new ArgumentException($"No colormap named '{name}' exists");
         }
 
         public (byte r, byte g, byte b) GetRGB(byte value)

--- a/src/ScottPlot/Drawing/ColormapFactory.cs
+++ b/src/ScottPlot/Drawing/ColormapFactory.cs
@@ -1,0 +1,79 @@
+﻿using ScottPlot.Drawing.Colormaps;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ScottPlot.Drawing
+{
+    public class ColormapFactory
+    {
+        private Dictionary<string, Func<IColormap>> avaialbeColormaps;
+        public ColormapFactory()
+        {
+            avaialbeColormaps = new Dictionary<string, Func<IColormap>>()
+            {
+                { "Algae", () => new Algae()},
+                { "Amp", () => new Amp()},
+                { "Balance", () => new Balance()},
+                { "Blues", () => new Blues()},
+                { "Curl", () => new Curl()},
+                { "Deep", () => new Deep()},
+                { "Delta", () => new Delta()},
+                { "Dense", () => new Dense()},
+                { "Diff", () => new Diff()},
+                { "Grayscale", () => new Grayscale()},
+                { "GrayscaleR", () => new GrayscaleR()},
+                { "Greens", () => new Greens()},
+                { "Haline", () => new Haline()},
+                { "Ice", () => new Ice()},
+                { "Inferno", () => new Inferno()},
+                { "Jet", () => new Jet()},
+                { "Magma", () => new Magma()},
+                { "Matter", () => new Matter()},
+                { "Oxy", () => new Oxy()},
+                { "Phase", () => new Phase()},
+                { "Plasma", () => new Plasma()},
+                { "Rain", () => new Rain()},
+                { "Solar", () => new Solar()},
+                { "Speed", () => new Speed()},
+                { "Tarn", () => new Tarn()},
+                { "Tempo", () => new Tempo()},
+                { "Thermal", () => new Thermal()},
+                { "Topo", () => new Topo()},
+                { "Turbid", () => new Turbid()},
+                { "Turbo", () => new Turbo()},
+                { "Viridis", () => new Viridis()},
+            };
+        }
+
+        public Colormap Create(string Name)
+        {
+            Func<IColormap> cmap;
+            if (avaialbeColormaps.TryGetValue(Name, out cmap))
+            {
+                return new Colormap(cmap());
+            }
+            return new Colormap(new Algae());
+        }
+
+        public Colormap CreateUnsafe(string Name)
+        {
+            Func<IColormap> cmap;
+            if (avaialbeColormaps.TryGetValue(Name, out cmap))
+            {
+                return new Colormap(cmap());
+            }
+            throw new ArgumentOutOfRangeException($"Can't find colormap with name={Name}");
+        }
+
+        public IEnumerable<string> GetAvailableNames()
+        {
+            return avaialbeColormaps.Keys;
+        }
+
+        public IEnumerable<Colormap> GetAvailableColormaps()
+        {
+            return avaialbeColormaps.Values.Select(f => new Colormap(f()));
+        }
+    }
+}

--- a/src/tests/Colormap/Colormap.cs
+++ b/src/tests/Colormap/Colormap.cs
@@ -5,8 +5,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-#pragma warning disable CS0618 // Type or member is obsolete
-
 namespace ScottPlotTests.Colormap
 {
     class Colormap
@@ -14,24 +12,27 @@ namespace ScottPlotTests.Colormap
         [Test]
         public void Test_Colormap_MultipleRequests()
         {
-            var plt = new ScottPlot.Plot();
-            var txt = plt.AddSignal(ScottPlot.DataGen.Sin(51));
-            var bmp = plt.Render();
+            var colormaps = ScottPlot.Drawing.Colormap.GetColormaps();
+            Assert.IsNotNull(colormaps);
+            Assert.IsNotEmpty(colormaps);
+        }
 
-            var colormaps1 = ScottPlot.Drawing.Colormap.GetColormaps();
-            Assert.IsNotNull(colormaps1);
-            Assert.IsNotEmpty(colormaps1);
+        [Test]
+        public void Test_Colormap_GetColormapNames()
+        {
+            string[] names = ScottPlot.Drawing.Colormap.GetColormapNames();
+            Assert.IsNotNull(names);
+            Assert.IsNotEmpty(names);
+            Assert.Contains("Blues", names);
+            Assert.Contains("Viridis", names);
+        }
 
-            var colormaps2 = ScottPlot.Drawing.Colormap.GetColormaps();
-            Assert.IsNotNull(colormaps2);
-            Assert.IsNotEmpty(colormaps2);
-
-            var oldColormaps = ScottPlot.Drawing.Colormap.GetColormapsOld();
-            for (int i = 0; i < oldColormaps.Length; i++)
-            {
-                Console.WriteLine(colormaps2[i].Name);
-                Assert.AreEqual(colormaps2[i].Name, oldColormaps[i].Name);
-            }
+        [Test]
+        public void Test_Colormap_GetColormapByName()
+        {
+            ScottPlot.Drawing.Colormap cmap = ScottPlot.Drawing.Colormap.GetColormapByName("Inferno");
+            Assert.IsNotNull(cmap);
+            Assert.AreEqual("Inferno", cmap.Name);
         }
     }
 }

--- a/src/tests/Colormap/ColormapFactoryTests.cs
+++ b/src/tests/Colormap/ColormapFactoryTests.cs
@@ -1,0 +1,107 @@
+﻿using NUnit.Framework;
+using ScottPlot.Drawing;
+using System;
+using System.Linq;
+
+namespace ScottPlotTests.Colormap
+{
+    [TestFixture]
+    public class ColormapFactoryTests
+    {
+        [TestCase("Solar")]
+        [TestCase("Amp")]
+        [TestCase("Balance")]
+        [TestCase("Ice")]
+        public void Create_AvailableName_NotThrows(string Name)
+        {
+            var factory = new ColormapFactory();
+            ScottPlot.Drawing.Colormap result = factory.Create(Name);
+        }
+
+        [TestCase("Solar")]
+        [TestCase("Amp")]
+        [TestCase("Balance")]
+        [TestCase("Ice")]
+        public void Create_AvailableName_ColormapNameMatchRequested(string Name)
+        {
+            var factory = new ColormapFactory();
+            ScottPlot.Drawing.Colormap result = factory.Create(Name);
+            Assert.AreEqual(Name, result.Name);
+        }
+
+        [TestCase("NotExistedColormap")]
+        [TestCase("a12")]
+        [TestCase("BestColormapEver")]
+        public void Create_NotAvailableName_ReturnDefaultAlgae(string Name)
+        {
+            var factory = new ColormapFactory();
+            ScottPlot.Drawing.Colormap result = factory.Create(Name);
+            Assert.AreEqual("Algae", result.Name);
+        }
+
+        [TestCase("Solar")]
+        [TestCase("Amp")]
+        [TestCase("Balance")]
+        [TestCase("Ice")]
+        public void CreateUnsafe_AvailableName_ColormapNameMatchrequested(string Name)
+        {
+            var factory = new ColormapFactory();
+            ScottPlot.Drawing.Colormap result = factory.CreateUnsafe(Name);
+            Assert.AreEqual(Name, result.Name);
+        }
+
+        [TestCase("NotExistedColormap")]
+        [TestCase("a12")]
+        [TestCase("BestColormapEver")]
+        public void CreateUnsafe_NotAvailableName_Throws(string Name)
+        {
+            var factory = new ColormapFactory();
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+           {
+               ScottPlot.Drawing.Colormap result = factory.CreateUnsafe(Name);
+           });
+        }
+
+        [TestCase("Solar")]
+        [TestCase("Amp")]
+        [TestCase("Balance")]
+        [TestCase("Ice")]
+        public void GetAvailableNames_ContainAvailableName(string Name)
+        {
+            var factory = new ColormapFactory();
+            var availableNames = factory.GetAvailableNames();
+            CollectionAssert.Contains(availableNames, Name);
+        }
+
+        [TestCase("NotExistedColormap")]
+        [TestCase("a12")]
+        [TestCase("BestColormapEver")]
+        public void GetAvailableNames_NotContainUnavailableName(string Name)
+        {
+            var factory = new ColormapFactory();
+            var availableNames = factory.GetAvailableNames();
+            CollectionAssert.DoesNotContain(availableNames, Name);
+        }
+
+        [TestCase("Solar")]
+        [TestCase("Amp")]
+        [TestCase("Balance")]
+        [TestCase("Ice")]
+        public void GetAvailableColormaps_ContainAvailableName(string Name)
+        {
+            var factory = new ColormapFactory();
+            var availableColormaps = factory.GetAvailableColormaps();
+            CollectionAssert.Contains(availableColormaps.Select(cm => cm.Name), Name);
+        }
+
+        [TestCase("NotExistedColormap")]
+        [TestCase("a12")]
+        [TestCase("BestColormapEver")]
+        public void GetAvailableColormaps_NotContainUnavailableName(string Name)
+        {
+            var factory = new ColormapFactory();
+            var availableColormaps = factory.GetAvailableColormaps();
+            CollectionAssert.DoesNotContain(availableColormaps.Select(cm => cm.Name), Name);
+        }
+    }
+}


### PR DESCRIPTION
**Purpose:**
Extends Colormap API with `ColormapFactory` class. #767
`ColormapFactory` allow get available colormaps names without creating `Colormap` instances.
And then create only `Colormap` with requested name.
For adding new types of `IColormap` it needs manual add single line in `availableColormaps` dictionary initializer.

Failed pipline report:
`Unrecognized command or argument '--dry-run'
`
It looks like not my fault.

**New Functionality:**
```cs
var factory = new ColormapFactory();
var names = factory.GetAvailableNames();
var lastColorMap = factory.Create(names.Last());
var oxyColormap = factory.Create("Oxy");
```