### PR TITLE
Fix Segmented tree wrong first layer calculation

### DIFF
--- a/src/ScottPlot/Plottable/DataStructures/SegmentedTree.cs
+++ b/src/ScottPlot/Plottable/DataStructures/SegmentedTree.cs
@@ -280,19 +280,19 @@ namespace ScottPlot.DataStructures
                 return;
             }
             // first iteration on source array that virtualy bottom of tree
-            if ((l & 1) != 1) // l is left child
+            if ((l & 1) == 1) // l is right child
             {
                 lowestValueT = MinExp(lowestValueT, sourceArray[l]);
                 highestValueT = MaxExp(highestValueT, sourceArray[l]);
             }
-            if ((r & 1) == 1) // r is right child
+            if ((r & 1) != 1) // r is left child
             {
                 lowestValueT = MinExp(lowestValueT, sourceArray[r]);
                 highestValueT = MaxExp(highestValueT, sourceArray[r]);
             }
             // go up from array to bottom of Tree
-            l = (l + n) / 2;
-            r = (r + n) / 2;
+            l = (l + n + 1) / 2;
+            r = (r + n - 1) / 2;
             // next iterations on tree
             while (l <= r)
             {

--- a/src/tests/MinMaxSearchStrategies/SegmentedTreeMinMaxSearchStrategyTests.cs
+++ b/src/tests/MinMaxSearchStrategies/SegmentedTreeMinMaxSearchStrategyTests.cs
@@ -152,5 +152,18 @@ namespace ScottPlotTests.MinMaxSearchStrategies
             Assert.AreEqual(-1000, min);
             Assert.AreEqual(-1000, max);
         }
+
+        [Test]
+        public void MinMaxRangeQuerryDouble_Issue783Bug_ReturnCorrect()
+        {
+            double[] sourceArray = new double[] { 105.02, 104.82, 104.84, 104.84 };
+            var strategy = CreateStrategy<double>();
+            strategy.SourceArray = sourceArray;
+
+            double min, max;
+            strategy.MinMaxRangeQuery(1, 2, out min, out max);
+            Assert.AreEqual(104.82, min);
+            Assert.AreEqual(104.84, max);
+        }
     }
 }


### PR DESCRIPTION
**Purpose:**
Segmented tree sometimes (l - odd, or r - even) grabbed several additional elements to provided range querry.
This wrong values was close to provided range, Therefore, it was not so noticeable and avoid existed UnitTests.
All `Const` plottables was affected by this.
Thanks to the report from @AlgoExecutor #783,  this error has now been fixed.

