### PR TITLE
Updated Plot.Add.cs to return a correct array of BarPlots

### DIFF
--- a/src/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot/Plot/Plot.Add.cs
@@ -129,6 +129,7 @@ namespace ScottPlot
                     ErrorCapSize = errorCapSize,
                     FillColor = GetNextColor()
                 };
+                bars[i] = bar;
                 Add(bar);
             }
 


### PR DESCRIPTION
Adds bar to BarPlot array so it now returns an array of BarPlots instead of a null array.

**Purpose:**
Beforehand, calling AddBarGroups would result in it returning an array with a single null element in it as seen below:

![image](https://user-images.githubusercontent.com/49352090/109399827-fc21bc00-793c-11eb-8477-66bf4049f97b.png)

All that had to be changed was actually adding the bar to the array within the loop! A nice quick fix and now I can change the styles of the bars in that group, which I wasn't able to do before. I created a quick extension method that copied the original with that addition and now you get the expected result:

![image](https://user-images.githubusercontent.com/49352090/109399875-5884db80-793d-11eb-88e6-dfe767006f08.png)
