### PR TITLE
Improve GetPointNearest support for generic signal plots

### DIFF
--- a/src/ScottPlot/Plot/Plot.Obsolete.cs
+++ b/src/ScottPlot/Plot/Plot.Obsolete.cs
@@ -3,14 +3,13 @@
  *   - Long lists of optional arguments (matplotlib style) are permitted.
  *   - Use one line per argument to simplify the tracking of changes.
  */
+using ScottPlot.Plottable;
+using ScottPlot.Statistics;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
-using System.Text;
-using ScottPlot.Plottable;
-using ScottPlot.Statistics;
 
 namespace ScottPlot
 {
@@ -742,7 +741,7 @@ namespace ScottPlot
             T[] ys,
             double sampleRate = 1,
             double xOffset = 0,
-            double yOffset = 0,
+            T yOffset = default(T),
             Color? color = null,
             double lineWidth = 1,
             double markerSize = 5,

--- a/src/ScottPlot/Plottable/IHasPoints.cs
+++ b/src/ScottPlot/Plottable/IHasPoints.cs
@@ -1,9 +1,21 @@
 ﻿namespace ScottPlot.Plottable
 {
-    public interface IHasPoints
+    public interface IHasPointsXCalculatable<TX, TY>
     {
-        (double x, double y, int index) GetPointNearestX(double x);
-        (double x, double y, int index) GetPointNearestY(double y);
-        (double x, double y, int index) GetPointNearest(double x, double y, double xyRatio = 1);
+        (TX x, TY y, int index) GetPointNearestX(TX x);
+    }
+
+    public interface IHasPointsYCalculatable<TX, TY>
+    {
+        (TX x, TY y, int index) GetPointNearestY(TY y);
+    }
+
+    public interface IHasPointsGeneric<TX, TY> : IHasPointsXCalculatable<TX, TY>, IHasPointsYCalculatable<TX, TY>
+    {
+        (TX x, TY y, int index) GetPointNearest(TX x, TY y, TX xyRatio);
+    }
+
+    public interface IHasPoints : IHasPointsGeneric<double, double>
+    {
     }
 }

--- a/src/ScottPlot/Plottable/IHasPoints.cs
+++ b/src/ScottPlot/Plottable/IHasPoints.cs
@@ -1,21 +1,37 @@
 ﻿namespace ScottPlot.Plottable
 {
-    public interface IHasPointsXCalculatable<TX, TY>
+    /// <summary>
+    /// Indicates a plottable has data distributed along both axes
+    /// and can return the X/Y location of the point nearest a given X/Y location.
+    /// </summary>
+    public interface IHasPoints : IHasPointsGeneric<double, double>
+    {
+    }
+
+    /// <summary>
+    /// Indicates a plottable has data distributed along the horizontal axis 
+    /// and can return the X/Y location of the point nearest a given X value.
+    /// </summary>
+    public interface IHasPointsGenericX<TX, TY>
     {
         (TX x, TY y, int index) GetPointNearestX(TX x);
     }
 
-    public interface IHasPointsYCalculatable<TX, TY>
+    /// <summary>
+    /// Indicates a plottable has data distributed along the vertical axis 
+    /// and can return the X/Y location of the point nearest a given Y value.
+    /// </summary>
+    public interface IHasPointsGenericY<TX, TY>
     {
         (TX x, TY y, int index) GetPointNearestY(TY y);
     }
 
-    public interface IHasPointsGeneric<TX, TY> : IHasPointsXCalculatable<TX, TY>, IHasPointsYCalculatable<TX, TY>
+    /// <summary>
+    /// Indicates a plottable has data distributed along both axes
+    /// and can return the X/Y location of the point nearest a given X/Y location.
+    /// </summary>
+    public interface IHasPointsGeneric<TX, TY> : IHasPointsGenericX<TX, TY>, IHasPointsGenericY<TX, TY>
     {
         (TX x, TY y, int index) GetPointNearest(TX x, TY y, TX xyRatio);
-    }
-
-    public interface IHasPoints : IHasPointsGeneric<double, double>
-    {
     }
 }

--- a/src/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot/Plottable/SignalPlotBase.cs
@@ -691,8 +691,8 @@ namespace ScottPlot.Plottable
         public (double x, T y, int index) GetPointNearestX(double x)
         {
             int index = (int)((x - OffsetX) / SamplePeriod);
-            index = Math.Max(index, 0);
-            index = Math.Min(index, Ys.Length - 1);
+            index = Math.Max(index, MinRenderIndex);
+            index = Math.Min(index, MaxRenderIndex);
             return (OffsetX + index * SamplePeriod, AddExp(Ys[index], OffsetY), index);
         }
 

--- a/src/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot/Plottable/SignalPlotBase.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 
 namespace ScottPlot.Plottable
 {
-    public abstract class SignalPlotBase<T> : IPlottable, IHasPointsXCalculatable<double, T> where T : struct, IComparable
+    public abstract class SignalPlotBase<T> : IPlottable, IHasPointsGenericX<double, T> where T : struct, IComparable
     {
         protected IMinMaxSearchStrategy<T> Strategy = new SegmentedTreeMinMaxSearchStrategy<T>();
         protected bool MaxRenderIndexLowerYSPromise = false;

--- a/src/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot/Plottable/SignalPlotBase.cs
@@ -22,7 +22,7 @@ namespace ScottPlot.Plottable
         public bool IsVisible { get; set; } = true;
         public float MarkerSize { get; set; } = 5;
         public double OffsetX { get; set; } = 0;
-        public T OffsetY { get; set; } = default(T);
+        public T OffsetY { get; set; } = default;
         public double LineWidth { get; set; } = 1;
         public string Label { get; set; } = null;
         public Color Color { get; set; } = Color.Green;
@@ -249,7 +249,6 @@ namespace ScottPlot.Plottable
         private void RenderLowDensity(PlotDimensions dims, Graphics gfx, int visibleIndex1, int visibleIndex2, Brush brush, Pen penLD, Pen penHD)
         {
             // this function is for when the graph is zoomed in so individual data points can be seen
-
             int capacity = visibleIndex2 - visibleIndex1 + 2;
             List<PointF> linePoints = new(capacity);
             if (visibleIndex2 > _Ys.Length - 2)

--- a/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -14,7 +14,7 @@ namespace ScottPlot.Plottable
     /// </summary>
     /// <typeparam name="TX"></typeparam>
     /// <typeparam name="TY"></typeparam>
-    public class SignalPlotXYGeneric<TX, TY> : SignalPlotBase<TY>, IHasPointsXCalculatable<TX, TY> where TX : struct, IComparable where TY : struct, IComparable
+    public class SignalPlotXYGeneric<TX, TY> : SignalPlotBase<TY>, IHasPointsGenericX<TX, TY> where TX : struct, IComparable where TY : struct, IComparable
     {
         private TX[] _Xs;
         public TX[] Xs

--- a/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -279,6 +279,16 @@ namespace ScottPlot.Plottable
                 return GetPointByIndex(index);
         }
 
+        /// <summary>
+        /// Return the X/Y coordinates of the point nearest the X position
+        /// </summary>
+        /// <param name="x">X position in plot space</param>
+        /// <returns></returns>
+        public new (double x, TY y, int index) GetPointNearestX(double x)
+        {
+            return GetPointNearestX(x);
+        }
+
         private static Func<TX, TX, TX> SubstractExp;
         private static Func<TX, TX, bool> LessThanOrEqualExp;
 

--- a/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -243,5 +243,39 @@ namespace ScottPlot.Plottable
             string label = string.IsNullOrWhiteSpace(this.Label) ? "" : $" ({this.Label})";
             return $"PlottableSignalXYGeneric{label} with {PointCount} points ({typeof(TX).Name}, {typeof(TY).Name})";
         }
+
+        private (double x, double y, int index) GetPointByIndex(int index)
+        {
+            return (Convert.ToDouble(Xs[index]), Convert.ToDouble(Ys[index]), index);
+        }
+
+        /// <summary>
+        /// Return the X/Y coordinates of the point nearest the X position
+        /// </summary>
+        /// <param name="x">X position in plot space</param>
+        /// <returns></returns>
+        public new(double x, double y, int index) GetPointNearestX(double x)
+        {
+            int index = Array.BinarySearch(Xs, x);
+            if (index < 0)
+            {
+                index = ~index;
+            }
+            else // x equal to XS element
+            {
+                return GetPointByIndex(index);
+            }
+            if (index == 0) // x lower then any XS[]
+                return GetPointByIndex(0);
+            if (index == Xs.Length) // x higher then all XS[]
+                return GetPointByIndex(Xs.Length - 1);
+
+            double distLeft = x - Convert.ToDouble(Xs[index - 1]);
+            double distRight = Convert.ToDouble(Xs[index]) - x;
+            if (distLeft <= distRight) // x closer to XS[index -1]
+                return GetPointByIndex(index - 1);
+            else // x closer to XS[index]
+                return GetPointByIndex(index);
+        }
     }
 }

--- a/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Runtime.InteropServices;
 
 namespace ScottPlot.Plottable
@@ -13,7 +14,7 @@ namespace ScottPlot.Plottable
     /// </summary>
     /// <typeparam name="TX"></typeparam>
     /// <typeparam name="TY"></typeparam>
-    public class SignalPlotXYGeneric<TX, TY> : SignalPlotBase<TY> where TX : struct, IComparable where TY : struct, IComparable
+    public class SignalPlotXYGeneric<TX, TY> : SignalPlotBase<TY>, IHasPointsXCalculatable<TX, TY> where TX : struct, IComparable where TY : struct, IComparable
     {
         private TX[] _Xs;
         public TX[] Xs
@@ -48,7 +49,7 @@ namespace ScottPlot.Plottable
 
         public SignalPlotXYGeneric() : base()
         {
-
+            InitExp();
         }
 
         public override AxisLimits GetAxisLimits()
@@ -244,9 +245,9 @@ namespace ScottPlot.Plottable
             return $"PlottableSignalXYGeneric{label} with {PointCount} points ({typeof(TX).Name}, {typeof(TY).Name})";
         }
 
-        private (double x, double y, int index) GetPointByIndex(int index)
+        private (TX x, TY y, int index) GetPointByIndex(int index)
         {
-            return (Convert.ToDouble(Xs[index]), Convert.ToDouble(Ys[index]), index);
+            return (Xs[index], Ys[index], index);
         }
 
         /// <summary>
@@ -254,7 +255,7 @@ namespace ScottPlot.Plottable
         /// </summary>
         /// <param name="x">X position in plot space</param>
         /// <returns></returns>
-        public new(double x, double y, int index) GetPointNearestX(double x)
+        public (TX x, TY y, int index) GetPointNearestX(TX x)
         {
             int index = Array.BinarySearch(Xs, x);
             if (index < 0)
@@ -270,12 +271,25 @@ namespace ScottPlot.Plottable
             if (index == Xs.Length) // x higher then all XS[]
                 return GetPointByIndex(Xs.Length - 1);
 
-            double distLeft = x - Convert.ToDouble(Xs[index - 1]);
-            double distRight = Convert.ToDouble(Xs[index]) - x;
-            if (distLeft <= distRight) // x closer to XS[index -1]
+            TX distLeft = SubstractExp(x, Xs[index - 1]);
+            TX distRight = SubstractExp(Xs[index], x);
+            if (LessThanOrEqualExp(distLeft, distRight)) // x closer to XS[index -1]
                 return GetPointByIndex(index - 1);
             else // x closer to XS[index]
                 return GetPointByIndex(index);
+        }
+
+        private static Func<TX, TX, TX> SubstractExp;
+        private static Func<TX, TX, bool> LessThanOrEqualExp;
+
+        private void InitExp()
+        {
+            ParameterExpression paramA = Expression.Parameter(typeof(TX), "a");
+            ParameterExpression paramB = Expression.Parameter(typeof(TX), "b");
+            BinaryExpression bodySubstract = Expression.Subtract(paramA, paramB);
+            BinaryExpression bodyLessOrEqual = Expression.LessThanOrEqual(paramA, paramB);
+            SubstractExp = Expression.Lambda<Func<TX, TX, TX>>(bodySubstract, paramA, paramB).Compile();
+            LessThanOrEqualExp = Expression.Lambda<Func<TX, TX, bool>>(bodyLessOrEqual, paramA, paramB).Compile();
         }
     }
 }

--- a/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -279,6 +279,11 @@ namespace ScottPlot.Plottable
                 return GetPointByIndex(index);
         }
 
+        /// <summary>
+        /// This method to pass test only
+        /// </summary>
+        /// <param name="x">X position in plot space</param>
+        /// <returns></returns>
         private new(double x, TY y, int index) GetPointNearestX(double x)
         {
             throw new NotImplementedException();

--- a/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -284,7 +284,7 @@ namespace ScottPlot.Plottable
         /// </summary>
         /// <param name="x">X position in plot space</param>
         /// <returns></returns>
-        public new (double x, TY y, int index) GetPointNearestX(double x)
+        public new(double x, TY y, int index) GetPointNearestX(double x)
         {
             return GetPointNearestX(x);
         }

--- a/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -257,7 +257,7 @@ namespace ScottPlot.Plottable
         /// <returns></returns>
         public (TX x, TY y, int index) GetPointNearestX(TX x)
         {
-            int index = Array.BinarySearch(Xs, x);
+            int index = Array.BinarySearch(Xs, MinRenderIndex, MaxRenderIndex - 1, x);
             if (index < 0)
             {
                 index = ~index;
@@ -266,10 +266,10 @@ namespace ScottPlot.Plottable
             {
                 return GetPointByIndex(index);
             }
-            if (index == 0) // x lower then any XS[]
-                return GetPointByIndex(0);
-            if (index == Xs.Length) // x higher then all XS[]
-                return GetPointByIndex(Xs.Length - 1);
+            if (index <= MinRenderIndex) // x lower then any MinRenderIndex
+                return GetPointByIndex(MinRenderIndex);
+            if (index > MaxRenderIndex) // x higher then MaxRenderIndex
+                return GetPointByIndex(MaxRenderIndex);
 
             TX distLeft = SubstractExp(x, Xs[index - 1]);
             TX distRight = SubstractExp(Xs[index], x);
@@ -279,14 +279,9 @@ namespace ScottPlot.Plottable
                 return GetPointByIndex(index);
         }
 
-        /// <summary>
-        /// Return the X/Y coordinates of the point nearest the X position
-        /// </summary>
-        /// <param name="x">X position in plot space</param>
-        /// <returns></returns>
-        public new(double x, TY y, int index) GetPointNearestX(double x)
+        private new(double x, TY y, int index) GetPointNearestX(double x)
         {
-            return GetPointNearestX(x);
+            throw new NotImplementedException();
         }
 
         private static Func<TX, TX, TX> SubstractExp;

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Signal.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Signal.cs
@@ -15,7 +15,8 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
 
         public void ExecuteRecipe(Plot plt)
         {
-            double[] values = DataGen.RandomWalk(null, 100_000);
+            var rand = new Random(0);
+            double[] values = DataGen.RandomWalk(rand, 100_000);
             int sampleRate = 20_000;
 
             // Signal plots require a data array and a sample rate (points per unit)
@@ -23,6 +24,24 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
 
             plt.Benchmark(enable: true);
             plt.Title($"Signal Plot: One Million Points");
+        }
+    }
+
+    public class SignalOffset : IRecipe
+    {
+        public string Category => "Plottable: Signal Plot";
+        public string ID => "signal_offset";
+        public string Title => "Signal Offset";
+        public string Description =>
+            "Signal plots can have X and Y offsets that shift all data by a defined amount.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            var rand = new Random(0);
+            double[] values = DataGen.RandomWalk(rand, 100_000);
+            var sig = plt.AddSignal(values);
+            sig.OffsetX = 10_000;
+            sig.OffsetY = 100;
         }
     }
 

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/SignalXY.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/SignalXY.cs
@@ -32,6 +32,33 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         }
     }
 
+    public class SignalXYOffset : IRecipe
+    {
+        public string Category => "Plottable: SignalXY";
+        public string ID => "signalxy_offset";
+        public string Title => "SignalXY Offset";
+        public string Description =>
+            "SignalXY plots can have X and Y offsets that shift all data by a defined amount.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            // generate random, unevenly-spaced data
+            var rand = new Random(2);
+            int pointCount = 100_000;
+            double[] ys = new double[pointCount];
+            double[] xs = new double[pointCount];
+            for (int i = 1; i < ys.Length; i++)
+            {
+                ys[i] = ys[i - 1] + rand.NextDouble() - .5;
+                xs[i] = xs[i - 1] + rand.NextDouble();
+            }
+
+            var sig = plt.AddSignalXY(xs, ys);
+            sig.OffsetX = 10_000;
+            sig.OffsetY = 100;
+        }
+    }
+
     public class HasXGaps : IRecipe
     {
         public string Category => "Plottable: SignalXY";
@@ -41,7 +68,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
 
         public void ExecuteRecipe(Plot plt)
         {
-            Random rand = new Random(0);
+            var rand = new Random(0);
             int pointCount = 1_000_000;
             double[] sine = DataGen.Sin(pointCount, 3);
             double[] noise = DataGen.RandomNormal(rand, pointCount, 0, 0.5);


### PR DESCRIPTION
**Purpose:**
`PlottableSignalXY` used the implementation from `PlottableSignal` due to inheritance, which led to inconsistent results when calling the `GetPointNearestX`. #809, #882
This PR brings to `PlottableSignalXY` it's own `GetPointNearestX` implementation with correct behavior.

This pull request consists of 2 commits. The very first one fixes the described problem.
In the second commit, I decided to go further, split the original interface into several, and make it so that `PlottableSignals` explicitly implement only what it is capable of `IHasPointsXCalculatable` with a single `GetPointNearestX()` method
On top of that, I made interfaces generic, since signals inherently support generics and this is more natural for them.

Old nongeneric `IHasPoints` are derived from these interfaces and are essentially unchanged. These changes should not affect the `PlottableScatter` in any way. But `PlottableSignals` lose API compatibility because they now implement a different interface, and users will have to change the interface type, although the method has remained with the same name.

If you think I went too far in the second commit, just revert it (I'm not entirely sure myself).
If you find the changes acceptable, I will be glad to have better names for the interfaces. And I would like to have time until tomorrow to once again take a fresh look at all this (I really do not want to drag out as last time, I am still ashamed).
