### PR TITLE
1086 Implement an update method in RadarPlot

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -4,6 +4,7 @@
 * Made it easier to use custom color palettes (see cookbook) (#1058, #1082) _Thanks @EmanuelFeru_
 * Added a `IgnoreAxisAuto` field to axis lines and spans (#999) _Thanks @kirsan31_
 * Heatmaps now have a `Smooth` field which uses bicubic interpolation to display smooth heatmaps (#1003) _Thanks @xichaoqiang_
+* Radar plots now have an `Update()` method for updating data values without clearing the plot (#1086, #1091) _Thanks @arthurits_
 
 ## ScottPlot 4.1.15
 * Hide design-time error message component at run time to reduce flicking when resizing (#1073, #1075) _Thanks @Superberti and @bclehmann_

--- a/src/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot/Plot/Plot.Add.cs
@@ -706,8 +706,13 @@ namespace ScottPlot
         }
 
         /// <summary>
-        /// Add a radar plot
+        /// Add a radar plot (a two-dimensional chart of three or more quantitative variables represented on axes starting from the same point)
         /// </summary>
+        /// <param name="values">2D array containing categories (columns) and groups (rows)</param>
+        /// <param name="independentAxes">if true, axis (category) values are scaled independently</param>
+        /// <param name="maxValues">if provided, each category (column) is normalized to these values</param>
+        /// <param name="disableFrameAndGrid">also make the plot frameless and disable its grid</param>
+        /// <returns>the radar plot that was just created and added to the plot</returns>
         public RadarPlot AddRadar(double[,] values, bool independentAxes = false, double[] maxValues = null, bool disableFrameAndGrid = true)
         {
 
@@ -717,7 +722,7 @@ namespace ScottPlot
 
             Color[] fills = colors.Select(x => Color.FromArgb(50, x)).ToArray();
 
-            RadarPlot plottable = new RadarPlot(values, colors, fills, independentAxes, maxValues);
+            RadarPlot plottable = new(values, colors, fills, independentAxes, maxValues);
             Add(plottable);
 
             if (disableFrameAndGrid)

--- a/src/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot/Plottable/RadarPlot.cs
@@ -45,7 +45,7 @@ namespace ScottPlot.Plottable
         /// Updates the internal data array <see cref="Norm"/> that holds the values to be plotted. It also computes the normalization values for the axis, which are later needed in <see cref="Render(PlotDimensions, Bitmap, bool)"/>.
         /// </summary>
         /// <param name="values">Values to be plotted. Rows correspond to the <see cref="GroupLabels"/> property and columns to the <see cref="CategoryLabels"/> property</param>
-        /// <param name="maxValues">Only needed for user-normalizing (scaling) the axes. If <see cref="IndependentAxes"/> is set to <see langword="false"/>, then only the first element of this array is considered (all axis is normalized by the same factor). If <see cref="IndependentAxes"/> is set to <see langword="true"/>, then its elements correspond to each axis (categories) and are normalized independently</param>
+        /// <param name="maxValues">Only needed for user-normalizing (scaling) of the axis. If <see cref="IndependentAxes"/> is set to <see langword="false"/>, then only the first element of this array is considered (all axis are normalized by the same factor). If <see cref="IndependentAxes"/> is set to <see langword="true"/>, then its elements correspond to each axes (categories) and are normalized independently.</param>
         public void Update(double[,] values, double[] maxValues = null)
         {
             // The passed values are copied into the internal array 'Norm', which stores the plot's data.

--- a/src/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot/Plottable/RadarPlot.cs
@@ -45,16 +45,16 @@ namespace ScottPlot.Plottable
         /// Updates the internal data array <see cref="Norm"/> that holds the values to be plotted. It also computes the normalization values for the axis, which are later needed in <see cref="Render(PlotDimensions, Bitmap, bool)"/>.
         /// </summary>
         /// <param name="values">Values to be plotted. Rows correspond to the <see cref="GroupLabels"/> property and columns to the <see cref="CategoryLabels"/> property</param>
-        /// <param name="maxValues">Only needed for user-normalizing (scaling) of the axis. If <see cref="IndependentAxes"/> is set to <see langword="false"/>, then only the first element of this array is considered (all axis are normalized by the same factor). If <see cref="IndependentAxes"/> is set to <see langword="true"/>, then its elements correspond to each axes (categories) and are normalized independently.</param>
+        /// <param name="maxValues">Only needed for user-normalizing (scaling) of the axis. Typically this would be null unless the user wants to manually set the axis's upper limit. If <see cref="IndependentAxes"/> is set to <see langword="false"/>, then only the first element of this array is considered (all axis are normalized by the same factor). If <see cref="IndependentAxes"/> is set to <see langword="true"/>, then its elements correspond to each axes (categories) which are normalized independently.</param>
         public void Update(double[,] values, double[] maxValues = null)
         {
             // The passed values are copied into the internal array 'Norm', which stores the plot's data.
-            // Consider (@swharden and @bclehmann) if this is needed or desirable: do we want to allow the user to update its "value" array and call Render, (similarly to SignalPlot)?
-            // If so, then the Array.Copy could be left out, and move the normalization at the beginning of the Render() method.
+            // Consider (@swharden and @bclehmann) if this is needed or desirable: do we want to allow the user to update its "value" array and call Render, (similarly to SignalPlot)? After all, in SignalPlot, the Update() method is used whenever the array is redimensioned but not when the array values are modified.
+            // If so, then the Array.Copy could be left out (just keep a reference to 'values'); and move the normalization at the beginning of the Render() method.
             Norm = new double[values.GetLength(0), values.GetLength(1)];
             Array.Copy(values, 0, Norm, 0, values.Length);
-            
-            // Normalize values, which are needed later to render the plot.
+
+            // Normalize the acis values, which are needed later to render the plot.
             // Consider moving this code to the very beginning of Render() method, just before the "using" statements.
             if (this.IndependentAxes)
                 NormMaxes = NormalizeSeveralInPlace(Norm, maxValues);


### PR DESCRIPTION
**Purpose:**
Pull request for issue [#1086](https://github.com/ScottPlot/ScottPlot/issues/1086)

**New functionality:**
Implements an `Update()` method.
The class initializer calls this `Update()` method.
`Norm`, `NormMax`, and `NormMaxes` are no longer `readonly`.
Added documentation.
Suggestions (as comments) for leaving out the `Array.Copy` as well as for moving the normalization to the `Render()` method.