### PR TITLE
Add support of negetive OLE Automation Date values

### DIFF
--- a/src/ScottPlot/Ticks/TickCollection.cs
+++ b/src/ScottPlot/Ticks/TickCollection.cs
@@ -1,5 +1,5 @@
-﻿using ScottPlot.Ticks.DateTimeTickUnits;
-using ScottPlot.Drawing;
+﻿using ScottPlot.Drawing;
+using ScottPlot.Ticks.DateTimeTickUnits;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -131,7 +131,7 @@ namespace ScottPlot.Ticks
 
             if (low < high)
             {
-                low = Math.Max(low, new DateTime( 0100, 1, 1, 0, 0, 0).ToOADate()); // minimum OADate value
+                low = Math.Max(low, new DateTime(0100, 1, 1, 0, 0, 0).ToOADate()); // minimum OADate value
                 high = Math.Min(high, DateTime.MaxValue.ToOADate());
 
                 var dtManualUnits = (verticalAxis) ? manualDateTimeSpacingUnitY : manualDateTimeSpacingUnitX;

--- a/src/ScottPlot/Ticks/TickCollection.cs
+++ b/src/ScottPlot/Ticks/TickCollection.cs
@@ -131,7 +131,7 @@ namespace ScottPlot.Ticks
 
             if (low < high)
             {
-                low = Math.Max(low, DateTime.MinValue.ToOADate());
+                low = Math.Max(low, new DateTime( 0100, 1, 1, 0, 0, 0).ToOADate()); // minimum OADate value
                 high = Math.Min(high, DateTime.MaxValue.ToOADate());
 
                 var dtManualUnits = (verticalAxis) ? manualDateTimeSpacingUnitY : manualDateTimeSpacingUnitX;


### PR DESCRIPTION
**Purpose:**
OLE Automation date support negative values, and it's minimum value is midnight, 1 January 0100.##806
This PR allow to use negative values and expand avalable range.

**New Functionality:**
![image](https://user-images.githubusercontent.com/53831487/108390450-bde01a80-7221-11eb-8f17-37e1c53192c5.png)