### PR TITLE
Fix SignalXY right edge clipping bug

### DIFF
--- a/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -163,7 +163,7 @@ namespace ScottPlot.Plottable
                 IEnumerable<PointF> VisiblePoints;
                 if (UseParallel)
                 {
-                    VisiblePoints = Enumerable.Range(0, (int)dims.DataWidth)
+                    VisiblePoints = Enumerable.Range(0, (int)Math.Round(dims.DataWidth))
                                               .AsParallel()
                                               .AsOrdered()
                                               .Select(x => ProcessInterval(x, searchFrom, searchTo - searchFrom + 1, dims))
@@ -172,7 +172,7 @@ namespace ScottPlot.Plottable
                 }
                 else
                 {
-                    VisiblePoints = Enumerable.Range(0, (int)dims.DataWidth)
+                    VisiblePoints = Enumerable.Range(0, (int)Math.Round(dims.DataWidth))
                                               .Select(x => ProcessInterval(x, searchFrom, searchTo - searchFrom + 1, dims))
                                               .SelectMany(x => x);
                 }


### PR DESCRIPTION
**Purpose:**
Fix for `SignalXY` wrong clipping on right edge. https://github.com/ScottPlot/ScottPlot/issues/889#issuecomment-803582419

The problem was not at incorrect clipping, but that `float` `DataWidth`, when cast to `int`, is not correctly rounded. thus, for example, with a width of `627.998`, a simple conversion to int gives 627 instead of 628.
And the points that should have gotten into the last column did not get there. as a consequence, interpolation did not go from the last point of the last column, but from the last point of the previous colomn. Which gave such an effect if points in last and previous columns had many difference.

In general, it is very strange to use `float` variable for the pixels count, a quick glance at the project showed that cast to int is still used in many places, they can also play a cruel joke.