### PR TITLE
track click-drag travel distance #891

### DIFF
--- a/src/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot/Control/Backend.cs
@@ -196,6 +196,11 @@ namespace ScottPlot.Control
         private int BitmapRenderCount = 0;
 
         /// <summary>
+        /// Tracks the total distance the mouse was click-dragged
+        /// </summary>
+        private (float X, float Y) MouseDownTravelDistance = (0, 0);
+
+        /// <summary>
         /// Create a back-end for a user control
         /// </summary>
         /// <param name="width">initial bitmap size (pixels)</param>
@@ -407,6 +412,7 @@ namespace ScottPlot.Control
             IsLeftDown = input.LeftWasJustPressed;
             PlottableBeingDragged = GetDraggableUnderMouse(input.X, input.Y);
             Settings.MouseDown(input.X, input.Y);
+            MouseDownTravelDistance = (0, 0);
         }
 
         /// <summary>
@@ -436,6 +442,9 @@ namespace ScottPlot.Control
             bool isMiddleClickDragZooming = IsMiddleDown;
             bool isZooming = IsZoomingWithAlt || isMiddleClickDragZooming;
             IsZoomingRectangle = isZooming && Configuration.MiddleClickDragZoom;
+
+            MouseDownTravelDistance.X += Math.Abs(input.X - MouseLocationX);
+            MouseDownTravelDistance.Y += Math.Abs(input.Y - MouseLocationY);
 
             MouseLocationX = input.X;
             MouseLocationY = input.Y;
@@ -515,7 +524,7 @@ namespace ScottPlot.Control
         public void MouseUp(InputState input)
         {
             PlottableBeingDragged = null;
-            bool mouseWasDragged = Settings.MouseHasMoved(input.X, input.Y);
+            bool mouseWasDragged = (MouseDownTravelDistance.X + MouseDownTravelDistance.Y) > 0;
 
             IUIEvent mouseEvent;
             if (IsZoomingRectangle && mouseWasDragged && Configuration.MiddleClickDragZoom)

--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -356,10 +356,6 @@ namespace ScottPlot
             MouseDownY = mouseDownY;
         }
 
-        public bool MouseHasMoved(float mouseNowX, float mouseNowY, float threshold = 2) =>
-            Math.Abs(mouseNowX - MouseDownX) >= threshold &&
-            Math.Abs(mouseNowY - MouseDownY) >= threshold;
-
         /// <summary>
         /// Pan all axes based on the mouse position now vs that last given to MouseDown()
         /// </summary>


### PR DESCRIPTION
Don't deploy right-click menu if the right mouse button was dragged a large distance and returned to its original location