### PR TITLE
Allow user to select axises used for scale calculation for EqualScale mode

### DIFF
--- a/src/ScottPlot/Enums/EqualScaleMode.cs
+++ b/src/ScottPlot/Enums/EqualScaleMode.cs
@@ -1,0 +1,33 @@
+﻿namespace ScottPlot
+{
+    /// <summary>
+    /// Defines if/how axis scales (units per pixel) are matched between horizontal and vertical axes.
+    /// </summary>
+    public enum EqualScaleMode
+    {
+        /// <summary>
+        /// Horizontal and vertical axes can be scaled independently. 
+        /// Squares and circles may stretch to rectangles and ovals.
+        /// </summary>
+        Disabled,
+
+        /// <summary>
+        /// Axis scales are locked so geometry of squares and circles is preserved.
+        /// After axes are set, the vertical scale (units per pixel) is applied to the horizontal axis.
+        /// </summary>
+        PreserveY,
+
+        /// <summary>
+        /// Axis scales are locked so geometry of squares and circles is preserved.
+        /// After axes are set, the horizontal scale (units per pixel) is applied to the vertical axis.
+        /// </summary>
+        PreserveX,
+
+        /// <summary>
+        /// Axis scales are locked so geometry of squares and circles is preserved.
+        /// After axes are set, the largest scale (most units per pixel) is applied to both axes.
+        /// Apply the most zoomed-out scale to both axes.
+        /// </summary>
+        ZoomOut
+    }
+}

--- a/src/ScottPlot/Plot/Plot.Axis.cs
+++ b/src/ScottPlot/Plot/Plot.Axis.cs
@@ -463,10 +463,12 @@ namespace ScottPlot
         /// Lock X and Y axis scales (units per pixel) together to protect symmetry of circles and squares
         /// </summary>
         /// <param name="enable">if true, scales are locked</param>
-        public void AxisScaleLock(bool enable)
+        public void AxisScaleLock(bool enable, bool EqualScaleUseX = true, bool EqualScaleUseY = true)
         {
             settings.AxisAutoUnsetAxes();
             settings.AxisEqualScale = enable;
+            settings.EqualScaleUseX = EqualScaleUseX;
+            settings.EqualScaleUseY = EqualScaleUseY;
             settings.LayoutAuto();
             settings.EnforceEqualAxisScales();
         }

--- a/src/ScottPlot/Plot/Plot.Axis.cs
+++ b/src/ScottPlot/Plot/Plot.Axis.cs
@@ -462,13 +462,12 @@ namespace ScottPlot
         /// <summary>
         /// Lock X and Y axis scales (units per pixel) together to protect symmetry of circles and squares
         /// </summary>
-        /// <param name="enable">if true, scales are locked</param>
-        public void AxisScaleLock(bool enable, bool EqualScaleUseX = true, bool EqualScaleUseY = true)
+        /// <param name="enable">if true, scales are locked such that zooming one zooms the other</param>
+        /// <param name="scaleMode">defines behavior for how to adjust axis limits to achieve equal scales</param>
+        public void AxisScaleLock(bool enable, EqualScaleMode scaleMode = EqualScaleMode.PreserveY)
         {
             settings.AxisAutoUnsetAxes();
-            settings.AxisEqualScale = enable;
-            settings.EqualScaleUseX = EqualScaleUseX;
-            settings.EqualScaleUseY = EqualScaleUseY;
+            settings.EqualScaleMode = enable ? scaleMode : EqualScaleMode.Disabled;
             settings.LayoutAuto();
             settings.EnforceEqualAxisScales();
         }

--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -3,7 +3,6 @@ using ScottPlot.Plottable;
 using ScottPlot.Renderable;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 
@@ -42,6 +41,8 @@ namespace ScottPlot
         public Axis GetYAxis(int yAxisIndex) => Axes.Where(x => x.IsVertical && x.AxisIndex == yAxisIndex).First();
         public bool AllAxesHaveBeenSet => Axes.All(x => x.Dims.HasBeenSet);
         public bool AxisEqualScale = false;
+        public bool EqualScaleUseX = true;
+        public bool EqualScaleUseY = true;
 
         // shortcuts to fixed axes indexes
         public Axis YAxis => Axes[0];
@@ -234,7 +235,10 @@ namespace ScottPlot
             if (AxisEqualScale == false)
                 return;
 
-            double unitsPerPixel = Math.Max(XAxis.Dims.UnitsPerPx, YAxis.Dims.UnitsPerPx);
+            if (EqualScaleUseX == false && EqualScaleUseY == false)
+                return;
+
+            double unitsPerPixel = Math.Max(EqualScaleUseX ? XAxis.Dims.UnitsPerPx : 0, EqualScaleUseY ? YAxis.Dims.UnitsPerPx : 0);
             double xHalfSize = (XAxis.Dims.DataSizePx / 2) * unitsPerPixel;
             double yHalfSize = (YAxis.Dims.DataSizePx / 2) * unitsPerPixel;
 

--- a/src/sandbox/WinFormsFrameworkApp/Form1.Designer.cs
+++ b/src/sandbox/WinFormsFrameworkApp/Form1.Designer.cs
@@ -29,12 +29,38 @@ namespace WinFormsFrameworkApp
         /// </summary>
         private void InitializeComponent()
         {
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.comboBox1 = new System.Windows.Forms.ComboBox();
             this.formsPlot1 = new ScottPlot.FormsPlot();
-            this.btnScatter10 = new System.Windows.Forms.Button();
-            this.buttonScatter1k = new System.Windows.Forms.Button();
-            this.buttonSignal1M = new System.Windows.Forms.Button();
-            this.cbRenderQueue = new System.Windows.Forms.CheckBox();
+            this.groupBox1.SuspendLayout();
             this.SuspendLayout();
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.comboBox1);
+            this.groupBox1.Location = new System.Drawing.Point(12, 12);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(149, 47);
+            this.groupBox1.TabIndex = 1;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Axis Scale Lock";
+            // 
+            // comboBox1
+            // 
+            this.comboBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.comboBox1.FormattingEnabled = true;
+            this.comboBox1.Items.AddRange(new object[] {
+            "Disabled",
+            "Preserve Y",
+            "Preserve X",
+            "Zoom Out"});
+            this.comboBox1.Location = new System.Drawing.Point(6, 19);
+            this.comboBox1.Name = "comboBox1";
+            this.comboBox1.Size = new System.Drawing.Size(137, 21);
+            this.comboBox1.TabIndex = 2;
+            this.comboBox1.Text = "Disabled";
+            this.comboBox1.SelectedIndexChanged += new System.EventHandler(this.comboBox1_SelectedIndexChanged);
             // 
             // formsPlot1
             // 
@@ -47,73 +73,25 @@ namespace WinFormsFrameworkApp
             this.formsPlot1.Size = new System.Drawing.Size(776, 397);
             this.formsPlot1.TabIndex = 0;
             // 
-            // btnScatter10
-            // 
-            this.btnScatter10.Location = new System.Drawing.Point(12, 12);
-            this.btnScatter10.Name = "btnScatter10";
-            this.btnScatter10.Size = new System.Drawing.Size(75, 23);
-            this.btnScatter10.TabIndex = 1;
-            this.btnScatter10.Text = "10 scatter";
-            this.btnScatter10.UseVisualStyleBackColor = true;
-            this.btnScatter10.Click += new System.EventHandler(this.btnScatter10_Click);
-            // 
-            // buttonScatter1k
-            // 
-            this.buttonScatter1k.Location = new System.Drawing.Point(93, 12);
-            this.buttonScatter1k.Name = "buttonScatter1k";
-            this.buttonScatter1k.Size = new System.Drawing.Size(75, 23);
-            this.buttonScatter1k.TabIndex = 2;
-            this.buttonScatter1k.Text = "1K scatter";
-            this.buttonScatter1k.UseVisualStyleBackColor = true;
-            this.buttonScatter1k.Click += new System.EventHandler(this.buttonScatter1k_Click);
-            // 
-            // buttonSignal1M
-            // 
-            this.buttonSignal1M.Location = new System.Drawing.Point(174, 12);
-            this.buttonSignal1M.Name = "buttonSignal1M";
-            this.buttonSignal1M.Size = new System.Drawing.Size(75, 23);
-            this.buttonSignal1M.TabIndex = 3;
-            this.buttonSignal1M.Text = "1M signal";
-            this.buttonSignal1M.UseVisualStyleBackColor = true;
-            this.buttonSignal1M.Click += new System.EventHandler(this.buttonSignal1M_Click);
-            // 
-            // cbRenderQueue
-            // 
-            this.cbRenderQueue.AutoSize = true;
-            this.cbRenderQueue.Checked = true;
-            this.cbRenderQueue.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbRenderQueue.Location = new System.Drawing.Point(255, 16);
-            this.cbRenderQueue.Name = "cbRenderQueue";
-            this.cbRenderQueue.Size = new System.Drawing.Size(112, 17);
-            this.cbRenderQueue.TabIndex = 4;
-            this.cbRenderQueue.Text = "UseRenderQueue";
-            this.cbRenderQueue.UseVisualStyleBackColor = true;
-            this.cbRenderQueue.CheckedChanged += new System.EventHandler(this.cbRenderQueue_CheckedChanged);
-            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 450);
-            this.Controls.Add(this.cbRenderQueue);
-            this.Controls.Add(this.buttonSignal1M);
-            this.Controls.Add(this.buttonScatter1k);
-            this.Controls.Add(this.btnScatter10);
+            this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.formsPlot1);
             this.Name = "Form1";
             this.Text = "ScottPlot Sandbox - WinForms (.NET Framework)";
+            this.groupBox1.ResumeLayout(false);
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
         #endregion
 
         private ScottPlot.FormsPlot formsPlot1;
-        private System.Windows.Forms.Button btnScatter10;
-        private System.Windows.Forms.Button buttonScatter1k;
-        private System.Windows.Forms.Button buttonSignal1M;
-        private System.Windows.Forms.CheckBox cbRenderQueue;
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.ComboBox comboBox1;
     }
 }
 

--- a/src/sandbox/WinFormsFrameworkApp/Form1.cs
+++ b/src/sandbox/WinFormsFrameworkApp/Form1.cs
@@ -7,49 +7,26 @@ namespace WinFormsFrameworkApp
 {
     public partial class Form1 : Form
     {
-        private readonly Random Rand = new Random();
-
         public Form1()
         {
             InitializeComponent();
-            buttonScatter1k_Click(null, null);
-            cbRenderQueue.Checked = formsPlot1.Configuration.UseRenderQueue;
+            formsPlot1.Plot.AddSignal(ScottPlot.DataGen.Sin(51, mult: 10));
         }
 
-        private void btnScatter10_Click(object sender, EventArgs e)
+        private void comboBox1_SelectedIndexChanged(object sender, EventArgs e)
         {
-            int pointCount = 10;
-            double[] xs = ScottPlot.DataGen.Random(Rand, pointCount);
-            double[] ys = ScottPlot.DataGen.Random(Rand, pointCount);
-            formsPlot1.Plot.Clear();
-            formsPlot1.Plot.AddScatter(xs, ys);
-            formsPlot1.Plot.Title("Scatter Plot with 10 Points");
-            formsPlot1.RenderLowThenImmediateHighQuality();
-        }
+            if (comboBox1.Text == "Disabled")
+                formsPlot1.Plot.AxisScaleLock(enable: false);
+            else if (comboBox1.Text == "Preserve X")
+                formsPlot1.Plot.AxisScaleLock(enable: true, scaleMode: ScottPlot.EqualScaleMode.PreserveX);
+            else if (comboBox1.Text == "Preserve Y")
+                formsPlot1.Plot.AxisScaleLock(enable: true, scaleMode: ScottPlot.EqualScaleMode.PreserveY);
+            else if (comboBox1.Text == "Zoom Out")
+                formsPlot1.Plot.AxisScaleLock(enable: true, scaleMode: ScottPlot.EqualScaleMode.ZoomOut);
+            else
+                throw new InvalidOperationException();
 
-        private void buttonScatter1k_Click(object sender, EventArgs e)
-        {
-            int pointCount = 2_000;
-            double[] xs = ScottPlot.DataGen.Random(Rand, pointCount);
-            double[] ys = ScottPlot.DataGen.Random(Rand, pointCount);
-            formsPlot1.Plot.Clear();
-            formsPlot1.Plot.AddScatter(xs, ys);
-            formsPlot1.Plot.Title("Scatter Plot with 2,000 Points");
-            formsPlot1.RenderLowThenImmediateHighQuality();
+            formsPlot1.Render();
         }
-
-        private void buttonSignal1M_Click(object sender, EventArgs e)
-        {
-            int pointCount = 1_000_000;
-            int sampleRate = 48_000;
-            double[] data = ScottPlot.DataGen.RandomWalk(Rand, pointCount);
-            formsPlot1.Plot.Clear();
-            formsPlot1.Plot.AddSignal(data, sampleRate);
-            formsPlot1.Plot.Title("Signal Plot with 1,000,000 Points");
-            formsPlot1.RenderLowThenImmediateHighQuality();
-        }
-
-        private void cbRenderQueue_CheckedChanged(object sender, EventArgs e) =>
-            formsPlot1.Configuration.UseRenderQueue = cbRenderQueue.Checked;
     }
 }


### PR DESCRIPTION
**Purpose:**
This PR allow user to customize behaviour of EqualAxisScale mode. Discussed in detail in #857.
By default behavior stay as before.
But `Settings` have 2 additional fields `EqualScaleUseX = true` and `EqualScaleUseY=true`.
If User disable one of them, then remain axis only used for `EqualScale` calculation. 
This close to old behavior used in `EqualScale` on `Control` level.

**New Functionality:**
```c#
Plot.AxisScaleLock(true); // stay as it was

Plot.AxisScaleLock(true, false, true); // YAxisScale used for EqualAxisScale calculation, old `Control` behavior
```