### PR TITLE
Improve small candlestick rendering and support custom wick color

### DIFF
--- a/src/ScottPlot/Plottable/FinancePlot.cs
+++ b/src/ScottPlot/Plottable/FinancePlot.cs
@@ -38,6 +38,8 @@ namespace ScottPlot.Plottable
         public int YAxisIndex { get; set; } = 0;
         public Color ColorUp = Color.LightGreen;
         public Color ColorDown = Color.LightCoral;
+        public Color WickColor = Color.LightGray;
+        public bool SeparateWickColor = true;
 
         public AxisLimits GetAxisLimits()
         {
@@ -110,10 +112,10 @@ namespace ScottPlot.Plottable
                 boxWidth = (float)(spacingPx / 2 * fractionalTickWidth);
             }
 
+
             using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
             using Pen pen = new Pen(Color.Magenta);
             using SolidBrush brush = new SolidBrush(Color.Magenta);
-
             for (int i = 0; i < OHLCs.Length; i++)
             {
                 var ohlc = OHLCs[i];
@@ -127,6 +129,11 @@ namespace ScottPlot.Plottable
                 brush.Color = ohlc.closedHigher ? ColorUp : ColorDown;
                 pen.Width = (boxWidth >= 2) ? 2 : 1;
 
+                if (SeparateWickColor)
+                {
+                    pen.Color = WickColor;
+                }
+
                 // the wick below the box
                 PointF wickLowBot = new PointF(pixelX, dims.GetPixelY(ohlc.low));
                 PointF wickLowTop = new PointF(pixelX, dims.GetPixelY(ohlc.lowestOpenClose));
@@ -137,15 +144,21 @@ namespace ScottPlot.Plottable
                 PointF wickHighTop = new PointF(pixelX, dims.GetPixelY(ohlc.high));
                 gfx.DrawLine(pen, wickHighBot, wickHighTop);
 
-                // the candle
+
                 PointF boxLowerLeft = new PointF(pixelX, dims.GetPixelY(ohlc.lowestOpenClose));
                 PointF boxUpperRight = new PointF(pixelX, dims.GetPixelY(ohlc.highestOpenClose));
-                gfx.FillRectangle(brush, boxLowerLeft.X - boxWidth, boxUpperRight.Y, boxWidth * 2, boxLowerLeft.Y - boxUpperRight.Y);
 
                 if (ohlc.open == ohlc.close) // doji sesssion
                 {
                     gfx.DrawLine(pen, boxLowerLeft.X - boxWidth, boxLowerLeft.Y, boxLowerLeft.X + boxWidth, boxLowerLeft.Y);
                 }
+                else
+                {
+                    // the candle
+                    pen.Color = ohlc.closedHigher ? ColorUp : ColorDown;
+                    gfx.FillRectangle(brush, boxLowerLeft.X - boxWidth, boxUpperRight.Y, boxWidth * 2, boxLowerLeft.Y - boxUpperRight.Y);
+                }
+
             }
         }
 

--- a/src/ScottPlot/Plottable/FinancePlot.cs
+++ b/src/ScottPlot/Plottable/FinancePlot.cs
@@ -29,17 +29,28 @@ namespace ScottPlot.Plottable
         /// </summary>
         public bool Sequential;
 
-        // customizations
+        /// <summary>
+        /// Color of the candle if it closes at or above its open value
+        /// </summary>
+        public Color ColorUp = Color.LightGreen;
+
+        /// <summary>
+        /// Color of the candle if it closes below its open value
+        /// </summary>
+        public Color ColorDown = Color.LightCoral;
+
+        /// <summary>
+        /// This field controls the color of the wick and rectangular candle border.
+        /// If null, the wick is the same color as the candle and no border is applied.
+        /// </summary>
+        public Color? WickColor = null;
+
         public bool IsVisible { get; set; } = true;
-        public override string ToString() => $"PlottableOHLC with {PointCount} points";
+        public override string ToString() => $"FinancePlot with {PointCount} OHLC indicators";
         public LegendItem[] GetLegendItems() => null;
         public int PointCount { get => OHLCs.Length; }
         public int XAxisIndex { get; set; } = 0;
         public int YAxisIndex { get; set; } = 0;
-        public Color ColorUp = Color.LightGreen;
-        public Color ColorDown = Color.LightCoral;
-        public Color WickColor = Color.LightGray;
-        public bool SeparateWickColor = true;
 
         public AxisLimits GetAxisLimits()
         {
@@ -112,7 +123,6 @@ namespace ScottPlot.Plottable
                 boxWidth = (float)(spacingPx / 2 * fractionalTickWidth);
             }
 
-
             using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
             using Pen pen = new Pen(Color.Magenta);
             using SolidBrush brush = new SolidBrush(Color.Magenta);
@@ -125,43 +135,37 @@ namespace ScottPlot.Plottable
                 if (AutoWidth == false)
                     boxWidth = (float)(ohlc.timeSpan * dims.PxPerUnitX / 2 * fractionalTickWidth);
 
-                pen.Color = ohlc.closedHigher ? ColorUp : ColorDown;
-                brush.Color = ohlc.closedHigher ? ColorUp : ColorDown;
+                Color priceChangeColor = ohlc.closedHigher ? ColorUp : ColorDown;
+                pen.Color = WickColor ?? priceChangeColor;
                 pen.Width = (boxWidth >= 2) ? 2 : 1;
 
-                if (SeparateWickColor)
-                {
-                    pen.Color = WickColor;
-                }
-
-                // the wick below the box
+                // draw the wick below the box
                 PointF wickLowBot = new PointF(pixelX, dims.GetPixelY(ohlc.low));
                 PointF wickLowTop = new PointF(pixelX, dims.GetPixelY(ohlc.lowestOpenClose));
                 gfx.DrawLine(pen, wickLowBot, wickLowTop);
 
-                // the wick above the box
+                // draw the wick above the box
                 PointF wickHighBot = new PointF(pixelX, dims.GetPixelY(ohlc.highestOpenClose));
                 PointF wickHighTop = new PointF(pixelX, dims.GetPixelY(ohlc.high));
                 gfx.DrawLine(pen, wickHighBot, wickHighTop);
 
-
+                // draw the candle body
                 PointF boxLowerLeft = new PointF(pixelX, dims.GetPixelY(ohlc.lowestOpenClose));
                 PointF boxUpperRight = new PointF(pixelX, dims.GetPixelY(ohlc.highestOpenClose));
-
-                if (ohlc.open == ohlc.close) // doji sesssion
+                if (ohlc.open == ohlc.close)
                 {
+                    // draw OHLC (non-filled) candle
                     gfx.DrawLine(pen, boxLowerLeft.X - boxWidth, boxLowerLeft.Y, boxLowerLeft.X + boxWidth, boxLowerLeft.Y);
                 }
                 else
                 {
-                    // the candle
-                    pen.Color = ohlc.closedHigher ? ColorUp : ColorDown;
+                    // draw a filled candle
+                    brush.Color = priceChangeColor;
                     gfx.FillRectangle(brush, boxLowerLeft.X - boxWidth, boxUpperRight.Y, boxWidth * 2, boxLowerLeft.Y - boxUpperRight.Y);
 
-                    pen.Color = SeparateWickColor ? WickColor : pen.Color;
-                    gfx.DrawRectangle(pen, boxLowerLeft.X - boxWidth, boxUpperRight.Y - 1, boxWidth * 2, boxLowerLeft.Y - boxUpperRight.Y + 2);
+                    if (WickColor != null)
+                        gfx.DrawRectangle(pen, boxLowerLeft.X - boxWidth, boxUpperRight.Y - 1, boxWidth * 2, boxLowerLeft.Y - boxUpperRight.Y + 2);
                 }
-
             }
         }
 

--- a/src/ScottPlot/Plottable/FinancePlot.cs
+++ b/src/ScottPlot/Plottable/FinancePlot.cs
@@ -141,6 +141,11 @@ namespace ScottPlot.Plottable
                 PointF boxLowerLeft = new PointF(pixelX, dims.GetPixelY(ohlc.lowestOpenClose));
                 PointF boxUpperRight = new PointF(pixelX, dims.GetPixelY(ohlc.highestOpenClose));
                 gfx.FillRectangle(brush, boxLowerLeft.X - boxWidth, boxUpperRight.Y, boxWidth * 2, boxLowerLeft.Y - boxUpperRight.Y);
+
+                if (ohlc.open == ohlc.close) // doji sesssion
+                {
+                    gfx.DrawLine(pen, boxLowerLeft.X - boxWidth, boxLowerLeft.Y, boxLowerLeft.X + boxWidth, boxLowerLeft.Y);
+                }
             }
         }
 

--- a/src/ScottPlot/Plottable/FinancePlot.cs
+++ b/src/ScottPlot/Plottable/FinancePlot.cs
@@ -157,6 +157,9 @@ namespace ScottPlot.Plottable
                     // the candle
                     pen.Color = ohlc.closedHigher ? ColorUp : ColorDown;
                     gfx.FillRectangle(brush, boxLowerLeft.X - boxWidth, boxUpperRight.Y, boxWidth * 2, boxLowerLeft.Y - boxUpperRight.Y);
+
+                    pen.Color = SeparateWickColor ? WickColor : pen.Color;
+                    gfx.DrawRectangle(pen, boxLowerLeft.X - boxWidth, boxUpperRight.Y - 1, boxWidth * 2, boxLowerLeft.Y - boxUpperRight.Y + 2);
                 }
 
             }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Finance.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Finance.cs
@@ -165,4 +165,100 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             plt.YAxis2.Label("Price (USD)");
         }
     }
+
+    public class FinanceWickColor : IRecipe
+    {
+        public string Category => "Plottable: Finance";
+        public string ID => "finance_wick";
+        public string Title => "Custom Wick Color";
+        public string Description =>
+            "By default candle wicks are the same color as their bodies, but this can be customized.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            OHLC[] prices = DataGen.RandomStockPrices(null, 30, TimeSpan.FromMinutes(5));
+            var fp = plt.AddCandlesticks(prices);
+            fp.WickColor = Color.Black;
+        }
+    }
+
+    public class FinanceColor : IRecipe
+    {
+        public string Category => "Plottable: Finance";
+        public string ID => "finance_color";
+        public string Title => "Custom Colors";
+        public string Description =>
+            "Candles that close below their open price are colored differently from " +
+            "candles which close at or above it. These colors can be customized. " +
+            "Combine this styling with a custom wick color (which also controls the candle border) " +
+            "to create a different visual style.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            OHLC[] prices = DataGen.RandomStockPrices(null, 30, TimeSpan.FromMinutes(5));
+            var fp = plt.AddCandlesticks(prices);
+            fp.ColorDown = Color.Black;
+            fp.ColorUp = Color.White;
+            fp.WickColor = Color.Black;
+        }
+    }
+
+    public class FinanceDark : IRecipe
+    {
+        public string Category => "Plottable: Finance";
+        public string ID => "finance_dark";
+        public string Title => "Dark Mode";
+        public string Description =>
+            "A dark mode finance plot can be realized by customizing color options of the candles and figure. " +
+            "Colors in this example were chosen to mimic TC2000.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            // add some random candles
+            OHLC[] prices = DataGen.RandomStockPrices(null, 100, TimeSpan.FromMinutes(5));
+            double[] xs = prices.Select(x => x.time).ToArray();
+            var candlePlot = plt.AddCandlesticks(prices);
+            candlePlot.YAxisIndex = 1;
+
+            plt.XAxis.DateTimeFormat(true);
+
+            // add SMA indicators for 8 and 20 days
+            double[] sma8xs = xs.Skip(8).ToArray();
+            double[] sma8ys = Statistics.Finance.SMA(prices, 8);
+            double[] sma20xs = xs.Skip(20).ToArray();
+            double[] sma20ys = Statistics.Finance.SMA(prices, 20);
+            var sma8plot = plt.AddScatterLines(sma8xs, sma8ys, Color.Cyan, 2, label: "8 day SMA");
+            var sma20plot = plt.AddScatterLines(sma20xs, sma20ys, Color.Yellow, 2, label: "20 day SMA");
+            sma8plot.YAxisIndex = 1;
+            sma20plot.YAxisIndex = 1;
+
+            // customize candle styling
+            candlePlot.ColorDown = ColorTranslator.FromHtml("#00FF00");
+            candlePlot.ColorUp = ColorTranslator.FromHtml("#FF0000");
+
+            // customize figure styling
+            plt.Layout(padding: 12);
+            plt.Style(figureBackground: Color.Black, dataBackground: Color.Black);
+            plt.Frame(false);
+            plt.XAxis.TickLabelStyle(color: Color.White);
+            plt.XAxis.TickMarkColor(ColorTranslator.FromHtml("#333333"));
+            plt.XAxis.MajorGrid(color: ColorTranslator.FromHtml("#333333"));
+
+            // hide the left axis and show a right axis
+            plt.YAxis.Ticks(false);
+            plt.YAxis.Grid(false);
+            plt.YAxis2.Ticks(true);
+            plt.YAxis2.Grid(true);
+            plt.YAxis2.TickLabelStyle(color: ColorTranslator.FromHtml("#00FF00"));
+            plt.YAxis2.TickMarkColor(ColorTranslator.FromHtml("#333333"));
+            plt.YAxis2.MajorGrid(color: ColorTranslator.FromHtml("#333333"));
+
+            // customize the legend style
+            var legend = plt.Legend();
+            legend.FillColor = Color.Transparent;
+            legend.OutlineColor = Color.Transparent;
+            legend.Font.Color = Color.White;
+            legend.Font.Bold = true;
+        }
+    }
 }


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
Fixes the drawing of "Doji" candlesticks (i.e. open == close) #800 

**New Functionality:**
Adds a check for the Doji case and adds a red line where otherwise the candle body would not be drawn.

```cs
OHLC[] arr = DataGen.RandomStockPrices(new Random(0), 10);
arr[5] = new OHLC(arr[5].open, arr[5].high, arr[5].low, arr[5].open, arr[5].time); // Ensure a doji session exists

plt.AddCandlesticks(arr);
```

Before:
![image](https://user-images.githubusercontent.com/8635304/108140139-b46a7d00-707e-11eb-83b8-f9c5bc3ea887.png)

After:
![image](https://user-images.githubusercontent.com/8635304/108140094-9dc42600-707e-11eb-9aeb-9c70f924aad8.png)