### PR TITLE
Allow to customize LineStyle for SignalXY

### DIFF
--- a/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -108,7 +108,7 @@ namespace ScottPlot.Plottable
         {
             using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
             using (var brush = new SolidBrush(Color))
-            using (var penHD = GDI.Pen(Color, (float)LineWidth, LineStyle.Solid, true))
+            using (var penHD = GDI.Pen(Color, (float)LineWidth, LineStyle, true))
             {
 
                 PointF[] PointBefore;


### PR DESCRIPTION
**Purpose:**
Allow to customize `LineStyle` for `SignalXY`.
Although changing the style from a solid gives an incorrect result, it happens that someone really needs it #1016.

**New Functionality:**

Works for now:
```cs
SignalXY.LineStyle = LineStyle.Dash;
```