### PR TITLE
Add RenderRequest() to controls for non-blocking rendering

### DIFF
--- a/src/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot/Control/Backend.cs
@@ -352,28 +352,28 @@ namespace ScottPlot.Control
         {
             switch (renderType)
             {
-                case RenderType.LQOnly:
+                case RenderType.LowQuality:
                     ProcessEvent(EventFactory.CreateManualLowQualityRender());
                     return;
 
-                case RenderType.HQOnly:
+                case RenderType.HighQuality:
                     ProcessEvent(EventFactory.CreateManualHighQualityRender());
                     return;
 
-                case RenderType.HQDelayed:
+                case RenderType.HighQualityDelayed:
                     ProcessEvent(EventFactory.CreateManualDelayedHighQualityRender());
                     return;
 
-                case RenderType.HQAfterLQImmediately:
+                case RenderType.LowQualityThenHighQuality:
                     ProcessEvent(EventFactory.CreateManualLowQualityRender());
                     ProcessEvent(EventFactory.CreateManualHighQualityRender());
                     return;
 
-                case RenderType.HQAfterLQDelayed:
+                case RenderType.LowQualityThenHighQualityDelayed:
                     ProcessEvent(EventFactory.CreateManualDelayedHighQualityRender());
                     return;
 
-                case RenderType.None:
+                case RenderType.ProcessMouseEventsOnly:
                     return;
 
                 default:
@@ -412,7 +412,7 @@ namespace ScottPlot.Control
             Bmp = new System.Drawing.Bitmap((int)width, (int)height);
             BitmapRenderCount = 0;
 
-            RenderRequest(RenderType.HQDelayed);
+            RenderRequest(RenderType.HighQualityDelayed);
         }
 
         /// <summary>
@@ -495,7 +495,7 @@ namespace ScottPlot.Control
             {
                 uiEvent.ProcessEvent();
 
-                if (uiEvent.RenderType == RenderType.None)
+                if (uiEvent.RenderType == RenderType.ProcessMouseEventsOnly)
                     return;
 
                 bool lowQuality =

--- a/src/ScottPlot/Control/EventProcess/Events/RenderDelayedHighQuality.cs
+++ b/src/ScottPlot/Control/EventProcess/Events/RenderDelayedHighQuality.cs
@@ -8,7 +8,7 @@ namespace ScottPlot.Control.EventProcess.Events
 {
     class RenderDelayedHighQuality : IUIEvent
     {
-        public RenderType RenderType => RenderType.HQAfterLQDelayed;
+        public RenderType RenderType => RenderType.LowQualityThenHighQualityDelayed;
 
         public void ProcessEvent()
         {

--- a/src/ScottPlot/Control/EventProcess/Events/RenderHighQuality.cs
+++ b/src/ScottPlot/Control/EventProcess/Events/RenderHighQuality.cs
@@ -8,7 +8,7 @@ namespace ScottPlot.Control.EventProcess.Events
 {
     class RenderHighQuality : IUIEvent
     {
-        public RenderType RenderType => RenderType.HQOnly;
+        public RenderType RenderType => RenderType.HighQuality;
 
         public void ProcessEvent()
         {

--- a/src/ScottPlot/Control/EventProcess/Events/RenderLowQuality.cs
+++ b/src/ScottPlot/Control/EventProcess/Events/RenderLowQuality.cs
@@ -8,7 +8,7 @@ namespace ScottPlot.Control.EventProcess.Events
 {
     class RenderLowQuality : IUIEvent
     {
-        public RenderType RenderType => RenderType.LQOnly;
+        public RenderType RenderType => RenderType.LowQuality;
 
         public void ProcessEvent()
         {

--- a/src/ScottPlot/Control/EventProcess/EventsProcessor.cs
+++ b/src/ScottPlot/Control/EventProcess/EventsProcessor.cs
@@ -84,7 +84,7 @@ namespace ScottPlot.Control.EventProcess
         /// </summary>
         private void RenderPreview(RenderType renderType)
         {
-            if (renderType == RenderType.HQOnly)
+            if (renderType == RenderType.HighQuality)
                 return;
 
             RenderLowQuality();
@@ -98,21 +98,21 @@ namespace ScottPlot.Control.EventProcess
         {
             switch (renderType)
             {
-                case RenderType.LQOnly:
+                case RenderType.LowQuality:
                     // we don't need a HQ render if the type is LQ only
                     return true;
 
-                case RenderType.HQOnly:
+                case RenderType.HighQuality:
                     // A HQ version is always needed
                     RenderHighQuality();
                     return true;
 
-                case RenderType.HQAfterLQImmediately:
+                case RenderType.LowQualityThenHighQuality:
                     // A LQ version has been rendered, but we need a HQ version now
                     RenderHighQuality();
                     return true;
 
-                case RenderType.HQAfterLQDelayed:
+                case RenderType.LowQualityThenHighQualityDelayed:
                     // A LQ version has been rendered, but we need a HQ version after a delay
 
                     if (RenderDelayTimer.IsRunning == false)
@@ -146,7 +146,7 @@ namespace ScottPlot.Control.EventProcess
                 await Task.Delay(1);
             }
 
-            RenderType lastEventRenderType = RenderType.None;
+            RenderType lastEventRenderType = RenderType.ProcessMouseEventsOnly;
             while (true)
             {
                 QueueProcessorIsRunning = true;
@@ -156,10 +156,10 @@ namespace ScottPlot.Control.EventProcess
                     var uiEvent = Queue.Dequeue();
                     uiEvent.ProcessEvent();
 
-                    if (uiEvent.RenderType == RenderType.HQAfterLQDelayed)
+                    if (uiEvent.RenderType == RenderType.LowQualityThenHighQualityDelayed)
                         RenderDelayTimer.Restart();
 
-                    if (uiEvent.RenderType != RenderType.None)
+                    if (uiEvent.RenderType != RenderType.ProcessMouseEventsOnly)
                     {
                         lastEventRenderType = uiEvent.RenderType;
                         eventRenderRequested = true;

--- a/src/ScottPlot/Control/EventProcess/RenderType.cs
+++ b/src/ScottPlot/Control/EventProcess/RenderType.cs
@@ -19,6 +19,12 @@
         HQOnly,
 
         /// <summary>
+        /// Perform a high quality render after a delay.
+        /// This is the best render type to use when resizing windows.
+        /// </summary>
+        HQDelayed,
+
+        /// <summary>
         /// Render low quality and display it, then if no new render requests
         /// have been received immediately render a high quality version and display it.
         /// This is the best render option to use when requesting renders programmatically

--- a/src/ScottPlot/Control/QualityConfiguration.cs
+++ b/src/ScottPlot/Control/QualityConfiguration.cs
@@ -15,10 +15,10 @@ namespace ScottPlot.Control
     /// </summary>
     public class QualityConfiguration
     {
-        public RenderType BenchmarkToggle = RenderType.HQOnly;
-        public RenderType AutoAxis = RenderType.HQAfterLQDelayed;
-        public RenderType MouseInteractiveDragged = RenderType.LQOnly;
-        public RenderType MouseInteractiveDropped = RenderType.HQOnly;
-        public RenderType MouseWheelScrolled = RenderType.HQAfterLQDelayed;
+        public RenderType BenchmarkToggle = RenderType.HighQuality;
+        public RenderType AutoAxis = RenderType.LowQualityThenHighQualityDelayed;
+        public RenderType MouseInteractiveDragged = RenderType.LowQuality;
+        public RenderType MouseInteractiveDropped = RenderType.HighQuality;
+        public RenderType MouseWheelScrolled = RenderType.LowQualityThenHighQualityDelayed;
     }
 }

--- a/src/ScottPlot/Enums/RenderType.cs
+++ b/src/ScottPlot/Enums/RenderType.cs
@@ -1,9 +1,9 @@
-﻿namespace ScottPlot.Control.EventProcess
+﻿namespace ScottPlot
 {
     /// <summary>
     /// Describes how a render should be performed with respect to quality.
     /// High quality enables anti-aliasing but is slower.
-    /// Some options allow a fast initial render followed by a slower higher quality render.
+    /// Some options describe multiple renders, with or without a delay between them.
     /// </summary>
     public enum RenderType
 
@@ -11,37 +11,37 @@
         /// <summary>
         /// Only render using low quality (anti-aliasing off)
         /// </summary>
-        LQOnly,
+        LowQuality,
 
         /// <summary>
         /// Only render using high quality (anti-aliasing on)
         /// </summary>
-        HQOnly,
+        HighQuality,
 
         /// <summary>
         /// Perform a high quality render after a delay.
         /// This is the best render type to use when resizing windows.
         /// </summary>
-        HQDelayed,
+        HighQualityDelayed,
 
         /// <summary>
         /// Render low quality and display it, then if no new render requests
         /// have been received immediately render a high quality version and display it.
         /// This is the best render option to use when requesting renders programmatically
         /// </summary>
-        HQAfterLQImmediately,
+        LowQualityThenHighQuality,
 
         /// <summary>
         /// Render low quality and display it, wait a small period of time for new render requests to arrive,
         /// and if no new requests have been received render a high quality version and display it.
         /// This is the best render option to use for mouse interaction.
         /// </summary>
-        HQAfterLQDelayed,
+        LowQualityThenHighQualityDelayed,
 
         /// <summary>
         /// Process mouse events only (pan, zoom, etc) and do not render graphics on a Bitmap,
         /// then if no new requests have been received render using the last-used render type.
         /// </summary>
-        None,
+        ProcessMouseEventsOnly,
     }
 }

--- a/src/controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
+++ b/src/controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
@@ -68,6 +68,7 @@ namespace ScottPlot.Avalonia
         public void Reset() => Backend.Reset((float)this.Bounds.Width, (float)this.Bounds.Height);
         public void Reset(Plot newPlot) => Backend.Reset((float)this.Bounds.Width, (float)this.Bounds.Height, newPlot);
         public void Render(bool lowQuality = false) => Backend.Render(lowQuality);
+        public void RenderRequest(Control.EventProcess.RenderType renderType) => Backend.RenderRequest(renderType);
         private void PlottableCountTimer_Tick(object sender, EventArgs e) => Backend.RenderIfPlottableCountChanged();
 
         private Task SetImagePlot(Func<Ava.Media.Imaging.Bitmap> getBmp)

--- a/src/controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
+++ b/src/controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
@@ -68,7 +68,7 @@ namespace ScottPlot.Avalonia
         public void Reset() => Backend.Reset((float)this.Bounds.Width, (float)this.Bounds.Height);
         public void Reset(Plot newPlot) => Backend.Reset((float)this.Bounds.Width, (float)this.Bounds.Height, newPlot);
         public void Render(bool lowQuality = false) => Backend.Render(lowQuality);
-        public void RenderRequest(Control.EventProcess.RenderType renderType) => Backend.RenderRequest(renderType);
+        public void RenderRequest(RenderType renderType) => Backend.RenderRequest(renderType);
         private void PlottableCountTimer_Tick(object sender, EventArgs e) => Backend.RenderIfPlottableCountChanged();
 
         private Task SetImagePlot(Func<Ava.Media.Imaging.Bitmap> getBmp)

--- a/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
+++ b/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
@@ -102,9 +102,24 @@ namespace ScottPlot
         public void Render(bool lowQuality = false) => Backend.Render(lowQuality);
 
         /// <summary>
+        /// Render the plot using low quality
+        /// </summary>
+        public void RenderLowQuality() => Backend.RenderLowQuality();
+
+        /// <summary>
+        /// Render the plot using high quality
+        /// </summary>
+        public void RenderHighQuality() => Backend.RenderHighQuality();
+
+        /// <summary>
         /// Render the plot using low quality (fast) then immediate re-render using high quality (slower)
         /// </summary>
         public void RenderLowThenImmediateHighQuality() => Backend.RenderLowThenImmediateHighQuality();
+
+        /// <summary>
+        /// Render the plot using low quality (fast) then delayed re-render using high quality (slower).
+        /// </summary>
+        public void RenderDelayedHighQuality() => Backend.RenderDelayedHighQuality();
 
         private void PlottableCountTimer_Tick(object sender, EventArgs e) => Backend.RenderIfPlottableCountChanged();
         private void OnBitmapChanged(object sender, EventArgs e) => PlotImage.Source = BmpImageFromBmp(Backend.GetLatestBitmap());

--- a/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
+++ b/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
@@ -105,7 +105,7 @@ namespace ScottPlot
         /// Request the control re-render the next time it is available.
         /// This method does not block the calling thread.
         /// </summary>
-        public void RenderRequest(RenderType renderType) => Backend.RenderRequest(renderType);
+        public void RenderRequest(RenderType renderType = RenderType.LowQualityThenHighQualityDelayed) => Backend.RenderRequest(renderType);
 
         private void PlottableCountTimer_Tick(object sender, EventArgs e) => Backend.RenderIfPlottableCountChanged();
         private void OnBitmapChanged(object sender, EventArgs e) => PlotImage.Source = BmpImageFromBmp(Backend.GetLatestBitmap());

--- a/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
+++ b/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
@@ -102,24 +102,10 @@ namespace ScottPlot
         public void Render(bool lowQuality = false) => Backend.Render(lowQuality);
 
         /// <summary>
-        /// Render the plot using low quality
+        /// Request the control re-render the next time it is available.
+        /// This method does not block the calling thread.
         /// </summary>
-        public void RenderLowQuality() => Backend.RenderLowQuality();
-
-        /// <summary>
-        /// Render the plot using high quality
-        /// </summary>
-        public void RenderHighQuality() => Backend.RenderHighQuality();
-
-        /// <summary>
-        /// Render the plot using low quality (fast) then immediate re-render using high quality (slower)
-        /// </summary>
-        public void RenderLowThenImmediateHighQuality() => Backend.RenderLowThenImmediateHighQuality();
-
-        /// <summary>
-        /// Render the plot using low quality (fast) then delayed re-render using high quality (slower).
-        /// </summary>
-        public void RenderDelayedHighQuality() => Backend.RenderDelayedHighQuality();
+        public void RenderRequest(Control.EventProcess.RenderType renderType) => Backend.RenderRequest(renderType);
 
         private void PlottableCountTimer_Tick(object sender, EventArgs e) => Backend.RenderIfPlottableCountChanged();
         private void OnBitmapChanged(object sender, EventArgs e) => PlotImage.Source = BmpImageFromBmp(Backend.GetLatestBitmap());

--- a/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
+++ b/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
@@ -105,7 +105,7 @@ namespace ScottPlot
         /// Request the control re-render the next time it is available.
         /// This method does not block the calling thread.
         /// </summary>
-        public void RenderRequest(Control.EventProcess.RenderType renderType) => Backend.RenderRequest(renderType);
+        public void RenderRequest(RenderType renderType) => Backend.RenderRequest(renderType);
 
         private void PlottableCountTimer_Tick(object sender, EventArgs e) => Backend.RenderIfPlottableCountChanged();
         private void OnBitmapChanged(object sender, EventArgs e) => PlotImage.Source = BmpImageFromBmp(Backend.GetLatestBitmap());

--- a/src/controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/controls/ScottPlot.WinForms/FormsPlot.cs
@@ -102,9 +102,24 @@ namespace ScottPlot
         }
 
         /// <summary>
+        /// Render the plot using low quality
+        /// </summary>
+        public void RenderLowQuality() => Backend.RenderLowQuality();
+
+        /// <summary>
+        /// Render the plot using high quality
+        /// </summary>
+        public void RenderHighQuality() => Backend.RenderHighQuality();
+
+        /// <summary>
         /// Render the plot using low quality (fast) then immediate re-render using high quality (slower)
         /// </summary>
         public void RenderLowThenImmediateHighQuality() => Backend.RenderLowThenImmediateHighQuality();
+
+        /// <summary>
+        /// Render the plot using low quality (fast) then delayed re-render using high quality (slower).
+        /// </summary>
+        public void RenderDelayedHighQuality() => Backend.RenderDelayedHighQuality();
 
         private void PlottableCountTimer_Tick(object sender, EventArgs e) => Backend.RenderIfPlottableCountChanged();
         private void FormsPlot_Load(object sender, EventArgs e) { OnSizeChanged(null, null); }

--- a/src/controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/controls/ScottPlot.WinForms/FormsPlot.cs
@@ -105,7 +105,7 @@ namespace ScottPlot
         /// Request the control re-render the next time it is available.
         /// This method does not block the calling thread.
         /// </summary>
-        public void RenderRequest(RenderType renderType) => Backend.RenderRequest(renderType);
+        public void RenderRequest(RenderType renderType = RenderType.LowQualityThenHighQualityDelayed) => Backend.RenderRequest(renderType);
 
         private void PlottableCountTimer_Tick(object sender, EventArgs e) => Backend.RenderIfPlottableCountChanged();
         private void FormsPlot_Load(object sender, EventArgs e) { OnSizeChanged(null, null); }

--- a/src/controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/controls/ScottPlot.WinForms/FormsPlot.cs
@@ -102,24 +102,10 @@ namespace ScottPlot
         }
 
         /// <summary>
-        /// Render the plot using low quality
+        /// Request the control re-render the next time it is available.
+        /// This method does not block the calling thread.
         /// </summary>
-        public void RenderLowQuality() => Backend.RenderLowQuality();
-
-        /// <summary>
-        /// Render the plot using high quality
-        /// </summary>
-        public void RenderHighQuality() => Backend.RenderHighQuality();
-
-        /// <summary>
-        /// Render the plot using low quality (fast) then immediate re-render using high quality (slower)
-        /// </summary>
-        public void RenderLowThenImmediateHighQuality() => Backend.RenderLowThenImmediateHighQuality();
-
-        /// <summary>
-        /// Render the plot using low quality (fast) then delayed re-render using high quality (slower).
-        /// </summary>
-        public void RenderDelayedHighQuality() => Backend.RenderDelayedHighQuality();
+        public void RenderRequest(Control.EventProcess.RenderType renderType) => Backend.RenderRequest(renderType);
 
         private void PlottableCountTimer_Tick(object sender, EventArgs e) => Backend.RenderIfPlottableCountChanged();
         private void FormsPlot_Load(object sender, EventArgs e) { OnSizeChanged(null, null); }

--- a/src/controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/controls/ScottPlot.WinForms/FormsPlot.cs
@@ -105,7 +105,7 @@ namespace ScottPlot
         /// Request the control re-render the next time it is available.
         /// This method does not block the calling thread.
         /// </summary>
-        public void RenderRequest(Control.EventProcess.RenderType renderType) => Backend.RenderRequest(renderType);
+        public void RenderRequest(RenderType renderType) => Backend.RenderRequest(renderType);
 
         private void PlottableCountTimer_Tick(object sender, EventArgs e) => Backend.RenderIfPlottableCountChanged();
         private void FormsPlot_Load(object sender, EventArgs e) { OnSizeChanged(null, null); }


### PR DESCRIPTION
**Purpose:**
It is useful enough to provide the user with the ability to manually update Plot using the RenderQueue. #1032
This PR redirects all available rendering methods from the backend to controls.
- RenderLowQuality()
- RenderHighQuality()
- RenderDelayedHighQuality()
- RenderLowThenImmediateHighQuality() - already present

Avalonia control was left without these possibilities, I'm afraid to break something there because I have no experience.

**New Functionality:**

```cs
formsPlot1.RenderHighQuality();
formsPlot1.RenderLowQuality();
formsPlot1.RenderDelayedHighQuality();
```