### PR TITLE
Improve multi-axis support for crosshair labels

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -1,7 +1,10 @@
 # ScottPlot Changelog
 
 ## ScottPlot 4.1.17
-* Improved `RadarPlot.Update()` default arguments (#1097) _Thanks @arthurits_
+* Radar Plot: Improved `Update()` default arguments (#1097) _Thanks @arthurits_
+* Crosshair: Added `XLabelOnTop` and `YLabelOnRight` options to improve multi-axis support and label customization (#1147) _Thanks @rutkowskit_
+* Signal Plot: Added `StepDisplay` option to render signal plots as step plots when zoomed in (#1092, #1128) _Thanks @EmanuelFeru_
+* Testing: Improved error reporting on failed XML documentation tests (#1127) _Thanks @StendProg_
 
 ## ScottPlot 4.1.16
 * Made it easier to use custom color palettes (see cookbook) (#1058, #1082) _Thanks @EmanuelFeru_

--- a/src/ScottPlot/Plottable/Crosshair.cs
+++ b/src/ScottPlot/Plottable/Crosshair.cs
@@ -64,6 +64,16 @@ namespace ScottPlot.Plottable
         /// </summary>
         public bool IsVisibleY = true;
 
+        /// <summary>
+        /// Control whether the label for the X crosshair appears on the top or bottom edge of the plot
+        /// </summary>
+        public bool XLabelOnTop = false;
+
+        /// <summary>
+        /// Control whether the label for the Y crosshair appears on the left or right edge of the plot
+        /// </summary>
+        public bool YLabelOnRight = false;
+
         public LineStyle LineStyle = LineStyle.Dash;
         public float LineWidth = 1;
         public Color LineColor = Color.FromArgb(150, Color.Red);
@@ -94,45 +104,54 @@ namespace ScottPlot.Plottable
             using var fillBrush = Drawing.GDI.Brush(LabelBackgroundColor);
             using var fontBrush = Drawing.GDI.Brush(LabelFont.Color);
 
-            if (X >= dims.XMin && X <= dims.XMax && IsVisibleX)
-            {
-                // vertical line and label centered at X
-                float xPixel = dims.GetPixelX(X);
-                gfx.DrawLine(pen, xPixel, dims.DataOffsetY, xPixel, dims.DataOffsetY + dims.DataHeight);
+            RenderVerticalLine(dims, gfx, pen, fnt, fillBrush, fontBrush);
+            RenderHorizontalLine(dims, gfx, pen, fnt, fillBrush, fontBrush);
+        }
 
-                string xLabel = IsDateTimeX ? DateTime.FromOADate(X).ToString(StringFormatX) : X.ToString(StringFormatX);
-                SizeF xLabelSize = Drawing.GDI.MeasureString(xLabel, LabelFont);
+        private void RenderHorizontalLine(PlotDimensions dims, Graphics gfx, Pen pen, Font fnt, Brush fillBrush, Brush fontBrush)
+        {
+            if (!IsVisibleY)
+                return;
 
-                var xPos = xPixel - xLabelSize.Width / 2;
-                var yPos = XAxisIndex == 0
-                    ? dims.DataOffsetY + dims.DataHeight
-                    : dims.DataOffsetY - xLabelSize.Height;
+            if (Y < dims.YMin || Y > dims.YMax)
+                return;
 
-                RectangleF xLabelRect = new(xPos, yPos, xLabelSize.Width, xLabelSize.Height);
-                gfx.FillRectangle(fillBrush, xLabelRect);
-                var sf = Drawing.GDI.StringFormat(HorizontalAlignment.Center, VerticalAlignment.Upper);
-                gfx.DrawString(xLabel, fnt, fontBrush, xPixel, yPos, sf);
-            }
+            float yPixel = dims.GetPixelY(Y);
+            gfx.DrawLine(pen, dims.DataOffsetX, yPixel, dims.DataOffsetX + dims.DataWidth, yPixel);
 
-            if (Y >= dims.YMin && Y <= dims.YMax && IsVisibleY)
-            {
-                // horizontal line and label centered at Y
-                float yPixel = dims.GetPixelY(Y);
-                gfx.DrawLine(pen, dims.DataOffsetX, yPixel, dims.DataOffsetX + dims.DataWidth, yPixel);
+            string yLabel = IsDateTimeY ? DateTime.FromOADate(Y).ToString(StringFormatY) : Y.ToString(StringFormatY);
+            SizeF yLabelSize = Drawing.GDI.MeasureString(yLabel, LabelFont);
 
-                string yLabel = IsDateTimeY ? DateTime.FromOADate(Y).ToString(StringFormatY) : Y.ToString(StringFormatY);
-                SizeF yLabelSize = Drawing.GDI.MeasureString(yLabel, LabelFont);
+            float xPos = YLabelOnRight ? dims.DataOffsetX + dims.DataWidth : dims.DataOffsetX - yLabelSize.Width;
+            float yPos = yPixel - yLabelSize.Height / 2;
 
-                var xPos = YAxisIndex == 0
-                    ? dims.DataOffsetX - yLabelSize.Width
-                    : dims.DataOffsetX + dims.DataWidth;
-                var yPos = yPixel - yLabelSize.Height / 2;
+            RectangleF xLabelRect = new(xPos, yPos, yLabelSize.Width, yLabelSize.Height);
+            gfx.FillRectangle(fillBrush, xLabelRect);
+            var sf = Drawing.GDI.StringFormat(HorizontalAlignment.Left, VerticalAlignment.Middle);
+            gfx.DrawString(yLabel, fnt, fontBrush, xPos, yPixel, sf);
+        }
 
-                RectangleF xLabelRect = new(xPos, yPos, yLabelSize.Width, yLabelSize.Height);
-                gfx.FillRectangle(fillBrush, xLabelRect);
-                var sf = Drawing.GDI.StringFormat(HorizontalAlignment.Left, VerticalAlignment.Middle);
-                gfx.DrawString(yLabel, fnt, fontBrush, xPos, yPixel, sf);
-            }
+        private void RenderVerticalLine(PlotDimensions dims, Graphics gfx, Pen pen, Font fnt, Brush fillBrush, Brush fontBrush)
+        {
+            if (!IsVisibleX)
+                return;
+
+            if (X < dims.XMin || X > dims.XMax)
+                return;
+
+            float xPixel = dims.GetPixelX(X);
+            gfx.DrawLine(pen, xPixel, dims.DataOffsetY, xPixel, dims.DataOffsetY + dims.DataHeight);
+
+            string xLabel = IsDateTimeX ? DateTime.FromOADate(X).ToString(StringFormatX) : X.ToString(StringFormatX);
+            SizeF xLabelSize = Drawing.GDI.MeasureString(xLabel, LabelFont);
+
+            float xPos = xPixel - xLabelSize.Width / 2;
+            float yPos = XLabelOnTop ? dims.DataOffsetY - xLabelSize.Height : dims.DataOffsetY + dims.DataHeight;
+
+            RectangleF xLabelRect = new(xPos, yPos, xLabelSize.Width, xLabelSize.Height);
+            gfx.FillRectangle(fillBrush, xLabelRect);
+            var sf = Drawing.GDI.StringFormat(HorizontalAlignment.Center, VerticalAlignment.Upper);
+            gfx.DrawString(xLabel, fnt, fontBrush, xPixel, yPos, sf);
         }
     }
 }

--- a/src/ScottPlot/Plottable/Crosshair.cs
+++ b/src/ScottPlot/Plottable/Crosshair.cs
@@ -102,10 +102,16 @@ namespace ScottPlot.Plottable
 
                 string xLabel = IsDateTimeX ? DateTime.FromOADate(X).ToString(StringFormatX) : X.ToString(StringFormatX);
                 SizeF xLabelSize = Drawing.GDI.MeasureString(xLabel, LabelFont);
-                RectangleF xLabelRect = new(xPixel - xLabelSize.Width / 2, dims.DataOffsetY + dims.DataHeight, xLabelSize.Width, xLabelSize.Height);
+
+                var xPos = xPixel - xLabelSize.Width / 2;
+                var yPos = XAxisIndex == 0
+                    ? dims.DataOffsetY + dims.DataHeight
+                    : dims.DataOffsetY - xLabelSize.Height;
+
+                RectangleF xLabelRect = new(xPos, yPos, xLabelSize.Width, xLabelSize.Height);
                 gfx.FillRectangle(fillBrush, xLabelRect);
                 var sf = Drawing.GDI.StringFormat(HorizontalAlignment.Center, VerticalAlignment.Upper);
-                gfx.DrawString(xLabel, fnt, fontBrush, xPixel, dims.DataOffsetY + dims.DataHeight, sf);
+                gfx.DrawString(xLabel, fnt, fontBrush, xPixel, yPos, sf);
             }
 
             if (Y >= dims.YMin && Y <= dims.YMax && IsVisibleY)
@@ -116,10 +122,16 @@ namespace ScottPlot.Plottable
 
                 string yLabel = IsDateTimeY ? DateTime.FromOADate(Y).ToString(StringFormatY) : Y.ToString(StringFormatY);
                 SizeF yLabelSize = Drawing.GDI.MeasureString(yLabel, LabelFont);
-                RectangleF xLabelRect = new(dims.DataOffsetX - yLabelSize.Width, yPixel - yLabelSize.Height / 2, yLabelSize.Width, yLabelSize.Height);
+
+                var xPos = YAxisIndex == 0
+                    ? dims.DataOffsetX - yLabelSize.Width
+                    : dims.DataOffsetX + dims.DataWidth;
+                var yPos = yPixel - yLabelSize.Height / 2;
+
+                RectangleF xLabelRect = new(xPos, yPos, yLabelSize.Width, yLabelSize.Height);
                 gfx.FillRectangle(fillBrush, xLabelRect);
-                var sf = Drawing.GDI.StringFormat(HorizontalAlignment.Right, VerticalAlignment.Middle);
-                gfx.DrawString(yLabel, fnt, fontBrush, dims.DataOffsetX, yPixel, sf);
+                var sf = Drawing.GDI.StringFormat(HorizontalAlignment.Left, VerticalAlignment.Middle);
+                gfx.DrawString(yLabel, fnt, fontBrush, xPos, yPixel, sf);
             }
         }
     }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Crosshair.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Crosshair.cs
@@ -136,6 +136,8 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             signal2.XAxisIndex = 1;
 
             var cross2 = plt.AddCrosshair(33, 5.1);
+            cross2.YLabelOnRight = true;
+            cross2.XLabelOnTop = true;
             cross2.YAxisIndex = signal2.YAxisIndex;
             cross2.XAxisIndex = signal2.XAxisIndex;
             cross2.LineStyle = LineStyle.Dot;

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Crosshair.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Crosshair.cs
@@ -121,7 +121,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string Category => "Plottable: Crosshair";
         public string ID => "crosshair_multiple_different_axes";
         public string Title => "Crosshairs on Multiple Axes";
-        public string Description => "Crosshairs label coordinates on the primary axes by default, but " + 
+        public string Description => "Crosshairs label coordinates on the primary axes by default, but " +
             "the axis index can be changed allowing multiple crosshairs to label multiple axes.";
 
         public void ExecuteRecipe(Plot plt)

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Crosshair.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Crosshair.cs
@@ -115,4 +115,46 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             ch.StringFormatY = "F4";
         }
     }
+
+    public class CrosshairMultipleForDifferentAxes : IRecipe
+    {
+        public string Category => "Plottable: Crosshair";
+        public string ID => "crosshair_multiple_different_axes";
+        public string Title => "Crosshairs on Multiple Axes";
+        public string Description => "Crosshairs label coordinates on the primary axes by default, but " + 
+            "the axis index can be changed allowing multiple crosshairs to label multiple axes.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            // add a signal and crosshair to the primary X and Y axis (index 0)
+            var signal1 = plt.AddSignal(DataGen.RandomWalk(null, 100));
+            var cross1 = plt.AddCrosshair(24, 5.29);
+
+            // add a signal and crosshair to the secondary X and Y axis (index 1)
+            var signal2 = plt.AddSignal(DataGen.RandomWalk(null, 50));
+            signal2.YAxisIndex = 1;
+            signal2.XAxisIndex = 1;
+
+            var cross2 = plt.AddCrosshair(33, 5.1);
+            cross2.YAxisIndex = signal2.YAxisIndex;
+            cross2.XAxisIndex = signal2.XAxisIndex;
+            cross2.LineStyle = LineStyle.Dot;
+
+            // apply signal colors to the crosshairs
+            cross1.LineColor = signal1.Color;
+            cross2.LineColor = signal2.Color;
+            cross1.LabelBackgroundColor = signal1.Color;
+            cross2.LabelBackgroundColor = signal2.Color;
+
+            // add axis labels
+            plt.Title("Multiple Crosshairs for different Axes");
+            plt.XLabel("Horizontal Axis");
+            plt.YLabel("Vertical Axis");
+            plt.YAxis2.Label("Signal2 Value");
+
+            // show ticks for axes where ticks are hidden by default
+            plt.YAxis2.Ticks(true);
+            plt.XAxis2.Ticks(true);
+        }
+    }
 }


### PR DESCRIPTION
**Purpose:**
Current Crosshair implementation doesn't work well when you want to attach it to Right or Top axis. 
After setting YAxisIndex to 1, I would expect the label with the value on the right axis. 
After setting XAxisIndex to 1, I would expect the label with the value on the top axis. 
This Pull Request contains a small fix to handle this case.

Below is the code of a sample recipe for multiple crosshairs attached to different axes.
```cs
    public class CrosshairMultipleForDifferentAxes : IRecipe
    {
        public string Category => "Plottable: Crosshair";
        public string ID => "crosshair_multiple_different_axes";
        public string Title => "Multiple crosshairs for different axes";
        public string Description => "Chrosshair for right and top axis";

        public void ExecuteRecipe(Plot plt)
        {
            plt.Title("Multiple Crosshairs for different Axes");
            plt.XLabel("Horizontal Axis");
            plt.YLabel("Vertical Axis");
            plt.YAxis2.Label("Signal2 Value");
            plt.YAxis2.Ticks(true);
            plt.XAxis2.Ticks(true);

            var signal = plt.AddSignal(DataGen.RandomWalk(null, 100));
            var signal2 = plt.AddSignal(DataGen.RandomWalk(null, 50));
            signal2.YAxisIndex = 1;
            signal2.XAxisIndex = 1;

            var ch1 = plt.AddCrosshair(40, signal.Ys[50]);
            ch1.LabelBackgroundColor = signal.Color;

            var ch2 = plt.AddCrosshair(20, signal.Ys[25]);            
            ch2.LineColor = System.Drawing.Color.Transparent; 
            ch2.LabelBackgroundColor = signal2.Color;
            ch2.YAxisIndex = signal2.YAxisIndex;
            ch2.XAxisIndex = signal2.XAxisIndex;
        }
    }
```