### PR TITLE
Prevent designer error messages from showing in non-error conditions

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -1,5 +1,8 @@
 # ScottPlot Changelog
 
+## ScottPlot 4.1.15 (work in progress)
+* Hide design-time error message component at run time to reduce flicking when resizing (#1073, #1075) _Thanks @Superberti and @bclehmann_
+
 ## ScottPlot 4.1.14
 * Add support for custom linestyles in SignalXY plots (#1017, #1016) _Thanks @StendProg and @breakwinz_
 * Improved Avalonia dependency versioning (#1018, #1041) _Thanks @bclehmann_

--- a/src/controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
+++ b/src/controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
@@ -161,6 +161,9 @@ namespace ScottPlot.Avalonia
                     return;
                 }
             }
+
+            this.Find<TextBlock>("ErrorLabel").IsVisible = false;
+
             Canvas canvas = new Canvas();
             mainGrid.Children.Add(canvas);
             canvas.Children.Add(PlotImage);

--- a/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
+++ b/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
@@ -67,6 +67,8 @@ namespace ScottPlot
                 }
             }
 
+            ErrorLabel.Visibility = System.Windows.Visibility.Hidden;
+
             Backend.Resize((float)ActualWidth, (float)ActualHeight);
             Backend.BitmapChanged += new EventHandler(OnBitmapChanged);
             Backend.BitmapUpdated += new EventHandler(OnBitmapUpdated);

--- a/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
+++ b/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
@@ -67,8 +67,6 @@ namespace ScottPlot
                 }
             }
 
-            ErrorLabel.Visibility = System.Windows.Visibility.Hidden;
-
             Backend.Resize((float)ActualWidth, (float)ActualHeight);
             Backend.BitmapChanged += new EventHandler(OnBitmapChanged);
             Backend.BitmapUpdated += new EventHandler(OnBitmapUpdated);
@@ -93,6 +91,8 @@ namespace ScottPlot
             PlottableCountTimer.Start();
 
             InitializeComponent();
+
+            ErrorLabel.Visibility = System.Windows.Visibility.Hidden;
 
             Backend.StartProcessingEvents();
         }

--- a/src/controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/controls/ScottPlot.WinForms/FormsPlot.cs
@@ -61,6 +61,8 @@ namespace ScottPlot
                 }
             }
 
+            rtbErrorMessage.Visible = false;
+
             Backend.Resize(Width, Height);
             Backend.BitmapChanged += new EventHandler(OnBitmapChanged);
             Backend.BitmapUpdated += new EventHandler(OnBitmapUpdated);

--- a/src/controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/controls/ScottPlot.WinForms/FormsPlot.cs
@@ -61,8 +61,6 @@ namespace ScottPlot
                 }
             }
 
-            rtbErrorMessage.Visible = false;
-
             Backend.Resize(Width, Height);
             Backend.BitmapChanged += new EventHandler(OnBitmapChanged);
             Backend.BitmapUpdated += new EventHandler(OnBitmapUpdated);
@@ -82,6 +80,8 @@ namespace ScottPlot
             };
 
             InitializeComponent();
+
+            rtbErrorMessage.Visible = false;
             pictureBox1.BackColor = System.Drawing.Color.Transparent;
             BackColor = System.Drawing.Color.Transparent;
             Plot.Style(figureBackground: BackColor);


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
#1073 

I tested this by simply hiding the `PlotImage` to see if anything was behind it, rather than trying to replicate the styling.

**New Functionality:**
N/A