### PR TITLE
Allow realtime updates of OHLC plots

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -4,6 +4,7 @@
 * Add support for custom linestyles in SignalXY plots (#1017, #1016) _Thanks @StendProg and @breakwinz_
 * Support Avalonia 0.10.4 (#1018) _Thanks @bclehmann_
 * Controls now properly process `MouseEnter` and `MouseLeave` events (#999) _Thanks @kirsan31 and @breakwinz_
+* Added Last() to finance plots to make it easier to access the final OHLC (#1038) _Thanks @CalderWhite_
 
 ## ScottPlot 4.1.13-beta
 * `Plot.Render()` and `Plot.SaveFig()` now have a `scale` argument to allow for the creation of high resolution scaled plots (#983, #982, #981) _Thanks @PeterDavidson_

--- a/src/ScottPlot/Plottable/FinancePlot.cs
+++ b/src/ScottPlot/Plottable/FinancePlot.cs
@@ -12,6 +12,10 @@ namespace ScottPlot.Plottable
     public class FinancePlot : IPlottable
     {
         private readonly List<OHLC> OHLCs = new List<OHLC>();
+        
+        // <summary>
+        // Returns the last element of OHLCs so users can modify FinancePlots in real time.
+        // </summary>
         public OHLC Last() => OHLCs.Last();
 
         /// <summary>

--- a/src/ScottPlot/Plottable/FinancePlot.cs
+++ b/src/ScottPlot/Plottable/FinancePlot.cs
@@ -12,6 +12,7 @@ namespace ScottPlot.Plottable
     public class FinancePlot : IPlottable
     {
         private readonly List<OHLC> OHLCs = new List<OHLC>();
+        public OHLC Last() => OHLCs.Last();
 
         /// <summary>
         /// Display prices as filled candlesticks (otherwise display as OHLC lines)

--- a/src/ScottPlot/Plottable/FinancePlot.cs
+++ b/src/ScottPlot/Plottable/FinancePlot.cs
@@ -13,9 +13,9 @@ namespace ScottPlot.Plottable
     {
         private readonly List<OHLC> OHLCs = new List<OHLC>();
 
-        // <summary>
-        // Returns the last element of OHLCs so users can modify FinancePlots in real time.
-        // </summary>
+        /// <summary>
+        /// Returns the last element of OHLCs so users can modify FinancePlots in real time.
+        /// </summary>
         public OHLC Last() => OHLCs.Last();
 
         /// <summary>

--- a/src/ScottPlot/Plottable/FinancePlot.cs
+++ b/src/ScottPlot/Plottable/FinancePlot.cs
@@ -12,7 +12,7 @@ namespace ScottPlot.Plottable
     public class FinancePlot : IPlottable
     {
         private readonly List<OHLC> OHLCs = new List<OHLC>();
-        
+
         // <summary>
         // Returns the last element of OHLCs so users can modify FinancePlots in real time.
         // </summary>


### PR DESCRIPTION
**Purpose:**
I added in your suggested change from #827. Have been building it locally with my own project that uses ScottPlot and it works great!

**New Functionality:**
Adds the following to `FinancePlot.cs`:
```cs
public OHLC Last() => OHLCs.Last();
```

This allows users to mutate the last item of the list, allowing for realtime plotting updates.

**Notes:**

Although, I am unable to horizontally zoom the plot. Maybe the key bindings from that type of zoom have been changed in the beta, but that is unrelated.

I don't think I am being much help here since you already proposed the change, but at the very least I am using it and it works!

Thanks for the project, it's one of the few C# graphing libraries that has what I need and doesn't make me pay for it :)