### PR TITLE
Fixes visual issue in Avalonia Demo with incorrect left margin

### DIFF
--- a/src/demo/ScottPlot.Demo.Avalonia/MainWindow.axaml
+++ b/src/demo/ScottPlot.Demo.Avalonia/MainWindow.axaml
@@ -34,8 +34,8 @@
 				</Grid.ColumnDefinitions>
 
 				<StackPanel Grid.Row="0" Grid.Column="0">
-					<TextBlock DockPanel.Dock="Top" FontSize="24" FontWeight="SemiBold">ScottPlot Demo</TextBlock>
-					<TextBlock DockPanel.Dock="Top" Name="VersionLabel" FontSize="12" Margin="0,0,0,0" Foreground="Gray" Width="109" HorizontalAlignment="Left">version 8.8.88</TextBlock>
+					<TextBlock DockPanel.Dock="Top" FontSize="24" FontWeight="SemiBold" Margin="5,0,0,0">ScottPlot Demo</TextBlock>
+					<TextBlock DockPanel.Dock="Top" Name="VersionLabel" FontSize="12" Margin="5,0,0,0" Foreground="Gray" Width="109" HorizontalAlignment="Left">version 8.8.88</TextBlock>
 				</StackPanel>
 
 				<Button Name="WebsiteLabel" ToolTip.Tip="Launch ScottPlot Website" Foreground="Gray" FontSize="14" HorizontalAlignment="Right" Grid.Row="0" Grid.Column="0">

--- a/src/demo/ScottPlot.Demo.Avalonia/MainWindow.axaml
+++ b/src/demo/ScottPlot.Demo.Avalonia/MainWindow.axaml
@@ -6,7 +6,7 @@
         x:Class="ScottPlot.Demo.Avalonia.MainWindow"
         xmlns:ScottPlot="clr-namespace:ScottPlot.Avalonia;assembly=ScottPlot.Avalonia"
         Title="ScottPlot Demo"
-        Width="500"
+        Width="520"
         Height="350"
         >
 	<ScrollViewer>


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
Fixes a tiny visual issue in the Avalonia Demo. Note the left margin on the title, and that the "Website" button is no longer cut off.

**New Functionality:**

Before:
![image](https://user-images.githubusercontent.com/8635304/114317997-10beab80-9ac8-11eb-85f3-056f4ec33dc6.png)

After:
![image](https://user-images.githubusercontent.com/8635304/114318034-495e8500-9ac8-11eb-9366-86ee7bfdf3ec.png)
