### PR TITLE
4.0.x Fixes crash with ScatterPlots containing a single point

### DIFF
--- a/dev/devops/azure-pipelines.yml
+++ b/dev/devops/azure-pipelines.yml
@@ -52,7 +52,7 @@ steps:
   inputs:
     command: 'custom'
     custom: 'format'
-    arguments: '-w src/ScottPlotV4.sln --dry-run --check --verbosity diagnostic'
+    arguments: '-w src/ScottPlotV4.sln --check --verbosity diagnostic'
 
 ### INSTALL NUGET AND RESTORE PACKAGES
 

--- a/src/ScottPlot/plottables/PlottableScatter.cs
+++ b/src/ScottPlot/plottables/PlottableScatter.cs
@@ -176,7 +176,7 @@ namespace ScottPlot
                 }
 
                 // draw the lines connecting points
-                if (lineWidth > 0 && lineStyle != LineStyle.None)
+                if (lineWidth > 0 && lineStyle != LineStyle.None && points.Length > 1)
                 {
                     if (stepDisplay)
                     {

--- a/src/autoformat.bat
+++ b/src/autoformat.bat
@@ -1,3 +1,9 @@
-dotnet tool install --global dotnet-format
+:: Install and update the dotnet 4 autoformatter
+::dotnet tool install --global dotnet-format
+
+:: Install and update the dotnet 5 autoformatter
+dotnet tool update -g dotnet-format
+
+:: Run the dotnet formatter
 dotnet format
 pause


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
#948 

I don't know how you feel about backporting fixes to 4.0.x right now, I guess it depends on how soon you plan to release 4.1. In my opinion, even if you released 4.1.0 tomorrow trivial fixes like this should continue for at least a little while because 4.0 -> 4.1 does entail a sizeable number of breaking changes, even if many of them can be alleviated by search and replace. This is made easier by the fact that 4.0.48 seems pretty stable, so it shouldn't be too difficult to maintain.

The only difficulty is that 4.0.x and 4.1.x have different directory structures and the solution file has a different name. Which means you have to close Visual Studio and normally run `git clean -df` and sometimes `git reset --hard` when switching between the branches. I think this is supposed to be what git worktrees are for but I've never used them. Regardless, more an annoyance than anything else.

**New Functionality:**
N/A