### PR TITLE
Drag processing

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -8,6 +8,7 @@
 * Testing: Improved error reporting on failed XML documentation tests (#1127) _Thanks @StendProg_
 * Histogram: Marked `ScottPlot.Statistics.Histogram` obsolete in favor of static methods in `ScottPlot.Statistics.Common` designed to create histograms and probability function curves (#1051, #1166). See cookbook for usage examples. _Thanks @breakwinz and @bclehmann_
 * WpfPlot: Improve memory management for dynamically created and destroyed WpfPlot controls by properly unloading the dispatcher timer (#1115, #1117) _Thanks @RamsayGit, @bclehmann, @StendProg, and @Orace_
+* Mouse Processing: Improved bug that affected fast drag-dropping of draggable objects (#1076)
 
 ## ScottPlot 4.1.16
 * Made it easier to use custom color palettes (see cookbook) (#1058, #1082) _Thanks @EmanuelFeru_

--- a/src/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot/Control/Backend.cs
@@ -521,6 +521,7 @@ namespace ScottPlot.Control
             }
             else
             {
+                //Console.WriteLine($"[{DateTime.Now:ss.ffff}] PROCESSING: {uiEvent}");
                 uiEvent.ProcessEvent();
 
                 if (uiEvent.RenderType == RenderType.ProcessMouseEventsOnly)
@@ -570,7 +571,6 @@ namespace ScottPlot.Control
         public void MouseUp(InputState input)
         {
             var droppedPlottable = PlottableBeingDragged;
-            PlottableBeingDragged = null;
 
             IUIEvent mouseEvent;
             if (IsZoomingRectangle && MouseDownDragged && Configuration.MiddleClickDragZoom)
@@ -592,6 +592,10 @@ namespace ScottPlot.Control
 
             if (droppedPlottable != null)
                 PlottableDropped(droppedPlottable, EventArgs.Empty);
+
+            PlottableBeingDragged = null;
+            if (droppedPlottable != null)
+                ProcessEvent(EventFactory.CreateMouseUpClearRender());
         }
 
         /// <summary>

--- a/src/sandbox/WinFormsFrameworkApp/Form1.cs
+++ b/src/sandbox/WinFormsFrameworkApp/Form1.cs
@@ -12,6 +12,8 @@ namespace WinFormsFrameworkApp
         {
             InitializeComponent();
             formsPlot1.Plot.AddSignal(ScottPlot.DataGen.Sin(100));
+            var vline = formsPlot1.Plot.AddVerticalLine(50);
+            vline.DragEnabled = true;
         }
 
         private void button1_Click(object sender, EventArgs e)


### PR DESCRIPTION
This PR fixes a bug where fast-drag-dropping a plottable would cause unexpected placement or unintended panning in addition to missing a final render. This PR fixes #1076