### PR TITLE
Remove a Console.WriteLine() Call in ScatterPlotList.Render()

### DIFF
--- a/src/ScottPlot/Plottable/ScatterPlotList.cs
+++ b/src/ScottPlot/Plottable/ScatterPlotList.cs
@@ -109,9 +109,6 @@ namespace ScottPlot.Plottable
             {
                 if (LineStyle != LineStyle.None && LineWidth > 0 && Count > 1)
                 {
-                    for (int i = 0; i < Count; i++)
-                        Console.WriteLine(points[i]);
-
                     gfx.DrawLines(linePen, points);
                 }
 


### PR DESCRIPTION
**Purpose:**

Removes an unnecessary, performance-degrading `Console.WriteLine()` call inside the `ScatterPlotList`s `Render` method.