### PR TITLE
Adds request for environment info on applicable issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,11 @@ labels: 'BUG'
 assignees: ''
 
 ---
+### Your Environment
+- ScottPlot Version:
+- Operating System:
+- Is it a GUI app? What platform?
+    - Platforms include WinForms, WPF, and Avalonia
 
 Describe the bug and how we can reproduce it.
 

--- a/.github/ISSUE_TEMPLATE/question-about-scottplot.md
+++ b/.github/ISSUE_TEMPLATE/question-about-scottplot.md
@@ -6,6 +6,11 @@ labels: 'Question'
 assignees: ''
 
 ---
+### Your Environment
+- ScottPlot Version:
+- Operating System:
+- Is it a GUI app? What platform?
+    - Platforms include WinForms, WPF, and Avalonia
 
 **Before asking a question** see if it is already answered in:
 * [ScottPlot Cookbook](http://swharden.com/scottplot/cookbook)


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
I've noticed that a lot of recent issues have stemmed from users attempting to use ScottPlot 4.1 methods in 4.0 or vice versa. 

Additionally, when answering a lot of questions one has to preface them with "If you're using 4.1.x do ... If you're using 4.0.x do ...". This also happens to a lesser degree when answering GUI questions, one has to modify their answer for WinForms or WPF or Avalonia.

I think to help mitigate this we should edit the issue templates so that they ask the user for this information up front. I modified the `bug_report` and the `question-about-scottplot` templates to ask for this information:
- ScottPlot version
- Operating System
- Which platform (WPF, WinForms, Avalonia)

Let me know what you think.
**New Functionality:**
N/A