### PR TITLE
Custom pie chart slice and label colors

### DIFF
--- a/src/ScottPlot/Plottable/PiePlot.cs
+++ b/src/ScottPlot/Plottable/PiePlot.cs
@@ -17,6 +17,7 @@ namespace ScottPlot.Plottable
         public string[] SliceLabels;
 
         public Color[] SliceFillColors;
+        public Color[] SliceLabelColors;
         public Color BackgroundColor;
 
         public bool Explode;
@@ -86,7 +87,7 @@ namespace ScottPlot.Plottable
             using (Pen outlinePen = GDI.Pen(OutlineColor, OutlineSize))
             using (Brush sliceFillBrush = GDI.Brush(Color.Black))
             using (var sliceFont = GDI.Font(SliceFont))
-            using (Brush sliceFontBrush = GDI.Brush(SliceFont.Color))
+            using (SolidBrush sliceFontBrush = (SolidBrush)GDI.Brush(SliceFont.Color))
             using (var centerFont = GDI.Font(CenterFont))
             using (Brush centerFontBrush = GDI.Brush(CenterFont.Color))
             using (StringFormat sfCenter = new StringFormat() { LineAlignment = StringAlignment.Center, Alignment = StringAlignment.Center })
@@ -166,7 +167,10 @@ namespace ScottPlot.Plottable
 
                 for (int i = 0; i < Values.Length; i++)
                     if (!string.IsNullOrWhiteSpace(labelStrings[i]))
+                    {
+                        sliceFontBrush.Color = SliceLabelColors is null ? SliceFont.Color : SliceLabelColors[i];
                         gfx.DrawString(labelStrings[i], sliceFont, sliceFontBrush, (float)labelXs[i], (float)labelYs[i], sfCenter);
+                    }
 
                 if (OutlineSize > 0)
                     gfx.DrawEllipse(

--- a/src/ScottPlot/Plottable/PiePlot.cs
+++ b/src/ScottPlot/Plottable/PiePlot.cs
@@ -165,10 +165,12 @@ namespace ScottPlot.Plottable
                     start += sweep;
                 }
 
+                bool useCustomLabelColors = SliceLabelColors is not null && SliceLabelColors.Length == Values.Length;
+
                 for (int i = 0; i < Values.Length; i++)
                     if (!string.IsNullOrWhiteSpace(labelStrings[i]))
                     {
-                        if (SliceLabelColors is not null && SliceLabelColors.Length == Values.Length)
+                        if (useCustomLabelColors)
                             sliceFontBrush.Color = SliceLabelColors[i];
 
                         gfx.DrawString(labelStrings[i], sliceFont, sliceFontBrush, (float)labelXs[i], (float)labelYs[i], sfCenter);

--- a/src/ScottPlot/Plottable/PiePlot.cs
+++ b/src/ScottPlot/Plottable/PiePlot.cs
@@ -168,7 +168,9 @@ namespace ScottPlot.Plottable
                 for (int i = 0; i < Values.Length; i++)
                     if (!string.IsNullOrWhiteSpace(labelStrings[i]))
                     {
-                        sliceFontBrush.Color = SliceLabelColors is null ? SliceFont.Color : SliceLabelColors[i];
+                        if (SliceLabelColors is not null && SliceLabelColors.Length == Values.Length)
+                            sliceFontBrush.Color = SliceLabelColors[i];
+
                         gfx.DrawString(labelStrings[i], sliceFont, sliceFontBrush, (float)labelXs[i], (float)labelYs[i], sfCenter);
                     }
 

--- a/src/ScottPlot/Plottable/PiePlot.cs
+++ b/src/ScottPlot/Plottable/PiePlot.cs
@@ -165,6 +165,7 @@ namespace ScottPlot.Plottable
                     start += sweep;
                 }
 
+                // TODO: move length checking logic into new validation system (triaged March, 2021)
                 bool useCustomLabelColors = SliceLabelColors is not null && SliceLabelColors.Length == Values.Length;
 
                 for (int i = 0; i < Values.Length; i++)

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Pie.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Pie.cs
@@ -126,6 +126,15 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             var pie = plt.AddPie(values);
             pie.SliceLabels = labels;
             pie.ShowLabels = true;
+            pie.SliceFillColors = new Color[] { // From https://github.com/ozh/github-colors
+				Color.FromArgb(0x17, 0x86, 0x00),
+                Color.FromArgb(0xB0, 0x72, 0x19),
+                Color.FromArgb(0x35, 0x72, 0xA5),
+                Color.FromArgb(0xB8, 0x45, 0xFC),
+                Color.FromArgb(0x4F, 0x5D, 0x95)
+            };
+
+            pie.SliceLabelColors = new Color[] { Color.White, Color.Silver, Color.Silver, Color.Silver, Color.Silver }; // Highlight the largest section
         }
     }
 

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Pie.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Pie.cs
@@ -111,30 +111,44 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         }
     }
 
-    public class PieShowLabels : IRecipe
+    public class PieCustomColors : IRecipe
     {
         public string Category => "Plottable: Pie";
-        public string ID => "pie_sliceLabels";
-        public string Title => "Slice Labels";
+        public string ID => "pie_customColors";
+        public string Title => "Customize Pie Colors";
         public string Description =>
-            "The label for each slice can be displayed at its center.";
+            "Colors for pie slices and labels can be customized.";
 
         public void ExecuteRecipe(Plot plt)
         {
             double[] values = { 778, 43, 283, 76, 184 };
             string[] labels = { "C#", "JAVA", "Python", "F#", "PHP" };
+
+            // Language colors from https://github.com/ozh/github-colors
+            Color[] sliceColors =
+            {
+                ColorTranslator.FromHtml("#178600"),
+                ColorTranslator.FromHtml("#B07219"),
+                ColorTranslator.FromHtml("#3572A5"),
+                ColorTranslator.FromHtml("#B845FC"),
+                ColorTranslator.FromHtml("#4F5D95"),
+            };
+
+            // Show labels using different transparencies
+            Color[] labelColors =
+                new Color[] {
+                Color.FromArgb(255, Color.White),
+                Color.FromArgb(100, Color.White),
+                Color.FromArgb(250, Color.White),
+                Color.FromArgb(150, Color.White),
+                Color.FromArgb(200, Color.White),
+            };
+
             var pie = plt.AddPie(values);
             pie.SliceLabels = labels;
             pie.ShowLabels = true;
-            pie.SliceFillColors = new Color[] { // From https://github.com/ozh/github-colors
-				Color.FromArgb(0x17, 0x86, 0x00),
-                Color.FromArgb(0xB0, 0x72, 0x19),
-                Color.FromArgb(0x35, 0x72, 0xA5),
-                Color.FromArgb(0xB8, 0x45, 0xFC),
-                Color.FromArgb(0x4F, 0x5D, 0x95)
-            };
-
-            pie.SliceLabelColors = new Color[] { Color.White, Color.Silver, Color.Silver, Color.Silver, Color.Silver }; // Highlight the largest section
+            pie.SliceFillColors = sliceColors;
+            pie.SliceLabelColors = labelColors;
         }
     }
 


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
#844 

**New Functionality:**
A new `SliceLabelColors` array is exposed.

```cs
double[] values = { 778, 43, 283, 76, 184 };
string[] labels = { "C#", "JAVA", "Python", "F#", "PHP" };
var pie = plt.AddPie(values);
pie.SliceLabels = labels;
pie.ShowLabels = true;
pie.SliceFillColors = new Color[] { // From https://github.com/ozh/github-colors
	Color.FromArgb(0x17, 0x86, 0x00),
	Color.FromArgb(0xB0, 0x72, 0x19),
	Color.FromArgb(0x35, 0x72, 0xA5),
	Color.FromArgb(0xB8, 0x45, 0xFC),
	Color.FromArgb(0x4F, 0x5D, 0x95)
};

pie.SliceLabelColors = new Color[] { Color.White, Color.Silver, Color.Silver, Color.Silver, Color.Silver }; // Highlight the largest section
```

![image](https://user-images.githubusercontent.com/8635304/111557512-6b2b4d00-8752-11eb-9f45-6cc240de4f97.png)
