### PR TITLE
AddHeatMapCoordinated → AddHeatmapCoordinated

### DIFF
--- a/src/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot/Plot/Plot.Add.cs
@@ -368,7 +368,7 @@ namespace ScottPlot
         /// Returns the heatmap that was added to the plot.
         /// Act on its public fields and methods to customize it or update its data.
         /// </returns>
-        public CoordinatedHeatmap AddHeatMapCoordinated(double?[,] intensities, double? xMin = null, double? xMax = null, double? yMin = null, double? yMax = null, Drawing.Colormap colormap = null)
+        public CoordinatedHeatmap AddHeatmapCoordinated(double?[,] intensities, double? xMin = null, double? xMax = null, double? yMin = null, double? yMax = null, Drawing.Colormap colormap = null)
         {
             var plottable = new CoordinatedHeatmap();
 
@@ -437,7 +437,7 @@ namespace ScottPlot
         /// Returns the heatmap that was added to the plot.
         /// Act on its public fields and methods to customize it or update its data.
         /// </returns>
-        public CoordinatedHeatmap AddHeatMapCoordinated(double[,] intensities, double? xMin = null, double? xMax = null, double? yMin = null, double? yMax = null, Drawing.Colormap colormap = null)
+        public CoordinatedHeatmap AddHeatmapCoordinated(double[,] intensities, double? xMin = null, double? xMax = null, double? yMin = null, double? yMax = null, Drawing.Colormap colormap = null)
         {
             var plottable = new CoordinatedHeatmap();
 

--- a/src/ScottPlot/Plot/Plot.Obsolete.cs
+++ b/src/ScottPlot/Plot/Plot.Obsolete.cs
@@ -33,21 +33,21 @@ namespace ScottPlot
 
         [Obsolete("Use AddAnnotation() and customize the object it returns")]
         public Annotation PlotAnnotation(
-        string label,
-        double xPixel = 10,
-        double yPixel = 10,
-        double fontSize = 12,
-        string fontName = "Segoe UI",
-        Color? fontColor = null,
-        double fontAlpha = 1,
-        bool fill = true,
-        Color? fillColor = null,
-        double fillAlpha = .2,
-        double lineWidth = 1,
-        Color? lineColor = null,
-        double lineAlpha = 1,
-        bool shadow = false
-        )
+            string label,
+            double xPixel = 10,
+            double yPixel = 10,
+            double fontSize = 12,
+            string fontName = "Segoe UI",
+            Color? fontColor = null,
+            double fontAlpha = 1,
+            bool fill = true,
+            Color? fillColor = null,
+            double fillAlpha = .2,
+            double lineWidth = 1,
+            Color? lineColor = null,
+            double lineAlpha = 1,
+            bool shadow = false
+            )
         {
             fontColor ??= Color.Black;
             fillColor ??= Color.Yellow;

--- a/src/ScottPlot/Plot/Plot.Obsolete.cs
+++ b/src/ScottPlot/Plot/Plot.Obsolete.cs
@@ -7,6 +7,7 @@ using ScottPlot.Plottable;
 using ScottPlot.Statistics;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
@@ -15,23 +16,38 @@ namespace ScottPlot
 {
     public partial class Plot
     {
+        [Obsolete("Use AddHeatmapCoordinated (note capitalization)")]
+        [EditorBrowsable(EditorBrowsableState.Never)] // Prevents suggestions in Intellisense for downstream users. Still shows up while editing this assembly.
+        public CoordinatedHeatmap AddHeatMapCoordinated(double?[,] intensities, double? xMin = null, double? xMax = null, double? yMin = null, double? yMax = null, Drawing.Colormap colormap = null)
+        {
+            return AddHeatmapCoordinated(intensities, xMin, xMax, yMin, yMax, colormap);
+        }
+
+        [Obsolete("Use AddHeatmapCoordinated (note capitalization)")]
+        [EditorBrowsable(EditorBrowsableState.Never)] // Prevents suggestions in Intellisense for downstream users. Still shows up while editing this assembly.
+        public CoordinatedHeatmap AddHeatMapCoordinated(double[,] intensities, double? xMin = null, double? xMax = null, double? yMin = null, double? yMax = null, Drawing.Colormap colormap = null)
+        {
+            return AddHeatmapCoordinated(intensities, xMin, xMax, yMin, yMax, colormap);
+        }
+
+
         [Obsolete("Use AddAnnotation() and customize the object it returns")]
         public Annotation PlotAnnotation(
-            string label,
-            double xPixel = 10,
-            double yPixel = 10,
-            double fontSize = 12,
-            string fontName = "Segoe UI",
-            Color? fontColor = null,
-            double fontAlpha = 1,
-            bool fill = true,
-            Color? fillColor = null,
-            double fillAlpha = .2,
-            double lineWidth = 1,
-            Color? lineColor = null,
-            double lineAlpha = 1,
-            bool shadow = false
-            )
+        string label,
+        double xPixel = 10,
+        double yPixel = 10,
+        double fontSize = 12,
+        string fontName = "Segoe UI",
+        Color? fontColor = null,
+        double fontAlpha = 1,
+        bool fill = true,
+        Color? fillColor = null,
+        double fillAlpha = .2,
+        double lineWidth = 1,
+        Color? lineColor = null,
+        double lineAlpha = 1,
+        bool shadow = false
+        )
         {
             fontColor ??= Color.Black;
             fillColor ??= Color.Yellow;

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
@@ -182,7 +182,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             double[,] intensities = Tools.XYToIntensities(mode: IntensityMode.Gaussian,
                 xs: xs, ys: ys, width: 50, height: 50, sampleWidth: 4);
 
-            var hmc = plt.AddHeatMapCoordinated(intensities, xMin: -100, xMax: 500, yMin: 200, yMax: 201);
+            var hmc = plt.AddHeatmapCoordinated(intensities, xMin: -100, xMax: 500, yMin: 200, yMax: 201);
             var cb = plt.AddColorbar(hmc);
         }
     }


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
#955 

This renaming preserves the previous method signature but marks it as obsolete. The warning points to the new method.

I also used ` [EditorBrowsable(EditorBrowsableState.Never)]` so that IDEs which respect this attribute will not show it in code completion. Note it will always be shown on the ScottPlot assembly, but not in projects which use the library. I think this attribute can be controversial, I'm using it here because the previous method signature is nearly identical and does the same thing, which can make the two difficult to differentiate. I wouldn't use this attribute on obsolete methods like `PlotHeatmap` because that method does actually do something different and thus shouldn't be hidden. I think it's okay in this case since anyone who is looking for `AddHeatMapCoordinated` should use `AddHeatmapCoordinated` and they wouldn't notice the difference, while still protecting people from accidentally using the deprecated method through code completion.

There was discussion on #955 about refactoring the heatmap plottables and potentially adding other scaling options such as cropping, zooming, scaling only one axis, etc. That might be interesting for a future PR, depending on your opinion.

**New Functionality:**
N/A