### PR TITLE
Allow user to customize mouse wheel Zoom speed.

### DIFF
--- a/src/ScottPlot/Control/Configuration.cs
+++ b/src/ScottPlot/Control/Configuration.cs
@@ -44,26 +44,23 @@ namespace ScottPlot.Control
         /// </summary>
         public bool ScrollWheelZoom = true;
 
-        private double _scrollWheelZoomIncrement = 0.15;
+        private double _scrollWheelZoomFraction = 0.15;
 
         /// <summary>
-        /// Zoom value for a single scroll of the mouse wheel.
-        /// Available range is (0, 1).
-        /// Zoom in goes (1 + value) times, 
-        /// Zoom out goes (1 - value) times.
-        /// Default value is 0.15
+        /// Fractional amount to zoom in or out when the mouse wheel is scrolled.
+        /// Value must be between 0 and 1 (default is 0.15).
         /// </summary>
-        public double ScrollWheelZoomIncrement
+        public double ScrollWheelZoomFraction
         {
-            get => _scrollWheelZoomIncrement;
+            get => _scrollWheelZoomFraction;
             set
             {
                 if (value <= 0)
-                    throw new ArgumentOutOfRangeException("ScrollWheelZoomIncrement", "must be positive");
+                    throw new ArgumentOutOfRangeException("ScrollWheelZoomFraction", "must be positive");
                 if (value >= 1)
-                    throw new ArgumentOutOfRangeException("ScrollWheelZoomIncrement", "must be less than 1");
+                    throw new ArgumentOutOfRangeException("ScrollWheelZoomFraction", "must be less than 1");
 
-                _scrollWheelZoomIncrement = value;
+                _scrollWheelZoomFraction = value;
             }
         }
 

--- a/src/ScottPlot/Control/Configuration.cs
+++ b/src/ScottPlot/Control/Configuration.cs
@@ -44,6 +44,29 @@ namespace ScottPlot.Control
         /// </summary>
         public bool ScrollWheelZoom = true;
 
+        private double _scrollWheelZoomIncrement = 0.15;
+
+        /// <summary>
+        /// Zoom value for a single scroll of the mouse wheel.
+        /// Available range is (0, 1).
+        /// Zoom in goes (1 + value) times, 
+        /// Zoom out goes (1 - value) times.
+        /// Default value is 0.15
+        /// </summary>
+        public double ScrollWheelZoomIncrement
+        {
+            get => _scrollWheelZoomIncrement;
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentOutOfRangeException("ScrollWheelZoomIncrement", "must be positive");
+                if (value >= 1)
+                    throw new ArgumentOutOfRangeException("ScrollWheelZoomIncrement", "must be less than 1");
+
+                _scrollWheelZoomIncrement = value;
+            }
+        }
+
         /// <summary>
         /// Number of milliseconds after low quality scroll wheel zoom to re-render using high quality
         /// </summary>

--- a/src/ScottPlot/Control/EventProcess/Events/MouseScrollEvent.cs
+++ b/src/ScottPlot/Control/EventProcess/Events/MouseScrollEvent.cs
@@ -23,8 +23,8 @@
 
         public void ProcessEvent()
         {
-            double increment = 1.0 + Configuration.ScrollWheelZoomIncrement;
-            double decrement = 1.0 - Configuration.ScrollWheelZoomIncrement;
+            double increment = 1.0 + Configuration.ScrollWheelZoomFraction;
+            double decrement = 1.0 - Configuration.ScrollWheelZoomFraction;
 
             double xFrac = ScrolledUp ? increment : decrement;
             double yFrac = ScrolledUp ? increment : decrement;

--- a/src/ScottPlot/Control/EventProcess/Events/MouseScrollEvent.cs
+++ b/src/ScottPlot/Control/EventProcess/Events/MouseScrollEvent.cs
@@ -23,8 +23,11 @@
 
         public void ProcessEvent()
         {
-            double xFrac = ScrolledUp ? 1.15 : 0.85;
-            double yFrac = ScrolledUp ? 1.15 : 0.85;
+            double increment = 1.0 + Configuration.ScrollWheelZoomIncrement;
+            double decrement = 1.0 - Configuration.ScrollWheelZoomIncrement;
+
+            double xFrac = ScrolledUp ? increment : decrement;
+            double yFrac = ScrolledUp ? increment : decrement;
 
             if (Configuration.LockHorizontalAxis)
                 xFrac = 1;

--- a/src/tests/Control/ConfigurationTests.cs
+++ b/src/tests/Control/ConfigurationTests.cs
@@ -1,0 +1,32 @@
+﻿using NUnit.Framework;
+using ScottPlot.Control;
+using System;
+
+namespace ScottPlotTests.Control
+{
+
+    [TestFixture]
+    public class ConfigurationTests
+    {
+        [TestCase(0.01)]
+        [TestCase(0.15)]
+        [TestCase(0.7)]
+        [TestCase(0.5)]
+        public void ScrollWheelZoomIncrement_WithinValidRange_NotThrows(double value)
+        {
+            Configuration config = new Configuration();
+            config.ScrollWheelZoomIncrement = value;
+        }
+
+        [TestCase(-5)]
+        [TestCase(2)]
+        [TestCase(7)]
+        [TestCase(0)]
+        [TestCase(1)]
+        public void ScrollWheelZoomIncrement_WithoutValidRange_Throws(double value)
+        {
+            Configuration config = new Configuration();
+            Assert.Throws<ArgumentOutOfRangeException>(() => config.ScrollWheelZoomIncrement = value);
+        }
+    }
+}

--- a/src/tests/Control/ConfigurationTests.cs
+++ b/src/tests/Control/ConfigurationTests.cs
@@ -15,7 +15,7 @@ namespace ScottPlotTests.Control
         public void ScrollWheelZoomIncrement_WithinValidRange_NotThrows(double value)
         {
             Configuration config = new Configuration();
-            config.ScrollWheelZoomIncrement = value;
+            config.ScrollWheelZoomFraction = value;
         }
 
         [TestCase(-5)]
@@ -26,7 +26,7 @@ namespace ScottPlotTests.Control
         public void ScrollWheelZoomIncrement_WithoutValidRange_Throws(double value)
         {
             Configuration config = new Configuration();
-            Assert.Throws<ArgumentOutOfRangeException>(() => config.ScrollWheelZoomIncrement = value);
+            Assert.Throws<ArgumentOutOfRangeException>(() => config.ScrollWheelZoomFraction = value);
         }
     }
 }


### PR DESCRIPTION
**Purpose:**
Allow user to setup mouse wheel zoom speed. #937


**New Functionality:**
Introduce new `ScrollWheelZoomIncrement` property for `Control.Configuration`.
Available range is (0, 1).
`0.15` default value match to previous behaviour.

```cs
Control.Configuration.ScrollWheelZoomIncrement = 0.01; // very slow mouse wheel zoom
Control.Configuration.ScrollWheelZoomIncrement = 0.5 // fast mouuse wheel zoom
Control.Configuration.ScrollWheelZoomIncrement = 0.15 // default value
```