### PR TITLE
1087 auto render

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -4,6 +4,7 @@
 * Made it easier to use custom color palettes (see cookbook) (#1058, #1082) _Thanks @EmanuelFeru_
 * Added a `IgnoreAxisAuto` field to axis lines and spans (#999) _Thanks @kirsan31_
 * Heatmaps now have a `Smooth` field which uses bicubic interpolation to display smooth heatmaps (#1003) _Thanks @xichaoqiang_
+* Controls now automatically render after the list of plottables is modified (previously it was after the number of plottables changed). This behavior can be disabled by setting a public field in the control's `Configuration` module. (#1087, #1088) _Thanks @bftrock_
 
 ## ScottPlot 4.1.15
 * Hide design-time error message component at run time to reduce flicking when resizing (#1073, #1075) _Thanks @Superberti and @bclehmann_

--- a/src/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot/Control/Backend.cs
@@ -402,8 +402,12 @@ namespace ScottPlot.Control
         /// </summary>
         public void RenderIfPlottableCountChanged()
         {
+            if (Configuration.RenderIfPlottableCountChanges == false)
+                return;
+
             if (Bmp is null)
                 return;
+
             if (Settings.Plottables.Count != PlottableCountOnLastRender)
                 Render();
         }

--- a/src/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot/Control/Backend.cs
@@ -174,10 +174,10 @@ namespace ScottPlot.Control
         private AxisLimits LimitsOnLastRender = new();
 
         /// <summary>
-        /// Store the total number of plottables so user controls can implement a timer
-        /// to automatically update the plot if this number changes.
+        /// Unique identifier of the plottables list that was last rendered.
+        /// This value is used to determine if the plottables list was modified (requiring a re-render).
         /// </summary>
-        private int PlottableCountOnLastRender = -1;
+        private int PlottablesIdentifierAtLastRender = 0;
 
         /// <summary>
         /// This is set to True while the render loop is running.
@@ -338,7 +338,7 @@ namespace ScottPlot.Control
             Plot.Render(Bmp, lowQuality);
             BitmapRenderCount += 1;
             RenderCount += 1;
-            PlottableCountOnLastRender = Settings.Plottables.Count;
+            PlottablesIdentifierAtLastRender = Settings.PlottablesIdentifier;
 
             AxisLimits newLimits = Plot.GetAxisLimits();
             if (!newLimits.Equals(LimitsOnLastRender) && Configuration.AxesChangedEventEnabled)
@@ -400,15 +400,15 @@ namespace ScottPlot.Control
         /// Check if the number of plottibles has changed and if so request a render.
         /// This is typically called by a continuously running timer in the user control.
         /// </summary>
-        public void RenderIfPlottableCountChanged()
+        public void RenderIfPlottableListChanged()
         {
-            if (Configuration.RenderIfPlottableCountChanges == false)
+            if (Configuration.RenderIfPlottableListChanges == false)
                 return;
 
             if (Bmp is null)
                 return;
 
-            if (Settings.Plottables.Count != PlottableCountOnLastRender)
+            if (Settings.PlottablesIdentifier != PlottablesIdentifierAtLastRender)
                 Render();
         }
 

--- a/src/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot/Control/Backend.cs
@@ -206,6 +206,11 @@ namespace ScottPlot.Control
         private int BitmapRenderCount = 0;
 
         /// <summary>
+        /// Total number of renders performed.
+        /// </summary>
+        public int RenderCount { get; private set; } = 0;
+
+        /// <summary>
         /// Tracks the total distance the mouse was click-dragged (rectangular pixel units)
         /// </summary>
         private float MouseDownTravelDistance;
@@ -223,12 +228,11 @@ namespace ScottPlot.Control
         public ControlBackEnd(float width, float height)
         {
             EventFactory = new UIEventFactory(Configuration, Settings, Plot);
-            Reset(width, height);
-
-            // create an event processor and later request new renders by interacting with it.
             EventsProcessor = new EventsProcessor(
                     renderAction: (lowQuality) => Render(lowQuality),
                     renderDelay: (int)Configuration.ScrollWheelZoomHighQualityDelay);
+
+            Reset(width, height);
         }
 
         /// <summary>
@@ -251,7 +255,7 @@ namespace ScottPlot.Control
             Plot = newPlot;
             Settings = Plot.GetSettings(false);
             EventFactory = new UIEventFactory(Configuration, Settings, Plot);
-            Resize(width, height);
+            Resize(width, height, renderToo: false);
         }
 
         /// <summary>
@@ -333,6 +337,7 @@ namespace ScottPlot.Control
 
             Plot.Render(Bmp, lowQuality);
             BitmapRenderCount += 1;
+            RenderCount += 1;
             PlottableCountOnLastRender = Settings.Plottables.Count;
 
             AxisLimits newLimits = Plot.GetAxisLimits();
@@ -406,7 +411,7 @@ namespace ScottPlot.Control
         /// <summary>
         /// Resize the control (creates a new Bitmap and requests a render)
         /// </summary>
-        public void Resize(float width, float height)
+        public void Resize(float width, float height, bool renderToo = true)
         {
             // don't render if the requested size cannot produce a valid bitmap
             if (width < 1 || height < 1)
@@ -422,7 +427,8 @@ namespace ScottPlot.Control
             Bmp = new System.Drawing.Bitmap((int)width, (int)height);
             BitmapRenderCount = 0;
 
-            RenderRequest(RenderType.HighQualityDelayed);
+            if (renderToo)
+                RenderRequest(RenderType.HighQualityDelayed);
         }
 
         /// <summary>

--- a/src/ScottPlot/Control/Configuration.cs
+++ b/src/ScottPlot/Control/Configuration.cs
@@ -105,9 +105,9 @@ namespace ScottPlot.Control
         public bool LockHorizontalAxis = false;
 
         /// <summary>
-        /// Controls whether or not a render event will be triggered if a change in the number of plottables is detected
+        /// If enabled the control will automatically re-render as plottables are added and removed
         /// </summary>
-        public bool RenderIfPlottableCountChanges = true;
+        public bool RenderIfPlottableListChanges = true;
 
         /// <summary>
         /// Controls whether or not a render event will be triggered if a change in the axis limits is detected

--- a/src/ScottPlot/Plot/Plot.cs
+++ b/src/ScottPlot/Plot/Plot.cs
@@ -90,6 +90,18 @@ namespace ScottPlot
         }
 
         /// <summary>
+        /// Remove the plottable at the specified index of the list
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to remove</param>
+        public void RemoveAt(int index)
+        {
+            settings.Plottables.RemoveAt(index);
+
+            if (settings.Plottables.Count == 0)
+                settings.ResetAxisLimits();
+        }
+
+        /// <summary>
         /// Return a copy of the list of plottables
         /// </summary>
         /// <returns>list of plottables</returns>

--- a/src/ScottPlot/Plot/Plot.cs
+++ b/src/ScottPlot/Plot/Plot.cs
@@ -54,7 +54,11 @@ namespace ScottPlot
         /// Add a plottable to the plot
         /// </summary>
         /// <param name="plottable">a plottable the user created</param>
-        public void Add(IPlottable plottable) => settings.Plottables.Add(plottable);
+        public void Add(IPlottable plottable)
+        {
+            settings.Plottables.Add(plottable);
+            settings.PlottablesModified();
+        }
 
         /// <summary>
         /// Clear all plottables
@@ -63,6 +67,7 @@ namespace ScottPlot
         {
             settings.Plottables.Clear();
             settings.ResetAxisLimits();
+            settings.PlottablesModified();
         }
 
         /// <summary>
@@ -75,6 +80,8 @@ namespace ScottPlot
 
             if (settings.Plottables.Count == 0)
                 settings.ResetAxisLimits();
+
+            settings.PlottablesModified();
         }
 
         /// <summary>
@@ -87,6 +94,8 @@ namespace ScottPlot
 
             if (settings.Plottables.Count == 0)
                 settings.ResetAxisLimits();
+
+            settings.PlottablesModified();
         }
 
         /// <summary>
@@ -99,6 +108,8 @@ namespace ScottPlot
 
             if (settings.Plottables.Count == 0)
                 settings.ResetAxisLimits();
+
+            settings.PlottablesModified();
         }
 
         /// <summary>

--- a/src/ScottPlot/Plot/Plot.cs
+++ b/src/ScottPlot/Plot/Plot.cs
@@ -74,8 +74,13 @@ namespace ScottPlot
         /// <param name="plottableType">all plottables of this type will be removed</param>
         public void Clear(Type plottableType)
         {
-            foreach (IPlottable plottable in settings.Plottables.Where(x => x.GetType() == plottableType))
-                settings.Plottables.Remove(plottable);
+            var plottablesWithSameType = settings.Plottables.Where(x => x.GetType() == plottableType).ToList();
+
+            while (plottablesWithSameType.Count > 0)
+            {
+                settings.Plottables.Remove(plottablesWithSameType[0]);
+                plottablesWithSameType.RemoveAt(0);
+            }
 
             if (settings.Plottables.Count == 0)
                 settings.ResetAxisLimits();

--- a/src/ScottPlot/Plot/Plot.cs
+++ b/src/ScottPlot/Plot/Plot.cs
@@ -57,7 +57,6 @@ namespace ScottPlot
         public void Add(IPlottable plottable)
         {
             settings.Plottables.Add(plottable);
-            settings.PlottablesModified();
         }
 
         /// <summary>
@@ -67,7 +66,6 @@ namespace ScottPlot
         {
             settings.Plottables.Clear();
             settings.ResetAxisLimits();
-            settings.PlottablesModified();
         }
 
         /// <summary>
@@ -76,12 +74,11 @@ namespace ScottPlot
         /// <param name="plottableType">all plottables of this type will be removed</param>
         public void Clear(Type plottableType)
         {
-            settings.Plottables.RemoveAll(x => x.GetType() == plottableType);
+            foreach (IPlottable plottable in settings.Plottables.Where(x => x.GetType() == plottableType))
+                settings.Plottables.Remove(plottable);
 
             if (settings.Plottables.Count == 0)
                 settings.ResetAxisLimits();
-
-            settings.PlottablesModified();
         }
 
         /// <summary>
@@ -94,8 +91,6 @@ namespace ScottPlot
 
             if (settings.Plottables.Count == 0)
                 settings.ResetAxisLimits();
-
-            settings.PlottablesModified();
         }
 
         /// <summary>
@@ -108,8 +103,6 @@ namespace ScottPlot
 
             if (settings.Plottables.Count == 0)
                 settings.ResetAxisLimits();
-
-            settings.PlottablesModified();
         }
 
         /// <summary>

--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -14,8 +14,25 @@ namespace ScottPlot
     /// </summary>
     public class Settings
     {
-        // plottables
-        public readonly List<IPlottable> Plottables = new List<IPlottable>();
+        /// <summary>
+        /// This List contains all plottables managed by this Plot.
+        /// Render order is from lowest (first) to highest (last).
+        /// </summary>
+        public readonly List<IPlottable> Plottables = new();
+
+        /// <summary>
+        /// Unique value that changes any time the list of plottables is modified.
+        /// </summary>
+        public int PlottablesIdentifier { get; private set; } = 0;
+
+        /// <summary>
+        /// Indicate that the list of plottables was modified (changing the value of PlottablesIdentifier)
+        /// </summary>
+        public void PlottablesModified() => PlottablesIdentifier++;
+
+        /// <summary>
+        /// Return the next color from PlottablePalette based on the current number of plottables
+        /// </summary>
         public Color GetNextColor() => PlottablePalette.GetColor(Plottables.Count);
 
         // renderable objects the user can customize

--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -3,6 +3,8 @@ using ScottPlot.Plottable;
 using ScottPlot.Renderable;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Drawing;
 using System.Linq;
 
@@ -18,17 +20,12 @@ namespace ScottPlot
         /// This List contains all plottables managed by this Plot.
         /// Render order is from lowest (first) to highest (last).
         /// </summary>
-        public readonly List<IPlottable> Plottables = new();
+        public readonly ObservableCollection<IPlottable> Plottables = new();
 
         /// <summary>
         /// Unique value that changes any time the list of plottables is modified.
         /// </summary>
         public int PlottablesIdentifier { get; private set; } = 0;
-
-        /// <summary>
-        /// Indicate that the list of plottables was modified (changing the value of PlottablesIdentifier)
-        /// </summary>
-        public void PlottablesModified() => PlottablesIdentifier++;
 
         /// <summary>
         /// Return the next color from PlottablePalette based on the current number of plottables
@@ -73,6 +70,11 @@ namespace ScottPlot
         public float DataOffsetY => YAxis.Dims.DataOffsetPx;
         public float DataWidth => XAxis.Dims.DataSizePx;
         public float DataHeight => YAxis.Dims.DataSizePx;
+
+        public Settings()
+        {
+            Plottables.CollectionChanged += (object sender, NotifyCollectionChangedEventArgs e) => PlottablesIdentifier++;
+        }
 
         /// <summary>
         /// Return figure dimensions for the specified X and Y axes

--- a/src/controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
+++ b/src/controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
@@ -101,7 +101,7 @@ namespace ScottPlot.Avalonia
         public void Reset(Plot newPlot) => Backend.Reset((float)this.Bounds.Width, (float)this.Bounds.Height, newPlot);
         public void Render(bool lowQuality = false) => Backend.Render(lowQuality);
         public void RenderRequest(RenderType renderType) => Backend.RenderRequest(renderType);
-        private void PlottableCountTimer_Tick(object sender, EventArgs e) => Backend.RenderIfPlottableCountChanged();
+        private void PlottableCountTimer_Tick(object sender, EventArgs e) => Backend.RenderIfPlottableListChanged();
 
         private Task SetImagePlot(Func<Ava.Media.Imaging.Bitmap> getBmp)
         {

--- a/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
+++ b/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
@@ -150,7 +150,7 @@ namespace ScottPlot
         /// </summary>
         public void RenderRequest(RenderType renderType = RenderType.LowQualityThenHighQualityDelayed) => Backend.RenderRequest(renderType);
 
-        private void PlottableCountTimer_Tick(object sender, EventArgs e) => Backend.RenderIfPlottableCountChanged();
+        private void PlottableCountTimer_Tick(object sender, EventArgs e) => Backend.RenderIfPlottableListChanged();
         private void OnBitmapChanged(object sender, EventArgs e) => PlotImage.Source = BmpImageFromBmp(Backend.GetLatestBitmap());
         private void OnBitmapUpdated(object sender, EventArgs e) => PlotImage.Source = BmpImageFromBmp(Backend.GetLatestBitmap());
         private void OnCursorChanged(object sender, EventArgs e) => Cursor = Cursors[Backend.Cursor];

--- a/src/controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/controls/ScottPlot.WinForms/FormsPlot.cs
@@ -149,7 +149,7 @@ namespace ScottPlot
         /// </summary>
         public void RenderRequest(RenderType renderType = RenderType.LowQualityThenHighQualityDelayed) => Backend.RenderRequest(renderType);
 
-        private void PlottableCountTimer_Tick(object sender, EventArgs e) => Backend.RenderIfPlottableCountChanged();
+        private void PlottableCountTimer_Tick(object sender, EventArgs e) => Backend.RenderIfPlottableListChanged();
         private void FormsPlot_Load(object sender, EventArgs e) { OnSizeChanged(null, null); }
         private void OnBitmapUpdated(object sender, EventArgs e) { Application.DoEvents(); pictureBox1.Invalidate(); }
         private void OnBitmapChanged(object sender, EventArgs e) { pictureBox1.Image = Backend.GetLatestBitmap(); }

--- a/src/sandbox/WinFormsFrameworkApp/Form1.Designer.cs
+++ b/src/sandbox/WinFormsFrameworkApp/Form1.Designer.cs
@@ -30,7 +30,8 @@ namespace WinFormsFrameworkApp
         private void InitializeComponent()
         {
             this.formsPlot1 = new ScottPlot.FormsPlot();
-            this.label1 = new System.Windows.Forms.Label();
+            this.button1 = new System.Windows.Forms.Button();
+            this.button2 = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // formsPlot1
@@ -39,39 +40,50 @@ namespace WinFormsFrameworkApp
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.formsPlot1.BackColor = System.Drawing.Color.Transparent;
-            this.formsPlot1.Location = new System.Drawing.Point(12, 32);
+            this.formsPlot1.Location = new System.Drawing.Point(12, 41);
             this.formsPlot1.Name = "formsPlot1";
-            this.formsPlot1.Size = new System.Drawing.Size(776, 406);
+            this.formsPlot1.Size = new System.Drawing.Size(776, 397);
             this.formsPlot1.TabIndex = 0;
             // 
-            // label1
+            // button1
             // 
-            this.label1.AutoSize = true;
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(12, 9);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(171, 20);
-            this.label1.TabIndex = 1;
-            this.label1.Text = "waiting for interaction...";
+            this.button1.Location = new System.Drawing.Point(12, 12);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(75, 23);
+            this.button1.TabIndex = 1;
+            this.button1.Text = "add";
+            this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += new System.EventHandler(this.button1_Click);
+            // 
+            // button2
+            // 
+            this.button2.Location = new System.Drawing.Point(93, 12);
+            this.button2.Name = "button2";
+            this.button2.Size = new System.Drawing.Size(75, 23);
+            this.button2.TabIndex = 2;
+            this.button2.Text = "replace";
+            this.button2.UseVisualStyleBackColor = true;
+            this.button2.Click += new System.EventHandler(this.button2_Click);
             // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 450);
-            this.Controls.Add(this.label1);
+            this.Controls.Add(this.button2);
+            this.Controls.Add(this.button1);
             this.Controls.Add(this.formsPlot1);
             this.Name = "Form1";
             this.Text = "ScottPlot Sandbox - WinForms (.NET Framework)";
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
         #endregion
 
         private ScottPlot.FormsPlot formsPlot1;
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button button2;
     }
 }
 

--- a/src/sandbox/WinFormsFrameworkApp/Form1.cs
+++ b/src/sandbox/WinFormsFrameworkApp/Form1.cs
@@ -8,25 +8,26 @@ namespace WinFormsFrameworkApp
 {
     public partial class Form1 : Form
     {
+        private readonly Random Rand = new Random();
+
         public Form1()
         {
             InitializeComponent();
+            AddSignal();
         }
 
-        private void button1_Click(object sender, EventArgs e)
-        {
-            formsPlot1.Plot.AddSignal(ScottPlot.DataGen.Cos(51, offset: new Random().NextDouble()));
-        }
+        private void AddSignal() =>
+            formsPlot1.Plot.AddSignal(
+                ys: ScottPlot.DataGen.Cos(pointCount: 51, phase: new Random().NextDouble()),
+                color: ScottPlot.DataGen.RandomColor(Rand));
+
+        private void button1_Click(object sender, EventArgs e) => AddSignal();
 
         private void button2_Click(object sender, EventArgs e)
         {
-            var plottables = formsPlot1.Plot.GetPlottables();
-            if (plottables.Length == 0)
-                return;
-
-            formsPlot1.Plot.Remove(plottables[0]);
-
-            formsPlot1.Plot.AddSignal(ScottPlot.DataGen.Cos(51, offset: new Random().NextDouble()));
+            if (formsPlot1.Plot.GetPlottables().Length > 0)
+                formsPlot1.Plot.RemoveAt(0);
+            AddSignal();
         }
     }
 }

--- a/src/sandbox/WinFormsFrameworkApp/Form1.cs
+++ b/src/sandbox/WinFormsFrameworkApp/Form1.cs
@@ -11,29 +11,22 @@ namespace WinFormsFrameworkApp
         public Form1()
         {
             InitializeComponent();
-
-            formsPlot1.Plot.AddSignal(ScottPlot.DataGen.Sin(51));
-            formsPlot1.Plot.AddSignal(ScottPlot.DataGen.Cos(51));
-
-            var vline1 = formsPlot1.Plot.AddVerticalLine(11, Color.Blue);
-            vline1.DragEnabled = true;
-            var vline2 = formsPlot1.Plot.AddVerticalLine(22, Color.Red);
-            vline2.DragEnabled = true;
-
-            formsPlot1.PlottableDragged += FormsPlot1_PlottableDragged;
-            formsPlot1.PlottableDropped += FormsPlot1_PlottableDropped;
         }
 
-        private void FormsPlot1_PlottableDragged(object sender, EventArgs e)
+        private void button1_Click(object sender, EventArgs e)
         {
-            if (sender is ScottPlot.Plottable.VLine vline)
-                label1.Text = $"dragged {vline.Color} to X={vline.X:N3}";
+            formsPlot1.Plot.AddSignal(ScottPlot.DataGen.Cos(51, offset: new Random().NextDouble()));
         }
 
-        private void FormsPlot1_PlottableDropped(object sender, EventArgs e)
+        private void button2_Click(object sender, EventArgs e)
         {
-            if (sender is ScottPlot.Plottable.VLine vline)
-                label1.Text = $"dropped {vline.Color} at X={vline.X:N3}";
+            var plottables = formsPlot1.Plot.GetPlottables();
+            if (plottables.Length == 0)
+                return;
+
+            formsPlot1.Plot.Remove(plottables[0]);
+
+            formsPlot1.Plot.AddSignal(ScottPlot.DataGen.Cos(51, offset: new Random().NextDouble()));
         }
     }
 }

--- a/src/tests/Control/ConfigurationTests.cs
+++ b/src/tests/Control/ConfigurationTests.cs
@@ -28,5 +28,85 @@ namespace ScottPlotTests.Control
             Configuration config = new Configuration();
             Assert.Throws<ArgumentOutOfRangeException>(() => config.ScrollWheelZoomFraction = value);
         }
+
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(7)]
+        public void Test_RenderCount_Increments(int renderCount)
+        {
+            ControlBackEnd backend = new(400, 300);
+            for (int i = 0; i < renderCount; i++)
+                backend.Render();
+            Assert.AreEqual(renderCount, backend.RenderCount);
+        }
+
+        public void Test_AutoRender_CanBeDisabled()
+        {
+            ControlBackEnd backend = new(400, 300);
+            backend.Plot.AddVerticalLine(123);
+            backend.Render();
+            int originalCount = backend.RenderCount;
+
+            backend.Configuration.RenderIfPlottableCountChanges = false;
+            backend.Plot.AddVerticalLine(123);
+            backend.RenderIfPlottableCountChanged();
+
+            Assert.AreEqual(originalCount, backend.RenderCount);
+        }
+
+        [Test]
+        public void Test_AutoRender_AfterPlottablesAdded()
+        {
+            ControlBackEnd backend = new(600, 400);
+
+            backend.Plot.AddVerticalLine(123);
+            Assert.AreEqual(0, backend.RenderCount);
+
+            backend.RenderIfPlottableCountChanged();
+            Assert.AreEqual(1, backend.RenderCount);
+
+            backend.RenderIfPlottableCountChanged();
+            Assert.AreEqual(1, backend.RenderCount);
+
+            backend.Plot.AddVerticalLine(123);
+            backend.RenderIfPlottableCountChanged();
+            Assert.AreEqual(2, backend.RenderCount);
+        }
+
+        [Test]
+        public void Test_AutoRender_AfterPlottablesRemoved()
+        {
+            ControlBackEnd backend = new(600, 400);
+
+            var p1 = backend.Plot.AddVerticalLine(123);
+            var p2 = backend.Plot.AddVerticalLine(123);
+            var p3 = backend.Plot.AddVerticalLine(123);
+            backend.RenderIfPlottableCountChanged();
+            Assert.AreEqual(1, backend.RenderCount);
+
+            // remove a plottable
+            backend.Plot.Remove(p3);
+            backend.RenderIfPlottableCountChanged();
+            Assert.AreEqual(2, backend.RenderCount);
+        }
+
+        [Test]
+        public void Test_AutoRender_AfterPlottablesChanged()
+        {
+            ControlBackEnd backend = new(600, 400);
+
+            var p1 = backend.Plot.AddVerticalLine(123);
+            var p2 = backend.Plot.AddVerticalLine(123);
+            var p3 = backend.Plot.AddVerticalLine(123);
+            backend.RenderIfPlottableCountChanged();
+            Assert.AreEqual(1, backend.RenderCount);
+
+            // remove and replace a plottable
+            backend.Plot.Remove(p3);
+            var p4 = backend.Plot.AddVerticalLine(123);
+            backend.RenderIfPlottableCountChanged();
+            Assert.AreEqual(2, backend.RenderCount);
+        }
     }
 }

--- a/src/tests/Control/ConfigurationTests.cs
+++ b/src/tests/Control/ConfigurationTests.cs
@@ -48,9 +48,9 @@ namespace ScottPlotTests.Control
             backend.Render();
             int originalCount = backend.RenderCount;
 
-            backend.Configuration.RenderIfPlottableCountChanges = false;
+            backend.Configuration.RenderIfPlottableListChanges = false;
             backend.Plot.AddVerticalLine(123);
-            backend.RenderIfPlottableCountChanged();
+            backend.RenderIfPlottableListChanged();
 
             Assert.AreEqual(originalCount, backend.RenderCount);
         }
@@ -63,14 +63,14 @@ namespace ScottPlotTests.Control
             backend.Plot.AddVerticalLine(123);
             Assert.AreEqual(0, backend.RenderCount);
 
-            backend.RenderIfPlottableCountChanged();
+            backend.RenderIfPlottableListChanged();
             Assert.AreEqual(1, backend.RenderCount);
 
-            backend.RenderIfPlottableCountChanged();
+            backend.RenderIfPlottableListChanged();
             Assert.AreEqual(1, backend.RenderCount);
 
             backend.Plot.AddVerticalLine(123);
-            backend.RenderIfPlottableCountChanged();
+            backend.RenderIfPlottableListChanged();
             Assert.AreEqual(2, backend.RenderCount);
         }
 
@@ -82,12 +82,12 @@ namespace ScottPlotTests.Control
             var p1 = backend.Plot.AddVerticalLine(123);
             var p2 = backend.Plot.AddVerticalLine(123);
             var p3 = backend.Plot.AddVerticalLine(123);
-            backend.RenderIfPlottableCountChanged();
+            backend.RenderIfPlottableListChanged();
             Assert.AreEqual(1, backend.RenderCount);
 
             // remove a plottable
             backend.Plot.Remove(p3);
-            backend.RenderIfPlottableCountChanged();
+            backend.RenderIfPlottableListChanged();
             Assert.AreEqual(2, backend.RenderCount);
         }
 
@@ -99,13 +99,13 @@ namespace ScottPlotTests.Control
             var p1 = backend.Plot.AddVerticalLine(123);
             var p2 = backend.Plot.AddVerticalLine(123);
             var p3 = backend.Plot.AddVerticalLine(123);
-            backend.RenderIfPlottableCountChanged();
+            backend.RenderIfPlottableListChanged();
             Assert.AreEqual(1, backend.RenderCount);
 
             // remove and replace a plottable
             backend.Plot.Remove(p3);
             var p4 = backend.Plot.AddVerticalLine(123);
-            backend.RenderIfPlottableCountChanged();
+            backend.RenderIfPlottableListChanged();
             Assert.AreEqual(2, backend.RenderCount);
         }
     }


### PR DESCRIPTION
fixes #1087

* backend configuration's `RenderIfPlottableCountChanges` is now `RenderIfPlottableListChanges`
* automatic render detection is no longer based on the length of `Plottables`
* `Plottables` is now an `ObservableCollection` instead of a `List`