### PR TITLE
Implement OffsetX/OffsetY support for SignalXY.

### DIFF
--- a/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -55,8 +55,8 @@ namespace ScottPlot.Plottable
         public override AxisLimits GetAxisLimits()
         {
             var baseLimits = base.GetAxisLimits();
-            var newXMin = Convert.ToDouble(Xs[MinRenderIndex]);
-            var newXMax = Convert.ToDouble(Xs[MaxRenderIndex]);
+            var newXMin = Convert.ToDouble(Xs[MinRenderIndex]) + OffsetX;
+            var newXMax = Convert.ToDouble(Xs[MaxRenderIndex]) + OffsetX;
             Debug.WriteLine($"Limits: {newXMin} {newXMax}");
             return new AxisLimits(newXMin, newXMax, baseLimits.YMin, baseLimits.YMax);
         }
@@ -71,8 +71,8 @@ namespace ScottPlot.Plottable
         /// <returns></returns>
         public IEnumerable<PointF> ProcessInterval(int x, int from, int length, PlotDimensions dims)
         {
-            TX start = (TX)Convert.ChangeType(dims.XMin + dims.XSpan / dims.DataWidth * x, typeof(TX));
-            TX end = (TX)Convert.ChangeType(dims.XMin + dims.XSpan / dims.DataWidth * (x + 1), typeof(TX));
+            TX start = (TX)Convert.ChangeType(dims.XMin + dims.XSpan / dims.DataWidth * x - OffsetX, typeof(TX));
+            TX end = (TX)Convert.ChangeType(dims.XMin + dims.XSpan / dims.DataWidth * (x + 1) - OffsetX, typeof(TX));
 
             int startIndex = Array.BinarySearch(Xs, from, length, start);
             if (startIndex < 0)
@@ -95,12 +95,12 @@ namespace ScottPlot.Plottable
 
             var pointsCount = endIndex - startIndex;
 
-            yield return new PointF(x + dims.DataOffsetX, dims.GetPixelY(Strategy.SourceElement(startIndex)));
+            yield return new PointF(x + dims.DataOffsetX, dims.GetPixelY(Strategy.SourceElement(startIndex) + Convert.ToDouble(OffsetY)));
             if (pointsCount > 1)
             {
-                yield return new PointF(x + dims.DataOffsetX, dims.GetPixelY(min));
-                yield return new PointF(x + dims.DataOffsetX, dims.GetPixelY(max));
-                yield return new PointF(x + dims.DataOffsetX, dims.GetPixelY(Strategy.SourceElement(endIndex - 1)));
+                yield return new PointF(x + dims.DataOffsetX, dims.GetPixelY(min + Convert.ToDouble(OffsetY)));
+                yield return new PointF(x + dims.DataOffsetX, dims.GetPixelY(max + Convert.ToDouble(OffsetY)));
+                yield return new PointF(x + dims.DataOffsetX, dims.GetPixelY(Strategy.SourceElement(endIndex - 1) + Convert.ToDouble(OffsetY)));
             }
         }
 
@@ -117,7 +117,7 @@ namespace ScottPlot.Plottable
                 int searchTo;
 
                 // Calculate point before displayed points
-                int pointBeforeIndex = Array.BinarySearch(Xs, MinRenderIndex, MaxRenderIndex - MinRenderIndex + 1, Convert.ChangeType(dims.XMin, typeof(TX)));
+                int pointBeforeIndex = Array.BinarySearch(Xs, MinRenderIndex, MaxRenderIndex - MinRenderIndex + 1, Convert.ChangeType(dims.XMin - OffsetX, typeof(TX)));
                 if (pointBeforeIndex < 0)
                 {
                     pointBeforeIndex = ~pointBeforeIndex;
@@ -127,8 +127,8 @@ namespace ScottPlot.Plottable
                 {
                     PointBefore = new PointF[]
                     {
-                        new PointF(dims.GetPixelX(Convert.ToDouble(Xs[pointBeforeIndex - 1])),
-                                   dims.GetPixelY(Strategy.SourceElement(pointBeforeIndex - 1)))
+                        new PointF(dims.GetPixelX(Convert.ToDouble(Xs[pointBeforeIndex - 1]) + OffsetX),
+                                   dims.GetPixelY(Strategy.SourceElement(pointBeforeIndex - 1) + Convert.ToDouble(OffsetY)))
                     };
                     searchFrom = pointBeforeIndex;
                 }
@@ -139,7 +139,7 @@ namespace ScottPlot.Plottable
                 }
 
                 // Calculate point after displayed points
-                int pointAfterIndex = Array.BinarySearch(Xs, MinRenderIndex, MaxRenderIndex - MinRenderIndex + 1, Convert.ChangeType(dims.XMax, typeof(TX)));
+                int pointAfterIndex = Array.BinarySearch(Xs, MinRenderIndex, MaxRenderIndex - MinRenderIndex + 1, Convert.ChangeType(dims.XMax - OffsetX, typeof(TX)));
                 if (pointAfterIndex < 0)
                 {
                     pointAfterIndex = ~pointAfterIndex;
@@ -149,8 +149,8 @@ namespace ScottPlot.Plottable
                 {
                     PointAfter = new PointF[]
                     {
-                        new PointF(dims.GetPixelX(Convert.ToDouble(Xs[pointAfterIndex])),
-                                   dims.GetPixelY(Strategy.SourceElement(pointAfterIndex)))
+                        new PointF(dims.GetPixelX(Convert.ToDouble(Xs[pointAfterIndex]) + OffsetX),
+                                   dims.GetPixelY(Strategy.SourceElement(pointAfterIndex) + Convert.ToDouble(OffsetY)))
                     };
                     searchTo = pointAfterIndex;
                 }


### PR DESCRIPTION
**Purpose:**
Implement OffsetX/OffsetY support for SignalXY.#890

The implementation is in its simplest form, it will be possible to use precompiled lambdas in the future. But I don't like the offsetX / offsetY approach itself, so I would like to discuss its necessity before moving on.

**New Functionality:**
```cs
var sig = plt.AddSignalXY(xs, ys);
sig.OffsetX = 10_000;
sig.OffsetY = 100;
```
![image](https://user-images.githubusercontent.com/53831487/112027589-5da60680-8b48-11eb-9504-927fa671c9e3.png)
