### PR TITLE
SignalPlotList

### DIFF
--- a/src/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot/Plot/Plot.Add.cs
@@ -784,6 +784,22 @@ namespace ScottPlot
         }
 
         /// <summary>
+        /// Create a SignalList, add it to the plot, and return it.
+        /// A SignalList is a ScatterPlot that is designed to grow using Add() and AddRange() methods.
+        /// </summary>
+        public SignalPlotList AddSignalList(double sampleRate = 1, Color? color = null, string label = null, int capacity = 100_000)
+        {
+            SignalPlotList plottable = new SignalPlotList(capacity)
+            {
+                SampleRate = sampleRate,
+                Color = color ?? settings.GetNextColor(),
+                Label = label,
+            };
+            Add(plottable);
+            return plottable;
+        }
+
+        /// <summary>
         /// Display text at specific X/Y coordinates
         /// </summary>
         public Text AddText(string label, double x, double y, float size = 12, Color? color = null) =>

--- a/src/ScottPlot/Plottable/SignalPlotList.cs
+++ b/src/ScottPlot/Plottable/SignalPlotList.cs
@@ -1,0 +1,129 @@
+﻿using ScottPlot.MinMaxSearchStrategies;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Plottable
+{
+    /// <summary>
+    /// A SignalPlotList is a SignalPlot that is designed to grow using Add() and AddRange() methods
+    /// </summary>
+    public class SignalPlotList : SignalPlotBase<double>
+    {
+        /// <summary>
+        /// The total number of values the list can hold without resizing.
+        /// </summary>
+        public int Capacity => Ys.Length;
+
+        /// <summary>
+        /// Number of values in the list.
+        /// This number will never exceed the Capacity.
+        /// </summary>
+        public int Count => NextPointIndex;
+
+        /// <summary>
+        /// Percentage of the capacity currently filled with data
+        /// </summary>
+        public double FillPercentage => 100.0 * Count / Capacity;
+
+        /// <summary>
+        /// Return the last value in the list (or null if empty)
+        /// </summary>
+        public double? LastY => (Count > 0) ? Ys[NextPointIndex - 1] : null;
+
+        /// <summary>
+        /// Return the time point fot the last value in the list (or null if empty)
+        /// </summary>
+        public double? LastX => (Count > 0) ? (NextPointIndex - 1) / SampleRate + OffsetX : null;
+
+        /// <summary>
+        /// Index in the Ys array where the next data point will be placed.
+        /// </summary>
+        private int NextPointIndex = 0;
+
+        /// <summary>
+        /// When the Ys array must be expanded, increase its length by this number of values.
+        /// </summary>
+        private readonly int CapacityIncriment;
+
+        /// <summary>
+        /// Create a SignalPlotList
+        /// </summary>
+        /// <param name="capacity">Initial capacity of the list. Also the size by which to expand it as needed.</param>
+        public SignalPlotList(int capacity) : base()
+        {
+            CapacityIncriment = capacity;
+            Strategy = new LinearDoubleOnlyMinMaxStrategy();
+            Clear(resetCapacity: true);
+        }
+
+        public override string ToString() =>
+            $"SignalPlotList (label={Label}) with {Count}/{Capacity} points filled ({FillPercentage:N2}%)";
+
+        /// <summary>
+        /// Add a single point to the list.
+        /// The internal data structure will be automatically expanded in memory if needed.
+        /// </summary>
+        /// <param name="y">new Y value</param>
+        public void Add(double y)
+        {
+            if (Count >= Capacity)
+                IncreaseCapacity(Capacity + CapacityIncriment);
+            Ys[NextPointIndex] = y;
+            MaxRenderIndex = NextPointIndex;
+            NextPointIndex += 1;
+        }
+
+        /// <summary>
+        /// Add a multiple points to the list.
+        /// The internal data structure will be automatically expanded in memory if needed.
+        /// </summary>
+        /// <param name="ys">new Y values</param>
+        public void AddRange(double[] ys)
+        {
+            // TODO: this can be optimized
+            foreach (var y in ys)
+                Add(y);
+        }
+
+        /// <summary>
+        /// Add a multiple points to the list.
+        /// The internal data structure will be automatically expanded in memory if needed.
+        /// </summary>
+        /// <param name="ys">new Y values</param>
+        public void AddRange(IEnumerable<double> ys)
+        {
+            // TODO: this can be optimized
+            foreach (var y in ys)
+                Add(y);
+        }
+
+        /// <summary>
+        /// Replace the Ys array with a new array of larger size, copying-over the old values.
+        /// </summary>
+        /// <param name="newCapacity">length of the new array</param>
+        private void IncreaseCapacity(int newCapacity)
+        {
+            if (newCapacity <= Capacity)
+                throw new ArgumentException("new capacity must be greater than the current capacity");
+
+            double[] newYs = new double[newCapacity];
+            Array.Copy(Ys, 0, newYs, 0, Ys.Length);
+            Ys = newYs;
+        }
+
+        /// <summary>
+        /// Clear the list
+        /// </summary>
+        /// <param name="resetCapacity">if true, the internal data structure will be reset to its initial size</param>
+        public void Clear(bool resetCapacity = false)
+        {
+            if (resetCapacity)
+                Ys = new double[CapacityIncriment];
+            NextPointIndex = 0;
+            MaxRenderIndex = 0; // TODO: should this be -1 to indicate no points should be rendered?
+        }
+    }
+}

--- a/src/sandbox/WinFormsApp/Form1.Designer.cs
+++ b/src/sandbox/WinFormsApp/Form1.Designer.cs
@@ -29,13 +29,26 @@ namespace WinFormsApp
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
+            this.timer1 = new System.Windows.Forms.Timer(this.components);
+            this.timer2 = new System.Windows.Forms.Timer(this.components);
             this.SuspendLayout();
+            // 
+            // timer1
+            // 
+            this.timer1.Interval = 1;
+            this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
+            // 
+            // timer2
+            // 
+            this.timer2.Interval = 25;
+            this.timer2.Tick += new System.EventHandler(this.timer2_Tick);
             // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.ClientSize = new System.Drawing.Size(434, 261);
             this.Name = "Form1";
             this.Text = "ScottPlot Sandbox - WinForms";
             this.ResumeLayout(false);
@@ -43,6 +56,9 @@ namespace WinFormsApp
         }
 
         #endregion
+
+        private System.Windows.Forms.Timer timer1;
+        private System.Windows.Forms.Timer timer2;
     }
 }
 

--- a/src/sandbox/WinFormsApp/Form1.cs
+++ b/src/sandbox/WinFormsApp/Form1.cs
@@ -1,26 +1,48 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Windows.Forms;
 
 namespace WinFormsApp
 {
     public partial class Form1 : Form
     {
-        private readonly ScottPlot.FormsPlot formsPlot1;
+        readonly ScottPlot.FormsPlot formsPlot1;
+        readonly Random Rand = new Random(0);
+        readonly ScottPlot.Plottable.SignalPlotList SignalPlotList;
+        readonly Stopwatch Stopwatch = Stopwatch.StartNew();
 
         public Form1()
         {
             InitializeComponent();
 
-            // add this manually because the .NET winforms designer is still in preview mode
-            // and the FormsPlot user control typically does not appear in the toolbox
+            // The plot control is added manually because the .NET core winforms designer is still buggy
+            // and does not always show it in the toolbox
             formsPlot1 = new ScottPlot.FormsPlot() { Dock = DockStyle.Fill };
             Controls.Add(formsPlot1);
 
-            int pointCount = 10;
-            var rand = new Random(0);
-            double[] xs = ScottPlot.DataGen.Random(rand, pointCount);
-            double[] ys = ScottPlot.DataGen.Random(rand, pointCount);
-            formsPlot1.Plot.AddScatter(xs, ys);
+            SignalPlotList = formsPlot1.Plot.AddSignalList();
+            formsPlot1.Plot.SetAxisLimitsY(-2, 2);
+
+            timer1.Enabled = true;
+            timer2.Enabled = true;
+        }
+
+        // high frequency tick (1 ms) adds data
+        private void timer1_Tick(object sender, EventArgs e)
+        {
+            double newValue = Math.Sin(Stopwatch.Elapsed.TotalSeconds) + Rand.NextDouble() - .5;
+            SignalPlotList.Add(newValue);
+        }
+
+        // low frequency tick (20 ms) renders the plot
+        private void timer2_Tick(object sender, EventArgs e)
+        {
+            var axisLimits = formsPlot1.Plot.GetAxisLimits();
+
+            if (axisLimits.XMax < SignalPlotList.LastX)
+                formsPlot1.Plot.SetAxisLimits(xMax: axisLimits.XMax + 250);
+
+            formsPlot1.Render();
         }
     }
 }

--- a/src/tests/PlotTypes/SignalPlotList.cs
+++ b/src/tests/PlotTypes/SignalPlotList.cs
@@ -1,0 +1,131 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlotTests.PlotTypes
+{
+    class SignalPlotList
+    {
+        [Test]
+        public void Test_SignalPlotList_InitRespectsCapacity()
+        {
+            var plt = new ScottPlot.Plot();
+            var spl = plt.AddSignalList(capacity: 3);
+
+            Assert.AreEqual(3, spl.Capacity);
+            Assert.AreEqual(0, spl.Count);
+            Assert.AreEqual(0, spl.FillPercentage);
+        }
+
+        [Test]
+        public void Test_SignalPlotList_AddFillsYs()
+        {
+            var plt = new ScottPlot.Plot();
+            var spl = plt.AddSignalList(capacity: 3);
+
+            spl.Add(111);
+            spl.Add(222);
+            spl.Add(333);
+            Assert.AreEqual(new double[] { 111, 222, 333 }, spl.Ys);
+            Assert.AreEqual(3, spl.Count);
+            Assert.AreEqual(100, spl.FillPercentage);
+        }
+
+        [Test]
+        public void Test_SignalPlotList_YsGrowsAutomatically()
+        {
+            var plt = new ScottPlot.Plot();
+            var spl = plt.AddSignalList(capacity: 3);
+
+            spl.Add(111);
+            spl.Add(222);
+            spl.Add(333);
+            spl.Add(444);
+            spl.Add(555);
+            spl.Add(666);
+            Assert.AreEqual(new double[] { 111, 222, 333, 444, 555, 666 }, spl.Ys);
+        }
+
+        [Test]
+        public void Test_SignalPlotList_AddMovesMaxRenderIndex()
+        {
+            var plt = new ScottPlot.Plot();
+            var spl = plt.AddSignalList(capacity: 3);
+
+            spl.Add(111);
+            Assert.AreEqual(0, spl.MaxRenderIndex);
+
+            spl.Add(222);
+            Assert.AreEqual(1, spl.MaxRenderIndex);
+
+            spl.Add(333);
+            Assert.AreEqual(2, spl.MaxRenderIndex);
+
+            spl.Add(444);
+            Assert.AreEqual(3, spl.MaxRenderIndex);
+
+            spl.Add(555);
+            Assert.AreEqual(4, spl.MaxRenderIndex);
+        }
+
+        [Test]
+        public void Test_SignalPlotList_Clear()
+        {
+            var plt = new ScottPlot.Plot();
+            var spl = plt.AddSignalList(capacity: 3);
+
+            spl.Add(111);
+            spl.Add(222);
+            Assert.AreEqual(1, spl.MaxRenderIndex);
+            Assert.AreEqual(2, spl.Count);
+            Assert.AreEqual(100.0 * 2 / 3, spl.FillPercentage);
+
+            spl.Clear();
+            Assert.AreEqual(new double[] { 111, 222, 0 }, spl.Ys);
+            Assert.AreEqual(0, spl.MaxRenderIndex);
+            Assert.AreEqual(0, spl.Count);
+            Assert.AreEqual(0, spl.FillPercentage);
+
+            spl.Add(333);
+            spl.Add(444);
+            spl.Add(555);
+            spl.Add(666);
+            Assert.AreEqual(new double[] { 333, 444, 555, 666, 0, 0 }, spl.Ys);
+            Assert.AreEqual(4, spl.Count);
+            Assert.AreEqual(100.0 * 4 / 6, spl.FillPercentage);
+        }
+
+        [Test]
+        public void Test_SignalPlotList_AddRange()
+        {
+            var plt = new ScottPlot.Plot();
+            var spl = plt.AddSignalList(capacity: 3);
+
+            spl.AddRange(new double[] { 111, 222, 333 });
+            Assert.AreEqual(new double[] { 111, 222, 333 }, spl.Ys);
+        }
+
+        [Test]
+        public void Test_SignalPlotList_AddRangeGrowsAutomatically()
+        {
+            var plt = new ScottPlot.Plot();
+            var spl = plt.AddSignalList(capacity: 3);
+
+            spl.AddRange(new double[] { 111, 222, 333, 444 });
+            Assert.AreEqual(new double[] { 111, 222, 333, 444, 0, 0 }, spl.Ys);
+        }
+
+        [Test]
+        public void Test_SignalPlotList_AddRangeListWorksToo()
+        {
+            var plt = new ScottPlot.Plot();
+            var spl = plt.AddSignalList(capacity: 3);
+
+            spl.AddRange(new List<double>() { 111, 222, 333, 444 });
+            Assert.AreEqual(new double[] { 111, 222, 333, 444, 0, 0 }, spl.Ys);
+        }
+    }
+}


### PR DESCRIPTION
**The goal of `SignalPlotList` is to make it easier to efficiently display growing datasets with Signal plots.**

`SignalPlotList` doesn't use `List<T>` to store data; it just behaves like `List<T>` with `Add()`, `AddRange()`, `Capacity`, and `Count`. It still uses `double[] Ys` for data storage, but when data is added `maxRenderIndex` is moved automatically and `Ys` is resized as needed.

@StendProg, do you have any thoughts about this idea? Do you think it would be a good idea to move this functionality into `SignalPlotBase` so it could be used in all types of Signal plots?

### WinForms Demonstration

```cs
readonly ScottPlot.Plottable.SignalPlotList SignalPlotList;

public Form1()
{
    InitializeComponent();
    SignalPlotList = formsPlot1.Plot.AddSignalList();
}

// high frequency tick (1 ms) adds data
private void timer1_Tick(object sender, EventArgs e)
{
    SignalPlotList.AddRange(/* new data */);
}

// low frequency tick (20 ms) renders the plot
private void timer2_Tick(object sender, EventArgs e)
{
    var axisLimits = formsPlot1.Plot.GetAxisLimits();
    if (axisLimits.XMax < SignalPlotList.LastX)
        formsPlot1.Plot.SetAxisLimits(xMax: axisLimits.XMax + 250);
    formsPlot1.Render();
}

```

https://user-images.githubusercontent.com/4165489/108639071-90cd7b00-7460-11eb-95b2-35ff9a4574af.mp4