### PR TITLE
Draggable Scaatter, Signal, SignalXY (CoordinatedHeatmap)

### DIFF
--- a/src/ScottPlot/Control/EventProcess/EventFactory.cs
+++ b/src/ScottPlot/Control/EventProcess/EventFactory.cs
@@ -47,6 +47,9 @@ namespace ScottPlot.Control.EventProcess
         public IUIEvent CreatePlottableDrag(float x, float y, bool shiftDown, IDraggable draggable) =>
              new PlottableDragEvent(x, y, shiftDown, draggable, Plot, Configuration);
 
+        public IUIEvent CreatePlottableDragModern(double xFrom, double xTo, double yFrom, double yTo, bool shiftDown, IDraggableModern draggable) =>
+             new PlottableDragModernEvent(xFrom, xTo, yFrom, yTo, shiftDown, draggable, Configuration);
+
         public IUIEvent CreateManualLowQualityRender() => new RenderLowQuality();
 
         public IUIEvent CreateManualHighQualityRender() => new RenderHighQuality();

--- a/src/ScottPlot/Control/EventProcess/Events/PlottableDragModernEvent.cs
+++ b/src/ScottPlot/Control/EventProcess/Events/PlottableDragModernEvent.cs
@@ -1,0 +1,37 @@
+﻿using ScottPlot.Plottable;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Control.EventProcess.Events
+{
+    public class PlottableDragModernEvent: IUIEvent
+    {
+        private readonly double XFrom;
+        private readonly double XTo;
+        private readonly double YFrom;
+        private readonly double YTo;
+        private readonly IDraggableModern PlottableBeingDragged;
+        private readonly bool ShiftDown;
+        private readonly Configuration Configuration;
+        public RenderType RenderType => Configuration.QualityConfiguration.MouseInteractiveDragged;
+
+        public PlottableDragModernEvent(double xFrom, double xTo, double yFrom, double yTo,bool shiftDown, IDraggableModern plottable, Configuration config)
+        {
+            XFrom = xFrom;
+            XTo = xTo;
+            YFrom = yFrom;
+            YTo = yTo;
+            ShiftDown = shiftDown;
+            PlottableBeingDragged = plottable;
+            Configuration = config;
+        }
+
+        public void ProcessEvent()
+        {
+            PlottableBeingDragged.Drag(XFrom, XTo, YFrom, YTo, fixedSize: ShiftDown);
+        }
+    }
+}

--- a/src/ScottPlot/Control/EventProcess/Events/PlottableDragModernEvent.cs
+++ b/src/ScottPlot/Control/EventProcess/Events/PlottableDragModernEvent.cs
@@ -1,13 +1,8 @@
 ﻿using ScottPlot.Plottable;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ScottPlot.Control.EventProcess.Events
 {
-    public class PlottableDragModernEvent: IUIEvent
+    public class PlottableDragModernEvent : IUIEvent
     {
         private readonly double XFrom;
         private readonly double XTo;
@@ -18,7 +13,7 @@ namespace ScottPlot.Control.EventProcess.Events
         private readonly Configuration Configuration;
         public RenderType RenderType => Configuration.QualityConfiguration.MouseInteractiveDragged;
 
-        public PlottableDragModernEvent(double xFrom, double xTo, double yFrom, double yTo,bool shiftDown, IDraggableModern plottable, Configuration config)
+        public PlottableDragModernEvent(double xFrom, double xTo, double yFrom, double yTo, bool shiftDown, IDraggableModern plottable, Configuration config)
         {
             XFrom = xFrom;
             XTo = xTo;

--- a/src/ScottPlot/Plottable/AxisLine.cs
+++ b/src/ScottPlot/Plottable/AxisLine.cs
@@ -1,5 +1,4 @@
-﻿using ScottPlot.Ticks;
-using ScottPlot.Drawing;
+﻿using ScottPlot.Drawing;
 using System;
 using System.Drawing;
 
@@ -31,7 +30,7 @@ namespace ScottPlot.Plottable
         public VLine() : base(false) { }
     }
 
-    public abstract class AxisLine : IDraggable, IPlottable
+    public abstract class AxisLine : IDraggableModern, IPlottable
     {
         // orientation and location
         protected double Position;
@@ -104,6 +103,26 @@ namespace ScottPlot.Plottable
                     gfx.DrawLine(pen, pixelX, pixelY1, pixelX, pixelY2);
                 }
             }
+        }
+
+        public void Drag(double xFrom, double xTo, double yFrom, double yTo, bool fixedSize)
+        {
+            if (!DragEnabled)
+                return;
+
+            if (IsHorizontal)
+            {
+                Position += yTo - yFrom;
+            }
+            else
+            {
+                Position += xTo - xFrom;
+            }
+
+            if (Position < DragLimitMin) Position = DragLimitMin;
+            if (Position > DragLimitMax) Position = DragLimitMax;
+
+            Dragged(this, EventArgs.Empty);
         }
 
         /// <summary>

--- a/src/ScottPlot/Plottable/CoordinatedHeatmap.cs
+++ b/src/ScottPlot/Plottable/CoordinatedHeatmap.cs
@@ -10,13 +10,18 @@ namespace ScottPlot.Plottable
     /// This variation of the Heatmap renders intensity data as a rectangle 
     /// sized to fit user-defined axis limits
     /// </summary>
-    public class CoordinatedHeatmap : Heatmap
+    public class CoordinatedHeatmap : Heatmap, IDraggableModern
     {
         public double XMin { get; set; }
         public double XMax { get; set; }
         public double YMin { get; set; }
         public double YMax { get; set; }
         public InterpolationMode Interpolation { get; set; } = InterpolationMode.NearestNeighbor;
+        public bool DragEnabled { get; set; } = true;
+
+        public Cursor DragCursor => Cursor.Hand;
+
+        public event EventHandler Dragged = delegate{};
 
         protected override void RenderHeatmap(PlotDimensions dims, Bitmap bmp, bool lowQuality)
         {
@@ -46,6 +51,30 @@ namespace ScottPlot.Plottable
         public override AxisLimits GetAxisLimits()
         {
             return new AxisLimits(XMin, XMax, YMin, YMax);
+        }
+
+        public void Drag(double coordinateXFrom, double coordinateXTo, double coordinateYFrom, double coordinateYTo, bool fixedSize)
+        {
+            var offsetX = coordinateXTo - coordinateXFrom;
+            var offsetY = coordinateYTo - coordinateYFrom;
+            XMin += offsetX;
+            XMax += offsetX;
+            YMin += offsetY;
+            YMax += offsetY;
+            Dragged(this, EventArgs.Empty);
+        }
+
+        public bool IsUnderMouse(double coordinateX, double coordinateY, double snapX, double snapY)
+        {
+            return (coordinateX >= (XMin - snapX))
+                && (coordinateX <= (XMax + snapX))
+                && (coordinateY >= (YMin - snapY))
+                && (coordinateY <= (YMax + snapY));
+        }
+
+        public void DragTo(double coordinateX, double coordinateY, bool fixedSize)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/ScottPlot/Plottable/CoordinatedHeatmap.cs
+++ b/src/ScottPlot/Plottable/CoordinatedHeatmap.cs
@@ -53,6 +53,14 @@ namespace ScottPlot.Plottable
             return new AxisLimits(XMin, XMax, YMin, YMax);
         }
 
+        /// <summary>
+        /// Move the CoordinatedHeatmap to a new coordinate in plot space.
+        /// </summary>
+        /// <param name="coordinateXFrom">Move signal from X coordinate</param>
+        /// <param name="coordinateXTo">Move signal from Y coordinate</param>
+        /// <param name="CoordinateYFrom">Move signal to X coordinate</param>
+        /// <param name="coordinateYTo">Move Signal to Y coordinate</param>
+        /// <param name="fixedSize">Unused flag</param>
         public void Drag(double coordinateXFrom, double coordinateXTo, double coordinateYFrom, double coordinateYTo, bool fixedSize)
         {
             var offsetX = coordinateXTo - coordinateXFrom;
@@ -64,6 +72,14 @@ namespace ScottPlot.Plottable
             Dragged(this, EventArgs.Empty);
         }
 
+        /// <summary>
+        /// Return True if either CoordinatedHeatmap is within a certain number of pixels (snap) to the mouse
+        /// </summary>
+        /// <param name="coordinateX">mouse position X (coordinate space)</param>
+        /// <param name="coordinateY">mouse position Y(coordinate space)</param>
+        /// <param name="snapX">snap distance X axes (coordinate space)</param>
+        /// <param name="snapY">snap distance X axes (coordinate space)</param>
+        /// <returns>True if signal is within a mouse</returns>
         public bool IsUnderMouse(double coordinateX, double coordinateY, double snapX, double snapY)
         {
             return (coordinateX >= (XMin - snapX))
@@ -72,6 +88,12 @@ namespace ScottPlot.Plottable
                 && (coordinateY <= (YMax + snapY));
         }
 
+        /// <summary>
+        /// Never called 
+        /// </summary>
+        /// <param name="coordinateX"></param>
+        /// <param name="coordinateY"></param>
+        /// <param name="fixedSize"></param>
         public void DragTo(double coordinateX, double coordinateY, bool fixedSize)
         {
             throw new NotImplementedException();

--- a/src/ScottPlot/Plottable/CoordinatedHeatmap.cs
+++ b/src/ScottPlot/Plottable/CoordinatedHeatmap.cs
@@ -21,7 +21,7 @@ namespace ScottPlot.Plottable
 
         public Cursor DragCursor => Cursor.Hand;
 
-        public event EventHandler Dragged = delegate{};
+        public event EventHandler Dragged = delegate { };
 
         protected override void RenderHeatmap(PlotDimensions dims, Bitmap bmp, bool lowQuality)
         {

--- a/src/ScottPlot/Plottable/HelperAlgorithms/AABBChecker.cs
+++ b/src/ScottPlot/Plottable/HelperAlgorithms/AABBChecker.cs
@@ -1,0 +1,87 @@
+﻿using System;
+
+namespace ScottPlot.Plottable.HelperAlgorithms
+{
+    /// <summary>
+    /// Check for point inside axis-aligned bounding box (AABB)
+    /// </summary>
+    public class AABBChecker
+    {
+        public double SnapX { get; set; }
+        public double SnapY { get; set; }
+        public double CenterX { get; set; }
+        public double CenterY { get; set; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="centerX">center x coordinate</param>
+        /// <param name="centerY">center y coordinate</param>
+        /// <param name="snapX">half width of AABB</param>
+        /// <param name="snapY">half height of AABB</param>
+        public AABBChecker(double centerX, double centerY, double snapX, double snapY)
+        {
+            CenterX = centerX;
+            CenterY = centerY;
+            SnapX = snapX;
+            SnapY = snapY;
+        }
+
+        /// <summary>
+        /// Check for point inside axis-aligned bounding box
+        /// </summary>
+        /// <param name="x">x coordinate</param>
+        /// <param name="y">y coordinate</param>
+        /// <returns>True if point inside AABB</returns>
+        public bool CheckInsideAABB(double x, double y)
+        {
+            return (x >= CenterX - SnapX && x <= CenterX + SnapX
+                && y >= CenterY - SnapY && y <= CenterY + SnapY);
+        }
+
+        /// <summary>
+        /// Chek for any point from array inside axis-aligned bounding box
+        /// </summary>
+        /// <param name="x">x coordinates of points</param>
+        /// <param name="y">y coordinates of points</param>
+        /// <returns>True if any point inside AABB</returns>
+        public bool CheckInsideAABB(double[] x, double[] y)
+        {
+            for (int i = 0; i < x.Length; i++)
+            {
+                if (CheckInsideAABB(x[i], y[i]))
+                    return true;
+            }
+            return false;
+        }
+
+        public bool CheckInsideAABB(Func<int, double> x, Func<int, double> y, int length)
+        {
+            for (int i = 0; i < length; i++)
+            {
+                if (CheckInsideAABB(x(i), y(i)))
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Check if any point inside axis-aligned bounding box
+        /// </summary>
+        /// <param name="x">Function which returns x coordinate by index</param>
+        /// <param name="y">Function which returns y coordinate by index</param>
+        /// <param name="from">start index</param>
+        /// <param name="to">last index</param>
+        /// <returns>True if any point inside AABB</returns>
+        public bool CheckInsideAABB(Func<int, double> x, Func<int, double> y, int from, int to)
+        {
+            for (int i = from; i < to; i++)
+            {
+                if (CheckInsideAABB(x(i), y(i)))
+                    return true;
+            }
+            return false;
+        }
+
+    }
+}

--- a/src/ScottPlot/Plottable/HelperAlgorithms/AABBChecker.cs
+++ b/src/ScottPlot/Plottable/HelperAlgorithms/AABBChecker.cs
@@ -38,50 +38,5 @@ namespace ScottPlot.Plottable.HelperAlgorithms
             return (x >= CenterX - SnapX && x <= CenterX + SnapX
                 && y >= CenterY - SnapY && y <= CenterY + SnapY);
         }
-
-        /// <summary>
-        /// Chek for any point from array inside axis-aligned bounding box
-        /// </summary>
-        /// <param name="x">x coordinates of points</param>
-        /// <param name="y">y coordinates of points</param>
-        /// <returns>True if any point inside AABB</returns>
-        public bool CheckInsideAABB(double[] x, double[] y)
-        {
-            for (int i = 0; i < x.Length; i++)
-            {
-                if (CheckInsideAABB(x[i], y[i]))
-                    return true;
-            }
-            return false;
-        }
-
-        public bool CheckInsideAABB(Func<int, double> x, Func<int, double> y, int length)
-        {
-            for (int i = 0; i < length; i++)
-            {
-                if (CheckInsideAABB(x(i), y(i)))
-                    return true;
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Check if any point inside axis-aligned bounding box
-        /// </summary>
-        /// <param name="x">Function which returns x coordinate by index</param>
-        /// <param name="y">Function which returns y coordinate by index</param>
-        /// <param name="from">start index</param>
-        /// <param name="to">last index</param>
-        /// <returns>True if any point inside AABB</returns>
-        public bool CheckInsideAABB(Func<int, double> x, Func<int, double> y, int from, int to)
-        {
-            for (int i = from; i < to; i++)
-            {
-                if (CheckInsideAABB(x(i), y(i)))
-                    return true;
-            }
-            return false;
-        }
-
     }
 }

--- a/src/ScottPlot/Plottable/HelperAlgorithms/CloseToSegmentChecker.cs
+++ b/src/ScottPlot/Plottable/HelperAlgorithms/CloseToSegmentChecker.cs
@@ -1,5 +1,11 @@
 ﻿namespace ScottPlot.Plottable.HelperAlgorithms
 {
+    /// <summary>
+    /// Check if point close to segment
+    /// This algorithm is not completely fair, and cannot be used separately;
+    /// a separate preliminary check for proximity to the ends of the segment (AABBChecker)
+    /// makes the results of this algorithm reliable.
+    /// </summary>
     public class CloseToSegmentChecker
     {
         public double SnapX { get; set; }

--- a/src/ScottPlot/Plottable/HelperAlgorithms/CloseToSegmentChecker.cs
+++ b/src/ScottPlot/Plottable/HelperAlgorithms/CloseToSegmentChecker.cs
@@ -1,0 +1,100 @@
+﻿namespace ScottPlot.Plottable.HelperAlgorithms
+{
+    public class CloseToSegmentChecker
+    {
+        public double SnapX { get; set; }
+        public double SnapY { get; set; }
+        public double CoordinateX { get; set; }
+        public double CoordinateY { get; set; }
+
+        private (double x, double y)[][] _boundaryPolys;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="coordinateX">point x coordinate</param>
+        /// <param name="coordinateY">point y coordinate</param>
+        /// <param name="snapX">permissible deviation for x</param>
+        /// <param name="snapY">permissible deviation for y</param>
+        public CloseToSegmentChecker(double coordinateX, double coordinateY, double snapX, double snapY)
+        {
+            CoordinateX = coordinateX;
+            CoordinateY = coordinateY;
+            SnapX = snapX;
+            SnapY = snapY;
+
+            _boundaryPolys = new (double x, double y)[][]
+                {
+                    new (double x, double y)[]
+                    {
+                        (0, 0),
+                        (0, 0),
+                        (0, 0),
+                        (0, 0),
+                    },
+                    new (double x, double y)[]
+                    {
+                        (0, 0),
+                        (0, 0),
+                        (0, 0),
+                        (0, 0),
+                    }
+                };
+        }
+
+        /// <summary>
+        /// Check for point close to segment
+        /// </summary>
+        /// <param name="x">segment first point x coordinate</param>
+        /// <param name="y">segment first point y coordinate</param>
+        /// <param name="x1">segment second point x coordinate</param>
+        /// <param name="y1">segment second point y coordinate</param>
+        /// <returns>true if point close to segment</returns>
+        public bool IsClose(double x, double y, double x1, double y1)
+        {
+            // fix first poly
+            _boundaryPolys[0][0].x = x;
+            _boundaryPolys[0][0].y = y + SnapY;
+
+            _boundaryPolys[0][1].x = x;
+            _boundaryPolys[0][1].y = y - SnapY;
+
+            _boundaryPolys[0][2].x = x1;
+            _boundaryPolys[0][2].y = y1 - SnapY;
+
+            _boundaryPolys[0][3].x = x1;
+            _boundaryPolys[0][3].y = y1 + SnapY;
+
+            // fix second poly
+            _boundaryPolys[1][0].x = x - SnapX;
+            _boundaryPolys[1][0].y = y;
+
+            _boundaryPolys[1][1].x = x + SnapX;
+            _boundaryPolys[1][1].y = y;
+
+            _boundaryPolys[1][2].x = x1 + SnapX;
+            _boundaryPolys[1][2].y = y1;
+
+            _boundaryPolys[1][3].x = x1 - SnapX;
+            _boundaryPolys[1][3].y = y1;
+
+
+            for (int k = 0; k < _boundaryPolys.Length; k++)
+            {
+                bool inside = false;
+                for (int j = 0, j1 = _boundaryPolys[k].Length - 1; j < _boundaryPolys[k].Length; j1 = j++)
+                {
+                    if ((_boundaryPolys[k][j].y > CoordinateY) != (_boundaryPolys[k][j1].y > CoordinateY) &&
+                        (CoordinateX < (_boundaryPolys[k][j1].x - _boundaryPolys[k][j].x) * (CoordinateY - _boundaryPolys[k][j].y) / (_boundaryPolys[k][j1].y - _boundaryPolys[k][j].y) + _boundaryPolys[k][j].x))
+                    {
+                        inside = !inside;
+                    }
+                }
+                if (inside)
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/ScottPlot/Plottable/IDraggable.cs
+++ b/src/ScottPlot/Plottable/IDraggable.cs
@@ -11,7 +11,7 @@ namespace ScottPlot.Plottable
         event EventHandler Dragged;
     }
 
-    public interface IDraggableModern: IDraggable
+    public interface IDraggableModern : IDraggable
     {
         void Drag(double coordinateXFrom, double coordinateXTo, double CoordinateYFrom, double coordinateYTo, bool fixedSize);
     }

--- a/src/ScottPlot/Plottable/IDraggable.cs
+++ b/src/ScottPlot/Plottable/IDraggable.cs
@@ -10,4 +10,9 @@ namespace ScottPlot.Plottable
         void DragTo(double coordinateX, double coordinateY, bool fixedSize);
         event EventHandler Dragged;
     }
+
+    public interface IDraggableModern: IDraggable
+    {
+        void Drag(double coordinateXFrom, double coordinateXTo, double CoordinateYFrom, double coordinateYTo, bool fixedSize);
+    }
 }

--- a/src/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot/Plottable/ScatterPlot.cs
@@ -401,7 +401,7 @@ namespace ScottPlot.Plottable
                         return true;
 
                 }
-                else if ( ((cx - bx) * (ax - bx) + ( cy - by)*(ay - by) )  < 0 )
+                else if (((cx - bx) * (ax - bx) + (cy - by) * (ay - by)) < 0)
                 {
                     double distanceB = (cx - bx) * (cx - bx) + (cy - by) * (cy - by);
                     if (distanceB < snapX * snapX)
@@ -414,13 +414,13 @@ namespace ScottPlot.Plottable
                     double projectionY;
                     if ((bx - ax) == 0)
                     {
-                         projectionX = ax;
-                         projectionY = cy;
+                        projectionX = ax;
+                        projectionY = cy;
                     }
                     else if ((by - ay) == 0)
                     {
-                         projectionX = cx;
-                         projectionY = ay;
+                        projectionX = cx;
+                        projectionY = ay;
                     }
                     else
                     {

--- a/src/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot/Plottable/ScatterPlot.cs
@@ -38,7 +38,7 @@ namespace ScottPlot.Plottable
         public float ArrowheadWidth = 0;
         public float ArrowheadLength = 0;
 
-        public event EventHandler Dragged;
+        public event EventHandler Dragged = delegate { };
 
         // TODO: think about better/additional API ?
         public int? MinRenderIndex { get; set; }

--- a/src/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot/Plottable/ScatterPlot.cs
@@ -369,6 +369,14 @@ namespace ScottPlot.Plottable
             return (Xs[minIndex], Ys[minIndex], minIndex);
         }
 
+        /// <summary>
+        /// Move the Scatter to a new coordinate in plot space.
+        /// </summary>
+        /// <param name="coordinateXFrom">Move scatter from X coordinate</param>
+        /// <param name="coordinateXTo">Move scatter from Y coordinate</param>
+        /// <param name="CoordinateYFrom">Move scatter to X coordinate</param>
+        /// <param name="coordinateYTo">Move scatter to Y coordinate</param>
+        /// <param name="fixedSize">Unused flag</param>
         public void Drag(double coordinateXFrom, double coordinateXTo, double CoordinateYFrom, double coordinateYTo, bool fixedSize)
         {
             double offsetX = coordinateXTo - coordinateXFrom;
@@ -382,6 +390,14 @@ namespace ScottPlot.Plottable
             Dragged(this, EventArgs.Empty);
         }
 
+        /// <summary>
+        /// Return True if either scatter is within a certain number of pixels (snap) to the mouse
+        /// </summary>
+        /// <param name="coordinateX">mouse position X (coordinate space)</param>
+        /// <param name="coordinateY">mouse position Y(coordinate space)</param>
+        /// <param name="snapX">snap distance X axes (coordinate space)</param>
+        /// <param name="snapY">snap distance X axes (coordinate space)</param>
+        /// <returns>True if scatter is within a mouse</returns>
         public bool IsUnderMouse(double coordinateX, double coordinateY, double snapX, double snapY)
         {
             double cx = coordinateX;
@@ -439,6 +455,12 @@ namespace ScottPlot.Plottable
             return false;
         }
 
+        /// <summary>
+        /// Never called 
+        /// </summary>
+        /// <param name="coordinateX"></param>
+        /// <param name="coordinateY"></param>
+        /// <param name="fixedSize"></param>
         public void DragTo(double coordinateX, double coordinateY, bool fixedSize)
         {
             throw new NotImplementedException();

--- a/src/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot/Plottable/SignalPlotBase.cs
@@ -729,6 +729,14 @@ namespace ScottPlot.Plottable
             return (OffsetX + index * SamplePeriod, AddYsGeneric(Ys[index], OffsetY), index);
         }
 
+        /// <summary>
+        /// Move the signal to a new coordinate in plot space.
+        /// </summary>
+        /// <param name="coordinateXFrom">Move signal from X coordinate</param>
+        /// <param name="coordinateXTo">Move signal from Y coordinate</param>
+        /// <param name="CoordinateYFrom">Move signal to X coordinate</param>
+        /// <param name="coordinateYTo">Move signal to Y coordinate</param>
+        /// <param name="fixedSize">Unused flag</param>
         public void Drag(double coordinateXFrom, double coordinateXTo, double CoordinateYFrom, double coordinateYTo, bool fixedSize)
         {
             double offsetX = coordinateXTo - coordinateXFrom;
@@ -739,6 +747,14 @@ namespace ScottPlot.Plottable
             Dragged(this, EventArgs.Empty);
         }
 
+        /// <summary>
+        /// Return True if either signal is within a certain number of pixels (snap) to the mouse
+        /// </summary>
+        /// <param name="coordinateX">mouse position X (coordinate space)</param>
+        /// <param name="coordinateY">mouse position Y(coordinate space)</param>
+        /// <param name="snapX">snap distance X axes (coordinate space)</param>
+        /// <param name="snapY">snap distance X axes (coordinate space)</param>
+        /// <returns>True if signal is within a mouse</returns>
         public bool IsUnderMouse(double coordinateX, double coordinateY, double snapX, double snapY)
         {
             var from = (int)(Math.Floor((coordinateX - snapX - OffsetX) / SamplePeriod));
@@ -799,6 +815,12 @@ namespace ScottPlot.Plottable
             return false;
         }
 
+        /// <summary>
+        /// Never called 
+        /// </summary>
+        /// <param name="coordinateX"></param>
+        /// <param name="coordinateY"></param>
+        /// <param name="fixedSize"></param>
         public void DragTo(double coordinateX, double coordinateY, bool fixedSize)
         {
             throw new NotImplementedException();

--- a/src/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot/Plottable/SignalPlotBase.cs
@@ -771,6 +771,10 @@ namespace ScottPlot.Plottable
                 if (x > coordinateX - snapX && x < coordinateX + snapX && y > coordinateY - snapY && y < coordinateY + snapY)
                     return true;
             }
+
+            if (LineWidth == 0)
+                return false;
+
             // intersect with lines?
             for (int i = from; i < to; i++)
             {

--- a/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -1,4 +1,5 @@
 ﻿using ScottPlot.Drawing;
+using ScottPlot.Plottable.HelperAlgorithms;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -334,17 +335,21 @@ namespace ScottPlot.Plottable
                     to = index + 1;
             }
 
+            AABBChecker checker = new AABBChecker(coordinateX, coordinateY, snapX, snapY);
+
             // intersect with points?
             for (int i = from; i <= to; i++)
             {
                 double x = Convert.ToDouble(Xs[i]) + OffsetX;
                 double y = Convert.ToDouble(AddYsGeneric(Ys[i], OffsetY));
-                if (x > coordinateX - snapX && x < coordinateX + snapX && y > coordinateY - snapY && y < coordinateY + snapY)
+                if (checker.CheckInsideAABB(x, y))
                     return true;
             }
 
             if (LineWidth == 0)
                 return false;
+
+            CloseToSegmentChecker segmentChecker = new CloseToSegmentChecker(coordinateX, coordinateY, snapX, snapY);
 
             // intersect with lines?
             for (int i = from; i < to; i++)
@@ -354,38 +359,8 @@ namespace ScottPlot.Plottable
                 double x1 = Convert.ToDouble(Xs[i + 1]) + OffsetX;
                 double y1 = Convert.ToDouble(AddYsGeneric(Ys[i + 1], OffsetY));
 
-                (double x, double y)[][] boundaryPolys = new (double x, double y)[][]
-                {
-                    new (double x, double y)[]
-                    {
-                        (x, y + snapY),
-                        (x, y - snapY),
-                        (x1, y1 - snapY),
-                        (x1, y1 + snapY),
-                    },
-                    new (double x, double y)[]
-                    {
-                        (x - snapX, y),
-                        (x + snapX, y),
-                        (x1 + snapX, y1),
-                        (x1 - snapX, y1),
-                    }
-                };
-
-                for (int k = 0; k < boundaryPolys.Length; k++)
-                {
-                    bool inside = false;
-                    for (int j = 0, j1 = boundaryPolys[k].Length - 1; j < boundaryPolys[k].Length; j1 = j++)
-                    {
-                        if ((boundaryPolys[k][j].y > coordinateY) != (boundaryPolys[k][j1].y > coordinateY) &&
-                            (coordinateX < (boundaryPolys[k][j1].x - boundaryPolys[k][j].x) * (coordinateY - boundaryPolys[k][j].y) / (boundaryPolys[k][j1].y - boundaryPolys[k][j].y) + boundaryPolys[k][j].x))
-                        {
-                            inside = !inside;
-                        }
-                    }
-                    if (inside)
-                        return true;
-                }
+                if (segmentChecker.IsClose(x, y, x1, y1))
+                    return true;
             }
             return false;
         }

--- a/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -290,6 +290,14 @@ namespace ScottPlot.Plottable
         }
 
 
+        /// <summary>
+        /// Return True if either signalXY is within a certain number of pixels (snap) to the mouse
+        /// </summary>
+        /// <param name="coordinateX">mouse position X (coordinate space)</param>
+        /// <param name="coordinateY">mouse position Y(coordinate space)</param>
+        /// <param name="snapX">snap distance X axes (coordinate space)</param>
+        /// <param name="snapY">snap distance X axes (coordinate space)</param>
+        /// <returns>True if signal is within a mouse</returns>
         public new bool IsUnderMouse(double coordinateX, double coordinateY, double snapX, double snapY)
         {
             int from;

--- a/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -342,6 +342,10 @@ namespace ScottPlot.Plottable
                 if (x > coordinateX - snapX && x < coordinateX + snapX && y > coordinateY - snapY && y < coordinateY + snapY)
                     return true;
             }
+
+            if (LineWidth == 0)
+                return false;
+
             // intersect with lines?
             for (int i = from; i < to; i++)
             {

--- a/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -315,7 +315,7 @@ namespace ScottPlot.Plottable
             {
                 to = index;
             }
-            else 
+            else
             {
                 index = ~index;
                 if (index <= MinRenderIndex) // x lower then any MinRenderIndex
@@ -329,7 +329,7 @@ namespace ScottPlot.Plottable
             // intersect with points?
             for (int i = from; i <= to; i++)
             {
-                double x = Convert.ToDouble(Xs[i]) +OffsetX;
+                double x = Convert.ToDouble(Xs[i]) + OffsetX;
                 double y = Convert.ToDouble(AddYsGeneric(Ys[i], OffsetY));
                 if (x > coordinateX - snapX && x < coordinateX + snapX && y > coordinateY - snapY && y < coordinateY + snapY)
                     return true;
@@ -339,7 +339,7 @@ namespace ScottPlot.Plottable
             {
                 double x = Convert.ToDouble(Xs[i]) + OffsetX;
                 double y = Convert.ToDouble(AddYsGeneric(Ys[i], OffsetY));
-                double x1 = Convert.ToDouble(Xs[i+1]) + OffsetX;
+                double x1 = Convert.ToDouble(Xs[i + 1]) + OffsetX;
                 double y1 = Convert.ToDouble(AddYsGeneric(Ys[i + 1], OffsetY));
 
                 (double x, double y)[][] boundaryPolys = new (double x, double y)[][]

--- a/src/tests/HelperAlgorithmsTests/AABBCheckerTests.cs
+++ b/src/tests/HelperAlgorithmsTests/AABBCheckerTests.cs
@@ -1,0 +1,59 @@
+﻿using NUnit.Framework;
+using ScottPlot.Plottable.HelperAlgorithms;
+
+namespace ScottPlotTests.HelperAlgorithmsTests
+{
+    [TestFixture]
+    public class AABBCheckerTests
+    {
+        [TestCase(5, 2)]
+        [TestCase(0, 0)]
+        [TestCase(1, -7)]
+        [TestCase(5, 10)]
+        [TestCase(-5, 10)]
+        [TestCase(-5, -10)]
+        public void CheckInsideAABB_SomeAABBPointsInside_ReturnTrue(double x, double y)
+        {
+            AABBChecker checker = new AABBChecker(0, 0, 5, 10);
+            var result = checker.CheckInsideAABB(x, y);
+            Assert.True(result);
+        }
+
+        [TestCase(6, 0)]
+        [TestCase(-1000, 1)]
+        [TestCase(42, 42)]
+        [TestCase(12, 3)]
+        [TestCase(5.0001, 0)]
+        public void CheckInsideAABB_SomeAABBPointsOutside_ReturnFalse(double x, double y)
+        {
+            AABBChecker checker = new AABBChecker(0, 0, 5, 10);
+            var result = checker.CheckInsideAABB(x, y);
+            Assert.False(result);
+        }
+
+        [TestCase(11, -7)]
+        [TestCase(15, -10)]
+        [TestCase(19, -11)]
+        [TestCase(15, -9)]
+        [TestCase(20, -12)]
+        [TestCase(10, -6)]
+        public void CheckInsideAABB_OffsetedAABBPointsInside_ReturnTrue(double x, double y)
+        {
+            AABBChecker checker = new AABBChecker(15, -9, 5, 3);
+            var result = checker.CheckInsideAABB(x, y);
+            Assert.True(result);
+        }
+
+        [TestCase(0, 0)]
+        [TestCase(9, -9)]
+        [TestCase(42, 42)]
+        [TestCase(20, 20)]
+        [TestCase(20.001, -9)]
+        public void CheckInsideAABB_OffsetedAABBPointsOutside_ReturnFalse(double x, double y)
+        {
+            AABBChecker checker = new AABBChecker(15, -9, 5, 3);
+            var result = checker.CheckInsideAABB(x, y);
+            Assert.False(result);
+        }
+    }
+}

--- a/src/tests/HelperAlgorithmsTests/CloseToSegmentCheckerTests.cs
+++ b/src/tests/HelperAlgorithmsTests/CloseToSegmentCheckerTests.cs
@@ -1,0 +1,60 @@
+﻿using NUnit.Framework;
+using ScottPlot.Plottable.HelperAlgorithms;
+
+namespace ScottPlotTests.HelperAlgorithmsTests
+{
+    [TestFixture]
+    public class CloseToSegmentCheckerTests
+    {
+        [TestCase(9.9, 0.9)]
+        [TestCase(5, 0.5)]
+        [TestCase(5, -0.9)]
+        [TestCase(3, 0.9)]
+        [TestCase(0, 0)]
+        public void IsClose_HorisontalSegmentPointsClose_ReturnTrue(double x, double y)
+        {
+            CloseToSegmentChecker checker = new CloseToSegmentChecker(x, y, 1, 1);
+            var result = checker.IsClose(0, 0, 10, 0);
+            Assert.True(result);
+        }
+
+        [TestCase(5, 5)]
+        [TestCase(12, 0.3)]
+        [TestCase(1000, 0)]
+        [TestCase(0, 1000)]
+        [TestCase(3, -5)]
+        [TestCase(5, -1.05)]
+        public void IsClose_HorisontalSegmentPointsFarFrom_ReturnFalse(double x, double y)
+        {
+            CloseToSegmentChecker checker = new CloseToSegmentChecker(x, y, 1, 1);
+            var result = checker.IsClose(0, 0, 10, 0);
+            Assert.False(result);
+        }
+
+        [TestCase(4.9, 9.7)]
+        [TestCase(0, 20.5)]
+        [TestCase(-5.5, 30)]
+        [TestCase(-10, 39.3)]
+        [TestCase(0.3, 20.7)]
+        public void IsClose_SomeSegmentPointsClose_ReturnTrue(double x, double y)
+        {
+            CloseToSegmentChecker checker = new CloseToSegmentChecker(x, y, 1, 1);
+            var result = checker.IsClose(5, 10, -10, 40);
+            Assert.True(result);
+        }
+
+        [TestCase(0, 25.1)]
+        [TestCase(5, 8)]
+        [TestCase(-11.2, 40)]
+        [TestCase(-5.5, 28.7)]
+        [TestCase(10, 0)]
+        [TestCase(1000, 0)]
+        [TestCase(0, 1000)]
+        public void IsClose_SomeSegmentPointsFarFrom_ReturnFalse(double x, double y)
+        {
+            CloseToSegmentChecker checker = new CloseToSegmentChecker(x, y, 1, 1);
+            var result = checker.IsClose(5, 10, -10, 40);
+            Assert.False(result);
+        }
+    }
+}


### PR DESCRIPTION
Work In Progress

**Purpose:**
Implement IDraggableModern interface for Scatter, Signal, SignalXY (CoordinatedHeatmap). #1002

Early shared, I plan to add some work, but can do it only after weekend, and there is some question i want to discuss.
Questions to discuss:

1. IDraggableModern - is working title. We need to come up with a suitable name. On the other hand, We can absorb the existing IDraggable. Only Span for now use this old interface. With such a takeover, backward compatibility of users may be broken, or maybe not, they seem to not use DragTo() directly.
2. `Drag(double fromX, double toX, double fromY, double toY, ...)` can be transformed to
`Drag(double offsetX, double offsetY)`.  Initially, I thought that the starting point might be useful in the handler, but in fact it was never used.
3. If plot dimensions additionaly are passed to IsUnderMouse(), then it will be possible to carry out additional optimizations by collapsing a set of points into one column for `Signals`, as is done during rendering. Although, oddly enough, on the test signals, I did not notice any performance problems with the current implementation.
4. The scatter, oddly enough, has no offsets (OffsetX, OffsetY). So dragging happens through modifying the original (XS, YS) arrays. Which leads to funny effects. In the demo, many scatters have a common XS array, and when you drag one, all the others are dragged, but only in X. I think it would be a good idea to implement Offsets for the Scatter, and rewrite the drag to change offsets as it is done for signals. But this task is best solved in a separate PR.
5. For now all signals, scatters, DragEnabled by default for test porpouse. It would be nice to make separate demos for new  Plottable. Then we can turn off the default DragEnabled.
6. For dragging, I selected the existing hand cursor. Maybe we can think of something more interesting.

What do I plan to finish in this PR:
1.  :heavy_check_mark: implement the algorithm for intersection the cursor with the line for the scatter in the same way as for signals. I started with a scatter, and found a more efficient algorithm on the signals.
2. :heavy_check_mark: Do not search for intersections with lines if the display of lines is disabled.
3. :heavy_check_mark: Think about how to reduce the duplication of the intersection code for different Plottables.
4. :heavy_check_mark: Write tests for intersection algorithms.
5. :heavy_check_mark: Add xml documentation to methods and fields.
6. Make Demo.

**New Functionality:**
```cs
signal = Plot.AddSignalXY(xs, ys);
signal.DragEnabled = true;
```
![DraggableSignals](https://user-images.githubusercontent.com/53831487/120701118-25616380-c4bb-11eb-80c0-6a23168e90a3.gif)
