### PR TITLE
Axis: TickLabelFormat accepts Func<double, string>

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -7,6 +7,7 @@
 * Radar plots now have an `Update()` method for updating data values without clearing the plot (#1086, #1091) _Thanks @arthurits_
 * Controls now automatically render after the list of plottables is modified (previously it was after the number of plottables changed). This behavior can be disabled by setting a public field in the control's `Configuration` module. (#1087, #1088) _Thanks @bftrock_
 * New `Crosshair` plot type draws lines to highlight a point on the plot and labels their coordinates in the axes (#999, #1093) _Thanks @kirsan31_
+* Added support for a custom `Func<double, string>` to be used as custom tick label formatters (see cookbook) (#926, #1070) _Thanks @damiandixon and @ssalsinha_
 
 ## ScottPlot 4.1.15
 * Hide design-time error message component at run time to reduce flicking when resizing (#1073, #1075) _Thanks @Superberti and @bclehmann_

--- a/src/ScottPlot/Renderable/Axis.cs
+++ b/src/ScottPlot/Renderable/Axis.cs
@@ -170,6 +170,14 @@ namespace ScottPlot.Renderable
         }
 
         /// <summary>
+        /// Use a custom function to generate tick label strings
+        /// </summary>
+        public void TickLabelFormat(Func<double, string> tickFormatter)
+        {
+            AxisTicks.TickCollection.ManualTickFormatter = tickFormatter;
+        }
+
+        /// <summary>
         /// Manually define the string format to use for translating tick positions to tick labels
         /// </summary>
         public void TickLabelFormat(string format, bool dateTimeFormat)

--- a/src/ScottPlot/Ticks/TickCollection.cs
+++ b/src/ScottPlot/Ticks/TickCollection.cs
@@ -64,6 +64,11 @@ namespace ScottPlot.Ticks
         public string numericFormatString;
         public string dateTimeFormatString;
 
+        /// <summary>
+        /// If defined, this function will be used to generate tick labels from positions
+        /// </summary>
+        public Func<double, string> ManualTickFormatter = null;
+
         public int radix = 10;
         public string prefix = null;
 
@@ -372,7 +377,7 @@ namespace ScottPlot.Ticks
                 double adjustedPosition = (positions[i] - offset) / multiplier;
                 if (invertSign)
                     adjustedPosition *= -1;
-                labels[i] = FormatLocal(adjustedPosition, culture);
+                labels[i] = ManualTickFormatter is null ? FormatLocal(adjustedPosition, culture) : ManualTickFormatter(adjustedPosition);
                 if (labels[i] == "-0")
                     labels[i] = "0";
             }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/AxisAdvanced.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/AxisAdvanced.cs
@@ -457,4 +457,35 @@ namespace ScottPlot.Cookbook.Recipes
             plt.XAxis.MinimumTickSpacing(25);
         }
     }
+
+    class CustomTickFormatter : IRecipe
+    {
+        public string Category => "Advanced Axis Features";
+        public string ID => "asis_custom_tick_formatter";
+        public string Title => "Custom Tick Formatter";
+        public string Description => "For ultimate control over tick label format you can create " +
+            "a custom formatter function and use that to convert positions to labels. " +
+            "This allows logic to be used to format tick labels.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            plt.AddSignal(ScottPlot.DataGen.Sin(51));
+            plt.AddSignal(ScottPlot.DataGen.Cos(51));
+
+            // create a custom formatter as a static class
+            static string customTickFormatter(double position)
+            {
+                if (position == 0)
+                    return "zero";
+                else if (position > 0)
+                    return $"+{position:F2}";
+                else
+                    return $"({Math.Abs(position):F2})";
+            }
+
+            // use the custom formatter for horizontal and vertical tick labels
+            plt.XAxis.TickLabelFormat(customTickFormatter);
+            plt.YAxis.TickLabelFormat(customTickFormatter);
+        }
+    }
 }

--- a/src/tests/Axis/TickLabel.cs
+++ b/src/tests/Axis/TickLabel.cs
@@ -1,0 +1,51 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlotTests.Axis
+{
+    class TickLabel
+    {
+        [Test]
+        public void Test_TickLabel_CustomFunction()
+        {
+            var plt = new ScottPlot.Plot(400, 300);
+            plt.AddSignal(ScottPlot.DataGen.Sin(51));
+            plt.AddSignal(ScottPlot.DataGen.Cos(51));
+
+            static string customTickFormatter(double tickPosition)
+            {
+                if (tickPosition >= 0)
+                    return "+" + tickPosition.ToString("F2");
+                else
+                    return $"({Math.Abs(tickPosition).ToString("F2")})";
+            };
+
+            plt.XAxis.TickLabelFormat(customTickFormatter);
+            plt.YAxis.TickLabelFormat(customTickFormatter);
+
+            TestTools.SaveFig(plt);
+        }
+
+        [Test]
+        public void Test_TickLabel_CustomFunction2()
+        {
+            var plt = new ScottPlot.Plot(400, 300);
+
+            var prices = ScottPlot.DataGen.RandomStockPrices(new Random(0), 50, new TimeSpan(0, 15, 0));
+            plt.AddOHLCs(prices);
+
+            static string customTickFormatter(double tickPosition)
+            {
+                return DateTime.FromOADate(tickPosition).ToString("H:m");
+            }
+
+            plt.XAxis.TickLabelFormat(customTickFormatter);
+
+            TestTools.SaveFig(plt);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an option for the user to use a `Func<double, string>` to define how to generate tick labels from positions. 

Unlike current methods which only control the _format_ of labels or require the user to interact with a complex inheritance system, this is a quick and simple way to control tick label format in a way that uses logic.

```cs
plt.AddSignal(ScottPlot.DataGen.Sin(51));
plt.AddSignal(ScottPlot.DataGen.Cos(51));

static string customTickFormatter(double position)
{
    if (position == 0)
        return "zero";
    else if (position > 0)
        return $"+{position:F2}";
    else
        return $"({Math.Abs(position):F2})";
}

plt.XAxis.TickLabelFormat(customTickFormatter);
plt.YAxis.TickLabelFormat(customTickFormatter);
```

![image](https://user-images.githubusercontent.com/4165489/120118742-09c82700-c162-11eb-8545-b28a3c4dde34.png)

This PR was motivated by #926 and #1070