### PR TITLE
System.Drawing.Common version downgrade

### DIFF
--- a/src/ScottPlot/ScottPlot.csproj
+++ b/src/ScottPlot/ScottPlot.csproj
@@ -37,7 +37,7 @@ Release demo: https://swharden.com/scottplot/demo</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.6.1" />
     <None Include="icon.png" Pack="true" PackagePath="\" />
     <None Include="icon.ico" Pack="true" PackagePath="\" />
     <None Include="README.txt" Pack="true" PackagePath="\" />

--- a/src/controls/ScottPlot.WPF/ScottPlot.WPF.csproj
+++ b/src/controls/ScottPlot.WPF/ScottPlot.WPF.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\ScottPlot\ScottPlot.csproj" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
     <None Include="VisualStudioToolsManifest.xml" Pack="true" PackagePath="tools" />
   </ItemGroup>
 

--- a/src/sandbox/WinFormsFrameworkApp/WinFormsFrameworkApp.csproj
+++ b/src/sandbox/WinFormsFrameworkApp/WinFormsFrameworkApp.csproj
@@ -35,12 +35,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Drawing.Common.5.0.0\lib\net461\System.Drawing.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -72,7 +66,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/src/sandbox/WinFormsFrameworkApp/packages.config
+++ b/src/sandbox/WinFormsFrameworkApp/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.Drawing.Common" version="5.0.0" targetFramework="net48" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
-</packages>


### PR DESCRIPTION
This PR rolls System.Drawing.Common package from version 5 to version 4.6.1 to match the minimum supported version of .NET Framework and reduce pain associated with downgrading from version 5 to 4 

A detailed description is in #1004