### PR TITLE
improve DateTime tick spacing #725

### DIFF
--- a/src/ScottPlot/Renderable/Axis.cs
+++ b/src/ScottPlot/Renderable/Axis.cs
@@ -305,6 +305,16 @@ namespace ScottPlot.Renderable
         }
 
         /// <summary>
+        /// This value defines the packing density of tick labels.
+        /// A density of 1.0 means labels fit tightly based on measured maximum label size.
+        /// Higher densities place more ticks but tick labels may oberlap.
+        /// </summary>
+        public void SetTickDensity(double density = 1.0)
+        {
+            AxisTicks.TickCollection.TickDensity = (float)density;
+        }
+
+        /// <summary>
         /// Sets whether minor ticks are evenly spaced or log-distributed between major tick positions
         /// </summary>
         public void MinorLogScale(bool enable) => AxisTicks.TickCollection.MinorTickDistribution =

--- a/src/ScottPlot/Renderable/Axis.cs
+++ b/src/ScottPlot/Renderable/Axis.cs
@@ -309,9 +309,18 @@ namespace ScottPlot.Renderable
         /// A density of 1.0 means labels fit tightly based on measured maximum label size.
         /// Higher densities place more ticks but tick labels may oberlap.
         /// </summary>
-        public void SetTickDensity(double density = 1.0)
+        public void TickDensity(double ratio = 1.0)
         {
-            AxisTicks.TickCollection.TickDensity = (float)density;
+            AxisTicks.TickCollection.TickDensity = (float)ratio;
+        }
+
+        /// <summary>
+        /// Define the smallest distance between major ticks, grid lines, and tick labels in coordinate units.
+        /// This only works for numeric tick systems (DateTime ticks are not supported).
+        /// </summary>
+        public void MinimumTickSpacing(double spacing)
+        {
+            AxisTicks.TickCollection.MinimumTickSpacing = spacing;
         }
 
         /// <summary>

--- a/src/ScottPlot/Renderable/Axis.cs
+++ b/src/ScottPlot/Renderable/Axis.cs
@@ -47,7 +47,7 @@ namespace ScottPlot.Renderable
                 AxisLabel.Edge = value;
                 AxisTicks.Edge = value;
                 bool isVertical = (value == Edge.Left || value == Edge.Right);
-                AxisTicks.TickCollection.verticalAxis = isVertical;
+                AxisTicks.TickCollection.Orientation = isVertical ? AxisOrientation.Vertical : AxisOrientation.Horizontal;
                 Dims.IsInverted = isVertical;
             }
         }
@@ -122,7 +122,10 @@ namespace ScottPlot.Renderable
         /// <summary>
         /// DateTime format assumes axis represents DateTime.ToOATime() units and displays tick labels accordingly.
         /// </summary>
-        public void DateTimeFormat(bool enable) => AxisTicks.TickCollection.dateFormat = enable;
+        public void DateTimeFormat(bool enable) => AxisTicks.TickCollection.LabelFormat =
+            enable
+            ? ScottPlot.Ticks.TickLabelFormat.DateTime
+            : ScottPlot.Ticks.TickLabelFormat.Numeric;
 
         /// <summary>
         /// Configure the label of this axis
@@ -197,7 +200,7 @@ namespace ScottPlot.Renderable
             AxisTicks.TickCollection.useMultiplierNotation = multiplier ?? AxisTicks.TickCollection.useMultiplierNotation;
             AxisTicks.TickCollection.useOffsetNotation = offset ?? AxisTicks.TickCollection.useOffsetNotation;
             AxisTicks.TickCollection.useExponentialNotation = exponential ?? AxisTicks.TickCollection.useExponentialNotation;
-            AxisTicks.TickCollection.invertSign = invertSign ?? AxisTicks.TickCollection.invertSign;
+            AxisTicks.TickCollection.LabelUsingInvertedSign = invertSign ?? AxisTicks.TickCollection.LabelUsingInvertedSign;
             AxisTicks.TickCollection.radix = radix ?? AxisTicks.TickCollection.radix;
             AxisTicks.TickCollection.prefix = prefix ?? AxisTicks.TickCollection.prefix;
         }
@@ -304,7 +307,8 @@ namespace ScottPlot.Renderable
         /// <summary>
         /// Sets whether minor ticks are evenly spaced or log-distributed between major tick positions
         /// </summary>
-        public void MinorLogScale(bool enable) => AxisTicks.TickCollection.logScale = enable;
+        public void MinorLogScale(bool enable) => AxisTicks.TickCollection.MinorTickDistribution =
+            enable ? MinorTickDistribution.log : MinorTickDistribution.even;
 
         /// <summary>
         /// Configure the line drawn along the edge of the axis
@@ -355,7 +359,10 @@ namespace ScottPlot.Renderable
             AxisTicks.MinorGridColor = color ?? AxisTicks.MinorGridColor;
             AxisTicks.MinorGridWidth = lineWidth ?? AxisTicks.MinorGridWidth;
             AxisTicks.MinorGridStyle = lineStyle ?? AxisTicks.MinorGridStyle;
-            AxisTicks.TickCollection.logScale = logScale ?? AxisTicks.TickCollection.logScale;
+            if (logScale.HasValue)
+                AxisTicks.TickCollection.MinorTickDistribution = logScale.Value
+                    ? MinorTickDistribution.log
+                    : MinorTickDistribution.even;
         }
 
         /// <summary>
@@ -392,8 +399,8 @@ namespace ScottPlot.Renderable
                 if (AxisTicks.TickLabelVisible)
                 {
                     // determine how many pixels the largest tick label occupies
-                    float maxHeight = AxisTicks.TickCollection.maxLabelHeight;
-                    float maxWidth = AxisTicks.TickCollection.maxLabelWidth * 1.2f;
+                    float maxHeight = AxisTicks.TickCollection.LargestLabelHeight;
+                    float maxWidth = AxisTicks.TickCollection.LargestLabelWidth * 1.2f;
 
                     // calculate the width and height of the rotated label
                     float largerEdgeLength = Math.Max(maxWidth, maxHeight);

--- a/src/ScottPlot/Renderable/AxisTicksRender.cs
+++ b/src/ScottPlot/Renderable/AxisTicksRender.cs
@@ -100,9 +100,9 @@ namespace ScottPlot.Renderable
                                 y: dims.DataOffsetY + dims.DataHeight + PixelOffset + MajorTickLength);
 
                         sf.Alignment = StringAlignment.Far;
-                        gfx.DrawString(tc.cornerLabel, font, brush, format: sf,
+                        gfx.DrawString(tc.CornerLabel, font, brush, format: sf,
                             x: dims.DataOffsetX + dims.DataWidth,
-                            y: dims.DataOffsetY + dims.DataHeight + MajorTickLength + tc.maxLabelHeight);
+                            y: dims.DataOffsetY + dims.DataHeight + MajorTickLength + tc.LargestLabelHeight);
                     }
                     else
                     {
@@ -142,7 +142,7 @@ namespace ScottPlot.Renderable
 
                         sf.LineAlignment = StringAlignment.Far;
                         sf.Alignment = StringAlignment.Near;
-                        gfx.DrawString(tc.cornerLabel, font, brush, dims.DataOffsetX, dims.DataOffsetY, sf);
+                        gfx.DrawString(tc.CornerLabel, font, brush, dims.DataOffsetX, dims.DataOffsetY, sf);
                     }
                     else
                     {

--- a/src/ScottPlot/Ticks/TickCollection.cs
+++ b/src/ScottPlot/Ticks/TickCollection.cs
@@ -345,7 +345,7 @@ namespace ScottPlot.Ticks
             string[] labels = new string[positions.Length];
             string cornerLabel = "";
 
-            if (positions.Length <= 1)
+            if (positions.Length == 0)
                 return (labels, cornerLabel);
 
             double range = positions.Last() - positions.First();

--- a/src/ScottPlot/Ticks/TickCollection.cs
+++ b/src/ScottPlot/Ticks/TickCollection.cs
@@ -78,6 +78,8 @@ namespace ScottPlot.Ticks
         public bool useOffsetNotation = false;
         public bool useExponentialNotation = true;
 
+        public float TickDensity = 1.0f;
+
         public void Recalculate(PlotDimensions dims, Drawing.Font tickFont)
         {
             if (manualTickPositions is null)
@@ -219,7 +221,7 @@ namespace ScottPlot.Ticks
             {
                 low = dims.YMin - dims.UnitsPerPxY; // add an extra pixel to capture the edge tick
                 high = dims.YMax + dims.UnitsPerPxY; // add an extra pixel to capture the edge tick
-                maxTickCount = (int)(dims.DataHeight / labelHeight);
+                maxTickCount = (int)(dims.DataHeight / labelHeight * TickDensity);
                 maxTickCount = forcedTickCount ?? maxTickCount;
                 tickSpacing = (manualSpacingY != 0) ? manualSpacingY : GetIdealTickSpacing(low, high, maxTickCount, radix);
             }
@@ -227,7 +229,7 @@ namespace ScottPlot.Ticks
             {
                 low = dims.XMin - dims.UnitsPerPxX; // add an extra pixel to capture the edge tick
                 high = dims.XMax + dims.UnitsPerPxX; // add an extra pixel to capture the edge tick
-                maxTickCount = (int)(dims.DataWidth / labelWidth);
+                maxTickCount = (int)(dims.DataWidth / labelWidth * TickDensity);
                 maxTickCount = forcedTickCount ?? maxTickCount;
                 tickSpacing = (manualSpacingX != 0) ? manualSpacingX : GetIdealTickSpacing(low, high, maxTickCount, radix);
             }

--- a/src/ScottPlot/Ticks/TickCollection.cs
+++ b/src/ScottPlot/Ticks/TickCollection.cs
@@ -109,6 +109,17 @@ namespace ScottPlot.Ticks
                 if (s.Length > largestString.Length)
                     largestString = s;
 
+            if (dateFormat)
+            {
+                // widen largest string based on the longest month name
+                foreach (string s in new DateTimeFormatInfo().MonthGenitiveNames)
+                {
+                    string s2 = s + "\n" + "1985";
+                    if (s2.Length > largestString.Length)
+                        largestString = s2;
+                }
+            }
+
             var maxLabelSize = GDI.MeasureString(largestString.Trim(), tickFont);
             return (maxLabelSize.Width, maxLabelSize.Height);
         }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/AxisAdvanced.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/AxisAdvanced.cs
@@ -433,11 +433,29 @@ namespace ScottPlot.Cookbook.Recipes
             plt.AddSignal(DataGen.Sin(51));
             plt.AddSignal(DataGen.Cos(51));
 
-            plt.XAxis.Label("Low Density Ticks");
-            plt.XAxis.SetTickDensity(0.2);
+            plt.XAxis.Label("Lower Density Ticks");
+            plt.XAxis.TickDensity(0.2);
 
-            plt.YAxis.Label("High Density Ticks");
-            plt.YAxis.SetTickDensity(3);
+            plt.YAxis.Label("Higher Density Ticks");
+            plt.YAxis.TickDensity(3);
+        }
+    }
+
+    class MinimumTickSpacing : IRecipe
+    {
+        public string Category => "Advanced Axis Features";
+        public string ID => "asis_minimumTickSpacing";
+        public string Title => "Minimum Tick Spacing";
+        public string Description => "Minimum tick spacing can be defined such that zooming in " +
+            "does not produce more grid lines, ticks, and tick labels beyond the defined limit.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            plt.AddSignal(DataGen.Sin(51));
+            plt.AddSignal(DataGen.Cos(51));
+
+            plt.YAxis.MinimumTickSpacing(1);
+            plt.XAxis.MinimumTickSpacing(25);
         }
     }
 }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/AxisAdvanced.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/AxisAdvanced.cs
@@ -418,4 +418,26 @@ namespace ScottPlot.Cookbook.Recipes
             plt.XAxis.ImageLabel(new Bitmap("Images/theta.jpg"));
         }
     }
+
+    class TickDensity : IRecipe
+    {
+        public string Category => "Advanced Axis Features";
+        public string ID => "asis_tickDensity";
+        public string Title => "Tick Density";
+        public string Description => "Axis tick density can be adjusted by the user. " +
+            "The largest the density is, the more ticks are displayed. Setting this value too high " +
+            "will result in overlapping tick labels.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            plt.AddSignal(DataGen.Sin(51));
+            plt.AddSignal(DataGen.Cos(51));
+
+            plt.XAxis.Label("Low Density Ticks");
+            plt.XAxis.SetTickDensity(0.2);
+
+            plt.YAxis.Label("High Density Ticks");
+            plt.YAxis.SetTickDensity(3);
+        }
+    }
 }

--- a/src/tests/Ticks/DateTimeTickSpacing.cs
+++ b/src/tests/Ticks/DateTimeTickSpacing.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlotTests.Ticks
+{
+    class DateTimeTickSpacing
+    {
+        [Test]
+        public void Test_Spacing_MonthTicks()
+        {
+            int pointCount = 650;
+            var rand = new Random(0);
+            double[] values = ScottPlot.DataGen.RandomWalk(rand, pointCount);
+
+            var plt = new ScottPlot.Plot(600, 400);
+            var sig = plt.AddSignal(values);
+            sig.OffsetX = new DateTime(1985, 1, 1).ToOADate();
+            plt.XAxis.DateTimeFormat(true);
+            TestTools.SaveFig(plt);
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses #725 by using the longest month name to calculate the width for tick labels when plotting on a DateTime axis.

This PR also addresses #828 by giving the tick collection the ability to change the density of tick labels.

Before|After
---|---
![image](https://user-images.githubusercontent.com/4165489/112909364-45416900-90bf-11eb-84b7-53222643588c.png)|![image](https://user-images.githubusercontent.com/4165489/112914434-f4833d80-90c9-11eb-8dee-ad29bd002751.png)