### PR TITLE
Creates bash script for autoformatting

### DIFF
--- a/src/autoformat.sh
+++ b/src/autoformat.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Install/update the dotnet 5 autoformatter
+dotnet tool update -g dotnet-format
+
+# Run the dotnet formatter
+dotnet format


### PR DESCRIPTION
**Purpose:**
Creates an `autoformat.sh` script, just like there's an `autoformat.bat` script. Note that the bash script doesn't pause until the user presses a key, as I don't know why that was there in the first place.

**New Functionality:**
Linux and Mac users can now use an autoformat script.

We could consider creating a `ps1` script as well, but I don't know if that's necessary or not. Although PowerShell is cross-platform now.