### PR TITLE
add IgnoreAxisAuto field to axis lines and spans

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -2,6 +2,7 @@
 
 ## ScottPlot 4.1.16 (work in progress)
 * Made it easier to use custom color palettes (see cookbook) (#1058, #1082) _Thanks @EmanuelFeru_
+* Added a `IgnoreAxisAuto` field to axis lines and spans (#999) _Thanks @kirsan31_
 
 ## ScottPlot 4.1.15
 * Hide design-time error message component at run time to reduce flicking when resizing (#1073, #1075) _Thanks @Superberti and @bclehmann_

--- a/src/ScottPlot/Plottable/AxisLine.cs
+++ b/src/ScottPlot/Plottable/AxisLine.cs
@@ -37,6 +37,11 @@ namespace ScottPlot.Plottable
         protected double Position;
         private readonly bool IsHorizontal;
 
+        /// <summary>
+        /// If true, AxisAuto() will ignore the position of this line when determining axis limits
+        /// </summary>
+        public bool IgnoreAxisAuto = false;
+
         // customizations
         public bool IsVisible { get; set; } = true;
         public int XAxisIndex { get; set; } = 0;
@@ -62,10 +67,16 @@ namespace ScottPlot.Plottable
             IsHorizontal = isHorizontal;
         }
 
-        public AxisLimits GetAxisLimits() =>
-            IsHorizontal ?
-            new AxisLimits(double.NaN, double.NaN, Position, Position) :
-            new AxisLimits(Position, Position, double.NaN, double.NaN);
+        public AxisLimits GetAxisLimits()
+        {
+            if (IgnoreAxisAuto)
+                return new AxisLimits(double.NaN, double.NaN, double.NaN, double.NaN);
+
+            if (IsHorizontal)
+                return new AxisLimits(double.NaN, double.NaN, Position, Position);
+            else
+                return new AxisLimits(Position, Position, double.NaN, double.NaN);
+        }
 
         public void ValidateData(bool deep = false)
         {

--- a/src/ScottPlot/Plottable/AxisSpan.cs
+++ b/src/ScottPlot/Plottable/AxisSpan.cs
@@ -37,6 +37,11 @@ namespace ScottPlot.Plottable
         private double Max { get => Math.Max(Position1, Position2); }
         readonly bool IsHorizontal;
 
+        /// <summary>
+        /// If true, AxisAuto() will ignore the position of this span when determining axis limits
+        /// </summary>
+        public bool IgnoreAxisAuto = false;
+
         // configuration
         public int XAxisIndex { get; set; } = 0;
         public int YAxisIndex { get; set; } = 0;
@@ -82,10 +87,16 @@ namespace ScottPlot.Plottable
             return new LegendItem[] { singleItem };
         }
 
-        public AxisLimits GetAxisLimits() =>
-            IsHorizontal ?
-            new AxisLimits(Min, Max, double.NaN, double.NaN) :
-            new AxisLimits(double.NaN, double.NaN, Min, Max);
+        public AxisLimits GetAxisLimits()
+        {
+            if (IgnoreAxisAuto)
+                return new AxisLimits(double.NaN, double.NaN, double.NaN, double.NaN);
+
+            if (IsHorizontal)
+                return new AxisLimits(Min, Max, double.NaN, double.NaN);
+            else
+                return new AxisLimits(double.NaN, double.NaN, Min, Max);
+        }
 
         private enum Edge { Edge1, Edge2, Neither };
         Edge edgeUnderMouse = Edge.Neither;

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/AxisLineAndSpan.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/AxisLineAndSpan.cs
@@ -109,4 +109,29 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             hSpan.DragFixedSize = true;
         }
     }
+
+    public class AxisLineAndSpanIgnore : IRecipe
+    {
+        public string Category => "Plottable: Axis Line and Span";
+        public string ID => "axisSpan_ignore";
+        public string Title => "Ignore Axis Limits";
+        public string Description =>
+            "Calling Plot.AxisAuto (or middle-clicking the plot) will set the axis limits " +
+            "automatically to fit the data on the plot. By default the position of axis lines and spans are " +
+            "included in automatic axis limit calculations, but setting the '' flag can disable this behavior.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            plt.AddSignal(DataGen.Sin(51));
+            plt.AddSignal(DataGen.Cos(51));
+
+            var hline = plt.AddHorizontalLine(0.23);
+            hline.DragEnabled = true;
+            hline.IgnoreAxisAuto = true;
+
+            var hSpan = plt.AddHorizontalSpan(-10, 20);
+            hSpan.DragEnabled = true;
+            hSpan.IgnoreAxisAuto = true;
+        }
+    }
 }

--- a/src/tests/PlottableUnitTests/AxisLineAndSpanTests.cs
+++ b/src/tests/PlottableUnitTests/AxisLineAndSpanTests.cs
@@ -1,0 +1,64 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlotTests.PlottableUnitTests
+{
+    class AxisLineAndSpanTests
+    {
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void Test_AxisLine_AutoAxisRespected(bool ignore)
+        {
+            // plot with small data in the center
+            var plt = new ScottPlot.Plot();
+            plt.AddPoint(-10, -10);
+            plt.AddPoint(10, 10);
+            plt.AxisAuto();
+            var limits1 = plt.GetAxisLimits();
+
+            // large data
+            var line1 = plt.AddVerticalLine(999);
+            var line2 = plt.AddHorizontalLine(999);
+            line1.IgnoreAxisAuto = ignore;
+            line2.IgnoreAxisAuto = ignore;
+            plt.AxisAuto();
+            var limits2 = plt.GetAxisLimits();
+
+            if (ignore)
+                Assert.AreEqual(limits1, limits2);
+            else
+                Assert.AreNotEqual(limits1, limits2);
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void Test_AxisSpan_AutoAxisRespected(bool ignore)
+        {
+            // plot with small data in the center
+            var plt = new ScottPlot.Plot();
+            plt.AddPoint(-10, -10);
+            plt.AddPoint(10, 10);
+            plt.AxisAuto();
+            var limits1 = plt.GetAxisLimits();
+
+            // large data
+            var span1 = plt.AddVerticalSpan(-999, 999);
+            var span2 = plt.AddHorizontalSpan(-999, 999);
+            span1.IgnoreAxisAuto = ignore;
+            span2.IgnoreAxisAuto = ignore;
+            plt.AxisAuto();
+            var limits2 = plt.GetAxisLimits();
+
+            if (ignore)
+                Assert.AreEqual(limits1, limits2);
+            else
+                Assert.AreNotEqual(limits1, limits2);
+        }
+    }
+}


### PR DESCRIPTION
Adds `IgnoreAxisAuto` field to axis lines and spans so their positions are ignored when automatically resetting axis limits to fit the data (by calling `AxisAuto()` or middle-clicking a control).

Addresses one of the issues raised in #999