### PR TITLE
Bump Avalonia versions to 0.10.2

### DIFF
--- a/src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj
+++ b/src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj
@@ -33,8 +33,8 @@ Release demo: http://swharden.com/scottplot/demo</PackageReleaseNotes>
     <None Include="icon.png" Pack="true" PackagePath="\" />
     <None Include="icon.ico" Pack="true" PackagePath="\" />
     <None Include="README.txt" Pack="true" PackagePath="\" />
-    <PackageReference Include="Avalonia" Version="0.10.0" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
+    <PackageReference Include="Avalonia" Version="0.10.2" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.2" />
   </ItemGroup>
   
 </Project>

--- a/src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.csproj
+++ b/src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.csproj
@@ -5,8 +5,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.0" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
+    <PackageReference Include="Avalonia" Version="0.10.2" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.2" />
     <ProjectReference Include="..\..\ScottPlot\ScottPlot.csproj" />
   </ItemGroup>
 </Project>

--- a/src/demo/ScottPlot.Demo.Avalonia/Avalonia Demo.csproj
+++ b/src/demo/ScottPlot.Demo.Avalonia/Avalonia Demo.csproj
@@ -5,9 +5,9 @@
         <Platforms>AnyCPU;x64</Platforms>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="0.10.0" />
-        <PackageReference Include="Avalonia.Desktop" Version="0.10.0" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0" />
+        <PackageReference Include="Avalonia" Version="0.10.2" />
+        <PackageReference Include="Avalonia.Desktop" Version="0.10.2" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.2" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\controls\ScottPlot.Avalonia\ScottPlot.Avalonia.csproj" />


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
Avalonia versions go from 0.10.0 -> 0.10.2

(0.10.1 does exist but they released a new version a few hours later to undeprecate something: https://github.com/AvaloniaUI/Avalonia/discussions/5820)

**New Functionality:**
N/A