### PR TITLE
Dot, Lollipop and Cleveland Dot Plots

### DIFF
--- a/src/ScottPlot/Enums/Orientation.cs
+++ b/src/ScottPlot/Enums/Orientation.cs
@@ -1,0 +1,8 @@
+﻿namespace ScottPlot
+{
+    public enum Orientation
+    {
+        Horizontal,
+        Vertical
+    }
+}

--- a/src/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot/Plot/Plot.Add.cs
@@ -173,7 +173,7 @@ namespace ScottPlot
                 {
                     Label = seriesLabels[i],
                     BarWidth = barWidth * barWidthFraction,
-                    XOffset = i * barWidth,
+                    PositionOffset = i * barWidth,
                     ErrorCapSize = errorCapSize,
                     FillColor = GetNextColor()
                 };

--- a/src/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot/Plot/Plot.Add.cs
@@ -79,7 +79,7 @@ namespace ScottPlot
         public LollipopPlot AddLollipop(double[] values, Color? color = null)
         {
             double[] xs = DataGen.Consecutive(values.Length);
-            var plottable = new LollipopPlot(xs, values, null, null)
+            var plottable = new LollipopPlot(xs, values)
             {
                 LollipopColor = color ?? GetNextColor()
             };
@@ -92,7 +92,7 @@ namespace ScottPlot
         /// </summary>
         public LollipopPlot AddLollipop(double[] values, double[] positions, Color? color = null)
         {
-            var plottable = new LollipopPlot(positions, values, null, null)
+            var plottable = new LollipopPlot(positions, values)
             {
                 LollipopColor = color ?? GetNextColor()
             };

--- a/src/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot/Plot/Plot.Add.cs
@@ -53,6 +53,54 @@ namespace ScottPlot
         }
 
         /// <summary>
+        /// Add a Cleveland Dot plot for the given values. Cleveland Dots will be placed at X positions 0, 1, 2, etc.
+        /// </summary>
+        public ClevelandDotPlot AddClevelandDot(double[] ys1, double[] ys2)
+        {
+            double[] xs = DataGen.Consecutive(ys1.Length);
+            var plottable = new ClevelandDotPlot(xs, ys1, ys2);
+            Add(plottable);
+            return plottable;
+        }
+
+        /// <summary>
+        /// Add a Cleveland Dot plot for the given values using defined dot positions.
+        /// </summary>
+        public ClevelandDotPlot AddClevelandDot(double[] ys1, double[] ys2, double[] positions)
+        {
+            var plottable = new ClevelandDotPlot(positions, ys1, ys2);
+            Add(plottable);
+            return plottable;
+        }
+
+        /// <summary>
+        /// Add a Lollipop plot for the given values. Lollipops will be placed at X positions 0, 1, 2, etc.
+        /// </summary>
+        public LollipopPlot AddLollipop(double[] values, Color? color = null)
+        {
+            double[] xs = DataGen.Consecutive(values.Length);
+            var plottable = new LollipopPlot(xs, values, null, null)
+            {
+                LollipopColor = color ?? GetNextColor()
+            };
+            Add(plottable);
+            return plottable;
+        }
+
+        /// <summary>
+        /// Add a lollipop plot for the given values using defined lollipop positions
+        /// </summary>
+        public LollipopPlot AddLollipop(double[] values, double[] positions, Color? color = null)
+        {
+            var plottable = new LollipopPlot(positions, values, null, null)
+            {
+                LollipopColor = color ?? GetNextColor()
+            };
+            Add(plottable);
+            return plottable;
+        }
+
+        /// <summary>
         /// Add a bar plot for the given values. Bars will be placed at X positions 0, 1, 2, etc.
         /// </summary>
         public BarPlot AddBar(double[] values, Color? color = null)

--- a/src/ScottPlot/Plot/Plot.Obsolete.cs
+++ b/src/ScottPlot/Plot/Plot.Obsolete.cs
@@ -126,9 +126,9 @@ namespace ScottPlot
                 BorderColor = outlineColor ?? Color.Black,
                 VerticalOrientation = !horizontal,
                 ShowValuesAboveBars = showValues,
-                FontColor = valueColor ?? Color.Black,
                 FillColorNegative = negativeColor ?? nextColor
             };
+            barPlot.Font.Color = valueColor ?? Color.Black;
             Add(barPlot);
 
             if (autoAxis)

--- a/src/ScottPlot/Plottable/BarPlot.cs
+++ b/src/ScottPlot/Plottable/BarPlot.cs
@@ -5,269 +5,292 @@ using System.Data;
 
 namespace ScottPlot.Plottable
 {
-    public enum BarStyle
-    {
-        Bar,
-        Lollipop,
-    }
+	public enum BarStyle
+	{
+		Bar,
+		Lollipop,
+		ClevelandDot
+	}
 
-    /// <summary>
-    /// Bar plots display a series of bars. 
-    /// Positions are defined by Xs.
-    /// Heights are defined by Ys (relative to BaseValue and YOffsets).
-    /// </summary>
-    public class BarPlot : IPlottable
-    {
-        // data
-        public double[] Xs;
-        public double XOffset;
-        public double[] Ys;
-        public double[] YErrors;
-        public double[] YOffsets;
+	/// <summary>
+	/// Bar plots display a series of bars. 
+	/// Positions are defined by Xs.
+	/// Heights are defined by Ys (relative to BaseValue and YOffsets).
+	/// </summary>
+	public class BarPlot : IPlottable
+	{
+		// data
+		public double[] Xs;
+		public double XOffset;
+		public double[] Ys;
+		public double[] YErrors;
+		public double[] YOffsets;
 
-        // customization
-        public bool IsVisible { get; set; } = true;
-        public int XAxisIndex { get; set; } = 0;
-        public int YAxisIndex { get; set; } = 0;
-        public string Label;
-        public Color FillColor = Color.Green;
-        public Color FillColorNegative = Color.Red;
-        public Color FillColorHatch = Color.Blue;
-        public HatchStyle HatchStyle = HatchStyle.None;
-        public Color ErrorColor = Color.Black;
-        public float ErrorLineWidth = 1;
-        public double ErrorCapSize = .4;
-        public Color BorderColor = Color.Black;
-        public float BorderLineWidth = 1;
-        public BarStyle DisplayStyle = BarStyle.Bar;
-        public float LollipopRadius = 5;
+		// customization
+		public bool IsVisible { get; set; } = true;
+		public int XAxisIndex { get; set; } = 0;
+		public int YAxisIndex { get; set; } = 0;
+		public string Label;
+		public Color FillColor = Color.Green;
+		public Color FillColorNegative = Color.Red;
+		public Color FillColorHatch = Color.Blue;
+		public HatchStyle HatchStyle = HatchStyle.None;
+		public Color ErrorColor = Color.Black;
+		public float ErrorLineWidth = 1;
+		public double ErrorCapSize = .4;
+		public Color BorderColor = Color.Black;
+		public float BorderLineWidth = 1;
+		public BarStyle DisplayStyle = BarStyle.Bar;
+		public float LollipopRadius = 5;
+		public Color ClevelandColor1 = Color.Green;
+		public Color ClevelandColor2 = Color.Red;
 
-        public readonly Drawing.Font Font = new Drawing.Font();
-        public string FontName { set => Font.Name = value; }
-        public float FontSize { set => Font.Size = value; }
-        public bool FontBold { set => Font.Bold = value; }
-        public Color FontColor { set => Font.Color = value; }
+		public readonly Drawing.Font Font = new Drawing.Font();
+		public string FontName { set => Font.Name = value; }
+		public float FontSize { set => Font.Size = value; }
+		public bool FontBold { set => Font.Bold = value; }
+		public Color FontColor { set => Font.Color = value; }
 
-        public double BarWidth = .8;
-        public double BaseValue = 0;
-        public bool VerticalOrientation = true;
-        public bool HorizontalOrientation { get => !VerticalOrientation; set => VerticalOrientation = !value; }
-        public bool ShowValuesAboveBars;
+		public double BarWidth = .8;
+		public double BaseValue = 0;
+		public bool VerticalOrientation = true;
+		public bool HorizontalOrientation { get => !VerticalOrientation; set => VerticalOrientation = !value; }
+		public bool ShowValuesAboveBars;
 
-        public BarPlot(double[] xs, double[] ys, double[] yErr, double[] yOffsets)
-        {
-            if (ys is null || ys.Length == 0)
-                throw new InvalidOperationException("ys must be an array that contains elements");
+		public BarPlot(double[] xs, double[] ys, double[] yErr, double[] yOffsets)
+		{
+			if (ys is null || ys.Length == 0)
+				throw new InvalidOperationException("ys must be an array that contains elements");
 
-            Ys = ys;
-            Xs = xs ?? DataGen.Consecutive(ys.Length);
-            YErrors = yErr ?? DataGen.Zeros(ys.Length);
-            YOffsets = yOffsets ?? DataGen.Zeros(ys.Length);
-        }
+			Ys = ys;
+			Xs = xs ?? DataGen.Consecutive(ys.Length);
+			YErrors = yErr ?? DataGen.Zeros(ys.Length);
+			YOffsets = yOffsets ?? DataGen.Zeros(ys.Length);
+		}
 
-        public AxisLimits GetAxisLimits()
-        {
-            double valueMin = double.PositiveInfinity;
-            double valueMax = double.NegativeInfinity;
-            double positionMin = double.PositiveInfinity;
-            double positionMax = double.NegativeInfinity;
+		public AxisLimits GetAxisLimits()
+		{
+			double valueMin = double.PositiveInfinity;
+			double valueMax = double.NegativeInfinity;
+			double positionMin = double.PositiveInfinity;
+			double positionMax = double.NegativeInfinity;
 
-            for (int i = 0; i < Xs.Length; i++)
-            {
-                valueMin = Math.Min(valueMin, Ys[i] - YErrors[i] + YOffsets[i]);
-                valueMax = Math.Max(valueMax, Ys[i] + YErrors[i] + YOffsets[i]);
-                positionMin = Math.Min(positionMin, Xs[i]);
-                positionMax = Math.Max(positionMax, Xs[i]);
-            }
+			for (int i = 0; i < Xs.Length; i++)
+			{
+				valueMin = Math.Min(valueMin, Ys[i] - YErrors[i] + YOffsets[i]);
+				valueMax = Math.Max(valueMax, Ys[i] + YErrors[i] + YOffsets[i]);
+				positionMin = Math.Min(positionMin, Xs[i]);
+				positionMax = Math.Max(positionMax, Xs[i]);
+			}
 
-            valueMin = Math.Min(valueMin, BaseValue);
-            valueMax = Math.Max(valueMax, BaseValue);
+			valueMin = Math.Min(valueMin, BaseValue);
+			valueMax = Math.Max(valueMax, BaseValue);
 
-            if (ShowValuesAboveBars)
-                valueMax += (valueMax - valueMin) * .1; // increase by 10% to accomodate label
+			if (ShowValuesAboveBars)
+				valueMax += (valueMax - valueMin) * .1; // increase by 10% to accomodate label
 
-            positionMin -= BarWidth / 2;
-            positionMax += BarWidth / 2;
+			positionMin -= BarWidth / 2;
+			positionMax += BarWidth / 2;
 
-            positionMin += XOffset;
-            positionMax += XOffset;
+			positionMin += XOffset;
+			positionMax += XOffset;
 
-            return VerticalOrientation ?
-                new AxisLimits(positionMin, positionMax, valueMin, valueMax) :
-                new AxisLimits(valueMin, valueMax, positionMin, positionMax);
-        }
+			return VerticalOrientation ?
+				new AxisLimits(positionMin, positionMax, valueMin, valueMax) :
+				new AxisLimits(valueMin, valueMax, positionMin, positionMax);
+		}
 
-        public void ValidateData(bool deep = false)
-        {
-            Validate.AssertHasElements("xs", Xs);
-            Validate.AssertHasElements("ys", Ys);
-            Validate.AssertHasElements("yErr", YErrors);
-            Validate.AssertHasElements("yOffsets", YOffsets);
-            Validate.AssertEqualLength("xs, ys, yErr, and yOffsets", Xs, Ys, YErrors, YOffsets);
+		public void ValidateData(bool deep = false)
+		{
+			Validate.AssertHasElements("xs", Xs);
+			Validate.AssertHasElements("ys", Ys);
+			Validate.AssertHasElements("yErr", YErrors);
+			Validate.AssertHasElements("yOffsets", YOffsets);
+			Validate.AssertEqualLength("xs, ys, yErr, and yOffsets", Xs, Ys, YErrors, YOffsets);
 
-            if (deep)
-            {
-                Validate.AssertAllReal("xs", Xs);
-                Validate.AssertAllReal("ys", Ys);
-                Validate.AssertAllReal("yErr", YErrors);
-                Validate.AssertAllReal("yOffsets", YOffsets);
-            }
-        }
+			if (deep)
+			{
+				Validate.AssertAllReal("xs", Xs);
+				Validate.AssertAllReal("ys", Ys);
+				Validate.AssertAllReal("yErr", YErrors);
+				Validate.AssertAllReal("yOffsets", YOffsets);
+			}
+		}
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
-        {
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
-            {
-                for (int barIndex = 0; barIndex < Ys.Length; barIndex++)
-                {
-                    if (VerticalOrientation)
-                        RenderBarVertical(dims, gfx, Xs[barIndex] + XOffset, Ys[barIndex], YErrors[barIndex], YOffsets[barIndex]);
-                    else
-                        RenderBarHorizontal(dims, gfx, Xs[barIndex] + XOffset, Ys[barIndex], YErrors[barIndex], YOffsets[barIndex]);
-                }
-            }
-        }
+		public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+		{
+			using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+			{
+				for (int barIndex = 0; barIndex < Ys.Length; barIndex++)
+				{
+					if (VerticalOrientation)
+						RenderBarVertical(dims, gfx, Xs[barIndex] + XOffset, Ys[barIndex], YErrors[barIndex], YOffsets[barIndex]);
+					else
+						RenderBarHorizontal(dims, gfx, Xs[barIndex] + XOffset, Ys[barIndex], YErrors[barIndex], YOffsets[barIndex]);
+				}
+			}
+		}
 
-        private void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
-        {
-            using (var outlinePen = new Pen(BorderColor, BorderLineWidth))
-            using (var fillPen = new Pen(negative ? FillColorNegative : FillColor))
-            using (var fillBrush = GDI.Brush(negative ? FillColorNegative : FillColor, FillColorHatch, HatchStyle))
-            {
-                switch (DisplayStyle)
-                {
-                    case BarStyle.Lollipop:
-                        float centerPx = HorizontalOrientation ? rect.Y + rect.Height / 2 : rect.X + rect.Width / 2;
+		private void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
+		{
+			float centerPx = HorizontalOrientation ? rect.Y + rect.Height / 2 : rect.X + rect.Width / 2;
+			using (var outlinePen = new Pen(BorderColor, BorderLineWidth))
+			using (var fillPen = new Pen(negative ? FillColorNegative : FillColor))
+			using (var fillBrush = GDI.Brush(negative ? FillColorNegative : FillColor, FillColorHatch, HatchStyle))
+			{
+				switch (DisplayStyle)
+				{
+					case BarStyle.Lollipop:
 
-                        if (HorizontalOrientation)
-                        {
-                            gfx.FillEllipse(fillBrush, negative ? rect.X : rect.X + rect.Width, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
-                            gfx.DrawLine(fillPen, rect.X, centerPx, rect.X + rect.Width, centerPx);
-                        }
-                        else
-                        {
-                            gfx.FillEllipse(fillBrush, centerPx - LollipopRadius / 2, !negative ? rect.Y : rect.Y + rect.Height, LollipopRadius, LollipopRadius);
-                            gfx.DrawLine(fillPen, centerPx, rect.Y, centerPx, rect.Y + rect.Height);
-                        }
-                        break;
+						if (HorizontalOrientation)
+						{
+							gfx.FillEllipse(fillBrush, negative ? rect.X : rect.X + rect.Width, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
+							gfx.DrawLine(fillPen, rect.X, centerPx, rect.X + rect.Width, centerPx);
+						}
+						else
+						{
+							gfx.FillEllipse(fillBrush, centerPx - LollipopRadius / 2, !negative ? rect.Y : rect.Y + rect.Height, LollipopRadius, LollipopRadius);
+							gfx.DrawLine(fillPen, centerPx, rect.Y, centerPx, rect.Y + rect.Height);
+						}
+						break;
 
-                    case BarStyle.Bar:
-                    default:
-                        gfx.FillRectangle(fillBrush, rect.X, rect.Y, rect.Width, rect.Height);
-                        if (BorderLineWidth > 0)
-                        {
-                            gfx.DrawRectangle(outlinePen, rect.X, rect.Y, rect.Width, rect.Height);
-                        }
-                        break;
-                }
-            }
-        }
+					case BarStyle.ClevelandDot:
+						using(var dot1Brush = GDI.Brush(ClevelandColor1))
+						using(var dot2Brush = GDI.Brush(ClevelandColor2))
+						{
+							if (HorizontalOrientation)
+							{
+								gfx.FillEllipse(dot1Brush, negative ? rect.X + rect.Width : rect.X, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
+								gfx.FillEllipse(dot2Brush, negative ? rect.X : rect.X + rect.Width, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
+								gfx.DrawLine(fillPen, rect.X, centerPx, rect.X + rect.Width, centerPx);
+							}
+							else
+							{
+								gfx.FillEllipse(dot1Brush, centerPx - LollipopRadius / 2, !negative ? rect.Y + rect.Height : rect.Y, LollipopRadius, LollipopRadius);
+								gfx.FillEllipse(dot2Brush, centerPx - LollipopRadius / 2, !negative ? rect.Y : rect.Y + rect.Height, LollipopRadius, LollipopRadius);
+								gfx.DrawLine(fillPen, centerPx, rect.Y, centerPx, rect.Y + rect.Height);
+							}
+						}
 
-        private void RenderBarVertical(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
-        {
-            // bar body
-            float centerPx = dims.GetPixelX(position);
-            double edge1 = position - BarWidth / 2;
-            double value1 = Math.Min(BaseValue, value) + yOffset;
-            double value2 = Math.Max(BaseValue, value) + yOffset;
-            double valueSpan = value2 - value1;
+						break;
 
-            var rect = new RectangleF(
-                x: dims.GetPixelX(edge1),
-                y: dims.GetPixelY(value2),
-                width: (float)(BarWidth * dims.PxPerUnitX),
-                height: (float)(valueSpan * dims.PxPerUnitY));
+					case BarStyle.Bar:
+					default:
+						gfx.FillRectangle(fillBrush, rect.X, rect.Y, rect.Width, rect.Height);
+						if (BorderLineWidth > 0)
+						{
+							gfx.DrawRectangle(outlinePen, rect.X, rect.Y, rect.Width, rect.Height);
+						}
+						break;
+				}
+			}
+		}
 
-            // errorbar
-            double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
-            double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
-            float capPx1 = dims.GetPixelX(position - ErrorCapSize * BarWidth / 2);
-            float capPx2 = dims.GetPixelX(position + ErrorCapSize * BarWidth / 2);
-            float errorPx2 = dims.GetPixelY(error2);
-            float errorPx1 = dims.GetPixelY(error1);
+		private void RenderBarVertical(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
+		{
+			// bar body
+			float centerPx = dims.GetPixelX(position);
+			double edge1 = position - BarWidth / 2;
+			double value1 = Math.Min(BaseValue, value) + yOffset;
+			double value2 = Math.Max(BaseValue, value) + yOffset;
+			double valueSpan = value2 - value1;
 
-            RenderBarFromRect(rect, value < 0, gfx);
+			var rect = new RectangleF(
+				x: dims.GetPixelX(edge1),
+				y: dims.GetPixelY(value2),
+				width: (float)(BarWidth * dims.PxPerUnitX),
+				height: (float)(valueSpan * dims.PxPerUnitY));
 
-            if (ErrorLineWidth > 0 && valueError > 0)
-            {
-                using (var errorPen = new Pen(ErrorColor, ErrorLineWidth))
-                {
-                    gfx.DrawLine(errorPen, centerPx, errorPx1, centerPx, errorPx2);
-                    gfx.DrawLine(errorPen, capPx1, errorPx1, capPx2, errorPx1);
-                    gfx.DrawLine(errorPen, capPx1, errorPx2, capPx2, errorPx2);
-                }
-            }
+			// errorbar
+			double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
+			double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
+			float capPx1 = dims.GetPixelX(position - ErrorCapSize * BarWidth / 2);
+			float capPx2 = dims.GetPixelX(position + ErrorCapSize * BarWidth / 2);
+			float errorPx2 = dims.GetPixelY(error2);
+			float errorPx1 = dims.GetPixelY(error1);
 
-            if (ShowValuesAboveBars)
-                using (var valueTextFont = GDI.Font(Font))
-                using (var valueTextBrush = GDI.Brush(Font.Color))
-                using (var sf = new StringFormat() { LineAlignment = StringAlignment.Far, Alignment = StringAlignment.Center })
-                    gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, centerPx, rect.Y, sf);
-        }
+			RenderBarFromRect(rect, value < 0, gfx);
 
-        private void RenderBarHorizontal(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
-        {
-            // bar body
-            float centerPx = dims.GetPixelY(position);
-            double edge2 = position + BarWidth / 2;
-            double value1 = Math.Min(BaseValue, value) + yOffset;
-            double value2 = Math.Max(BaseValue, value) + yOffset;
-            double valueSpan = value2 - value1;
-            var rect = new RectangleF(
-                x: dims.GetPixelX(value1),
-                y: dims.GetPixelY(edge2),
-                height: (float)(BarWidth * dims.PxPerUnitY),
-                width: (float)(valueSpan * dims.PxPerUnitX));
+			if (ErrorLineWidth > 0 && valueError > 0)
+			{
+				using (var errorPen = new Pen(ErrorColor, ErrorLineWidth))
+				{
+					gfx.DrawLine(errorPen, centerPx, errorPx1, centerPx, errorPx2);
+					gfx.DrawLine(errorPen, capPx1, errorPx1, capPx2, errorPx1);
+					gfx.DrawLine(errorPen, capPx1, errorPx2, capPx2, errorPx2);
+				}
+			}
 
-            RenderBarFromRect(rect, value < 0, gfx);
+			if (ShowValuesAboveBars)
+				using (var valueTextFont = GDI.Font(Font))
+				using (var valueTextBrush = GDI.Brush(Font.Color))
+				using (var sf = new StringFormat() { LineAlignment = StringAlignment.Far, Alignment = StringAlignment.Center })
+					gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, centerPx, rect.Y, sf);
+		}
 
-            // errorbar
-            double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
-            double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
-            float capPx1 = dims.GetPixelY(position - ErrorCapSize * BarWidth / 2);
-            float capPx2 = dims.GetPixelY(position + ErrorCapSize * BarWidth / 2);
-            float errorPx2 = dims.GetPixelX(error2);
-            float errorPx1 = dims.GetPixelX(error1);
+		private void RenderBarHorizontal(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
+		{
+			// bar body
+			float centerPx = dims.GetPixelY(position);
+			double edge2 = position + BarWidth / 2;
+			double value1 = Math.Min(BaseValue, value) + yOffset;
+			double value2 = Math.Max(BaseValue, value) + yOffset;
+			double valueSpan = value2 - value1;
+			var rect = new RectangleF(
+				x: dims.GetPixelX(value1),
+				y: dims.GetPixelY(edge2),
+				height: (float)(BarWidth * dims.PxPerUnitY),
+				width: (float)(valueSpan * dims.PxPerUnitX));
 
-            if (ErrorLineWidth > 0 && valueError > 0)
-            {
-                using (var errorPen = new Pen(ErrorColor, ErrorLineWidth))
-                {
-                    gfx.DrawLine(errorPen, errorPx1, centerPx, errorPx2, centerPx);
-                    gfx.DrawLine(errorPen, errorPx1, capPx2, errorPx1, capPx1);
-                    gfx.DrawLine(errorPen, errorPx2, capPx2, errorPx2, capPx1);
-                }
-            }
+			RenderBarFromRect(rect, value < 0, gfx);
 
-            if (ShowValuesAboveBars)
-                using (var valueTextFont = GDI.Font(Font))
-                using (var valueTextBrush = GDI.Brush(Font.Color))
-                using (var sf = new StringFormat() { LineAlignment = StringAlignment.Center, Alignment = StringAlignment.Near })
-                    gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, rect.X + rect.Width, centerPx, sf);
-        }
+			// errorbar
+			double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
+			double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
+			float capPx1 = dims.GetPixelY(position - ErrorCapSize * BarWidth / 2);
+			float capPx2 = dims.GetPixelY(position + ErrorCapSize * BarWidth / 2);
+			float errorPx2 = dims.GetPixelX(error2);
+			float errorPx1 = dims.GetPixelX(error1);
 
-        public override string ToString()
-        {
-            string label = string.IsNullOrWhiteSpace(this.Label) ? "" : $" ({this.Label})";
-            return $"PlottableBar{label} with {PointCount} points";
-        }
+			if (ErrorLineWidth > 0 && valueError > 0)
+			{
+				using (var errorPen = new Pen(ErrorColor, ErrorLineWidth))
+				{
+					gfx.DrawLine(errorPen, errorPx1, centerPx, errorPx2, centerPx);
+					gfx.DrawLine(errorPen, errorPx1, capPx2, errorPx1, capPx1);
+					gfx.DrawLine(errorPen, errorPx2, capPx2, errorPx2, capPx1);
+				}
+			}
 
-        public int PointCount { get => Ys is null ? 0 : Ys.Length; }
+			if (ShowValuesAboveBars)
+				using (var valueTextFont = GDI.Font(Font))
+				using (var valueTextBrush = GDI.Brush(Font.Color))
+				using (var sf = new StringFormat() { LineAlignment = StringAlignment.Center, Alignment = StringAlignment.Near })
+					gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, rect.X + rect.Width, centerPx, sf);
+		}
 
-        public LegendItem[] GetLegendItems()
-        {
-            var singleItem = new LegendItem()
-            {
-                label = Label,
-                color = FillColor,
-                lineWidth = 10,
-                markerShape = MarkerShape.none,
-                hatchColor = FillColorHatch,
-                hatchStyle = HatchStyle,
-                borderColor = BorderColor,
-                borderWith = BorderLineWidth
-            };
-            return new LegendItem[] { singleItem };
-        }
-    }
+		public override string ToString()
+		{
+			string label = string.IsNullOrWhiteSpace(this.Label) ? "" : $" ({this.Label})";
+			return $"PlottableBar{label} with {PointCount} points";
+		}
+
+		public int PointCount { get => Ys is null ? 0 : Ys.Length; }
+
+		public LegendItem[] GetLegendItems()
+		{
+			var singleItem = new LegendItem()
+			{
+				label = Label,
+				color = FillColor,
+				lineWidth = 10,
+				markerShape = MarkerShape.none,
+				hatchColor = FillColorHatch,
+				hatchStyle = HatchStyle,
+				borderColor = BorderColor,
+				borderWith = BorderLineWidth
+			};
+			return new LegendItem[] { singleItem };
+		}
+	}
 }

--- a/src/ScottPlot/Plottable/BarPlot.cs
+++ b/src/ScottPlot/Plottable/BarPlot.cs
@@ -20,10 +20,6 @@ namespace ScottPlot.Plottable
         public Color FillColorHatch = Color.Blue;
         public HatchStyle HatchStyle = HatchStyle.None;
         public float BorderLineWidth = 1;
-        public Color ClevelandColor1 = Color.Green;
-        public Color ClevelandColor2 = Color.Red;
-        public string ClevelandLabel1 = "";
-        public string ClevelandLabel2 = "";
 
         public BarPlot(double[] xs, double[] ys, double[] yErr, double[] yOffsets) : base()
         {
@@ -39,7 +35,6 @@ namespace ScottPlot.Plottable
         protected override void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
         {
             using (var outlinePen = new Pen(BorderColor, BorderLineWidth))
-            using (var fillPen = new Pen(negative ? FillColorNegative : FillColor))
             using (var fillBrush = GDI.Brush(negative ? FillColorNegative : FillColor, FillColorHatch, HatchStyle))
             {
                 gfx.FillRectangle(fillBrush, rect.X, rect.Y, rect.Width, rect.Height);

--- a/src/ScottPlot/Plottable/BarPlot.cs
+++ b/src/ScottPlot/Plottable/BarPlot.cs
@@ -26,10 +26,10 @@ namespace ScottPlot.Plottable
             if (ys is null || ys.Length == 0)
                 throw new InvalidOperationException("ys must be an array that contains elements");
 
-            Ys = ys;
-            Xs = xs ?? DataGen.Consecutive(ys.Length);
-            YErrors = yErr ?? DataGen.Zeros(ys.Length);
-            YOffsets = yOffsets ?? DataGen.Zeros(ys.Length);
+            Values = ys;
+            Positions = xs ?? DataGen.Consecutive(ys.Length);
+            ValueErrors = yErr ?? DataGen.Zeros(ys.Length);
+            ValueOffsets = yOffsets ?? DataGen.Zeros(ys.Length);
         }
 
         protected override void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
@@ -47,11 +47,9 @@ namespace ScottPlot.Plottable
 
         public override string ToString()
         {
-            string label = string.IsNullOrWhiteSpace(this.Label) ? "" : $" ({this.Label})";
-            return $"PlottableBar{label} with {PointCount} points";
+            string label = string.IsNullOrWhiteSpace(Label) ? "" : $" ({Label})";
+            return $"PlottableBar{label} with {Values.Length} bars";
         }
-
-        public int PointCount { get => Ys is null ? 0 : Ys.Length; }
 
         public override LegendItem[] GetLegendItems()
         {

--- a/src/ScottPlot/Plottable/BarPlot.cs
+++ b/src/ScottPlot/Plottable/BarPlot.cs
@@ -40,6 +40,7 @@ namespace ScottPlot.Plottable
         public Color BorderColor = Color.Black;
         public float BorderLineWidth = 1;
         public BarStyle DisplayStyle = BarStyle.Bar;
+        public float LollipopRadius = 5;
 
         public readonly Drawing.Font Font = new Drawing.Font();
         public string FontName { set => Font.Name = value; }
@@ -136,17 +137,16 @@ namespace ScottPlot.Plottable
                 switch (DisplayStyle)
                 {
                     case BarStyle.Lollipop:
-                        const float RADIUS = 5;
                         float centerPx = HorizontalOrientation ? rect.Y + rect.Height / 2 : rect.X + rect.Width / 2;
 
                         if (HorizontalOrientation)
                         {
-                            gfx.FillEllipse(fillBrush, negative ? rect.X : rect.X + rect.Width, centerPx - RADIUS / 2, RADIUS, RADIUS);
+                            gfx.FillEllipse(fillBrush, negative ? rect.X : rect.X + rect.Width, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
                             gfx.DrawLine(fillPen, rect.X, centerPx, rect.X + rect.Width, centerPx);
                         }
                         else
                         {
-                            gfx.FillEllipse(fillBrush, centerPx - RADIUS / 2, !negative ? rect.Y : rect.Y + rect.Height, RADIUS, RADIUS);
+                            gfx.FillEllipse(fillBrush, centerPx - LollipopRadius / 2, !negative ? rect.Y : rect.Y + rect.Height, LollipopRadius, LollipopRadius);
                             gfx.DrawLine(fillPen, centerPx, rect.Y, centerPx, rect.Y + rect.Height);
                         }
                         break;

--- a/src/ScottPlot/Plottable/BarPlot.cs
+++ b/src/ScottPlot/Plottable/BarPlot.cs
@@ -5,292 +5,292 @@ using System.Data;
 
 namespace ScottPlot.Plottable
 {
-	public enum BarStyle
-	{
-		Bar,
-		Lollipop,
-		ClevelandDot
-	}
+    public enum BarStyle
+    {
+        Bar,
+        Lollipop,
+        ClevelandDot
+    }
 
-	/// <summary>
-	/// Bar plots display a series of bars. 
-	/// Positions are defined by Xs.
-	/// Heights are defined by Ys (relative to BaseValue and YOffsets).
-	/// </summary>
-	public class BarPlot : IPlottable
-	{
-		// data
-		public double[] Xs;
-		public double XOffset;
-		public double[] Ys;
-		public double[] YErrors;
-		public double[] YOffsets;
+    /// <summary>
+    /// Bar plots display a series of bars. 
+    /// Positions are defined by Xs.
+    /// Heights are defined by Ys (relative to BaseValue and YOffsets).
+    /// </summary>
+    public class BarPlot : IPlottable
+    {
+        // data
+        public double[] Xs;
+        public double XOffset;
+        public double[] Ys;
+        public double[] YErrors;
+        public double[] YOffsets;
 
-		// customization
-		public bool IsVisible { get; set; } = true;
-		public int XAxisIndex { get; set; } = 0;
-		public int YAxisIndex { get; set; } = 0;
-		public string Label;
-		public Color FillColor = Color.Green;
-		public Color FillColorNegative = Color.Red;
-		public Color FillColorHatch = Color.Blue;
-		public HatchStyle HatchStyle = HatchStyle.None;
-		public Color ErrorColor = Color.Black;
-		public float ErrorLineWidth = 1;
-		public double ErrorCapSize = .4;
-		public Color BorderColor = Color.Black;
-		public float BorderLineWidth = 1;
-		public BarStyle DisplayStyle = BarStyle.Bar;
-		public float LollipopRadius = 5;
-		public Color ClevelandColor1 = Color.Green;
-		public Color ClevelandColor2 = Color.Red;
+        // customization
+        public bool IsVisible { get; set; } = true;
+        public int XAxisIndex { get; set; } = 0;
+        public int YAxisIndex { get; set; } = 0;
+        public string Label;
+        public Color FillColor = Color.Green;
+        public Color FillColorNegative = Color.Red;
+        public Color FillColorHatch = Color.Blue;
+        public HatchStyle HatchStyle = HatchStyle.None;
+        public Color ErrorColor = Color.Black;
+        public float ErrorLineWidth = 1;
+        public double ErrorCapSize = .4;
+        public Color BorderColor = Color.Black;
+        public float BorderLineWidth = 1;
+        public BarStyle DisplayStyle = BarStyle.Bar;
+        public float LollipopRadius = 5;
+        public Color ClevelandColor1 = Color.Green;
+        public Color ClevelandColor2 = Color.Red;
 
-		public readonly Drawing.Font Font = new Drawing.Font();
-		public string FontName { set => Font.Name = value; }
-		public float FontSize { set => Font.Size = value; }
-		public bool FontBold { set => Font.Bold = value; }
-		public Color FontColor { set => Font.Color = value; }
+        public readonly Drawing.Font Font = new Drawing.Font();
+        public string FontName { set => Font.Name = value; }
+        public float FontSize { set => Font.Size = value; }
+        public bool FontBold { set => Font.Bold = value; }
+        public Color FontColor { set => Font.Color = value; }
 
-		public double BarWidth = .8;
-		public double BaseValue = 0;
-		public bool VerticalOrientation = true;
-		public bool HorizontalOrientation { get => !VerticalOrientation; set => VerticalOrientation = !value; }
-		public bool ShowValuesAboveBars;
+        public double BarWidth = .8;
+        public double BaseValue = 0;
+        public bool VerticalOrientation = true;
+        public bool HorizontalOrientation { get => !VerticalOrientation; set => VerticalOrientation = !value; }
+        public bool ShowValuesAboveBars;
 
-		public BarPlot(double[] xs, double[] ys, double[] yErr, double[] yOffsets)
-		{
-			if (ys is null || ys.Length == 0)
-				throw new InvalidOperationException("ys must be an array that contains elements");
+        public BarPlot(double[] xs, double[] ys, double[] yErr, double[] yOffsets)
+        {
+            if (ys is null || ys.Length == 0)
+                throw new InvalidOperationException("ys must be an array that contains elements");
 
-			Ys = ys;
-			Xs = xs ?? DataGen.Consecutive(ys.Length);
-			YErrors = yErr ?? DataGen.Zeros(ys.Length);
-			YOffsets = yOffsets ?? DataGen.Zeros(ys.Length);
-		}
+            Ys = ys;
+            Xs = xs ?? DataGen.Consecutive(ys.Length);
+            YErrors = yErr ?? DataGen.Zeros(ys.Length);
+            YOffsets = yOffsets ?? DataGen.Zeros(ys.Length);
+        }
 
-		public AxisLimits GetAxisLimits()
-		{
-			double valueMin = double.PositiveInfinity;
-			double valueMax = double.NegativeInfinity;
-			double positionMin = double.PositiveInfinity;
-			double positionMax = double.NegativeInfinity;
+        public AxisLimits GetAxisLimits()
+        {
+            double valueMin = double.PositiveInfinity;
+            double valueMax = double.NegativeInfinity;
+            double positionMin = double.PositiveInfinity;
+            double positionMax = double.NegativeInfinity;
 
-			for (int i = 0; i < Xs.Length; i++)
-			{
-				valueMin = Math.Min(valueMin, Ys[i] - YErrors[i] + YOffsets[i]);
-				valueMax = Math.Max(valueMax, Ys[i] + YErrors[i] + YOffsets[i]);
-				positionMin = Math.Min(positionMin, Xs[i]);
-				positionMax = Math.Max(positionMax, Xs[i]);
-			}
+            for (int i = 0; i < Xs.Length; i++)
+            {
+                valueMin = Math.Min(valueMin, Ys[i] - YErrors[i] + YOffsets[i]);
+                valueMax = Math.Max(valueMax, Ys[i] + YErrors[i] + YOffsets[i]);
+                positionMin = Math.Min(positionMin, Xs[i]);
+                positionMax = Math.Max(positionMax, Xs[i]);
+            }
 
-			valueMin = Math.Min(valueMin, BaseValue);
-			valueMax = Math.Max(valueMax, BaseValue);
+            valueMin = Math.Min(valueMin, BaseValue);
+            valueMax = Math.Max(valueMax, BaseValue);
 
-			if (ShowValuesAboveBars)
-				valueMax += (valueMax - valueMin) * .1; // increase by 10% to accomodate label
+            if (ShowValuesAboveBars)
+                valueMax += (valueMax - valueMin) * .1; // increase by 10% to accomodate label
 
-			positionMin -= BarWidth / 2;
-			positionMax += BarWidth / 2;
+            positionMin -= BarWidth / 2;
+            positionMax += BarWidth / 2;
 
-			positionMin += XOffset;
-			positionMax += XOffset;
+            positionMin += XOffset;
+            positionMax += XOffset;
 
-			return VerticalOrientation ?
-				new AxisLimits(positionMin, positionMax, valueMin, valueMax) :
-				new AxisLimits(valueMin, valueMax, positionMin, positionMax);
-		}
+            return VerticalOrientation ?
+                new AxisLimits(positionMin, positionMax, valueMin, valueMax) :
+                new AxisLimits(valueMin, valueMax, positionMin, positionMax);
+        }
 
-		public void ValidateData(bool deep = false)
-		{
-			Validate.AssertHasElements("xs", Xs);
-			Validate.AssertHasElements("ys", Ys);
-			Validate.AssertHasElements("yErr", YErrors);
-			Validate.AssertHasElements("yOffsets", YOffsets);
-			Validate.AssertEqualLength("xs, ys, yErr, and yOffsets", Xs, Ys, YErrors, YOffsets);
+        public void ValidateData(bool deep = false)
+        {
+            Validate.AssertHasElements("xs", Xs);
+            Validate.AssertHasElements("ys", Ys);
+            Validate.AssertHasElements("yErr", YErrors);
+            Validate.AssertHasElements("yOffsets", YOffsets);
+            Validate.AssertEqualLength("xs, ys, yErr, and yOffsets", Xs, Ys, YErrors, YOffsets);
 
-			if (deep)
-			{
-				Validate.AssertAllReal("xs", Xs);
-				Validate.AssertAllReal("ys", Ys);
-				Validate.AssertAllReal("yErr", YErrors);
-				Validate.AssertAllReal("yOffsets", YOffsets);
-			}
-		}
+            if (deep)
+            {
+                Validate.AssertAllReal("xs", Xs);
+                Validate.AssertAllReal("ys", Ys);
+                Validate.AssertAllReal("yErr", YErrors);
+                Validate.AssertAllReal("yOffsets", YOffsets);
+            }
+        }
 
-		public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
-		{
-			using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
-			{
-				for (int barIndex = 0; barIndex < Ys.Length; barIndex++)
-				{
-					if (VerticalOrientation)
-						RenderBarVertical(dims, gfx, Xs[barIndex] + XOffset, Ys[barIndex], YErrors[barIndex], YOffsets[barIndex]);
-					else
-						RenderBarHorizontal(dims, gfx, Xs[barIndex] + XOffset, Ys[barIndex], YErrors[barIndex], YOffsets[barIndex]);
-				}
-			}
-		}
+        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        {
+            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            {
+                for (int barIndex = 0; barIndex < Ys.Length; barIndex++)
+                {
+                    if (VerticalOrientation)
+                        RenderBarVertical(dims, gfx, Xs[barIndex] + XOffset, Ys[barIndex], YErrors[barIndex], YOffsets[barIndex]);
+                    else
+                        RenderBarHorizontal(dims, gfx, Xs[barIndex] + XOffset, Ys[barIndex], YErrors[barIndex], YOffsets[barIndex]);
+                }
+            }
+        }
 
-		private void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
-		{
-			float centerPx = HorizontalOrientation ? rect.Y + rect.Height / 2 : rect.X + rect.Width / 2;
-			using (var outlinePen = new Pen(BorderColor, BorderLineWidth))
-			using (var fillPen = new Pen(negative ? FillColorNegative : FillColor))
-			using (var fillBrush = GDI.Brush(negative ? FillColorNegative : FillColor, FillColorHatch, HatchStyle))
-			{
-				switch (DisplayStyle)
-				{
-					case BarStyle.Lollipop:
+        private void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
+        {
+            float centerPx = HorizontalOrientation ? rect.Y + rect.Height / 2 : rect.X + rect.Width / 2;
+            using (var outlinePen = new Pen(BorderColor, BorderLineWidth))
+            using (var fillPen = new Pen(negative ? FillColorNegative : FillColor))
+            using (var fillBrush = GDI.Brush(negative ? FillColorNegative : FillColor, FillColorHatch, HatchStyle))
+            {
+                switch (DisplayStyle)
+                {
+                    case BarStyle.Lollipop:
 
-						if (HorizontalOrientation)
-						{
-							gfx.FillEllipse(fillBrush, negative ? rect.X : rect.X + rect.Width, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
-							gfx.DrawLine(fillPen, rect.X, centerPx, rect.X + rect.Width, centerPx);
-						}
-						else
-						{
-							gfx.FillEllipse(fillBrush, centerPx - LollipopRadius / 2, !negative ? rect.Y : rect.Y + rect.Height, LollipopRadius, LollipopRadius);
-							gfx.DrawLine(fillPen, centerPx, rect.Y, centerPx, rect.Y + rect.Height);
-						}
-						break;
+                        if (HorizontalOrientation)
+                        {
+                            gfx.FillEllipse(fillBrush, negative ? rect.X : rect.X + rect.Width, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
+                            gfx.DrawLine(fillPen, rect.X, centerPx, rect.X + rect.Width, centerPx);
+                        }
+                        else
+                        {
+                            gfx.FillEllipse(fillBrush, centerPx - LollipopRadius / 2, !negative ? rect.Y : rect.Y + rect.Height, LollipopRadius, LollipopRadius);
+                            gfx.DrawLine(fillPen, centerPx, rect.Y, centerPx, rect.Y + rect.Height);
+                        }
+                        break;
 
-					case BarStyle.ClevelandDot:
-						using(var dot1Brush = GDI.Brush(ClevelandColor1))
-						using(var dot2Brush = GDI.Brush(ClevelandColor2))
-						{
-							if (HorizontalOrientation)
-							{
-								gfx.FillEllipse(dot1Brush, negative ? rect.X + rect.Width : rect.X, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
-								gfx.FillEllipse(dot2Brush, negative ? rect.X : rect.X + rect.Width, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
-								gfx.DrawLine(fillPen, rect.X, centerPx, rect.X + rect.Width, centerPx);
-							}
-							else
-							{
-								gfx.FillEllipse(dot1Brush, centerPx - LollipopRadius / 2, !negative ? rect.Y + rect.Height : rect.Y, LollipopRadius, LollipopRadius);
-								gfx.FillEllipse(dot2Brush, centerPx - LollipopRadius / 2, !negative ? rect.Y : rect.Y + rect.Height, LollipopRadius, LollipopRadius);
-								gfx.DrawLine(fillPen, centerPx, rect.Y, centerPx, rect.Y + rect.Height);
-							}
-						}
+                    case BarStyle.ClevelandDot:
+                        using (var dot1Brush = GDI.Brush(ClevelandColor1))
+                        using (var dot2Brush = GDI.Brush(ClevelandColor2))
+                        {
+                            if (HorizontalOrientation)
+                            {
+                                gfx.FillEllipse(dot1Brush, negative ? rect.X + rect.Width : rect.X, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
+                                gfx.FillEllipse(dot2Brush, negative ? rect.X : rect.X + rect.Width, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
+                                gfx.DrawLine(fillPen, rect.X, centerPx, rect.X + rect.Width, centerPx);
+                            }
+                            else
+                            {
+                                gfx.FillEllipse(dot1Brush, centerPx - LollipopRadius / 2, !negative ? rect.Y + rect.Height : rect.Y, LollipopRadius, LollipopRadius);
+                                gfx.FillEllipse(dot2Brush, centerPx - LollipopRadius / 2, !negative ? rect.Y : rect.Y + rect.Height, LollipopRadius, LollipopRadius);
+                                gfx.DrawLine(fillPen, centerPx, rect.Y, centerPx, rect.Y + rect.Height);
+                            }
+                        }
 
-						break;
+                        break;
 
-					case BarStyle.Bar:
-					default:
-						gfx.FillRectangle(fillBrush, rect.X, rect.Y, rect.Width, rect.Height);
-						if (BorderLineWidth > 0)
-						{
-							gfx.DrawRectangle(outlinePen, rect.X, rect.Y, rect.Width, rect.Height);
-						}
-						break;
-				}
-			}
-		}
+                    case BarStyle.Bar:
+                    default:
+                        gfx.FillRectangle(fillBrush, rect.X, rect.Y, rect.Width, rect.Height);
+                        if (BorderLineWidth > 0)
+                        {
+                            gfx.DrawRectangle(outlinePen, rect.X, rect.Y, rect.Width, rect.Height);
+                        }
+                        break;
+                }
+            }
+        }
 
-		private void RenderBarVertical(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
-		{
-			// bar body
-			float centerPx = dims.GetPixelX(position);
-			double edge1 = position - BarWidth / 2;
-			double value1 = Math.Min(BaseValue, value) + yOffset;
-			double value2 = Math.Max(BaseValue, value) + yOffset;
-			double valueSpan = value2 - value1;
+        private void RenderBarVertical(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
+        {
+            // bar body
+            float centerPx = dims.GetPixelX(position);
+            double edge1 = position - BarWidth / 2;
+            double value1 = Math.Min(BaseValue, value) + yOffset;
+            double value2 = Math.Max(BaseValue, value) + yOffset;
+            double valueSpan = value2 - value1;
 
-			var rect = new RectangleF(
-				x: dims.GetPixelX(edge1),
-				y: dims.GetPixelY(value2),
-				width: (float)(BarWidth * dims.PxPerUnitX),
-				height: (float)(valueSpan * dims.PxPerUnitY));
+            var rect = new RectangleF(
+                x: dims.GetPixelX(edge1),
+                y: dims.GetPixelY(value2),
+                width: (float)(BarWidth * dims.PxPerUnitX),
+                height: (float)(valueSpan * dims.PxPerUnitY));
 
-			// errorbar
-			double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
-			double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
-			float capPx1 = dims.GetPixelX(position - ErrorCapSize * BarWidth / 2);
-			float capPx2 = dims.GetPixelX(position + ErrorCapSize * BarWidth / 2);
-			float errorPx2 = dims.GetPixelY(error2);
-			float errorPx1 = dims.GetPixelY(error1);
+            // errorbar
+            double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
+            double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
+            float capPx1 = dims.GetPixelX(position - ErrorCapSize * BarWidth / 2);
+            float capPx2 = dims.GetPixelX(position + ErrorCapSize * BarWidth / 2);
+            float errorPx2 = dims.GetPixelY(error2);
+            float errorPx1 = dims.GetPixelY(error1);
 
-			RenderBarFromRect(rect, value < 0, gfx);
+            RenderBarFromRect(rect, value < 0, gfx);
 
-			if (ErrorLineWidth > 0 && valueError > 0)
-			{
-				using (var errorPen = new Pen(ErrorColor, ErrorLineWidth))
-				{
-					gfx.DrawLine(errorPen, centerPx, errorPx1, centerPx, errorPx2);
-					gfx.DrawLine(errorPen, capPx1, errorPx1, capPx2, errorPx1);
-					gfx.DrawLine(errorPen, capPx1, errorPx2, capPx2, errorPx2);
-				}
-			}
+            if (ErrorLineWidth > 0 && valueError > 0)
+            {
+                using (var errorPen = new Pen(ErrorColor, ErrorLineWidth))
+                {
+                    gfx.DrawLine(errorPen, centerPx, errorPx1, centerPx, errorPx2);
+                    gfx.DrawLine(errorPen, capPx1, errorPx1, capPx2, errorPx1);
+                    gfx.DrawLine(errorPen, capPx1, errorPx2, capPx2, errorPx2);
+                }
+            }
 
-			if (ShowValuesAboveBars)
-				using (var valueTextFont = GDI.Font(Font))
-				using (var valueTextBrush = GDI.Brush(Font.Color))
-				using (var sf = new StringFormat() { LineAlignment = StringAlignment.Far, Alignment = StringAlignment.Center })
-					gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, centerPx, rect.Y, sf);
-		}
+            if (ShowValuesAboveBars)
+                using (var valueTextFont = GDI.Font(Font))
+                using (var valueTextBrush = GDI.Brush(Font.Color))
+                using (var sf = new StringFormat() { LineAlignment = StringAlignment.Far, Alignment = StringAlignment.Center })
+                    gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, centerPx, rect.Y, sf);
+        }
 
-		private void RenderBarHorizontal(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
-		{
-			// bar body
-			float centerPx = dims.GetPixelY(position);
-			double edge2 = position + BarWidth / 2;
-			double value1 = Math.Min(BaseValue, value) + yOffset;
-			double value2 = Math.Max(BaseValue, value) + yOffset;
-			double valueSpan = value2 - value1;
-			var rect = new RectangleF(
-				x: dims.GetPixelX(value1),
-				y: dims.GetPixelY(edge2),
-				height: (float)(BarWidth * dims.PxPerUnitY),
-				width: (float)(valueSpan * dims.PxPerUnitX));
+        private void RenderBarHorizontal(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
+        {
+            // bar body
+            float centerPx = dims.GetPixelY(position);
+            double edge2 = position + BarWidth / 2;
+            double value1 = Math.Min(BaseValue, value) + yOffset;
+            double value2 = Math.Max(BaseValue, value) + yOffset;
+            double valueSpan = value2 - value1;
+            var rect = new RectangleF(
+                x: dims.GetPixelX(value1),
+                y: dims.GetPixelY(edge2),
+                height: (float)(BarWidth * dims.PxPerUnitY),
+                width: (float)(valueSpan * dims.PxPerUnitX));
 
-			RenderBarFromRect(rect, value < 0, gfx);
+            RenderBarFromRect(rect, value < 0, gfx);
 
-			// errorbar
-			double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
-			double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
-			float capPx1 = dims.GetPixelY(position - ErrorCapSize * BarWidth / 2);
-			float capPx2 = dims.GetPixelY(position + ErrorCapSize * BarWidth / 2);
-			float errorPx2 = dims.GetPixelX(error2);
-			float errorPx1 = dims.GetPixelX(error1);
+            // errorbar
+            double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
+            double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
+            float capPx1 = dims.GetPixelY(position - ErrorCapSize * BarWidth / 2);
+            float capPx2 = dims.GetPixelY(position + ErrorCapSize * BarWidth / 2);
+            float errorPx2 = dims.GetPixelX(error2);
+            float errorPx1 = dims.GetPixelX(error1);
 
-			if (ErrorLineWidth > 0 && valueError > 0)
-			{
-				using (var errorPen = new Pen(ErrorColor, ErrorLineWidth))
-				{
-					gfx.DrawLine(errorPen, errorPx1, centerPx, errorPx2, centerPx);
-					gfx.DrawLine(errorPen, errorPx1, capPx2, errorPx1, capPx1);
-					gfx.DrawLine(errorPen, errorPx2, capPx2, errorPx2, capPx1);
-				}
-			}
+            if (ErrorLineWidth > 0 && valueError > 0)
+            {
+                using (var errorPen = new Pen(ErrorColor, ErrorLineWidth))
+                {
+                    gfx.DrawLine(errorPen, errorPx1, centerPx, errorPx2, centerPx);
+                    gfx.DrawLine(errorPen, errorPx1, capPx2, errorPx1, capPx1);
+                    gfx.DrawLine(errorPen, errorPx2, capPx2, errorPx2, capPx1);
+                }
+            }
 
-			if (ShowValuesAboveBars)
-				using (var valueTextFont = GDI.Font(Font))
-				using (var valueTextBrush = GDI.Brush(Font.Color))
-				using (var sf = new StringFormat() { LineAlignment = StringAlignment.Center, Alignment = StringAlignment.Near })
-					gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, rect.X + rect.Width, centerPx, sf);
-		}
+            if (ShowValuesAboveBars)
+                using (var valueTextFont = GDI.Font(Font))
+                using (var valueTextBrush = GDI.Brush(Font.Color))
+                using (var sf = new StringFormat() { LineAlignment = StringAlignment.Center, Alignment = StringAlignment.Near })
+                    gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, rect.X + rect.Width, centerPx, sf);
+        }
 
-		public override string ToString()
-		{
-			string label = string.IsNullOrWhiteSpace(this.Label) ? "" : $" ({this.Label})";
-			return $"PlottableBar{label} with {PointCount} points";
-		}
+        public override string ToString()
+        {
+            string label = string.IsNullOrWhiteSpace(this.Label) ? "" : $" ({this.Label})";
+            return $"PlottableBar{label} with {PointCount} points";
+        }
 
-		public int PointCount { get => Ys is null ? 0 : Ys.Length; }
+        public int PointCount { get => Ys is null ? 0 : Ys.Length; }
 
-		public LegendItem[] GetLegendItems()
-		{
-			var singleItem = new LegendItem()
-			{
-				label = Label,
-				color = FillColor,
-				lineWidth = 10,
-				markerShape = MarkerShape.none,
-				hatchColor = FillColorHatch,
-				hatchStyle = HatchStyle,
-				borderColor = BorderColor,
-				borderWith = BorderLineWidth
-			};
-			return new LegendItem[] { singleItem };
-		}
-	}
+        public LegendItem[] GetLegendItems()
+        {
+            var singleItem = new LegendItem()
+            {
+                label = Label,
+                color = FillColor,
+                lineWidth = 10,
+                markerShape = MarkerShape.none,
+                hatchColor = FillColorHatch,
+                hatchStyle = HatchStyle,
+                borderColor = BorderColor,
+                borderWith = BorderLineWidth
+            };
+            return new LegendItem[] { singleItem };
+        }
+    }
 }

--- a/src/ScottPlot/Plottable/BarPlot.cs
+++ b/src/ScottPlot/Plottable/BarPlot.cs
@@ -136,19 +136,17 @@ namespace ScottPlot.Plottable
                 switch (DisplayStyle)
                 {
                     case BarStyle.Lollipop:
-                        const float RADIUS_FACTOR = 1 / 4f;
+                        const float RADIUS = 5;
                         float centerPx = HorizontalOrientation ? rect.Y + rect.Height / 2 : rect.X + rect.Width / 2;
 
                         if (HorizontalOrientation)
                         {
-                            float radius = rect.Height / 2 * RADIUS_FACTOR;
-                            gfx.FillEllipse(fillBrush, negative ? rect.X : rect.X + rect.Width, centerPx - radius / 2, radius, radius);
+                            gfx.FillEllipse(fillBrush, negative ? rect.X : rect.X + rect.Width, centerPx - RADIUS / 2, RADIUS, RADIUS);
                             gfx.DrawLine(fillPen, rect.X, centerPx, rect.X + rect.Width, centerPx);
                         }
                         else
                         {
-                            float radius = rect.Width / 2 * RADIUS_FACTOR;
-                            gfx.FillEllipse(fillBrush, centerPx - radius / 2, !negative ? rect.Y : rect.Y + rect.Height, radius, radius);
+                            gfx.FillEllipse(fillBrush, centerPx - RADIUS / 2, !negative ? rect.Y : rect.Y + rect.Height, RADIUS, RADIUS);
                             gfx.DrawLine(fillPen, centerPx, rect.Y, centerPx, rect.Y + rect.Height);
                         }
                         break;

--- a/src/ScottPlot/Plottable/BarPlot.cs
+++ b/src/ScottPlot/Plottable/BarPlot.cs
@@ -6,61 +6,26 @@ using System.Linq;
 
 namespace ScottPlot.Plottable
 {
-    public enum BarStyle
-    {
-        Bar,
-        Lollipop,
-        ClevelandDot
-    }
-
     /// <summary>
     /// Bar plots display a series of bars. 
     /// Positions are defined by Xs.
     /// Heights are defined by Ys (relative to BaseValue and YOffsets).
     /// </summary>
-    public class BarPlot : IPlottable
+    public class BarPlot : BarPlotBase, IPlottable
     {
-        // data
-        public double[] Xs;
-        public double XOffset;
-        public double[] Ys;
-        public double[] YErrors;
-        public double[] YOffsets;
-
         // customization
-        public bool IsVisible { get; set; } = true;
-        public int XAxisIndex { get; set; } = 0;
-        public int YAxisIndex { get; set; } = 0;
         public string Label;
         public Color FillColor = Color.Green;
         public Color FillColorNegative = Color.Red;
         public Color FillColorHatch = Color.Blue;
         public HatchStyle HatchStyle = HatchStyle.None;
-        public Color ErrorColor = Color.Black;
-        public float ErrorLineWidth = 1;
-        public double ErrorCapSize = .4;
-        public Color BorderColor = Color.Black;
         public float BorderLineWidth = 1;
-        public BarStyle DisplayStyle = BarStyle.Bar;
-        public float LollipopRadius = 5;
         public Color ClevelandColor1 = Color.Green;
         public Color ClevelandColor2 = Color.Red;
         public string ClevelandLabel1 = "";
         public string ClevelandLabel2 = "";
 
-        public readonly Drawing.Font Font = new Drawing.Font();
-        public string FontName { set => Font.Name = value; }
-        public float FontSize { set => Font.Size = value; }
-        public bool FontBold { set => Font.Bold = value; }
-        public Color FontColor { set => Font.Color = value; }
-
-        public double BarWidth = .8;
-        public double BaseValue = 0;
-        public bool VerticalOrientation = true;
-        public bool HorizontalOrientation { get => !VerticalOrientation; set => VerticalOrientation = !value; }
-        public bool ShowValuesAboveBars;
-
-        public BarPlot(double[] xs, double[] ys, double[] yErr, double[] yOffsets)
+        public BarPlot(double[] xs, double[] ys, double[] yErr, double[] yOffsets) : base()
         {
             if (ys is null || ys.Length == 0)
                 throw new InvalidOperationException("ys must be an array that contains elements");
@@ -71,213 +36,18 @@ namespace ScottPlot.Plottable
             YOffsets = yOffsets ?? DataGen.Zeros(ys.Length);
         }
 
-        public AxisLimits GetAxisLimits()
+        protected override void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
         {
-            double valueMin = double.PositiveInfinity;
-            double valueMax = double.NegativeInfinity;
-            double positionMin = double.PositiveInfinity;
-            double positionMax = double.NegativeInfinity;
-
-            for (int i = 0; i < Xs.Length; i++)
-            {
-                if (DisplayStyle != BarStyle.ClevelandDot)
-                {
-                    valueMin = Math.Min(valueMin, Ys[i] - YErrors[i] + YOffsets[i]);
-                    valueMax = Math.Max(valueMax, Ys[i] + YErrors[i] + YOffsets[i]);
-                }
-                else // For Cleveland Dot Plots the YOffset is rendered as a dot
-                {
-                    valueMin = new double[] { valueMin, Ys[i] - YErrors[i] + YOffsets[i], YOffsets[i] }.Min();
-                    valueMax = new double[] { valueMin, Ys[i] + YErrors[i] + YOffsets[i], YOffsets[i] }.Max();
-                }
-                positionMin = Math.Min(positionMin, Xs[i]);
-                positionMax = Math.Max(positionMax, Xs[i]);
-            }
-
-            valueMin = Math.Min(valueMin, BaseValue);
-            valueMax = Math.Max(valueMax, BaseValue);
-
-            if (ShowValuesAboveBars)
-                valueMax += (valueMax - valueMin) * .1; // increase by 10% to accomodate label
-
-            positionMin -= BarWidth / 2;
-            positionMax += BarWidth / 2;
-
-            positionMin += XOffset;
-            positionMax += XOffset;
-
-            return VerticalOrientation ?
-                new AxisLimits(positionMin, positionMax, valueMin, valueMax) :
-                new AxisLimits(valueMin, valueMax, positionMin, positionMax);
-        }
-
-        public void ValidateData(bool deep = false)
-        {
-            Validate.AssertHasElements("xs", Xs);
-            Validate.AssertHasElements("ys", Ys);
-            Validate.AssertHasElements("yErr", YErrors);
-            Validate.AssertHasElements("yOffsets", YOffsets);
-            Validate.AssertEqualLength("xs, ys, yErr, and yOffsets", Xs, Ys, YErrors, YOffsets);
-
-            if (deep)
-            {
-                Validate.AssertAllReal("xs", Xs);
-                Validate.AssertAllReal("ys", Ys);
-                Validate.AssertAllReal("yErr", YErrors);
-                Validate.AssertAllReal("yOffsets", YOffsets);
-            }
-        }
-
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
-        {
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
-            {
-                for (int barIndex = 0; barIndex < Ys.Length; barIndex++)
-                {
-                    if (VerticalOrientation)
-                        RenderBarVertical(dims, gfx, Xs[barIndex] + XOffset, Ys[barIndex], YErrors[barIndex], YOffsets[barIndex]);
-                    else
-                        RenderBarHorizontal(dims, gfx, Xs[barIndex] + XOffset, Ys[barIndex], YErrors[barIndex], YOffsets[barIndex]);
-                }
-            }
-        }
-
-        private void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
-        {
-            float centerPx = HorizontalOrientation ? rect.Y + rect.Height / 2 : rect.X + rect.Width / 2;
             using (var outlinePen = new Pen(BorderColor, BorderLineWidth))
             using (var fillPen = new Pen(negative ? FillColorNegative : FillColor))
             using (var fillBrush = GDI.Brush(negative ? FillColorNegative : FillColor, FillColorHatch, HatchStyle))
             {
-                switch (DisplayStyle)
+                gfx.FillRectangle(fillBrush, rect.X, rect.Y, rect.Width, rect.Height);
+                if (BorderLineWidth > 0)
                 {
-                    case BarStyle.Lollipop:
-
-                        if (HorizontalOrientation)
-                        {
-                            gfx.FillEllipse(fillBrush, negative ? rect.X : rect.X + rect.Width, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
-                            gfx.DrawLine(fillPen, rect.X, centerPx, rect.X + rect.Width, centerPx);
-                        }
-                        else
-                        {
-                            gfx.FillEllipse(fillBrush, centerPx - LollipopRadius / 2, !negative ? rect.Y : rect.Y + rect.Height, LollipopRadius, LollipopRadius);
-                            gfx.DrawLine(fillPen, centerPx, rect.Y, centerPx, rect.Y + rect.Height);
-                        }
-                        break;
-
-                    case BarStyle.ClevelandDot:
-                        using (var dot1Brush = GDI.Brush(ClevelandColor1))
-                        using (var dot2Brush = GDI.Brush(ClevelandColor2))
-                        {
-                            if (HorizontalOrientation)
-                            {
-                                gfx.FillEllipse(dot2Brush, negative ? rect.X : rect.X + rect.Width, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
-                                gfx.FillEllipse(dot1Brush, negative ? rect.X + rect.Width : rect.X, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius); // Ensure the first dot is drawn overtop the second
-                                gfx.DrawLine(fillPen, rect.X, centerPx, rect.X + rect.Width, centerPx);
-                            }
-                            else
-                            {
-                                gfx.FillEllipse(dot2Brush, centerPx - LollipopRadius / 2, !negative ? rect.Y : rect.Y + rect.Height, LollipopRadius, LollipopRadius);
-                                gfx.FillEllipse(dot1Brush, centerPx - LollipopRadius / 2, !negative ? rect.Y + rect.Height : rect.Y, LollipopRadius, LollipopRadius); // Ensure the first dot is drawn overtop the second
-                                gfx.DrawLine(fillPen, centerPx, rect.Y, centerPx, rect.Y + rect.Height);
-                            }
-                        }
-
-                        break;
-
-                    case BarStyle.Bar:
-                    default:
-                        gfx.FillRectangle(fillBrush, rect.X, rect.Y, rect.Width, rect.Height);
-                        if (BorderLineWidth > 0)
-                        {
-                            gfx.DrawRectangle(outlinePen, rect.X, rect.Y, rect.Width, rect.Height);
-                        }
-                        break;
+                    gfx.DrawRectangle(outlinePen, rect.X, rect.Y, rect.Width, rect.Height);
                 }
             }
-        }
-
-        private void RenderBarVertical(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
-        {
-            // bar body
-            float centerPx = dims.GetPixelX(position);
-            double edge1 = position - BarWidth / 2;
-            double value1 = Math.Min(BaseValue, value) + yOffset;
-            double value2 = Math.Max(BaseValue, value) + yOffset;
-            double valueSpan = value2 - value1;
-
-            var rect = new RectangleF(
-                x: dims.GetPixelX(edge1),
-                y: dims.GetPixelY(value2),
-                width: (float)(BarWidth * dims.PxPerUnitX),
-                height: (float)(valueSpan * dims.PxPerUnitY));
-
-            // errorbar
-            double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
-            double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
-            float capPx1 = dims.GetPixelX(position - ErrorCapSize * BarWidth / 2);
-            float capPx2 = dims.GetPixelX(position + ErrorCapSize * BarWidth / 2);
-            float errorPx2 = dims.GetPixelY(error2);
-            float errorPx1 = dims.GetPixelY(error1);
-
-            RenderBarFromRect(rect, value < 0, gfx);
-
-            if (ErrorLineWidth > 0 && valueError > 0)
-            {
-                using (var errorPen = new Pen(ErrorColor, ErrorLineWidth))
-                {
-                    gfx.DrawLine(errorPen, centerPx, errorPx1, centerPx, errorPx2);
-                    gfx.DrawLine(errorPen, capPx1, errorPx1, capPx2, errorPx1);
-                    gfx.DrawLine(errorPen, capPx1, errorPx2, capPx2, errorPx2);
-                }
-            }
-
-            if (ShowValuesAboveBars)
-                using (var valueTextFont = GDI.Font(Font))
-                using (var valueTextBrush = GDI.Brush(Font.Color))
-                using (var sf = new StringFormat() { LineAlignment = StringAlignment.Far, Alignment = StringAlignment.Center })
-                    gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, centerPx, rect.Y, sf);
-        }
-
-        private void RenderBarHorizontal(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
-        {
-            // bar body
-            float centerPx = dims.GetPixelY(position);
-            double edge2 = position + BarWidth / 2;
-            double value1 = Math.Min(BaseValue, value) + yOffset;
-            double value2 = Math.Max(BaseValue, value) + yOffset;
-            double valueSpan = value2 - value1;
-            var rect = new RectangleF(
-                x: dims.GetPixelX(value1),
-                y: dims.GetPixelY(edge2),
-                height: (float)(BarWidth * dims.PxPerUnitY),
-                width: (float)(valueSpan * dims.PxPerUnitX));
-
-            RenderBarFromRect(rect, value < 0, gfx);
-
-            // errorbar
-            double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
-            double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
-            float capPx1 = dims.GetPixelY(position - ErrorCapSize * BarWidth / 2);
-            float capPx2 = dims.GetPixelY(position + ErrorCapSize * BarWidth / 2);
-            float errorPx2 = dims.GetPixelX(error2);
-            float errorPx1 = dims.GetPixelX(error1);
-
-            if (ErrorLineWidth > 0 && valueError > 0)
-            {
-                using (var errorPen = new Pen(ErrorColor, ErrorLineWidth))
-                {
-                    gfx.DrawLine(errorPen, errorPx1, centerPx, errorPx2, centerPx);
-                    gfx.DrawLine(errorPen, errorPx1, capPx2, errorPx1, capPx1);
-                    gfx.DrawLine(errorPen, errorPx2, capPx2, errorPx2, capPx1);
-                }
-            }
-
-            if (ShowValuesAboveBars)
-                using (var valueTextFont = GDI.Font(Font))
-                using (var valueTextBrush = GDI.Brush(Font.Color))
-                using (var sf = new StringFormat() { LineAlignment = StringAlignment.Center, Alignment = StringAlignment.Near })
-                    gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, rect.X + rect.Width, centerPx, sf);
         }
 
         public override string ToString()
@@ -288,44 +58,20 @@ namespace ScottPlot.Plottable
 
         public int PointCount { get => Ys is null ? 0 : Ys.Length; }
 
-        public LegendItem[] GetLegendItems()
+        public override LegendItem[] GetLegendItems()
         {
-            if (DisplayStyle != BarStyle.ClevelandDot)
+            var singleItem = new LegendItem()
             {
-                var singleItem = new LegendItem()
-                {
-                    label = Label,
-                    color = FillColor,
-                    lineWidth = 10,
-                    markerShape = MarkerShape.none,
-                    hatchColor = FillColorHatch,
-                    hatchStyle = HatchStyle,
-                    borderColor = BorderColor,
-                    borderWith = BorderLineWidth
-                };
-                return new LegendItem[] { singleItem };
-            }
-            else
-            {
-                var firstDot = new LegendItem()
-                {
-                    label = ClevelandLabel1,
-                    color = ClevelandColor1,
-                    lineStyle = LineStyle.None,
-                    markerShape = MarkerShape.filledCircle,
-                    markerSize = 5,
-                };
-                var secondDot = new LegendItem()
-                {
-                    label = ClevelandLabel2,
-                    color = ClevelandColor2,
-                    lineStyle = LineStyle.None,
-                    markerShape = MarkerShape.filledCircle,
-                    markerSize = 5,
-                };
-
-                return new LegendItem[] { firstDot, secondDot };
-            }
+                label = Label,
+                color = FillColor,
+                lineWidth = 10,
+                markerShape = MarkerShape.none,
+                hatchColor = FillColorHatch,
+                hatchStyle = HatchStyle,
+                borderColor = BorderColor,
+                borderWith = BorderLineWidth
+            };
+            return new LegendItem[] { singleItem };
         }
     }
 }

--- a/src/ScottPlot/Plottable/BarPlot.cs
+++ b/src/ScottPlot/Plottable/BarPlot.cs
@@ -37,9 +37,9 @@ namespace ScottPlot.Plottable
             for (int barIndex = 0; barIndex < Values.Length; barIndex++)
             {
                 if (Orientation == Orientation.Vertical)
-                    RenderBarVertical(dims, gfx, Positions[barIndex] + XOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
+                    RenderBarVertical(dims, gfx, Positions[barIndex] + PositionOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
                 else
-                    RenderBarHorizontal(dims, gfx, Positions[barIndex] + XOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
+                    RenderBarHorizontal(dims, gfx, Positions[barIndex] + PositionOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
             }
         }
 

--- a/src/ScottPlot/Plottable/BarPlot.cs
+++ b/src/ScottPlot/Plottable/BarPlot.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Drawing;
 using System.Data;
+using System.Linq;
 
 namespace ScottPlot.Plottable
 {
@@ -77,8 +78,16 @@ namespace ScottPlot.Plottable
 
             for (int i = 0; i < Xs.Length; i++)
             {
-                valueMin = Math.Min(valueMin, Ys[i] - YErrors[i] + YOffsets[i]);
-                valueMax = Math.Max(valueMax, Ys[i] + YErrors[i] + YOffsets[i]);
+                if (DisplayStyle != BarStyle.ClevelandDot)
+                {
+                    valueMin = Math.Min(valueMin, Ys[i] - YErrors[i] + YOffsets[i]);
+                    valueMax = Math.Max(valueMax, Ys[i] + YErrors[i] + YOffsets[i]);
+				}
+				else // For Cleveland Dot Plots the YOffset is rendered as a dot
+				{
+                    valueMin = new double[] { valueMin, Ys[i] - YErrors[i] + YOffsets[i], YOffsets[i] }.Min();
+                    valueMax = new double[] { valueMin, Ys[i] + YErrors[i] + YOffsets[i], YOffsets[i] }.Max();
+                }
                 positionMin = Math.Min(positionMin, Xs[i]);
                 positionMax = Math.Max(positionMax, Xs[i]);
             }

--- a/src/ScottPlot/Plottable/BarPlot.cs
+++ b/src/ScottPlot/Plottable/BarPlot.cs
@@ -13,7 +13,6 @@ namespace ScottPlot.Plottable
     /// </summary>
     public class BarPlot : BarPlotBase, IPlottable
     {
-        // customization
         public string Label;
         public Color FillColor = Color.Green;
         public Color FillColorNegative = Color.Red;
@@ -32,7 +31,98 @@ namespace ScottPlot.Plottable
             ValueOffsets = yOffsets ?? DataGen.Zeros(ys.Length);
         }
 
-        protected override void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
+        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        {
+            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
+            for (int barIndex = 0; barIndex < Values.Length; barIndex++)
+            {
+                if (Orientation == Orientation.Vertical)
+                    RenderBarVertical(dims, gfx, Positions[barIndex] + XOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
+                else
+                    RenderBarHorizontal(dims, gfx, Positions[barIndex] + XOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
+            }
+        }
+
+        private void RenderBarVertical(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
+        {
+            // bar body
+            float centerPx = dims.GetPixelX(position);
+            double edge1 = position - BarWidth / 2;
+            double value1 = Math.Min(ValueBase, value) + yOffset;
+            double value2 = Math.Max(ValueBase, value) + yOffset;
+            double valueSpan = value2 - value1;
+
+            var rect = new RectangleF(
+                x: dims.GetPixelX(edge1),
+                y: dims.GetPixelY(value2),
+                width: (float)(BarWidth * dims.PxPerUnitX),
+                height: (float)(valueSpan * dims.PxPerUnitY));
+
+            // errorbar
+            double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
+            double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
+            float capPx1 = dims.GetPixelX(position - ErrorCapSize * BarWidth / 2);
+            float capPx2 = dims.GetPixelX(position + ErrorCapSize * BarWidth / 2);
+            float errorPx2 = dims.GetPixelY(error2);
+            float errorPx1 = dims.GetPixelY(error1);
+
+            RenderBarFromRect(rect, value < 0, gfx);
+
+            if (ErrorLineWidth > 0 && valueError > 0)
+            {
+                using var errorPen = new Pen(ErrorColor, ErrorLineWidth);
+                gfx.DrawLine(errorPen, centerPx, errorPx1, centerPx, errorPx2);
+                gfx.DrawLine(errorPen, capPx1, errorPx1, capPx2, errorPx1);
+                gfx.DrawLine(errorPen, capPx1, errorPx2, capPx2, errorPx2);
+            }
+
+            if (ShowValuesAboveBars)
+                using (var valueTextFont = GDI.Font(Font))
+                using (var valueTextBrush = GDI.Brush(Font.Color))
+                using (var sf = new StringFormat() { LineAlignment = StringAlignment.Far, Alignment = StringAlignment.Center })
+                    gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, centerPx, rect.Y, sf);
+        }
+
+        private void RenderBarHorizontal(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
+        {
+            // bar body
+            float centerPx = dims.GetPixelY(position);
+            double edge2 = position + BarWidth / 2;
+            double value1 = Math.Min(ValueBase, value) + yOffset;
+            double value2 = Math.Max(ValueBase, value) + yOffset;
+            double valueSpan = value2 - value1;
+            var rect = new RectangleF(
+                x: dims.GetPixelX(value1),
+                y: dims.GetPixelY(edge2),
+                height: (float)(BarWidth * dims.PxPerUnitY),
+                width: (float)(valueSpan * dims.PxPerUnitX));
+
+            RenderBarFromRect(rect, value < 0, gfx);
+
+            // errorbar
+            double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
+            double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
+            float capPx1 = dims.GetPixelY(position - ErrorCapSize * BarWidth / 2);
+            float capPx2 = dims.GetPixelY(position + ErrorCapSize * BarWidth / 2);
+            float errorPx2 = dims.GetPixelX(error2);
+            float errorPx1 = dims.GetPixelX(error1);
+
+            if (ErrorLineWidth > 0 && valueError > 0)
+            {
+                using var errorPen = new Pen(ErrorColor, ErrorLineWidth);
+                gfx.DrawLine(errorPen, errorPx1, centerPx, errorPx2, centerPx);
+                gfx.DrawLine(errorPen, errorPx1, capPx2, errorPx1, capPx1);
+                gfx.DrawLine(errorPen, errorPx2, capPx2, errorPx2, capPx1);
+            }
+
+            if (ShowValuesAboveBars)
+                using (var valueTextFont = GDI.Font(Font))
+                using (var valueTextBrush = GDI.Brush(Font.Color))
+                using (var sf = new StringFormat() { LineAlignment = StringAlignment.Center, Alignment = StringAlignment.Near })
+                    gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, rect.X + rect.Width, centerPx, sf);
+        }
+
+        protected void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
         {
             using (var outlinePen = new Pen(BorderColor, BorderLineWidth))
             using (var fillBrush = GDI.Brush(negative ? FillColorNegative : FillColor, FillColorHatch, HatchStyle))
@@ -51,7 +141,7 @@ namespace ScottPlot.Plottable
             return $"PlottableBar{label} with {Values.Length} bars";
         }
 
-        public override LegendItem[] GetLegendItems()
+        public LegendItem[] GetLegendItems()
         {
             var singleItem = new LegendItem()
             {
@@ -65,6 +155,11 @@ namespace ScottPlot.Plottable
                 borderWith = BorderLineWidth
             };
             return new LegendItem[] { singleItem };
+        }
+
+        public void ValidateData(bool deep = false)
+        {
+            // TODO: refactor entire data validation system for all plot types (triaged March 2021)
         }
     }
 }

--- a/src/ScottPlot/Plottable/BarPlot.cs
+++ b/src/ScottPlot/Plottable/BarPlot.cs
@@ -45,6 +45,8 @@ namespace ScottPlot.Plottable
         public float LollipopRadius = 5;
         public Color ClevelandColor1 = Color.Green;
         public Color ClevelandColor2 = Color.Red;
+        public string ClevelandLabel1 = "";
+        public string ClevelandLabel2 = "";
 
         public readonly Drawing.Font Font = new Drawing.Font();
         public string FontName { set => Font.Name = value; }
@@ -82,9 +84,9 @@ namespace ScottPlot.Plottable
                 {
                     valueMin = Math.Min(valueMin, Ys[i] - YErrors[i] + YOffsets[i]);
                     valueMax = Math.Max(valueMax, Ys[i] + YErrors[i] + YOffsets[i]);
-				}
-				else // For Cleveland Dot Plots the YOffset is rendered as a dot
-				{
+                }
+                else // For Cleveland Dot Plots the YOffset is rendered as a dot
+                {
                     valueMin = new double[] { valueMin, Ys[i] - YErrors[i] + YOffsets[i], YOffsets[i] }.Min();
                     valueMax = new double[] { valueMin, Ys[i] + YErrors[i] + YOffsets[i], YOffsets[i] }.Max();
                 }
@@ -169,14 +171,14 @@ namespace ScottPlot.Plottable
                         {
                             if (HorizontalOrientation)
                             {
-                                gfx.FillEllipse(dot1Brush, negative ? rect.X + rect.Width : rect.X, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
                                 gfx.FillEllipse(dot2Brush, negative ? rect.X : rect.X + rect.Width, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
+                                gfx.FillEllipse(dot1Brush, negative ? rect.X + rect.Width : rect.X, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius); // Ensure the first dot is drawn overtop the second
                                 gfx.DrawLine(fillPen, rect.X, centerPx, rect.X + rect.Width, centerPx);
                             }
                             else
                             {
-                                gfx.FillEllipse(dot1Brush, centerPx - LollipopRadius / 2, !negative ? rect.Y + rect.Height : rect.Y, LollipopRadius, LollipopRadius);
                                 gfx.FillEllipse(dot2Brush, centerPx - LollipopRadius / 2, !negative ? rect.Y : rect.Y + rect.Height, LollipopRadius, LollipopRadius);
+                                gfx.FillEllipse(dot1Brush, centerPx - LollipopRadius / 2, !negative ? rect.Y + rect.Height : rect.Y, LollipopRadius, LollipopRadius); // Ensure the first dot is drawn overtop the second
                                 gfx.DrawLine(fillPen, centerPx, rect.Y, centerPx, rect.Y + rect.Height);
                             }
                         }
@@ -288,18 +290,42 @@ namespace ScottPlot.Plottable
 
         public LegendItem[] GetLegendItems()
         {
-            var singleItem = new LegendItem()
+            if (DisplayStyle != BarStyle.ClevelandDot)
             {
-                label = Label,
-                color = FillColor,
-                lineWidth = 10,
-                markerShape = MarkerShape.none,
-                hatchColor = FillColorHatch,
-                hatchStyle = HatchStyle,
-                borderColor = BorderColor,
-                borderWith = BorderLineWidth
-            };
-            return new LegendItem[] { singleItem };
+                var singleItem = new LegendItem()
+                {
+                    label = Label,
+                    color = FillColor,
+                    lineWidth = 10,
+                    markerShape = MarkerShape.none,
+                    hatchColor = FillColorHatch,
+                    hatchStyle = HatchStyle,
+                    borderColor = BorderColor,
+                    borderWith = BorderLineWidth
+                };
+                return new LegendItem[] { singleItem };
+            }
+            else
+            {
+                var firstDot = new LegendItem()
+                {
+                    label = ClevelandLabel1,
+                    color = ClevelandColor1,
+                    lineStyle = LineStyle.None,
+                    markerShape = MarkerShape.filledCircle,
+                    markerSize = 5,
+                };
+                var secondDot = new LegendItem()
+                {
+                    label = ClevelandLabel2,
+                    color = ClevelandColor2,
+                    lineStyle = LineStyle.None,
+                    markerShape = MarkerShape.filledCircle,
+                    markerSize = 5,
+                };
+
+                return new LegendItem[] { firstDot, secondDot };
+            }
         }
     }
 }

--- a/src/ScottPlot/Plottable/BarPlotBase.cs
+++ b/src/ScottPlot/Plottable/BarPlotBase.cs
@@ -28,25 +28,25 @@ namespace ScottPlot.Plottable
         public double XOffset { get; set; }
 
         /// <summary>
-        /// Heights of each bar
+        /// Size of each bar
         /// </summary>
-        public double[] Ys { get; set; }
+        public double[] Values { get; set; }
 
         /// <summary>
         /// Position of each bar
         /// </summary>
-        public double[] Xs { get; set; }
+        public double[] Positions { get; set; }
 
         /// <summary>
         /// This array defines the base of each bar.
         /// Unless the user specifically defines it, this will be an array of zeros.
         /// </summary>
-        public double[] YOffsets { get; set; }
+        public double[] ValueOffsets { get; set; }
 
         /// <summary>
         /// If populated, this array describes the height of errorbars for each bar
         /// </summary>
-        public double[] YErrors { get; set; }
+        public double[] ValueErrors { get; set; }
 
         /// <summary>
         /// If true, errorbars will be drawn according to the values in the YErrors array
@@ -93,12 +93,12 @@ namespace ScottPlot.Plottable
             double positionMin = double.PositiveInfinity;
             double positionMax = double.NegativeInfinity;
 
-            for (int i = 0; i < Xs.Length; i++)
+            for (int i = 0; i < Positions.Length; i++)
             {
-                valueMin = Math.Min(valueMin, Ys[i] - YErrors[i] + YOffsets[i]);
-                valueMax = Math.Max(valueMax, Ys[i] + YErrors[i] + YOffsets[i]);
-                positionMin = Math.Min(positionMin, Xs[i]);
-                positionMax = Math.Max(positionMax, Xs[i]);
+                valueMin = Math.Min(valueMin, Values[i] - ValueErrors[i] + ValueOffsets[i]);
+                valueMax = Math.Max(valueMax, Values[i] + ValueErrors[i] + ValueOffsets[i]);
+                positionMin = Math.Min(positionMin, Positions[i]);
+                positionMax = Math.Max(positionMax, Positions[i]);
             }
 
             // TODO: what is BaseValue actually doing and can it be omitted?
@@ -124,12 +124,12 @@ namespace ScottPlot.Plottable
         public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
         {
             using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
-            for (int barIndex = 0; barIndex < Ys.Length; barIndex++)
+            for (int barIndex = 0; barIndex < Values.Length; barIndex++)
             {
                 if (Orientation == Orientation.Vertical)
-                    RenderBarVertical(dims, gfx, Xs[barIndex] + XOffset, Ys[barIndex], YErrors[barIndex], YOffsets[barIndex]);
+                    RenderBarVertical(dims, gfx, Positions[barIndex] + XOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
                 else
-                    RenderBarHorizontal(dims, gfx, Xs[barIndex] + XOffset, Ys[barIndex], YErrors[barIndex], YOffsets[barIndex]);
+                    RenderBarHorizontal(dims, gfx, Positions[barIndex] + XOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
             }
         }
 
@@ -216,23 +216,23 @@ namespace ScottPlot.Plottable
 
         public void ValidateData(bool deep = false)
         {
-            Validate.AssertHasElements("xs", Xs);
-            Validate.AssertHasElements("ys", Ys);
-            Validate.AssertHasElements("yErr", YErrors);
-            Validate.AssertHasElements("yOffsets", YOffsets);
-            Validate.AssertEqualLength("xs, ys, yErr, and yOffsets", Xs, Ys, YErrors, YOffsets);
+            Validate.AssertHasElements("xs", Positions);
+            Validate.AssertHasElements("ys", Values);
+            Validate.AssertHasElements("yErr", ValueErrors);
+            Validate.AssertHasElements("yOffsets", ValueOffsets);
+            Validate.AssertEqualLength("xs, ys, yErr, and yOffsets", Positions, Values, ValueErrors, ValueOffsets);
 
             if (deep)
             {
-                Validate.AssertAllReal("xs", Xs);
-                Validate.AssertAllReal("ys", Ys);
-                Validate.AssertAllReal("yErr", YErrors);
-                Validate.AssertAllReal("yOffsets", YOffsets);
+                Validate.AssertAllReal("xs", Positions);
+                Validate.AssertAllReal("ys", Values);
+                Validate.AssertAllReal("yErr", ValueErrors);
+                Validate.AssertAllReal("yOffsets", ValueOffsets);
             }
 
         }
 
-        [Obsolete("set the 'Orientation' field instead of this field", true)]
+        [Obsolete("Reference the 'Orientation' field instead of this field")]
         public bool VerticalOrientation
         {
             get => Orientation == Orientation.Vertical;
@@ -240,11 +240,25 @@ namespace ScottPlot.Plottable
         }
 
 
-        [Obsolete("set the 'Orientation' field instead of this field", true)]
+        [Obsolete("Reference the 'Orientation' field instead of this field")]
         public bool HorizontalOrientation
         {
             get => Orientation == Orientation.Horizontal;
             set => Orientation = value ? Orientation.Horizontal : Orientation.Vertical;
+        }
+
+        [Obsolete("Reference the 'Values' field instead of this field")]
+        public double[] Ys
+        {
+            get => Values;
+            set => Values = value;
+        }
+
+        [Obsolete("Reference the 'Positions' field instead of this field")]
+        public double[] Xs
+        {
+            get => Positions;
+            set => Positions = value;
         }
     }
 }

--- a/src/ScottPlot/Plottable/BarPlotBase.cs
+++ b/src/ScottPlot/Plottable/BarPlotBase.cs
@@ -1,0 +1,188 @@
+﻿using ScottPlot.Drawing;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Plottable
+{
+    public abstract class BarPlotBase : IPlottable
+    {
+        public bool IsVisible { get; set; } = true;
+        public int XAxisIndex { get; set; } = 0;
+        public int YAxisIndex { get; set; } = 0;
+        public bool VerticalOrientation { get; set; } = true;
+        public bool HorizontalOrientation { get => !VerticalOrientation; set => VerticalOrientation = !value; }
+        public double XOffset { get; set; }
+        public double[] Ys { get; set; }
+        public double[] YErrors { get; set; }
+        public double[] YOffsets { get; set; }
+        public double[] Xs { get; set; }
+        public bool ShowValuesAboveBars { get; set; }
+
+        public double BaseValue = 0;
+        public double BarWidth = .8;
+        public double ErrorCapSize = .4;
+        public float ErrorLineWidth = 1;
+        public Color BorderColor = Color.Black;
+        public Color ErrorColor = Color.Black;
+        public readonly Drawing.Font Font = new Drawing.Font();
+        public string FontName { set => Font.Name = value; }
+        public float FontSize { set => Font.Size = value; }
+        public bool FontBold { set => Font.Bold = value; }
+        public Color FontColor { set => Font.Color = value; }
+
+
+        public virtual AxisLimits GetAxisLimits()
+        {
+            double valueMin = double.PositiveInfinity;
+            double valueMax = double.NegativeInfinity;
+            double positionMin = double.PositiveInfinity;
+            double positionMax = double.NegativeInfinity;
+
+            for (int i = 0; i < Xs.Length; i++)
+            {
+                valueMin = Math.Min(valueMin, Ys[i] - YErrors[i] + YOffsets[i]);
+                valueMax = Math.Max(valueMax, Ys[i] + YErrors[i] + YOffsets[i]);
+                positionMin = Math.Min(positionMin, Xs[i]);
+                positionMax = Math.Max(positionMax, Xs[i]);
+            }
+
+            valueMin = Math.Min(valueMin, BaseValue);
+            valueMax = Math.Max(valueMax, BaseValue);
+
+            if (ShowValuesAboveBars)
+                valueMax += (valueMax - valueMin) * .1; // increase by 10% to accomodate label
+
+            positionMin -= BarWidth / 2;
+            positionMax += BarWidth / 2;
+
+            positionMin += XOffset;
+            positionMax += XOffset;
+
+            return VerticalOrientation ?
+                new AxisLimits(positionMin, positionMax, valueMin, valueMax) :
+                new AxisLimits(valueMin, valueMax, positionMin, positionMax);
+        }
+
+        public abstract LegendItem[] GetLegendItems();
+        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        {
+            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            {
+                for (int barIndex = 0; barIndex < Ys.Length; barIndex++)
+                {
+                    if (VerticalOrientation)
+                        RenderBarVertical(dims, gfx, Xs[barIndex] + XOffset, Ys[barIndex], YErrors[barIndex], YOffsets[barIndex]);
+                    else
+                        RenderBarHorizontal(dims, gfx, Xs[barIndex] + XOffset, Ys[barIndex], YErrors[barIndex], YOffsets[barIndex]);
+                }
+            }
+        }
+
+        protected abstract void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx);
+
+        private void RenderBarVertical(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
+        {
+            // bar body
+            float centerPx = dims.GetPixelX(position);
+            double edge1 = position - BarWidth / 2;
+            double value1 = Math.Min(BaseValue, value) + yOffset;
+            double value2 = Math.Max(BaseValue, value) + yOffset;
+            double valueSpan = value2 - value1;
+
+            var rect = new RectangleF(
+                x: dims.GetPixelX(edge1),
+                y: dims.GetPixelY(value2),
+                width: (float)(BarWidth * dims.PxPerUnitX),
+                height: (float)(valueSpan * dims.PxPerUnitY));
+
+            // errorbar
+            double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
+            double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
+            float capPx1 = dims.GetPixelX(position - ErrorCapSize * BarWidth / 2);
+            float capPx2 = dims.GetPixelX(position + ErrorCapSize * BarWidth / 2);
+            float errorPx2 = dims.GetPixelY(error2);
+            float errorPx1 = dims.GetPixelY(error1);
+
+            RenderBarFromRect(rect, value < 0, gfx);
+
+            if (ErrorLineWidth > 0 && valueError > 0)
+            {
+                using (var errorPen = new Pen(ErrorColor, ErrorLineWidth))
+                {
+                    gfx.DrawLine(errorPen, centerPx, errorPx1, centerPx, errorPx2);
+                    gfx.DrawLine(errorPen, capPx1, errorPx1, capPx2, errorPx1);
+                    gfx.DrawLine(errorPen, capPx1, errorPx2, capPx2, errorPx2);
+                }
+            }
+
+            if (ShowValuesAboveBars)
+                using (var valueTextFont = GDI.Font(Font))
+                using (var valueTextBrush = GDI.Brush(Font.Color))
+                using (var sf = new StringFormat() { LineAlignment = StringAlignment.Far, Alignment = StringAlignment.Center })
+                    gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, centerPx, rect.Y, sf);
+        }
+
+        private void RenderBarHorizontal(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
+        {
+            // bar body
+            float centerPx = dims.GetPixelY(position);
+            double edge2 = position + BarWidth / 2;
+            double value1 = Math.Min(BaseValue, value) + yOffset;
+            double value2 = Math.Max(BaseValue, value) + yOffset;
+            double valueSpan = value2 - value1;
+            var rect = new RectangleF(
+                x: dims.GetPixelX(value1),
+                y: dims.GetPixelY(edge2),
+                height: (float)(BarWidth * dims.PxPerUnitY),
+                width: (float)(valueSpan * dims.PxPerUnitX));
+
+            RenderBarFromRect(rect, value < 0, gfx);
+
+            // errorbar
+            double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
+            double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
+            float capPx1 = dims.GetPixelY(position - ErrorCapSize * BarWidth / 2);
+            float capPx2 = dims.GetPixelY(position + ErrorCapSize * BarWidth / 2);
+            float errorPx2 = dims.GetPixelX(error2);
+            float errorPx1 = dims.GetPixelX(error1);
+
+            if (ErrorLineWidth > 0 && valueError > 0)
+            {
+                using (var errorPen = new Pen(ErrorColor, ErrorLineWidth))
+                {
+                    gfx.DrawLine(errorPen, errorPx1, centerPx, errorPx2, centerPx);
+                    gfx.DrawLine(errorPen, errorPx1, capPx2, errorPx1, capPx1);
+                    gfx.DrawLine(errorPen, errorPx2, capPx2, errorPx2, capPx1);
+                }
+            }
+
+            if (ShowValuesAboveBars)
+                using (var valueTextFont = GDI.Font(Font))
+                using (var valueTextBrush = GDI.Brush(Font.Color))
+                using (var sf = new StringFormat() { LineAlignment = StringAlignment.Center, Alignment = StringAlignment.Near })
+                    gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, rect.X + rect.Width, centerPx, sf);
+        }
+
+        public void ValidateData(bool deep = false)
+        {
+            Validate.AssertHasElements("xs", Xs);
+            Validate.AssertHasElements("ys", Ys);
+            Validate.AssertHasElements("yErr", YErrors);
+            Validate.AssertHasElements("yOffsets", YOffsets);
+            Validate.AssertEqualLength("xs, ys, yErr, and yOffsets", Xs, Ys, YErrors, YOffsets);
+
+            if (deep)
+            {
+                Validate.AssertAllReal("xs", Xs);
+                Validate.AssertAllReal("ys", Ys);
+                Validate.AssertAllReal("yErr", YErrors);
+                Validate.AssertAllReal("yOffsets", YOffsets);
+            }
+
+        }
+    }
+}

--- a/src/ScottPlot/Plottable/BarPlotBase.cs
+++ b/src/ScottPlot/Plottable/BarPlotBase.cs
@@ -28,7 +28,7 @@ namespace ScottPlot.Plottable
         public double XOffset { get; set; }
 
         /// <summary>
-        /// Size of each bar
+        /// Size of each bar (along the axis defined by Orientation) relative to ValueBase
         /// </summary>
         public double[] Values { get; set; }
 
@@ -53,8 +53,10 @@ namespace ScottPlot.Plottable
         /// </summary>
         public bool ShowValuesAboveBars { get; set; }
 
-        // TODO: what does this value do?
-        public double BaseValue = 0;
+        /// <summary>
+        /// Bars are drawn from this level and extend according to the sizes defined in Values[]
+        /// </summary>
+        public double ValueBase { get; set; }
 
         /// <summary>
         /// Width of bars (axis units)
@@ -101,9 +103,8 @@ namespace ScottPlot.Plottable
                 positionMax = Math.Max(positionMax, Positions[i]);
             }
 
-            // TODO: what is BaseValue actually doing and can it be omitted?
-            valueMin = Math.Min(valueMin, BaseValue);
-            valueMax = Math.Max(valueMax, BaseValue);
+            valueMin = Math.Min(valueMin, ValueBase);
+            valueMax = Math.Max(valueMax, ValueBase);
 
             if (ShowValuesAboveBars)
                 valueMax += (valueMax - valueMin) * .1; // increase by 10% to accommodate label
@@ -140,8 +141,8 @@ namespace ScottPlot.Plottable
             // bar body
             float centerPx = dims.GetPixelX(position);
             double edge1 = position - BarWidth / 2;
-            double value1 = Math.Min(BaseValue, value) + yOffset;
-            double value2 = Math.Max(BaseValue, value) + yOffset;
+            double value1 = Math.Min(ValueBase, value) + yOffset;
+            double value2 = Math.Max(ValueBase, value) + yOffset;
             double valueSpan = value2 - value1;
 
             var rect = new RectangleF(
@@ -180,8 +181,8 @@ namespace ScottPlot.Plottable
             // bar body
             float centerPx = dims.GetPixelY(position);
             double edge2 = position + BarWidth / 2;
-            double value1 = Math.Min(BaseValue, value) + yOffset;
-            double value2 = Math.Max(BaseValue, value) + yOffset;
+            double value1 = Math.Min(ValueBase, value) + yOffset;
+            double value2 = Math.Max(ValueBase, value) + yOffset;
             double valueSpan = value2 - value1;
             var rect = new RectangleF(
                 x: dims.GetPixelX(value1),

--- a/src/ScottPlot/Plottable/BarPlotBase.cs
+++ b/src/ScottPlot/Plottable/BarPlotBase.cs
@@ -16,11 +16,10 @@ namespace ScottPlot.Plottable
         public Orientation Orientation = Orientation.Vertical;
 
         /// <summary>
-        /// Bars have width but positions are defined as a single point.
-        /// This value defines how to place a bar relative to its position.
-        /// If a bar has a width of 0.8, its X offset should be -0.4 to ensure it's centered on a whole number.
+        /// The position of each bar defines where the left edge of the bar should be.
+        /// To center the bar at each position, adjust this value to be negative one-half of the BarWidth.
         /// </summary>
-        public double XOffset { get; set; }
+        public double PositionOffset { get; set; }
 
         /// <summary>
         /// Size of each bar (along the axis defined by Orientation) relative to ValueBase
@@ -28,7 +27,8 @@ namespace ScottPlot.Plottable
         public double[] Values { get; set; }
 
         /// <summary>
-        /// Position of each bar
+        /// Location of the left edge of each bar.
+        /// To center bars on these positions, adjust PositionOffset to be negative one-half of the BarWidth.
         /// </summary>
         public double[] Positions { get; set; }
 
@@ -109,8 +109,8 @@ namespace ScottPlot.Plottable
             positionMin -= BarWidth / 2;
             positionMax += BarWidth / 2;
 
-            positionMin += XOffset;
-            positionMax += XOffset;
+            positionMin += PositionOffset;
+            positionMax += PositionOffset;
 
             return Orientation == Orientation.Vertical ?
                 new AxisLimits(positionMin, positionMax, valueMin, valueMax) :
@@ -143,6 +143,13 @@ namespace ScottPlot.Plottable
         {
             get => Positions;
             set => Positions = value;
+        }
+
+        [Obsolete("Reference the 'PositionOffset' field instead of this field", true)]
+        public double XOffset
+        {
+            get => PositionOffset;
+            set => PositionOffset = value;
         }
     }
 }

--- a/src/ScottPlot/Plottable/BarPlotBase.cs
+++ b/src/ScottPlot/Plottable/BarPlotBase.cs
@@ -14,17 +14,11 @@ namespace ScottPlot.Plottable
         public int XAxisIndex { get; set; } = 0;
         public int YAxisIndex { get; set; } = 0;
 
-        // TODO: replace orientation with an enum?
-
         /// <summary>
-        /// Display vertically-oriented bars with heights defined by Ys placed at horizontal positions defined by Xs
+        /// Orientation of the bars.
+        /// Default behavior is vertical so values are on the Y axis and positions are on the X axis.
         /// </summary>
-        public bool VerticalOrientation { get; set; } = true;
-
-        /// <summary>
-        /// Display horizontally-oriented bars with widths defined by Ys placed at vertical positions defined by Xs
-        /// </summary>
-        public bool HorizontalOrientation { get => !VerticalOrientation; set => VerticalOrientation = !value; }
+        public Orientation Orientation = Orientation.Vertical;
 
         /// <summary>
         /// Bars have width but positions are defined as a single point.
@@ -120,18 +114,19 @@ namespace ScottPlot.Plottable
             positionMin += XOffset;
             positionMax += XOffset;
 
-            return VerticalOrientation ?
+            return Orientation == Orientation.Vertical ?
                 new AxisLimits(positionMin, positionMax, valueMin, valueMax) :
                 new AxisLimits(valueMin, valueMax, positionMin, positionMax);
         }
 
         public abstract LegendItem[] GetLegendItems();
+
         public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
         {
             using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
             for (int barIndex = 0; barIndex < Ys.Length; barIndex++)
             {
-                if (VerticalOrientation)
+                if (Orientation == Orientation.Vertical)
                     RenderBarVertical(dims, gfx, Xs[barIndex] + XOffset, Ys[barIndex], YErrors[barIndex], YOffsets[barIndex]);
                 else
                     RenderBarHorizontal(dims, gfx, Xs[barIndex] + XOffset, Ys[barIndex], YErrors[barIndex], YOffsets[barIndex]);
@@ -235,6 +230,21 @@ namespace ScottPlot.Plottable
                 Validate.AssertAllReal("yOffsets", YOffsets);
             }
 
+        }
+
+        [Obsolete("set the 'Orientation' field instead of this field", true)]
+        public bool VerticalOrientation
+        {
+            get => Orientation == Orientation.Vertical;
+            set => Orientation = value ? Orientation.Vertical : Orientation.Horizontal;
+        }
+
+
+        [Obsolete("set the 'Orientation' field instead of this field", true)]
+        public bool HorizontalOrientation
+        {
+            get => Orientation == Orientation.Horizontal;
+            set => Orientation = value ? Orientation.Horizontal : Orientation.Vertical;
         }
     }
 }

--- a/src/ScottPlot/Plottable/ClevelandDotPlot.cs
+++ b/src/ScottPlot/Plottable/ClevelandDotPlot.cs
@@ -25,7 +25,11 @@ namespace ScottPlot.Plottable
             }
             set
             {
+                double[] diff = (Ys1 ?? DataGen.Zeros(value.Length)).Zip(value, (y, v) => y - v).ToArray();
                 YOffsets = value;
+
+                if (Ys2 != null)
+                    Ys2 = (Ys2 ?? DataGen.Zeros(value.Length)).Zip(diff, (y, v) => y + v).ToArray();
             }
         }
 
@@ -33,11 +37,16 @@ namespace ScottPlot.Plottable
         {
             get
             {
-                return Ys.Select((y, i) => y + Ys1[i]).ToArray();
+                if (Ys == null)
+                    return null;
+
+                double[] offsets = Ys1 ?? DataGen.Zeros(Ys.Length);
+                return Ys.Select((y, i) => y + offsets[i]).ToArray();
             }
             set
             {
-                Ys = value.Select((y, i) => y - Ys1[i]).ToArray();
+                double[] offsets = Ys1 ?? DataGen.Zeros(value.Length);
+                Ys = value.Select((y, i) => y - offsets[i]).ToArray();
             }
         }
 

--- a/src/ScottPlot/Plottable/ClevelandDotPlot.cs
+++ b/src/ScottPlot/Plottable/ClevelandDotPlot.cs
@@ -13,7 +13,7 @@ namespace ScottPlot.Plottable
     /// Positions are defined by Xs.
     /// Heights are defined by Ys1 and Ys2 (internally done with Ys and YOffsets).
     /// </summary>
-    public class ClevelandDotPlot : BarPlotBase
+    public class ClevelandDotPlot : BarPlotBase, IPlottable
     {
         /// <summary>
         /// Color for the line
@@ -153,7 +153,7 @@ namespace ScottPlot.Plottable
                 new AxisLimits(valueMin, valueMax, positionMin, positionMax);
         }
 
-        public override LegendItem[] GetLegendItems()
+        public LegendItem[] GetLegendItems()
         {
             var firstDot = new LegendItem()
             {
@@ -175,7 +175,24 @@ namespace ScottPlot.Plottable
             return new LegendItem[] { firstDot, secondDot };
         }
 
-        protected override void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
+        #region Render Implementation
+
+        // NOTE: These render methods contains a lot of code and complexity not required to render this plot type.
+        // TODO: Delete as much of this code as possible and simplify the render methods.
+
+        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        {
+            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
+            for (int barIndex = 0; barIndex < Values.Length; barIndex++)
+            {
+                if (Orientation == Orientation.Vertical)
+                    RenderBarVertical(dims, gfx, Positions[barIndex] + XOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
+                else
+                    RenderBarHorizontal(dims, gfx, Positions[barIndex] + XOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
+            }
+        }
+
+        private void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
         {
             float centerPx = Orientation == Orientation.Horizontal
                 ? rect.Y + rect.Height / 2
@@ -199,6 +216,92 @@ namespace ScottPlot.Plottable
             gfx.DrawLine(stemPen, points[0], points[1]);
             MarkerTools.DrawMarker(gfx, points[1], MarkerShape2, DotRadius, Color2);
             MarkerTools.DrawMarker(gfx, points[0], MarkerShape1, DotRadius, Color1); // First point should be drawn overtop the second.
+        }
+
+        private void RenderBarVertical(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
+        {
+            // bar body
+            float centerPx = dims.GetPixelX(position);
+            double edge1 = position - BarWidth / 2;
+            double value1 = Math.Min(ValueBase, value) + yOffset;
+            double value2 = Math.Max(ValueBase, value) + yOffset;
+            double valueSpan = value2 - value1;
+
+            var rect = new RectangleF(
+                x: dims.GetPixelX(edge1),
+                y: dims.GetPixelY(value2),
+                width: (float)(BarWidth * dims.PxPerUnitX),
+                height: (float)(valueSpan * dims.PxPerUnitY));
+
+            // errorbar
+            double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
+            double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
+            float capPx1 = dims.GetPixelX(position - ErrorCapSize * BarWidth / 2);
+            float capPx2 = dims.GetPixelX(position + ErrorCapSize * BarWidth / 2);
+            float errorPx2 = dims.GetPixelY(error2);
+            float errorPx1 = dims.GetPixelY(error1);
+
+            RenderBarFromRect(rect, value < 0, gfx);
+
+            if (ErrorLineWidth > 0 && valueError > 0)
+            {
+                using var errorPen = new Pen(ErrorColor, ErrorLineWidth);
+                gfx.DrawLine(errorPen, centerPx, errorPx1, centerPx, errorPx2);
+                gfx.DrawLine(errorPen, capPx1, errorPx1, capPx2, errorPx1);
+                gfx.DrawLine(errorPen, capPx1, errorPx2, capPx2, errorPx2);
+            }
+
+            if (ShowValuesAboveBars)
+                using (var valueTextFont = GDI.Font(Font))
+                using (var valueTextBrush = GDI.Brush(Font.Color))
+                using (var sf = new StringFormat() { LineAlignment = StringAlignment.Far, Alignment = StringAlignment.Center })
+                    gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, centerPx, rect.Y, sf);
+        }
+
+        private void RenderBarHorizontal(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
+        {
+            // bar body
+            float centerPx = dims.GetPixelY(position);
+            double edge2 = position + BarWidth / 2;
+            double value1 = Math.Min(ValueBase, value) + yOffset;
+            double value2 = Math.Max(ValueBase, value) + yOffset;
+            double valueSpan = value2 - value1;
+            var rect = new RectangleF(
+                x: dims.GetPixelX(value1),
+                y: dims.GetPixelY(edge2),
+                height: (float)(BarWidth * dims.PxPerUnitY),
+                width: (float)(valueSpan * dims.PxPerUnitX));
+
+            RenderBarFromRect(rect, value < 0, gfx);
+
+            // errorbar
+            double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
+            double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
+            float capPx1 = dims.GetPixelY(position - ErrorCapSize * BarWidth / 2);
+            float capPx2 = dims.GetPixelY(position + ErrorCapSize * BarWidth / 2);
+            float errorPx2 = dims.GetPixelX(error2);
+            float errorPx1 = dims.GetPixelX(error1);
+
+            if (ErrorLineWidth > 0 && valueError > 0)
+            {
+                using var errorPen = new Pen(ErrorColor, ErrorLineWidth);
+                gfx.DrawLine(errorPen, errorPx1, centerPx, errorPx2, centerPx);
+                gfx.DrawLine(errorPen, errorPx1, capPx2, errorPx1, capPx1);
+                gfx.DrawLine(errorPen, errorPx2, capPx2, errorPx2, capPx1);
+            }
+
+            if (ShowValuesAboveBars)
+                using (var valueTextFont = GDI.Font(Font))
+                using (var valueTextBrush = GDI.Brush(Font.Color))
+                using (var sf = new StringFormat() { LineAlignment = StringAlignment.Center, Alignment = StringAlignment.Near })
+                    gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, rect.X + rect.Width, centerPx, sf);
+        }
+
+        #endregion
+
+        public void ValidateData(bool deep = false)
+        {
+            // TODO: refactor entire data validation system for all plot types (triaged March 2021)
         }
     }
 }

--- a/src/ScottPlot/Plottable/ClevelandDotPlot.cs
+++ b/src/ScottPlot/Plottable/ClevelandDotPlot.cs
@@ -145,8 +145,8 @@ namespace ScottPlot.Plottable
             positionMin -= BarWidth / 2;
             positionMax += BarWidth / 2;
 
-            positionMin += XOffset;
-            positionMax += XOffset;
+            positionMin += PositionOffset;
+            positionMax += PositionOffset;
 
             return Orientation == Orientation.Vertical ?
                 new AxisLimits(positionMin, positionMax, valueMin, valueMax) :
@@ -186,9 +186,9 @@ namespace ScottPlot.Plottable
             for (int barIndex = 0; barIndex < Values.Length; barIndex++)
             {
                 if (Orientation == Orientation.Vertical)
-                    RenderBarVertical(dims, gfx, Positions[barIndex] + XOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
+                    RenderBarVertical(dims, gfx, Positions[barIndex] + PositionOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
                 else
-                    RenderBarHorizontal(dims, gfx, Positions[barIndex] + XOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
+                    RenderBarHorizontal(dims, gfx, Positions[barIndex] + PositionOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
             }
         }
 

--- a/src/ScottPlot/Plottable/ClevelandDotPlot.cs
+++ b/src/ScottPlot/Plottable/ClevelandDotPlot.cs
@@ -17,6 +17,30 @@ namespace ScottPlot.Plottable
     {
         public Color StemColor = Color.Gray;
         public float DotRadius { get; set; } = 5;
+        public double[] Ys1
+        {
+            get
+            {
+                return YOffsets;
+            }
+            set
+            {
+                YOffsets = value;
+            }
+        }
+
+        public double[] Ys2
+        {
+            get
+            {
+                return Ys.Select((y, i) => y + Ys1[i]).ToArray();
+            }
+            set
+            {
+                Ys = value.Select((y, i) => y - Ys1[i]).ToArray();
+            }
+        }
+
 
         private string Label1;
         private Color Color1 = Color.Green;
@@ -54,8 +78,8 @@ namespace ScottPlot.Plottable
 
         public ClevelandDotPlot(double[] xs, double[] ys1, double[] ys2) : base()
         {
-            this.Ys = ys2.Select((y, i) => y - ys1[i]).ToArray();
-            this.YOffsets = ys1;
+            this.Ys1 = ys1;
+            this.Ys2 = ys2;
             this.Xs = xs;
             this.YErrors = DataGen.Zeros(ys1.Length);
         }

--- a/src/ScottPlot/Plottable/ClevelandDotPlot.cs
+++ b/src/ScottPlot/Plottable/ClevelandDotPlot.cs
@@ -136,8 +136,8 @@ namespace ScottPlot.Plottable
                 positionMax = Math.Max(positionMax, Positions[i]);
             }
 
-            valueMin = Math.Min(valueMin, BaseValue);
-            valueMax = Math.Max(valueMax, BaseValue);
+            valueMin = Math.Min(valueMin, ValueBase);
+            valueMax = Math.Max(valueMax, ValueBase);
 
             if (ShowValuesAboveBars)
                 valueMax += (valueMax - valueMin) * .1; // increase by 10% to accomodate label

--- a/src/ScottPlot/Plottable/ClevelandDotPlot.cs
+++ b/src/ScottPlot/Plottable/ClevelandDotPlot.cs
@@ -32,7 +32,7 @@ namespace ScottPlot.Plottable
         /// <param name="color">The color of the dot, null for no change.</param>
         /// <param name="markerShape">The shape of the dot, null for no change.</param>
         /// <param name="label">The label of the dot in the legend, null for no change</param>
-        public void SetDot1Style(Color? color = null, MarkerShape? markerShape = null, string label = null)
+        public void SetPoint1Style(Color? color = null, MarkerShape? markerShape = null, string label = null)
         {
             Label1 = label ?? Label1;
             MarkerShape1 = markerShape ?? MarkerShape1;
@@ -45,7 +45,7 @@ namespace ScottPlot.Plottable
         /// <param name="color">The color of the dot, null for no change.</param>
         /// <param name="markerShape">The shape of the dot, null for no change.</param>
         /// <param name="label">The label of the dot in the legend, null for no change</param>
-        public void SetDot2Style(Color? color = null, MarkerShape? markerShape = null, string label = null)
+        public void SetPoint2Style(Color? color = null, MarkerShape? markerShape = null, string label = null)
         {
             Label2 = label ?? Label2;
             MarkerShape2 = markerShape ?? MarkerShape2;

--- a/src/ScottPlot/Plottable/ClevelandDotPlot.cs
+++ b/src/ScottPlot/Plottable/ClevelandDotPlot.cs
@@ -1,0 +1,128 @@
+﻿using ScottPlot.Drawing;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Plottable
+{
+    public class ClevelandDotPlot : BarPlotBase
+    {
+        public Color StemColor = Color.Gray;
+        public float DotRadius { get; set; } = 5;
+
+        private string Label1;
+        private Color Color1 = Color.Green;
+        private MarkerShape MarkerShape1 = MarkerShape.filledCircle;
+
+        private string Label2;
+        private Color Color2 = Color.Red;
+        private MarkerShape MarkerShape2 = MarkerShape.filledCircle;
+
+        public void SetDot1Style(Color? color = null, MarkerShape? markerShape = null, string? label = null)
+        {
+            Label1 = label ?? Label1;
+            MarkerShape1 = markerShape ?? MarkerShape1;
+            Color1 = color ?? Color1;
+        }
+
+        public void SetDot2Style(Color? color = null, MarkerShape? markerShape = null, string? label = null)
+        {
+            Label2 = label ?? Label2;
+            MarkerShape2 = markerShape ?? MarkerShape2;
+            Color2 = color ?? Color2;
+        }
+
+        public ClevelandDotPlot(double[] xs, double[] ys1, double[] ys2) : base()
+        {
+            this.Ys = ys2.Select((y, i) => y - ys1[i]).ToArray();
+            this.YOffsets = ys1;
+            this.Xs = xs;
+            this.YErrors = DataGen.Zeros(ys1.Length);
+        }
+
+        public override AxisLimits GetAxisLimits()
+        {
+            double valueMin = double.PositiveInfinity;
+            double valueMax = double.NegativeInfinity;
+            double positionMin = double.PositiveInfinity;
+            double positionMax = double.NegativeInfinity;
+
+            for (int i = 0; i < Xs.Length; i++)
+            {
+                valueMin = new double[] { valueMin, Ys[i] - YErrors[i] + YOffsets[i], YOffsets[i] }.Min();
+                valueMax = new double[] { valueMin, Ys[i] + YErrors[i] + YOffsets[i], YOffsets[i] }.Max();
+                positionMin = Math.Min(positionMin, Xs[i]);
+                positionMax = Math.Max(positionMax, Xs[i]);
+            }
+
+            valueMin = Math.Min(valueMin, BaseValue);
+            valueMax = Math.Max(valueMax, BaseValue);
+
+            if (ShowValuesAboveBars)
+                valueMax += (valueMax - valueMin) * .1; // increase by 10% to accomodate label
+
+            positionMin -= BarWidth / 2;
+            positionMax += BarWidth / 2;
+
+            positionMin += XOffset;
+            positionMax += XOffset;
+
+            return VerticalOrientation ?
+                new AxisLimits(positionMin, positionMax, valueMin, valueMax) :
+                new AxisLimits(valueMin, valueMax, positionMin, positionMax);
+        }
+
+        public override LegendItem[] GetLegendItems()
+        {
+            var firstDot = new LegendItem()
+            {
+                label = Label1,
+                color = Color1,
+                lineStyle = LineStyle.None,
+                markerShape = MarkerShape1,
+                markerSize = 5,
+            };
+            var secondDot = new LegendItem()
+            {
+                label = Label2,
+                color = Color2,
+                lineStyle = LineStyle.None,
+                markerShape = MarkerShape2,
+                markerSize = 5,
+            };
+
+            return new LegendItem[] { firstDot, secondDot };
+        }
+
+        protected override void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
+        {
+            float centerPx = HorizontalOrientation ? rect.Y + rect.Height / 2 : rect.X + rect.Width / 2;
+            using (var stemPen = new Pen(StemColor))
+            {
+                using (var dot1Brush = GDI.Brush(Color1))
+                using (var dot2Brush = GDI.Brush(Color2))
+                {
+                    PointF[] points = new PointF[2];
+                    if (HorizontalOrientation)
+                    {
+                        points[0] = new PointF(negative ? rect.X + rect.Width : rect.X, centerPx - DotRadius / 2);
+                        points[1] = new PointF(negative ? rect.X : rect.X + rect.Width, centerPx - DotRadius / 2);
+                    }
+                    else
+                    {
+                        points[0] = new PointF(centerPx - DotRadius / 2, !negative ? rect.Y + rect.Height : rect.Y);
+                        points[1] = new PointF(centerPx - DotRadius / 2, !negative ? rect.Y : rect.Y + rect.Height);
+                    }
+
+                    gfx.DrawLine(stemPen, points[0], points[1]);
+                    MarkerTools.DrawMarker(gfx, points[1], MarkerShape2, DotRadius, Color2);
+                    MarkerTools.DrawMarker(gfx, points[0], MarkerShape1, DotRadius, Color1); // First point should be drawn overtop the second.
+                }
+
+            }
+        }
+    }
+}

--- a/src/ScottPlot/Plottable/ClevelandDotPlot.cs
+++ b/src/ScottPlot/Plottable/ClevelandDotPlot.cs
@@ -29,14 +29,11 @@ namespace ScottPlot.Plottable
         // that lets the user update one or both arrays. This can also perform length checking.
         public double[] Ys1
         {
-            get
-            {
-                return YOffsets;
-            }
+            get => ValueOffsets;
             set
             {
                 double[] diff = (Ys1 ?? DataGen.Zeros(value.Length)).Zip(value, (y, v) => y - v).ToArray();
-                YOffsets = value;
+                ValueOffsets = value;
 
                 if (Ys2 != null)
                     Ys2 = (Ys2 ?? DataGen.Zeros(value.Length)).Zip(diff, (y, v) => y + v).ToArray();
@@ -47,16 +44,16 @@ namespace ScottPlot.Plottable
         {
             get
             {
-                if (Ys == null)
+                if (Values == null)
                     return null;
 
-                double[] offsets = Ys1 ?? DataGen.Zeros(Ys.Length);
-                return Ys.Select((y, i) => y + offsets[i]).ToArray();
+                double[] offsets = Ys1 ?? DataGen.Zeros(Values.Length);
+                return Values.Select((y, i) => y + offsets[i]).ToArray();
             }
             set
             {
                 double[] offsets = Ys1 ?? DataGen.Zeros(value.Length);
-                Ys = value.Select((y, i) => y - offsets[i]).ToArray();
+                Values = value.Select((y, i) => y - offsets[i]).ToArray();
             }
         }
 
@@ -120,8 +117,8 @@ namespace ScottPlot.Plottable
         {
             Ys1 = ys1;
             Ys2 = ys2;
-            Xs = xs;
-            YErrors = DataGen.Zeros(ys1.Length);
+            Positions = xs;
+            ValueErrors = DataGen.Zeros(ys1.Length);
         }
 
         public override AxisLimits GetAxisLimits()
@@ -131,12 +128,12 @@ namespace ScottPlot.Plottable
             double positionMin = double.PositiveInfinity;
             double positionMax = double.NegativeInfinity;
 
-            for (int i = 0; i < Xs.Length; i++)
+            for (int i = 0; i < Positions.Length; i++)
             {
-                valueMin = new double[] { valueMin, Ys[i] - YErrors[i] + YOffsets[i], YOffsets[i] }.Min();
-                valueMax = new double[] { valueMin, Ys[i] + YErrors[i] + YOffsets[i], YOffsets[i] }.Max();
-                positionMin = Math.Min(positionMin, Xs[i]);
-                positionMax = Math.Max(positionMax, Xs[i]);
+                valueMin = new double[] { valueMin, Values[i] - ValueErrors[i] + ValueOffsets[i], ValueOffsets[i] }.Min();
+                valueMax = new double[] { valueMin, Values[i] + ValueErrors[i] + ValueOffsets[i], ValueOffsets[i] }.Max();
+                positionMin = Math.Min(positionMin, Positions[i]);
+                positionMax = Math.Max(positionMax, Positions[i]);
             }
 
             valueMin = Math.Min(valueMin, BaseValue);

--- a/src/ScottPlot/Plottable/ClevelandDotPlot.cs
+++ b/src/ScottPlot/Plottable/ClevelandDotPlot.cs
@@ -8,6 +8,11 @@ using System.Threading.Tasks;
 
 namespace ScottPlot.Plottable
 {
+    /// <summary>
+    /// Cleveland Dot plots display a series of paired p[oints. 
+    /// Positions are defined by Xs.
+    /// Heights are defined by Ys1 and Ys2 (internally done with Ys and YOffsets).
+    /// </summary>
     public class ClevelandDotPlot : BarPlotBase
     {
         public Color StemColor = Color.Gray;
@@ -21,14 +26,26 @@ namespace ScottPlot.Plottable
         private Color Color2 = Color.Red;
         private MarkerShape MarkerShape2 = MarkerShape.filledCircle;
 
-        public void SetDot1Style(Color? color = null, MarkerShape? markerShape = null, string? label = null)
+        /// <summary>
+        /// Allows customizing the first point (set by ys1)
+        /// </summary>
+        /// <param name="color">The color of the dot, null for no change.</param>
+        /// <param name="markerShape">The shape of the dot, null for no change.</param>
+        /// <param name="label">The label of the dot in the legend, null for no change</param>
+        public void SetDot1Style(Color? color = null, MarkerShape? markerShape = null, string label = null)
         {
             Label1 = label ?? Label1;
             MarkerShape1 = markerShape ?? MarkerShape1;
             Color1 = color ?? Color1;
         }
 
-        public void SetDot2Style(Color? color = null, MarkerShape? markerShape = null, string? label = null)
+        /// <summary>
+        /// Allows customizing the second point (set by ys2)
+        /// </summary>
+        /// <param name="color">The color of the dot, null for no change.</param>
+        /// <param name="markerShape">The shape of the dot, null for no change.</param>
+        /// <param name="label">The label of the dot in the legend, null for no change</param>
+        public void SetDot2Style(Color? color = null, MarkerShape? markerShape = null, string label = null)
         {
             Label2 = label ?? Label2;
             MarkerShape2 = markerShape ?? MarkerShape2;

--- a/src/ScottPlot/Plottable/ClevelandDotPlot.cs
+++ b/src/ScottPlot/Plottable/ClevelandDotPlot.cs
@@ -151,7 +151,7 @@ namespace ScottPlot.Plottable
             positionMin += XOffset;
             positionMax += XOffset;
 
-            return VerticalOrientation ?
+            return Orientation == Orientation.Vertical ?
                 new AxisLimits(positionMin, positionMax, valueMin, valueMax) :
                 new AxisLimits(valueMin, valueMax, positionMin, positionMax);
         }
@@ -180,12 +180,15 @@ namespace ScottPlot.Plottable
 
         protected override void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
         {
-            float centerPx = HorizontalOrientation ? rect.Y + rect.Height / 2 : rect.X + rect.Width / 2;
+            float centerPx = Orientation == Orientation.Horizontal
+                ? rect.Y + rect.Height / 2
+                : rect.X + rect.Width / 2;
+
             using var stemPen = new Pen(StemColor);
             using var dot1Brush = GDI.Brush(Color1);
             using var dot2Brush = GDI.Brush(Color2);
             PointF[] points = new PointF[2];
-            if (HorizontalOrientation)
+            if (Orientation == Orientation.Horizontal)
             {
                 points[0] = new PointF(negative ? rect.X + rect.Width : rect.X, centerPx - DotRadius / 2);
                 points[1] = new PointF(negative ? rect.X : rect.X + rect.Width, centerPx - DotRadius / 2);

--- a/src/ScottPlot/Plottable/ClevelandDotPlot.cs
+++ b/src/ScottPlot/Plottable/ClevelandDotPlot.cs
@@ -15,8 +15,18 @@ namespace ScottPlot.Plottable
     /// </summary>
     public class ClevelandDotPlot : BarPlotBase
     {
+        /// <summary>
+        /// Color for the line
+        /// </summary>
         public Color StemColor = Color.Gray;
+
+        /// <summary>
+        /// Size of the markers at the ends of each line
+        /// </summary>
         public float DotRadius { get; set; } = 5;
+
+        // TODO: don't expose these, instead put them behind an Update() method
+        // that lets the user update one or both arrays. This can also perform length checking.
         public double[] Ys1
         {
             get
@@ -50,13 +60,34 @@ namespace ScottPlot.Plottable
             }
         }
 
-
+        /// <summary>
+        /// Text to display in the legend associated with the series 1 data
+        /// </summary>
         private string Label1;
+
+        /// <summary>
+        /// Color for one of the markers
+        /// </summary>
         private Color Color1 = Color.Green;
+
+        /// <summary>
+        /// Marker to use for the series 1 data
+        /// </summary>
         private MarkerShape MarkerShape1 = MarkerShape.filledCircle;
 
+        /// <summary>
+        /// Text to display in the legend associated with the series 2 data
+        /// </summary>
         private string Label2;
+
+        /// <summary>
+        /// Color for one of the markers
+        /// </summary>
         private Color Color2 = Color.Red;
+
+        /// <summary>
+        /// Marker to use for the series 2 data
+        /// </summary>
         private MarkerShape MarkerShape2 = MarkerShape.filledCircle;
 
         /// <summary>
@@ -87,10 +118,10 @@ namespace ScottPlot.Plottable
 
         public ClevelandDotPlot(double[] xs, double[] ys1, double[] ys2) : base()
         {
-            this.Ys1 = ys1;
-            this.Ys2 = ys2;
-            this.Xs = xs;
-            this.YErrors = DataGen.Zeros(ys1.Length);
+            Ys1 = ys1;
+            Ys2 = ys2;
+            Xs = xs;
+            YErrors = DataGen.Zeros(ys1.Length);
         }
 
         public override AxisLimits GetAxisLimits()
@@ -150,29 +181,24 @@ namespace ScottPlot.Plottable
         protected override void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
         {
             float centerPx = HorizontalOrientation ? rect.Y + rect.Height / 2 : rect.X + rect.Width / 2;
-            using (var stemPen = new Pen(StemColor))
+            using var stemPen = new Pen(StemColor);
+            using var dot1Brush = GDI.Brush(Color1);
+            using var dot2Brush = GDI.Brush(Color2);
+            PointF[] points = new PointF[2];
+            if (HorizontalOrientation)
             {
-                using (var dot1Brush = GDI.Brush(Color1))
-                using (var dot2Brush = GDI.Brush(Color2))
-                {
-                    PointF[] points = new PointF[2];
-                    if (HorizontalOrientation)
-                    {
-                        points[0] = new PointF(negative ? rect.X + rect.Width : rect.X, centerPx - DotRadius / 2);
-                        points[1] = new PointF(negative ? rect.X : rect.X + rect.Width, centerPx - DotRadius / 2);
-                    }
-                    else
-                    {
-                        points[0] = new PointF(centerPx - DotRadius / 2, !negative ? rect.Y + rect.Height : rect.Y);
-                        points[1] = new PointF(centerPx - DotRadius / 2, !negative ? rect.Y : rect.Y + rect.Height);
-                    }
-
-                    gfx.DrawLine(stemPen, points[0], points[1]);
-                    MarkerTools.DrawMarker(gfx, points[1], MarkerShape2, DotRadius, Color2);
-                    MarkerTools.DrawMarker(gfx, points[0], MarkerShape1, DotRadius, Color1); // First point should be drawn overtop the second.
-                }
-
+                points[0] = new PointF(negative ? rect.X + rect.Width : rect.X, centerPx - DotRadius / 2);
+                points[1] = new PointF(negative ? rect.X : rect.X + rect.Width, centerPx - DotRadius / 2);
             }
+            else
+            {
+                points[0] = new PointF(centerPx - DotRadius / 2, !negative ? rect.Y + rect.Height : rect.Y);
+                points[1] = new PointF(centerPx - DotRadius / 2, !negative ? rect.Y : rect.Y + rect.Height);
+            }
+
+            gfx.DrawLine(stemPen, points[0], points[1]);
+            MarkerTools.DrawMarker(gfx, points[1], MarkerShape2, DotRadius, Color2);
+            MarkerTools.DrawMarker(gfx, points[0], MarkerShape1, DotRadius, Color1); // First point should be drawn overtop the second.
         }
     }
 }

--- a/src/ScottPlot/Plottable/LollipopPlot.cs
+++ b/src/ScottPlot/Plottable/LollipopPlot.cs
@@ -8,6 +8,11 @@ using System.Threading.Tasks;
 
 namespace ScottPlot.Plottable
 {
+    /// <summary>
+    /// Lollipop plots display a series of "Lollipops" in place of bars. 
+    /// Positions are defined by Xs.
+    /// Heights are defined by Ys (relative to BaseValue and YOffsets).
+    /// </summary>
     public class LollipopPlot : BarPlotBase
     {
         public string Label { get; set; }

--- a/src/ScottPlot/Plottable/LollipopPlot.cs
+++ b/src/ScottPlot/Plottable/LollipopPlot.cs
@@ -15,19 +15,36 @@ namespace ScottPlot.Plottable
     /// </summary>
     public class LollipopPlot : BarPlotBase
     {
+        /// <summary>
+        /// Name for this series of values that will appear in the legend
+        /// </summary>
         public string Label { get; set; }
+
+        /// <summary>
+        /// Color of all lollipop components (the stick and the circle)
+        /// </summary>
         public Color LollipopColor { get; set; }
+
+        /// <summary>
+        /// Size of the circle at the end of each lollipop
+        /// </summary>
         public float LollipopRadius { get; set; } = 5;
 
-        public LollipopPlot(double[] xs, double[] ys, double[] yErr, double[] yOffsets) : base()
+        /// <summary>
+        /// Create a lollipop plot from arrays of positions and sizes
+        /// </summary>
+        /// <param name="positions">position of each lollipop</param>
+        /// <param name="values">height of each lollipop</param>
+        public LollipopPlot(double[] positions, double[] values) : base()
         {
-            if (ys is null || ys.Length == 0)
-                throw new InvalidOperationException("ys must be an array that contains elements");
+            if (positions is null || positions.Length == 0 || values is null || values.Length == 0)
+                throw new InvalidOperationException("xs and ys must be arrays that contains elements");
 
-            Ys = ys;
-            Xs = xs ?? DataGen.Consecutive(ys.Length);
-            YErrors = yErr ?? DataGen.Zeros(ys.Length);
-            YOffsets = yOffsets ?? DataGen.Zeros(ys.Length);
+            if (values.Length != positions.Length)
+                throw new InvalidOperationException("xs and ys must have the same number of elements");
+
+            Ys = values;
+            Xs = positions ?? DataGen.Consecutive(values.Length);
         }
 
         public override LegendItem[] GetLegendItems()
@@ -38,8 +55,6 @@ namespace ScottPlot.Plottable
                 color = LollipopColor,
                 lineWidth = 10,
                 markerShape = MarkerShape.none,
-                //hatchColor = FillColorHatch,
-                //hatchStyle = HatchStyle,
                 borderColor = BorderColor,
                 borderWith = 1
             };
@@ -49,20 +64,18 @@ namespace ScottPlot.Plottable
         protected override void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
         {
             float centerPx = HorizontalOrientation ? rect.Y + rect.Height / 2 : rect.X + rect.Width / 2;
-            using (var fillPen = new Pen(LollipopColor))
-            using (var fillBrush = GDI.Brush(LollipopColor))
-            {
+            using var fillPen = new Pen(LollipopColor);
+            using var fillBrush = GDI.Brush(LollipopColor);
 
-                if (HorizontalOrientation)
-                {
-                    gfx.FillEllipse(fillBrush, negative ? rect.X : rect.X + rect.Width, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
-                    gfx.DrawLine(fillPen, rect.X, centerPx, rect.X + rect.Width, centerPx);
-                }
-                else
-                {
-                    gfx.FillEllipse(fillBrush, centerPx - LollipopRadius / 2, !negative ? rect.Y : rect.Y + rect.Height, LollipopRadius, LollipopRadius);
-                    gfx.DrawLine(fillPen, centerPx, rect.Y, centerPx, rect.Y + rect.Height);
-                }
+            if (HorizontalOrientation)
+            {
+                gfx.FillEllipse(fillBrush, negative ? rect.X : rect.X + rect.Width, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
+                gfx.DrawLine(fillPen, rect.X, centerPx, rect.X + rect.Width, centerPx);
+            }
+            else
+            {
+                gfx.FillEllipse(fillBrush, centerPx - LollipopRadius / 2, !negative ? rect.Y : rect.Y + rect.Height, LollipopRadius, LollipopRadius);
+                gfx.DrawLine(fillPen, centerPx, rect.Y, centerPx, rect.Y + rect.Height);
             }
         }
     }

--- a/src/ScottPlot/Plottable/LollipopPlot.cs
+++ b/src/ScottPlot/Plottable/LollipopPlot.cs
@@ -1,0 +1,64 @@
+﻿using ScottPlot.Drawing;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Plottable
+{
+    public class LollipopPlot : BarPlotBase
+    {
+        public string Label { get; set; }
+        public Color LollipopColor { get; set; }
+        public float LollipopRadius { get; set; } = 5;
+
+        public LollipopPlot(double[] xs, double[] ys, double[] yErr, double[] yOffsets) : base()
+        {
+            if (ys is null || ys.Length == 0)
+                throw new InvalidOperationException("ys must be an array that contains elements");
+
+            Ys = ys;
+            Xs = xs ?? DataGen.Consecutive(ys.Length);
+            YErrors = yErr ?? DataGen.Zeros(ys.Length);
+            YOffsets = yOffsets ?? DataGen.Zeros(ys.Length);
+        }
+
+        public override LegendItem[] GetLegendItems()
+        {
+            var singleItem = new LegendItem()
+            {
+                label = Label,
+                color = LollipopColor,
+                lineWidth = 10,
+                markerShape = MarkerShape.none,
+                //hatchColor = FillColorHatch,
+                //hatchStyle = HatchStyle,
+                borderColor = BorderColor,
+                borderWith = 1
+            };
+            return new LegendItem[] { singleItem };
+        }
+
+        protected override void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
+        {
+            float centerPx = HorizontalOrientation ? rect.Y + rect.Height / 2 : rect.X + rect.Width / 2;
+            using (var fillPen = new Pen(LollipopColor))
+            using (var fillBrush = GDI.Brush(LollipopColor))
+            {
+
+                if (HorizontalOrientation)
+                {
+                    gfx.FillEllipse(fillBrush, negative ? rect.X : rect.X + rect.Width, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
+                    gfx.DrawLine(fillPen, rect.X, centerPx, rect.X + rect.Width, centerPx);
+                }
+                else
+                {
+                    gfx.FillEllipse(fillBrush, centerPx - LollipopRadius / 2, !negative ? rect.Y : rect.Y + rect.Height, LollipopRadius, LollipopRadius);
+                    gfx.DrawLine(fillPen, centerPx, rect.Y, centerPx, rect.Y + rect.Height);
+                }
+            }
+        }
+    }
+}

--- a/src/ScottPlot/Plottable/LollipopPlot.cs
+++ b/src/ScottPlot/Plottable/LollipopPlot.cs
@@ -65,11 +65,14 @@ namespace ScottPlot.Plottable
 
         protected override void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
         {
-            float centerPx = HorizontalOrientation ? rect.Y + rect.Height / 2 : rect.X + rect.Width / 2;
+            float centerPx = Orientation == Orientation.Horizontal
+                ? rect.Y + rect.Height / 2
+                : rect.X + rect.Width / 2;
+
             using var fillPen = new Pen(LollipopColor);
             using var fillBrush = GDI.Brush(LollipopColor);
 
-            if (HorizontalOrientation)
+            if (Orientation == Orientation.Horizontal)
             {
                 gfx.FillEllipse(fillBrush, negative ? rect.X : rect.X + rect.Width, centerPx - LollipopRadius / 2, LollipopRadius, LollipopRadius);
                 gfx.DrawLine(fillPen, rect.X, centerPx, rect.X + rect.Width, centerPx);

--- a/src/ScottPlot/Plottable/LollipopPlot.cs
+++ b/src/ScottPlot/Plottable/LollipopPlot.cs
@@ -43,6 +43,8 @@ namespace ScottPlot.Plottable
             if (values.Length != positions.Length)
                 throw new InvalidOperationException("xs and ys must have the same number of elements");
 
+            YErrors = DataGen.Zeros(values.Length);
+            YOffsets = DataGen.Zeros(values.Length);
             Ys = values;
             Xs = positions ?? DataGen.Consecutive(values.Length);
         }

--- a/src/ScottPlot/Plottable/LollipopPlot.cs
+++ b/src/ScottPlot/Plottable/LollipopPlot.cs
@@ -43,10 +43,10 @@ namespace ScottPlot.Plottable
             if (values.Length != positions.Length)
                 throw new InvalidOperationException("xs and ys must have the same number of elements");
 
-            YErrors = DataGen.Zeros(values.Length);
-            YOffsets = DataGen.Zeros(values.Length);
-            Ys = values;
-            Xs = positions ?? DataGen.Consecutive(values.Length);
+            ValueErrors = DataGen.Zeros(values.Length);
+            ValueOffsets = DataGen.Zeros(values.Length);
+            Values = values;
+            Positions = positions ?? DataGen.Consecutive(values.Length);
         }
 
         public override LegendItem[] GetLegendItems()

--- a/src/ScottPlot/Plottable/LollipopPlot.cs
+++ b/src/ScottPlot/Plottable/LollipopPlot.cs
@@ -13,7 +13,7 @@ namespace ScottPlot.Plottable
     /// Positions are defined by Xs.
     /// Heights are defined by Ys (relative to BaseValue and YOffsets).
     /// </summary>
-    public class LollipopPlot : BarPlotBase
+    public class LollipopPlot : BarPlotBase, IPlottable
     {
         /// <summary>
         /// Name for this series of values that will appear in the legend
@@ -49,7 +49,7 @@ namespace ScottPlot.Plottable
             Positions = positions ?? DataGen.Consecutive(values.Length);
         }
 
-        public override LegendItem[] GetLegendItems()
+        public LegendItem[] GetLegendItems()
         {
             var singleItem = new LegendItem()
             {
@@ -63,7 +63,24 @@ namespace ScottPlot.Plottable
             return new LegendItem[] { singleItem };
         }
 
-        protected override void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
+        #region Render Implementation
+
+        // NOTE: These render methods contains a lot of code and complexity not required to render this plot type.
+        // TODO: Delete as much of this code as possible and simplify the render methods.
+
+        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        {
+            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
+            for (int barIndex = 0; barIndex < Values.Length; barIndex++)
+            {
+                if (Orientation == Orientation.Vertical)
+                    RenderBarVertical(dims, gfx, Positions[barIndex] + XOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
+                else
+                    RenderBarHorizontal(dims, gfx, Positions[barIndex] + XOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
+            }
+        }
+
+        private void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)
         {
             float centerPx = Orientation == Orientation.Horizontal
                 ? rect.Y + rect.Height / 2
@@ -82,6 +99,92 @@ namespace ScottPlot.Plottable
                 gfx.FillEllipse(fillBrush, centerPx - LollipopRadius / 2, !negative ? rect.Y : rect.Y + rect.Height, LollipopRadius, LollipopRadius);
                 gfx.DrawLine(fillPen, centerPx, rect.Y, centerPx, rect.Y + rect.Height);
             }
+        }
+
+        private void RenderBarVertical(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
+        {
+            // bar body
+            float centerPx = dims.GetPixelX(position);
+            double edge1 = position - BarWidth / 2;
+            double value1 = Math.Min(ValueBase, value) + yOffset;
+            double value2 = Math.Max(ValueBase, value) + yOffset;
+            double valueSpan = value2 - value1;
+
+            var rect = new RectangleF(
+                x: dims.GetPixelX(edge1),
+                y: dims.GetPixelY(value2),
+                width: (float)(BarWidth * dims.PxPerUnitX),
+                height: (float)(valueSpan * dims.PxPerUnitY));
+
+            // errorbar
+            double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
+            double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
+            float capPx1 = dims.GetPixelX(position - ErrorCapSize * BarWidth / 2);
+            float capPx2 = dims.GetPixelX(position + ErrorCapSize * BarWidth / 2);
+            float errorPx2 = dims.GetPixelY(error2);
+            float errorPx1 = dims.GetPixelY(error1);
+
+            RenderBarFromRect(rect, value < 0, gfx);
+
+            if (ErrorLineWidth > 0 && valueError > 0)
+            {
+                using var errorPen = new Pen(ErrorColor, ErrorLineWidth);
+                gfx.DrawLine(errorPen, centerPx, errorPx1, centerPx, errorPx2);
+                gfx.DrawLine(errorPen, capPx1, errorPx1, capPx2, errorPx1);
+                gfx.DrawLine(errorPen, capPx1, errorPx2, capPx2, errorPx2);
+            }
+
+            if (ShowValuesAboveBars)
+                using (var valueTextFont = GDI.Font(Font))
+                using (var valueTextBrush = GDI.Brush(Font.Color))
+                using (var sf = new StringFormat() { LineAlignment = StringAlignment.Far, Alignment = StringAlignment.Center })
+                    gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, centerPx, rect.Y, sf);
+        }
+
+        private void RenderBarHorizontal(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
+        {
+            // bar body
+            float centerPx = dims.GetPixelY(position);
+            double edge2 = position + BarWidth / 2;
+            double value1 = Math.Min(ValueBase, value) + yOffset;
+            double value2 = Math.Max(ValueBase, value) + yOffset;
+            double valueSpan = value2 - value1;
+            var rect = new RectangleF(
+                x: dims.GetPixelX(value1),
+                y: dims.GetPixelY(edge2),
+                height: (float)(BarWidth * dims.PxPerUnitY),
+                width: (float)(valueSpan * dims.PxPerUnitX));
+
+            RenderBarFromRect(rect, value < 0, gfx);
+
+            // errorbar
+            double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
+            double error2 = value > 0 ? value2 + Math.Abs(valueError) : value1 + Math.Abs(valueError);
+            float capPx1 = dims.GetPixelY(position - ErrorCapSize * BarWidth / 2);
+            float capPx2 = dims.GetPixelY(position + ErrorCapSize * BarWidth / 2);
+            float errorPx2 = dims.GetPixelX(error2);
+            float errorPx1 = dims.GetPixelX(error1);
+
+            if (ErrorLineWidth > 0 && valueError > 0)
+            {
+                using var errorPen = new Pen(ErrorColor, ErrorLineWidth);
+                gfx.DrawLine(errorPen, errorPx1, centerPx, errorPx2, centerPx);
+                gfx.DrawLine(errorPen, errorPx1, capPx2, errorPx1, capPx1);
+                gfx.DrawLine(errorPen, errorPx2, capPx2, errorPx2, capPx1);
+            }
+
+            if (ShowValuesAboveBars)
+                using (var valueTextFont = GDI.Font(Font))
+                using (var valueTextBrush = GDI.Brush(Font.Color))
+                using (var sf = new StringFormat() { LineAlignment = StringAlignment.Center, Alignment = StringAlignment.Near })
+                    gfx.DrawString(value.ToString(), valueTextFont, valueTextBrush, rect.X + rect.Width, centerPx, sf);
+        }
+
+        #endregion
+
+        public void ValidateData(bool deep = false)
+        {
+            // TODO: refactor entire data validation system for all plot types (triaged March 2021)
         }
     }
 }

--- a/src/ScottPlot/Plottable/LollipopPlot.cs
+++ b/src/ScottPlot/Plottable/LollipopPlot.cs
@@ -74,9 +74,9 @@ namespace ScottPlot.Plottable
             for (int barIndex = 0; barIndex < Values.Length; barIndex++)
             {
                 if (Orientation == Orientation.Vertical)
-                    RenderBarVertical(dims, gfx, Positions[barIndex] + XOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
+                    RenderBarVertical(dims, gfx, Positions[barIndex] + PositionOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
                 else
-                    RenderBarHorizontal(dims, gfx, Positions[barIndex] + XOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
+                    RenderBarHorizontal(dims, gfx, Positions[barIndex] + PositionOffset, Values[barIndex], ValueErrors[barIndex], ValueOffsets[barIndex]);
             }
         }
 

--- a/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
+++ b/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
@@ -98,7 +98,7 @@ namespace ScottPlot
             if (isDesignerMode)
             {
                 MainGrid.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#003366"));
-                var sp = new StackPanel() { Orientation = Orientation.Horizontal };
+                var sp = new StackPanel() { Orientation = System.Windows.Controls.Orientation.Horizontal };
                 sp.Children.Add(new Label() { Content = "ScottPlot", Foreground = Brushes.White });
                 sp.Children.Add(new Label() { Content = ScottPlot.Plot.Version, Foreground = Brushes.White });
                 MainGrid.Children.Add(sp);

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
@@ -323,6 +323,10 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             bar.DisplayStyle = BarStyle.ClevelandDot;
             plt.XAxis.ManualTickPositions(label_positions, labels);
             plt.Title("British Premier League Champion Home vs Away Wins");
+
+            bar.ClevelandLabel1 = "Home Wins";
+            bar.ClevelandLabel2 = "Away Wins";
+            plt.Legend();
         }
     }
 }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
@@ -200,7 +200,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         {
             // generate random data to plot
             int groupCount = 5;
-            Random rand = new Random(0);
+            Random rand = new(0);
             double[] values1 = DataGen.RandomNormal(rand, groupCount, 20, 5);
             double[] values2 = DataGen.RandomNormal(rand, groupCount, 20, 5);
             double[] values3 = DataGen.RandomNormal(rand, groupCount, 20, 5);
@@ -289,15 +289,33 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
     {
         public string Category => "Plottable: Bar Graph";
         public string ID => "bar_lollipop";
-        public string Title => "Lollipop Plot";
-        public string Description => "Lollipop plots convey the same information as Bar plots but have a different appearance.";
+        public string Title => "Lollipop Plot Quickstart";
+        public string Description =>
+            "Lollipop plots convey the same information as Bar plots but have a different appearance.";
 
         public void ExecuteRecipe(Plot plt)
         {
             double[] values = { 26, 20, 23, 7, 16 };
+            plt.AddLollipop(values);
+        }
+    }
 
+    public class BarLollipopCustom : IRecipe
+    {
+        public string Category => "Plottable: Bar Graph";
+        public string ID => "bar_lollipop_custom";
+        public string Title => "Lollipop Plot Customizations";
+        public string Description => "Lollipop plots can be extensively customized.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[] values = { 26, 20, 23, 7, 16 };
             var lollipop = plt.AddLollipop(values);
             lollipop.HorizontalOrientation = true;
+            lollipop.LollipopRadius = 3;
+            lollipop.BorderColor = Color.Green;
+            lollipop.LollipopColor = Color.Blue;
+            lollipop.LollipopRadius = 10;
         }
     }
 
@@ -306,23 +324,22 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string Category => "Plottable: Bar Graph";
         public string ID => "bar_cleveland_dot";
         public string Title => "Cleveland Dot Plot";
-        public string Description => "Cleveland Dot Plots allow comparing two categories in situations where a Bar Plot may be crowded.";
+        public string Description =>
+            "Cleveland Dot Plots allow comparing two categories in situations where a Bar Plot may be crowded.";
 
         public void ExecuteRecipe(Plot plt)
         {
-            double[] home_wins = { 12, 17, 16, 18, 18 }; // Data collected from https://footystats.org/england/premier-league/home-away-league-table
-            double[] away_wins = { 11, 13, 16, 14, 14 };
-
+            // Data from https://footystats.org/england/premier-league/home-away-league-table
+            double[] homeWins = { 12, 17, 16, 18, 18 };
+            double[] awayWins = { 11, 13, 16, 14, 14 };
             string[] labels = { "2015/16", "2016/17", "2017/18", "2018/19", "2019/20" };
-            double[] label_positions = Enumerable.Range(0, labels.Length).Select(i => (double)i).ToArray();
 
-            var clevelandDot = plt.AddClevelandDot(home_wins, away_wins);
-            plt.XAxis.ManualTickPositions(label_positions, labels);
-            plt.Title("British Premier League Champion Home vs Away Wins");
-
+            var clevelandDot = plt.AddClevelandDot(homeWins, awayWins);
             clevelandDot.SetPoint1Style(label: "Home Wins");
             clevelandDot.SetPoint2Style(label: "Away Wins", markerShape: MarkerShape.triUp);
 
+            plt.XTicks(labels);
+            plt.Title("British Premier League Champion Home vs Away Wins");
             plt.Legend();
         }
     }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
@@ -71,7 +71,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
 
             // add errorbars to the bar graph and customize styling as desired
             double[] errors = { 3, 2, 5, 1, 3 };
-            bar.YErrors = errors;
+            bar.ValueErrors = errors;
             bar.ErrorCapSize = .1;
 
             // adjust axis limits so there is no padding below the bar graph
@@ -239,7 +239,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             double[] yOffsets = { -100, -100, -100, -100, -100 };
 
             var bar = plt.AddBar(values);
-            bar.YOffsets = yOffsets;
+            bar.ValueOffsets = yOffsets;
 
             // adjust axis limits so there is no padding below the bar graph
             plt.SetAxisLimits(yMin: -100);
@@ -279,7 +279,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             double[] offsets = Enumerable.Range(0, values.Length).Select(x => values.Take(x).Sum()).ToArray();
 
             var bar = plt.AddBar(values);
-            bar.YOffsets = offsets;
+            bar.ValueOffsets = offsets;
             bar.FillColorNegative = Color.Red;
             bar.FillColor = Color.Green;
         }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
@@ -301,4 +301,28 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             bar.HorizontalOrientation = true;
         }
     }
+
+    public class ClevelandDot : IRecipe
+    {
+        public string Category => "Plottable: Bar Graph";
+        public string ID => "bar_cleveland_dot";
+        public string Title => "Cleveland Dot Plot";
+        public string Description => "Cleveland Dot Plots allow comparing two categories in situations where a Bar Plot may be crowded.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[] home_wins = { 12, 17, 16, 18, 18}; // Data collected from https://footystats.org/england/premier-league/home-away-league-table
+            double[] away_wins = { 11, 13, 16, 14, 14};
+            away_wins = away_wins.Select((y, i) => y - home_wins[i]).ToArray(); // y2 should be absolute, not in terms of its distance from y1
+
+            string[] labels = { "2015/16", "2016/17", "2017/18", "2018/19", "2019/20" };
+            double[] label_positions = Enumerable.Range(0, labels.Length).Select(i => (double)i).ToArray();
+
+            var bar = plt.AddBar(away_wins);
+            bar.YOffsets = home_wins;
+            bar.DisplayStyle = BarStyle.ClevelandDot;
+            plt.XAxis.ManualTickPositions(label_positions, labels);
+            plt.Title("British Premier League Champion Home vs Away Wins");
+        }
+    }
 }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ScottPlot.Plottable;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -281,6 +282,23 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             bar.YOffsets = offsets;
             bar.FillColorNegative = Color.Red;
             bar.FillColor = Color.Green;
+        }
+    }
+
+    public class BarLollipop : IRecipe
+    {
+        public string Category => "Plottable: Bar Graph";
+        public string ID => "bar_lollipop";
+        public string Title => "Lollipop Plot";
+        public string Description => "Lollipop plots convey the same information as Bar plots but have a different appearance.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[] values = { 26, 20, 23, 7, 16 };
+
+            var bar = plt.AddBar(values);
+            bar.DisplayStyle = BarStyle.Lollipop;
+            bar.HorizontalOrientation = true;
         }
     }
 }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
@@ -179,7 +179,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
 
             // add a bar graph to the plot and customize it to render horizontally
             var bar = plt.AddBar(values, errors, positions);
-            bar.VerticalOrientation = false;
+            bar.Orientation = Orientation.Horizontal;
 
             // adjust axis limits so there is no padding to the left of the bar graph
             plt.SetAxisLimits(xMin: 0);
@@ -311,7 +311,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         {
             double[] values = { 26, 20, 23, 7, 16 };
             var lollipop = plt.AddLollipop(values);
-            lollipop.HorizontalOrientation = true;
+            lollipop.Orientation = Orientation.Horizontal;
             lollipop.LollipopRadius = 3;
             lollipop.BorderColor = Color.Green;
             lollipop.LollipopColor = Color.Blue;

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
@@ -320,8 +320,8 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             plt.XAxis.ManualTickPositions(label_positions, labels);
             plt.Title("British Premier League Champion Home vs Away Wins");
 
-            clevelandDot.SetDot1Style(label: "Home Wins");
-            clevelandDot.SetDot2Style(label: "Away Wins", markerShape: MarkerShape.triUp);
+            clevelandDot.SetPoint1Style(label: "Home Wins");
+            clevelandDot.SetPoint2Style(label: "Away Wins", markerShape: MarkerShape.triUp);
 
             plt.Legend();
         }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
@@ -296,9 +296,8 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         {
             double[] values = { 26, 20, 23, 7, 16 };
 
-            var bar = plt.AddBar(values);
-            bar.DisplayStyle = BarStyle.Lollipop;
-            bar.HorizontalOrientation = true;
+            var lollipop = plt.AddLollipop(values);
+            lollipop.HorizontalOrientation = true;
         }
     }
 
@@ -313,19 +312,17 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         {
             double[] home_wins = { 12, 17, 16, 18, 18 }; // Data collected from https://footystats.org/england/premier-league/home-away-league-table
             double[] away_wins = { 11, 13, 16, 14, 14 };
-            away_wins = away_wins.Select((y, i) => y - home_wins[i]).ToArray(); // y2 should be absolute, not in terms of its distance from y1
 
             string[] labels = { "2015/16", "2016/17", "2017/18", "2018/19", "2019/20" };
             double[] label_positions = Enumerable.Range(0, labels.Length).Select(i => (double)i).ToArray();
 
-            var bar = plt.AddBar(away_wins);
-            bar.YOffsets = home_wins;
-            bar.DisplayStyle = BarStyle.ClevelandDot;
+            var clevelandDot = plt.AddClevelandDot(home_wins, away_wins);
             plt.XAxis.ManualTickPositions(label_positions, labels);
             plt.Title("British Premier League Champion Home vs Away Wins");
 
-            bar.ClevelandLabel1 = "Home Wins";
-            bar.ClevelandLabel2 = "Away Wins";
+            clevelandDot.SetDot1Style(label: "Home Wins");
+            clevelandDot.SetDot2Style(label: "Away Wins", markerShape: MarkerShape.triUp);
+
             plt.Legend();
         }
     }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Bar.cs
@@ -311,8 +311,8 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
 
         public void ExecuteRecipe(Plot plt)
         {
-            double[] home_wins = { 12, 17, 16, 18, 18}; // Data collected from https://footystats.org/england/premier-league/home-away-league-table
-            double[] away_wins = { 11, 13, 16, 14, 14};
+            double[] home_wins = { 12, 17, 16, 18, 18 }; // Data collected from https://footystats.org/england/premier-league/home-away-league-table
+            double[] away_wins = { 11, 13, 16, 14, 14 };
             away_wins = away_wins.Select((y, i) => y - home_wins[i]).ToArray(); // y2 should be absolute, not in terms of its distance from y1
 
             string[] labels = { "2015/16", "2016/17", "2017/18", "2018/19", "2019/20" };

--- a/src/tests/PlotTypes/Bar.cs
+++ b/src/tests/PlotTypes/Bar.cs
@@ -96,7 +96,7 @@ namespace ScottPlotTests.PlotTypes
             var plt = new ScottPlot.Plot(400, 300);
 
             var bar1 = plt.AddBar(xs, ys1);
-            bar1.XOffset = -.20;
+            bar1.PositionOffset = -.20;
             bar1.BarWidth = .3;
             bar1.ShowValuesAboveBars = true;
             bar1.Orientation = ScottPlot.Orientation.Horizontal;
@@ -104,7 +104,7 @@ namespace ScottPlotTests.PlotTypes
 
             plt.AddBar(xs, ys2);
             var bar2 = plt.AddBar(xs, ys2);
-            bar2.XOffset = +.20;
+            bar2.PositionOffset = +.20;
             bar2.BarWidth = 0.3;
             bar2.ShowValuesAboveBars = true;
             bar2.Label = "Series B";
@@ -168,7 +168,7 @@ namespace ScottPlotTests.PlotTypes
             var plt = new ScottPlot.Plot(400, 300);
 
             var bar1 = plt.AddBar(xs, ys1);
-            bar1.XOffset = -.20;
+            bar1.PositionOffset = -.20;
             bar1.BarWidth = .3;
             bar1.ShowValuesAboveBars = true;
             bar1.Orientation = ScottPlot.Orientation.Horizontal;
@@ -176,7 +176,7 @@ namespace ScottPlotTests.PlotTypes
 
             plt.AddBar(xs, ys2);
             var bar2 = plt.AddBar(xs, ys2);
-            bar2.XOffset = +.20;
+            bar2.PositionOffset = +.20;
             bar2.BarWidth = 0.3;
             bar2.ShowValuesAboveBars = true;
             bar2.Label = "Series B";
@@ -199,7 +199,7 @@ namespace ScottPlotTests.PlotTypes
             var plt = new ScottPlot.Plot(400, 300);
 
             var bar1 = plt.AddBar(xs, ys1);
-            bar1.XOffset = -.20;
+            bar1.PositionOffset = -.20;
             bar1.BarWidth = .3;
             bar1.ShowValuesAboveBars = true;
             bar1.Orientation = ScottPlot.Orientation.Horizontal;
@@ -207,7 +207,7 @@ namespace ScottPlotTests.PlotTypes
 
             plt.AddBar(xs, ys2);
             var bar2 = plt.AddBar(xs, ys2);
-            bar2.XOffset = +.20;
+            bar2.PositionOffset = +.20;
             bar2.BarWidth = 0.3;
             bar2.ShowValuesAboveBars = true;
             bar2.Label = "Series B";

--- a/src/tests/PlotTypes/Bar.cs
+++ b/src/tests/PlotTypes/Bar.cs
@@ -99,7 +99,7 @@ namespace ScottPlotTests.PlotTypes
             bar1.XOffset = -.20;
             bar1.BarWidth = .3;
             bar1.ShowValuesAboveBars = true;
-            bar1.HorizontalOrientation = true;
+            bar1.Orientation = ScottPlot.Orientation.Horizontal;
             bar1.Label = "Series A";
 
             plt.AddBar(xs, ys2);
@@ -108,7 +108,7 @@ namespace ScottPlotTests.PlotTypes
             bar2.BarWidth = 0.3;
             bar2.ShowValuesAboveBars = true;
             bar2.Label = "Series B";
-            bar2.HorizontalOrientation = true;
+            bar2.Orientation = ScottPlot.Orientation.Horizontal;
 
             plt.Grid(lineStyle: ScottPlot.LineStyle.Dot);
             plt.XAxis.Grid(false);
@@ -125,7 +125,7 @@ namespace ScottPlotTests.PlotTypes
 
             var plt = new ScottPlot.Plot(400, 300);
             var bar = plt.AddBar(xs, ys, yErr);
-            bar.HorizontalOrientation = true;
+            bar.Orientation = ScottPlot.Orientation.Horizontal;
             plt.Grid(lineStyle: ScottPlot.LineStyle.Dot);
             TestTools.SaveFig(plt);
         }
@@ -171,7 +171,7 @@ namespace ScottPlotTests.PlotTypes
             bar1.XOffset = -.20;
             bar1.BarWidth = .3;
             bar1.ShowValuesAboveBars = true;
-            bar1.HorizontalOrientation = true;
+            bar1.Orientation = ScottPlot.Orientation.Horizontal;
             bar1.Label = "Series A";
 
             plt.AddBar(xs, ys2);
@@ -180,7 +180,7 @@ namespace ScottPlotTests.PlotTypes
             bar2.BarWidth = 0.3;
             bar2.ShowValuesAboveBars = true;
             bar2.Label = "Series B";
-            bar2.HorizontalOrientation = true;
+            bar2.Orientation = ScottPlot.Orientation.Horizontal;
 
             plt.Grid(lineStyle: ScottPlot.LineStyle.Dot);
             plt.XAxis.Grid(false);
@@ -202,7 +202,7 @@ namespace ScottPlotTests.PlotTypes
             bar1.XOffset = -.20;
             bar1.BarWidth = .3;
             bar1.ShowValuesAboveBars = true;
-            bar1.HorizontalOrientation = true;
+            bar1.Orientation = ScottPlot.Orientation.Horizontal;
             bar1.Label = "Series A";
 
             plt.AddBar(xs, ys2);
@@ -211,7 +211,7 @@ namespace ScottPlotTests.PlotTypes
             bar2.BarWidth = 0.3;
             bar2.ShowValuesAboveBars = true;
             bar2.Label = "Series B";
-            bar2.HorizontalOrientation = true;
+            bar2.Orientation = ScottPlot.Orientation.Horizontal;
 
             plt.Grid(lineStyle: ScottPlot.LineStyle.Dot);
             plt.XAxis.Grid(false);

--- a/src/tests/PlottableRenderTests/Bar.cs
+++ b/src/tests/PlottableRenderTests/Bar.cs
@@ -20,7 +20,7 @@ namespace ScottPlotTests.PlottableRenderTests
             var bmp1 = TestTools.GetLowQualityBitmap(plt);
 
             // change the plottable
-            bar.Ys[0] += 1;
+            bar.Values[0] += 1;
             var bmp2 = TestTools.GetLowQualityBitmap(plt);
 
             // measure what changed
@@ -48,7 +48,7 @@ namespace ScottPlotTests.PlottableRenderTests
             var bmp1 = TestTools.GetLowQualityBitmap(plt);
 
             // change the plottable
-            bar.YErrors[0] = .25;
+            bar.ValueErrors[0] = .25;
             var bmp2 = TestTools.GetLowQualityBitmap(plt);
 
             // measure what changed


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
#817 

**New Functionality:**
So far this only adds Lollipop plots because I'm still working on it.

I'm also unsure whether dot plots are worth the effort, dot plots offer no benefit compared to bar plots that I know of other than being easy to draw with typewriters or ASCII art. And adding dot plot support looks like it would be non-trivial if one wants to minimize the number of fractional dots drawn. If someone has a compelling use case I can come back to them.

### Lollipop
```cs
double[] values = { 26, 20, 23, 7, 16 };

var bar = plt.AddBar(values);
bar.DisplayStyle = BarStyle.Lollipop;
bar.HorizontalOrientation = true;
```

![image](https://user-images.githubusercontent.com/8635304/109433872-ced21e00-79cf-11eb-9bf8-8e2729e743c2.png)