### PR TITLE
Fix wrong pen for Signal in low density mode.

### DIFF
--- a/src/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot/Plottable/SignalPlotBase.cs
@@ -276,7 +276,7 @@ namespace ScottPlot.Plottable
                 ValidatePoints(pointsArray);
 
                 if (penLD.Width > 0)
-                    gfx.DrawLines(penHD, pointsArray);
+                    gfx.DrawLines(penLD, pointsArray);
 
                 if (FillType == FillType.FillAbove || FillType == FillType.FillBelow)
                 {


### PR DESCRIPTION
**Purpose:**
Fix wrong pen for Signal in low density mode. #929