### PR TITLE
Tooltip GetAxisLimits now returns all NaN instead of all zero

### DIFF
--- a/src/ScottPlot/Plottable/Tooltip.cs
+++ b/src/ScottPlot/Plottable/Tooltip.cs
@@ -35,7 +35,7 @@ namespace ScottPlot.Plottable
 
         public LegendItem[] GetLegendItems() => null;
 
-        public AxisLimits GetAxisLimits() => new AxisLimits();
+        public AxisLimits GetAxisLimits() => new AxisLimits(double.NaN, double.NaN, double.NaN, double.NaN);
 
         public void ValidateData(bool deep = false)
         {


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
Removes `Plottable.Tooltip` from `AxisAuto` calculations to fix #805 

**New Functionality:**

From the demo provided in https://github.com/ScottPlot/ScottPlot/issues/805#issue-810258752:

Before:
![image](https://user-images.githubusercontent.com/8635304/108453740-4feb2180-7228-11eb-8480-78c30f4b7757.png)

After:
![image](https://user-images.githubusercontent.com/8635304/108453751-55e10280-7228-11eb-90ea-b4260599714a.png)
