### PR TITLE
VectorField: options for scaled arrowheads and alternate anchoring

### DIFF
--- a/src/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot/Plot/Plot.Add.cs
@@ -1007,12 +1007,13 @@ namespace ScottPlot
             string label = null,
             Color? color = null,
             Drawing.Colormap colormap = null,
-            double scaleFactor = 1
-            )
+            double scaleFactor = 1,
+            bool fancyCaps = false,
+            bool anchorAtStart = false  )
         {
             // TODO: refactor constructor to eliminate styling arguments
             var vectorField = new VectorField(vectors, xs, ys,
-                colormap, scaleFactor, color ?? settings.GetNextColor())
+                colormap, scaleFactor, color ?? settings.GetNextColor(), fancyCaps, anchorAtStart)
             { Label = label };
 
             Add(vectorField);

--- a/src/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot/Plot/Plot.Add.cs
@@ -1009,7 +1009,7 @@ namespace ScottPlot
             Drawing.Colormap colormap = null,
             double scaleFactor = 1,
             bool fancyCaps = false,
-            bool anchorAtStart = false  )
+            bool anchorAtStart = false)
         {
             // TODO: refactor constructor to eliminate styling arguments
             var vectorField = new VectorField(vectors, xs, ys,

--- a/src/ScottPlot/Plottable/VectorField.cs
+++ b/src/ScottPlot/Plottable/VectorField.cs
@@ -7,197 +7,197 @@ using System.Linq;
 
 namespace ScottPlot.Plottable
 {
-	 /// <summary>
-	 /// The VectorField displays arrows representing a 2D array of 2D vectors
-	 /// </summary>
-	 public class VectorField : IPlottable
-	 {
-		  // data
-		  private readonly double[] Xs;
-		  private readonly double[] Ys;
-		  private readonly bool fancyCaps;
-		  private readonly bool anchorAtStart;
-		  private readonly Vector2[,] Vectors;
-		  private readonly Color[] VectorColors;
-		  private readonly PointF[] _poly = new PointF[5];
+    /// <summary>
+    /// The VectorField displays arrows representing a 2D array of 2D vectors
+    /// </summary>
+    public class VectorField : IPlottable
+    {
+        // data
+        private readonly double[] Xs;
+        private readonly double[] Ys;
+        private readonly bool fancyCaps;
+        private readonly bool anchorAtStart;
+        private readonly Vector2[,] Vectors;
+        private readonly Color[] VectorColors;
+        private readonly PointF[] _poly = new PointF[5];
 
-		  // customization
-		  public string Label;
-		  public bool IsVisible { get; set; } = true;
-		  public int XAxisIndex { get; set; } = 0;
-		  public int YAxisIndex { get; set; } = 0;
+        // customization
+        public string Label;
+        public bool IsVisible { get; set; } = true;
+        public int XAxisIndex { get; set; } = 0;
+        public int YAxisIndex { get; set; } = 0;
 
-		  /// <summary>
-		  /// 
-		  /// </summary>
-		  /// <param name="vectors"></param>
-		  /// <param name="xs"></param>
-		  /// <param name="ys"></param>
-		  /// <param name="colormap"></param>
-		  /// <param name="scaleFactor"></param>
-		  /// <param name="defaultColor"></param>
-		  /// <param name="fancyCaps">Plot custom arrow heads; slower but nicer looking.</param>
-		  /// <param name="anchorAtStart">Draw arrow starting from the x,y coordinate, instead of centering the arrow on the x,y coordinate.</param>
-		  public VectorField (Vector2[,] vectors, double[] xs, double[] ys, Colormap colormap, double scaleFactor, Color defaultColor,
-				bool fancyCaps = false, bool anchorAtStart = false)
-		  {
-				double minMagnitudeSquared = vectors[0, 0].LengthSquared();
-				double maxMagnitudeSquared = vectors[0, 0].LengthSquared();
-				for (int i = 0; i < xs.Length; i++)
-				{
-					 for (int j = 0; j < ys.Length; j++)
-					 {
-						  if (vectors[i, j].LengthSquared() > maxMagnitudeSquared)
-								maxMagnitudeSquared = vectors[i, j].LengthSquared();
-						  else if (vectors[i, j].LengthSquared() < minMagnitudeSquared)
-								minMagnitudeSquared = vectors[i, j].LengthSquared();
-					 }
-				}
-				double minMagnitude = Math.Sqrt(minMagnitudeSquared);
-				double maxMagnitude = Math.Sqrt(maxMagnitudeSquared);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="vectors"></param>
+        /// <param name="xs"></param>
+        /// <param name="ys"></param>
+        /// <param name="colormap"></param>
+        /// <param name="scaleFactor"></param>
+        /// <param name="defaultColor"></param>
+        /// <param name="fancyCaps">Plot custom arrow heads; slower but nicer looking.</param>
+        /// <param name="anchorAtStart">Draw arrow starting from the x,y coordinate, instead of centering the arrow on the x,y coordinate.</param>
+        public VectorField(Vector2[,] vectors, double[] xs, double[] ys, Colormap colormap, double scaleFactor, Color defaultColor,
+              bool fancyCaps = false, bool anchorAtStart = false)
+        {
+            double minMagnitudeSquared = vectors[0, 0].LengthSquared();
+            double maxMagnitudeSquared = vectors[0, 0].LengthSquared();
+            for (int i = 0; i < xs.Length; i++)
+            {
+                for (int j = 0; j < ys.Length; j++)
+                {
+                    if (vectors[i, j].LengthSquared() > maxMagnitudeSquared)
+                        maxMagnitudeSquared = vectors[i, j].LengthSquared();
+                    else if (vectors[i, j].LengthSquared() < minMagnitudeSquared)
+                        minMagnitudeSquared = vectors[i, j].LengthSquared();
+                }
+            }
+            double minMagnitude = Math.Sqrt(minMagnitudeSquared);
+            double maxMagnitude = Math.Sqrt(maxMagnitudeSquared);
 
-				double[,] intensities = new double[xs.Length, ys.Length];
-				for (int i = 0; i < xs.Length; i++)
-				{
-					 for (int j = 0; j < ys.Length; j++)
-					 {
-						  if (colormap != null)
-								intensities[i, j] = (vectors[i, j].Length() - minMagnitude) / (maxMagnitude - minMagnitude);
-						  vectors[i, j] = Vector2.Multiply(vectors[i, j], (float)(scaleFactor / (maxMagnitude * 1.2)));
-					 }
-				}
+            double[,] intensities = new double[xs.Length, ys.Length];
+            for (int i = 0; i < xs.Length; i++)
+            {
+                for (int j = 0; j < ys.Length; j++)
+                {
+                    if (colormap != null)
+                        intensities[i, j] = (vectors[i, j].Length() - minMagnitude) / (maxMagnitude - minMagnitude);
+                    vectors[i, j] = Vector2.Multiply(vectors[i, j], (float)(scaleFactor / (maxMagnitude * 1.2)));
+                }
+            }
 
-				double[] flattenedIntensities = intensities.Cast<double>().ToArray();
-				VectorColors = colormap is null ?
-					 Enumerable.Range(0, flattenedIntensities.Length).Select(x => defaultColor).ToArray() :
-					 Colormap.GetColors(flattenedIntensities, colormap);
+            double[] flattenedIntensities = intensities.Cast<double>().ToArray();
+            VectorColors = colormap is null ?
+                 Enumerable.Range(0, flattenedIntensities.Length).Select(x => defaultColor).ToArray() :
+                 Colormap.GetColors(flattenedIntensities, colormap);
 
-				this.Vectors = vectors;
-				this.Xs = xs;
-				this.Ys = ys;
-				this.fancyCaps = fancyCaps;
-				this.anchorAtStart = anchorAtStart;
-		  }
+            this.Vectors = vectors;
+            this.Xs = xs;
+            this.Ys = ys;
+            this.fancyCaps = fancyCaps;
+            this.anchorAtStart = anchorAtStart;
+        }
 
-		  public void ValidateData (bool deep = false) { /* validation occurs in constructor */ }
+        public void ValidateData(bool deep = false) { /* validation occurs in constructor */ }
 
-		  public LegendItem[] GetLegendItems ()
-		  {
-				var singleLegendItem = new LegendItem()
-				{
-					 label = Label,
-					 color = VectorColors[0],
-					 lineWidth = 10,
-					 markerShape = MarkerShape.none
-				};
-				return new LegendItem[] { singleLegendItem };
-		  }
+        public LegendItem[] GetLegendItems()
+        {
+            var singleLegendItem = new LegendItem()
+            {
+                label = Label,
+                color = VectorColors[0],
+                lineWidth = 10,
+                markerShape = MarkerShape.none
+            };
+            return new LegendItem[] { singleLegendItem };
+        }
 
-		  public AxisLimits GetAxisLimits () => new AxisLimits(Xs.Min() - 1, Xs.Max() + 1, Ys.Min() - 1, Ys.Max() + 1);
+        public AxisLimits GetAxisLimits() => new AxisLimits(Xs.Min() - 1, Xs.Max() + 1, Ys.Min() - 1, Ys.Max() + 1);
 
-		  public int PointCount { get => Vectors.Length; }
+        public int PointCount { get => Vectors.Length; }
 
-		  public void Render (PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
-		  {
-				using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
-				using (Pen pen = GDI.Pen(Color.Black))
-				{
-					 float tipScale = 0;
-					 float headAngle = 0;
-					 if (!fancyCaps)
-					 {
-						  pen.CustomEndCap = new AdjustableArrowCap(2, 2);
-					 }
-					 else
-					 {
-						  // The width of the arrow head part, relative to the length of the arrow.
-						  var arrowheadWidth = 0.15f;
-						  // The length of the arrow head part, relative to the total length of the arrow.
-						  var arrowheadLength = 0.5f;
+        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        {
+            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            using (Pen pen = GDI.Pen(Color.Black))
+            {
+                float tipScale = 0;
+                float headAngle = 0;
+                if (!fancyCaps)
+                {
+                    pen.CustomEndCap = new AdjustableArrowCap(2, 2);
+                }
+                else
+                {
+                    // The width of the arrow head part, relative to the length of the arrow.
+                    var arrowheadWidth = 0.15f;
+                    // The length of the arrow head part, relative to the total length of the arrow.
+                    var arrowheadLength = 0.5f;
 
-						  tipScale = (float)Math.Sqrt(arrowheadLength * arrowheadLength + arrowheadWidth * arrowheadWidth);
-						  headAngle = (float)Math.Atan2(arrowheadWidth, arrowheadLength);
-					 }
+                    tipScale = (float)Math.Sqrt(arrowheadLength * arrowheadLength + arrowheadWidth * arrowheadWidth);
+                    headAngle = (float)Math.Atan2(arrowheadWidth, arrowheadLength);
+                }
 
-					 for (int i = 0; i < Xs.Length; i++)
-					 {
-						  for (int j = 0; j < Ys.Length; j++)
-						  {
-								Vector2 v = Vectors[i, j];
-								float tailX, tailY, endX, endY;
-								if (anchorAtStart)
-								{
-									 tailX = dims.GetPixelX(Xs[i]);
-									 tailY = dims.GetPixelY(Ys[j]);
-									 endX = dims.GetPixelX(Xs[i] + v.X);
-									 endY = dims.GetPixelY(Ys[j] + v.Y);
-								}
-								else
-								{
-									 tailX = dims.GetPixelX(Xs[i] - v.X / 2);
-									 tailY = dims.GetPixelY(Ys[j] - v.Y / 2);
-									 endX = dims.GetPixelX(Xs[i] + v.X / 2);
-									 endY = dims.GetPixelY(Ys[j] + v.Y / 2);
-								}
-								pen.Color = VectorColors[i * Ys.Length + j];
-								if (fancyCaps)
-									 DrawFancyArrow(gfx, pen, tailX, tailY, endX, endY, headAngle, tipScale);
-								else
-									 gfx.DrawLine(pen, tailX, tailY, endX, endY);
-						  }
-					 }
-				}
-		  }
+                for (int i = 0; i < Xs.Length; i++)
+                {
+                    for (int j = 0; j < Ys.Length; j++)
+                    {
+                        Vector2 v = Vectors[i, j];
+                        float tailX, tailY, endX, endY;
+                        if (anchorAtStart)
+                        {
+                            tailX = dims.GetPixelX(Xs[i]);
+                            tailY = dims.GetPixelY(Ys[j]);
+                            endX = dims.GetPixelX(Xs[i] + v.X);
+                            endY = dims.GetPixelY(Ys[j] + v.Y);
+                        }
+                        else
+                        {
+                            tailX = dims.GetPixelX(Xs[i] - v.X / 2);
+                            tailY = dims.GetPixelY(Ys[j] - v.Y / 2);
+                            endX = dims.GetPixelX(Xs[i] + v.X / 2);
+                            endY = dims.GetPixelY(Ys[j] + v.Y / 2);
+                        }
+                        pen.Color = VectorColors[i * Ys.Length + j];
+                        if (fancyCaps)
+                            DrawFancyArrow(gfx, pen, tailX, tailY, endX, endY, headAngle, tipScale);
+                        else
+                            gfx.DrawLine(pen, tailX, tailY, endX, endY);
+                    }
+                }
+            }
+        }
 
-          /// <summary>
-          /// Draw arrow with tips without using CustomEndCap.
-          /// </summary>
-          /// <param name="gfx"></param>
-          /// <param name="pen"></param>
-          /// <param name="baseX"></param>
-          /// <param name="baseY"></param>
-          /// <param name="tipX"></param>
-          /// <param name="tipY"></param>
-          /// <param name="headAngle">Determines how 'pointy' the tip is.</param>
-          /// <param name="tipScale">Length of tip part, relative to total length.</param>
-          private void DrawFancyArrow (
-			 Graphics gfx, Pen pen,
-			 float baseX,
-			 float baseY,
-			 float tipX,
-			 float tipY,
-			 float headAngle,
-			 float tipScale)
-		  {
-				var dx = tipX - baseX;
-				var dy = tipY - baseY;
-				var arrowAngle = (float)Math.Atan2(dy, dx);
-				var sinA1 = (float)Math.Sin(headAngle - arrowAngle);
-				var cosA1 = (float)Math.Cos(headAngle - arrowAngle);
-				var sinA2 = (float)Math.Sin(headAngle + arrowAngle);
-				var cosA2 = (float)Math.Cos(headAngle + arrowAngle);
-				var len = (float)Math.Sqrt(dx * dx + dy * dy);
-				var hypLen = len * tipScale;
+        /// <summary>
+        /// Draw arrow with tips without using CustomEndCap.
+        /// </summary>
+        /// <param name="gfx"></param>
+        /// <param name="pen"></param>
+        /// <param name="baseX"></param>
+        /// <param name="baseY"></param>
+        /// <param name="tipX"></param>
+        /// <param name="tipY"></param>
+        /// <param name="headAngle">Determines how 'pointy' the tip is.</param>
+        /// <param name="tipScale">Length of tip part, relative to total length.</param>
+        private void DrawFancyArrow(
+           Graphics gfx, Pen pen,
+           float baseX,
+           float baseY,
+           float tipX,
+           float tipY,
+           float headAngle,
+           float tipScale)
+        {
+            var dx = tipX - baseX;
+            var dy = tipY - baseY;
+            var arrowAngle = (float)Math.Atan2(dy, dx);
+            var sinA1 = (float)Math.Sin(headAngle - arrowAngle);
+            var cosA1 = (float)Math.Cos(headAngle - arrowAngle);
+            var sinA2 = (float)Math.Sin(headAngle + arrowAngle);
+            var cosA2 = (float)Math.Cos(headAngle + arrowAngle);
+            var len = (float)Math.Sqrt(dx * dx + dy * dy);
+            var hypLen = len * tipScale;
 
-				var corner1X = tipX - hypLen * cosA1;
-				var corner1Y = tipY + hypLen * sinA1;
-				var corner2X = tipX - hypLen * cosA2;
-				var corner2Y = tipY - hypLen * sinA2;
+            var corner1X = tipX - hypLen * cosA1;
+            var corner1Y = tipY + hypLen * sinA1;
+            var corner2X = tipX - hypLen * cosA2;
+            var corner2Y = tipY - hypLen * sinA2;
 
-				_poly[0] = new PointF(baseX, baseY);
-				_poly[1] = new PointF(tipX, tipY);
-				_poly[2] = new PointF(corner1X, corner1Y);
-				_poly[3] = new PointF(tipX, tipY);
-				_poly[4] = new PointF(corner2X, corner2Y);
-				gfx.DrawLines(pen, _poly);
-		  }
+            _poly[0] = new PointF(baseX, baseY);
+            _poly[1] = new PointF(tipX, tipY);
+            _poly[2] = new PointF(corner1X, corner1Y);
+            _poly[3] = new PointF(tipX, tipY);
+            _poly[4] = new PointF(corner2X, corner2Y);
+            gfx.DrawLines(pen, _poly);
+        }
 
 
 
-		  public override string ToString ()
-		  {
-				string label = string.IsNullOrWhiteSpace(this.Label) ? "" : $" ({this.Label})";
-				return $"PlottableVectorField{label} with {PointCount} vectors";
-		  }
-	 }
+        public override string ToString()
+        {
+            string label = string.IsNullOrWhiteSpace(this.Label) ? "" : $" ({this.Label})";
+            return $"PlottableVectorField{label} with {PointCount} vectors";
+        }
+    }
 }

--- a/src/ScottPlot/Plottable/VectorField.cs
+++ b/src/ScottPlot/Plottable/VectorField.cs
@@ -7,105 +7,197 @@ using System.Linq;
 
 namespace ScottPlot.Plottable
 {
-    /// <summary>
-    /// The VectorField displays arrows representing a 2D array of 2D vectors
-    /// </summary>
-    public class VectorField : IPlottable
-    {
-        // data
-        private readonly double[] Xs;
-        private readonly double[] Ys;
-        private readonly Vector2[,] Vectors;
-        private readonly Color[] VectorColors;
+	 /// <summary>
+	 /// The VectorField displays arrows representing a 2D array of 2D vectors
+	 /// </summary>
+	 public class VectorField : IPlottable
+	 {
+		  // data
+		  private readonly double[] Xs;
+		  private readonly double[] Ys;
+		  private readonly bool fancyCaps;
+		  private readonly bool anchorAtStart;
+		  private readonly Vector2[,] Vectors;
+		  private readonly Color[] VectorColors;
+		  private readonly PointF[] _poly = new PointF[5];
 
-        // customization
-        public string Label;
-        public bool IsVisible { get; set; } = true;
-        public int XAxisIndex { get; set; } = 0;
-        public int YAxisIndex { get; set; } = 0;
+		  // customization
+		  public string Label;
+		  public bool IsVisible { get; set; } = true;
+		  public int XAxisIndex { get; set; } = 0;
+		  public int YAxisIndex { get; set; } = 0;
 
-        public VectorField(Vector2[,] vectors, double[] xs, double[] ys, Colormap colormap, double scaleFactor, Color defaultColor)
-        {
-            double minMagnitudeSquared = vectors[0, 0].LengthSquared();
-            double maxMagnitudeSquared = vectors[0, 0].LengthSquared();
-            for (int i = 0; i < xs.Length; i++)
-            {
-                for (int j = 0; j < ys.Length; j++)
-                {
-                    if (vectors[i, j].LengthSquared() > maxMagnitudeSquared)
-                        maxMagnitudeSquared = vectors[i, j].LengthSquared();
-                    else if (vectors[i, j].LengthSquared() < minMagnitudeSquared)
-                        minMagnitudeSquared = vectors[i, j].LengthSquared();
-                }
-            }
-            double minMagnitude = Math.Sqrt(minMagnitudeSquared);
-            double maxMagnitude = Math.Sqrt(maxMagnitudeSquared);
+		  /// <summary>
+		  /// 
+		  /// </summary>
+		  /// <param name="vectors"></param>
+		  /// <param name="xs"></param>
+		  /// <param name="ys"></param>
+		  /// <param name="colormap"></param>
+		  /// <param name="scaleFactor"></param>
+		  /// <param name="defaultColor"></param>
+		  /// <param name="fancyCaps">Plot custom arrow heads; slower but nicer looking.</param>
+		  /// <param name="anchorAtStart">Draw arrow starting from the x,y coordinate, instead of centering the arrow on the x,y coordinate.</param>
+		  public VectorField (Vector2[,] vectors, double[] xs, double[] ys, Colormap colormap, double scaleFactor, Color defaultColor,
+				bool fancyCaps = false, bool anchorAtStart = false)
+		  {
+				double minMagnitudeSquared = vectors[0, 0].LengthSquared();
+				double maxMagnitudeSquared = vectors[0, 0].LengthSquared();
+				for (int i = 0; i < xs.Length; i++)
+				{
+					 for (int j = 0; j < ys.Length; j++)
+					 {
+						  if (vectors[i, j].LengthSquared() > maxMagnitudeSquared)
+								maxMagnitudeSquared = vectors[i, j].LengthSquared();
+						  else if (vectors[i, j].LengthSquared() < minMagnitudeSquared)
+								minMagnitudeSquared = vectors[i, j].LengthSquared();
+					 }
+				}
+				double minMagnitude = Math.Sqrt(minMagnitudeSquared);
+				double maxMagnitude = Math.Sqrt(maxMagnitudeSquared);
 
-            double[,] intensities = new double[xs.Length, ys.Length];
-            for (int i = 0; i < xs.Length; i++)
-            {
-                for (int j = 0; j < ys.Length; j++)
-                {
-                    if (colormap != null)
-                        intensities[i, j] = (vectors[i, j].Length() - minMagnitude) / (maxMagnitude - minMagnitude);
-                    vectors[i, j] = Vector2.Multiply(vectors[i, j], (float)(scaleFactor / (maxMagnitude * 1.2)));
-                }
-            }
+				double[,] intensities = new double[xs.Length, ys.Length];
+				for (int i = 0; i < xs.Length; i++)
+				{
+					 for (int j = 0; j < ys.Length; j++)
+					 {
+						  if (colormap != null)
+								intensities[i, j] = (vectors[i, j].Length() - minMagnitude) / (maxMagnitude - minMagnitude);
+						  vectors[i, j] = Vector2.Multiply(vectors[i, j], (float)(scaleFactor / (maxMagnitude * 1.2)));
+					 }
+				}
 
-            double[] flattenedIntensities = intensities.Cast<double>().ToArray();
-            VectorColors = colormap is null ?
-                Enumerable.Range(0, flattenedIntensities.Length).Select(x => defaultColor).ToArray() :
-                Colormap.GetColors(flattenedIntensities, colormap);
+				double[] flattenedIntensities = intensities.Cast<double>().ToArray();
+				VectorColors = colormap is null ?
+					 Enumerable.Range(0, flattenedIntensities.Length).Select(x => defaultColor).ToArray() :
+					 Colormap.GetColors(flattenedIntensities, colormap);
 
-            this.Vectors = vectors;
-            this.Xs = xs;
-            this.Ys = ys;
-        }
+				this.Vectors = vectors;
+				this.Xs = xs;
+				this.Ys = ys;
+				this.fancyCaps = fancyCaps;
+				this.anchorAtStart = anchorAtStart;
+		  }
 
-        public void ValidateData(bool deep = false) { /* validation occurs in constructor */ }
+		  public void ValidateData (bool deep = false) { /* validation occurs in constructor */ }
 
-        public LegendItem[] GetLegendItems()
-        {
-            var singleLegendItem = new LegendItem()
-            {
-                label = Label,
-                color = VectorColors[0],
-                lineWidth = 10,
-                markerShape = MarkerShape.none
-            };
-            return new LegendItem[] { singleLegendItem };
-        }
+		  public LegendItem[] GetLegendItems ()
+		  {
+				var singleLegendItem = new LegendItem()
+				{
+					 label = Label,
+					 color = VectorColors[0],
+					 lineWidth = 10,
+					 markerShape = MarkerShape.none
+				};
+				return new LegendItem[] { singleLegendItem };
+		  }
 
-        public AxisLimits GetAxisLimits() => new AxisLimits(Xs.Min() - 1, Xs.Max() + 1, Ys.Min() - 1, Ys.Max() + 1);
+		  public AxisLimits GetAxisLimits () => new AxisLimits(Xs.Min() - 1, Xs.Max() + 1, Ys.Min() - 1, Ys.Max() + 1);
 
-        public int PointCount { get => Vectors.Length; }
+		  public int PointCount { get => Vectors.Length; }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
-        {
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
-            using (Pen pen = GDI.Pen(Color.Black))
-            {
-                pen.CustomEndCap = new AdjustableArrowCap(2, 2);
-                for (int i = 0; i < Xs.Length; i++)
-                {
-                    for (int j = 0; j < Ys.Length; j++)
-                    {
-                        Vector2 v = Vectors[i, j];
-                        float tailX = dims.GetPixelX(Xs[i] - v.X / 2);
-                        float tailY = dims.GetPixelY(Ys[j] - v.Y / 2);
-                        float endX = dims.GetPixelX(Xs[i] + v.X / 2);
-                        float endY = dims.GetPixelY(v.Y + Ys[j] - v.Y / 2);
-                        pen.Color = VectorColors[i * Ys.Length + j];
-                        gfx.DrawLine(pen, tailX, tailY, endX, endY);
-                    }
-                }
-            }
-        }
+		  public void Render (PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+		  {
+				using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+				using (Pen pen = GDI.Pen(Color.Black))
+				{
+					 float tipScale = 0;
+					 float headAngle = 0;
+					 if (!fancyCaps)
+					 {
+						  pen.CustomEndCap = new AdjustableArrowCap(2, 2);
+					 }
+					 else
+					 {
+						  // The width of the arrow head part, relative to the length of the arrow.
+						  var arrowheadWidth = 0.15f;
+						  // The length of the arrow head part, relative to the total length of the arrow.
+						  var arrowheadLength = 0.5f;
 
-        public override string ToString()
-        {
-            string label = string.IsNullOrWhiteSpace(this.Label) ? "" : $" ({this.Label})";
-            return $"PlottableVectorField{label} with {PointCount} vectors";
-        }
-    }
+						  tipScale = (float)Math.Sqrt(arrowheadLength * arrowheadLength + arrowheadWidth * arrowheadWidth);
+						  headAngle = (float)Math.Atan2(arrowheadWidth, arrowheadLength);
+					 }
+
+					 for (int i = 0; i < Xs.Length; i++)
+					 {
+						  for (int j = 0; j < Ys.Length; j++)
+						  {
+								Vector2 v = Vectors[i, j];
+								float tailX, tailY, endX, endY;
+								if (anchorAtStart)
+								{
+									 tailX = dims.GetPixelX(Xs[i]);
+									 tailY = dims.GetPixelY(Ys[j]);
+									 endX = dims.GetPixelX(Xs[i] + v.X);
+									 endY = dims.GetPixelY(Ys[j] + v.Y);
+								}
+								else
+								{
+									 tailX = dims.GetPixelX(Xs[i] - v.X / 2);
+									 tailY = dims.GetPixelY(Ys[j] - v.Y / 2);
+									 endX = dims.GetPixelX(Xs[i] + v.X / 2);
+									 endY = dims.GetPixelY(Ys[j] + v.Y / 2);
+								}
+								pen.Color = VectorColors[i * Ys.Length + j];
+								if (fancyCaps)
+									 DrawFancyArrow(gfx, pen, tailX, tailY, endX, endY, headAngle, tipScale);
+								else
+									 gfx.DrawLine(pen, tailX, tailY, endX, endY);
+						  }
+					 }
+				}
+		  }
+
+          /// <summary>
+          /// Draw arrow with tips without using CustomEndCap.
+          /// </summary>
+          /// <param name="gfx"></param>
+          /// <param name="pen"></param>
+          /// <param name="baseX"></param>
+          /// <param name="baseY"></param>
+          /// <param name="tipX"></param>
+          /// <param name="tipY"></param>
+          /// <param name="headAngle">Determines how 'pointy' the tip is.</param>
+          /// <param name="tipScale">Length of tip part, relative to total length.</param>
+          private void DrawFancyArrow (
+			 Graphics gfx, Pen pen,
+			 float baseX,
+			 float baseY,
+			 float tipX,
+			 float tipY,
+			 float headAngle,
+			 float tipScale)
+		  {
+				var dx = tipX - baseX;
+				var dy = tipY - baseY;
+				var arrowAngle = (float)Math.Atan2(dy, dx);
+				var sinA1 = (float)Math.Sin(headAngle - arrowAngle);
+				var cosA1 = (float)Math.Cos(headAngle - arrowAngle);
+				var sinA2 = (float)Math.Sin(headAngle + arrowAngle);
+				var cosA2 = (float)Math.Cos(headAngle + arrowAngle);
+				var len = (float)Math.Sqrt(dx * dx + dy * dy);
+				var hypLen = len * tipScale;
+
+				var corner1X = tipX - hypLen * cosA1;
+				var corner1Y = tipY + hypLen * sinA1;
+				var corner2X = tipX - hypLen * cosA2;
+				var corner2Y = tipY - hypLen * sinA2;
+
+				_poly[0] = new PointF(baseX, baseY);
+				_poly[1] = new PointF(tipX, tipY);
+				_poly[2] = new PointF(corner1X, corner1Y);
+				_poly[3] = new PointF(tipX, tipY);
+				_poly[4] = new PointF(corner2X, corner2Y);
+				gfx.DrawLines(pen, _poly);
+		  }
+
+
+
+		  public override string ToString ()
+		  {
+				string label = string.IsNullOrWhiteSpace(this.Label) ? "" : $" ({this.Label})";
+				return $"PlottableVectorField{label} with {PointCount} vectors";
+		  }
+	 }
 }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/VectorField.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/VectorField.cs
@@ -1,122 +1,143 @@
 ﻿using ScottPlot.Statistics;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace ScottPlot.Cookbook.Recipes.Plottable
 {
-    public class VectorFieldQuickstart : IRecipe
-    {
-        public string Category => "Plottable: Vector Field";
-        public string ID => "vectorField_quickstart";
-        public string Title => "Quickstart";
-        public string Description => "A vector field can be useful to show data explained by differential equations";
+	 public class VectorFieldQuickstart : IRecipe
+	 {
+		  public string Category => "Plottable: Vector Field";
+		  public string ID => "vectorField_quickstart";
+		  public string Title => "Quickstart";
+		  public string Description => "A vector field can be useful to show data explained by differential equations";
 
-        public void ExecuteRecipe(Plot plt)
-        {
-            double[] xPositions = DataGen.Range(0, 10);
-            double[] yPositions = DataGen.Range(0, 10);
-            Vector2[,] vectors = new Vector2[xPositions.Length, yPositions.Length];
+		  public void ExecuteRecipe (Plot plt)
+		  {
+				double[] xPositions = DataGen.Range(0, 10);
+				double[] yPositions = DataGen.Range(0, 10);
+				Vector2[,] vectors = new Vector2[xPositions.Length, yPositions.Length];
 
-            for (int x = 0; x < xPositions.Length; x++)
-                for (int y = 0; y < yPositions.Length; y++)
-                    vectors[x, y] = new Vector2(
-                        x: Math.Sin(xPositions[x]),
-                        y: Math.Sin(yPositions[y]));
+				for (int x = 0; x < xPositions.Length; x++)
+					 for (int y = 0; y < yPositions.Length; y++)
+						  vectors[x, y] = new Vector2(
+								x: Math.Sin(xPositions[x]),
+								y: Math.Sin(yPositions[y]));
 
-            plt.AddVectorField(vectors, xPositions, yPositions);
-        }
-    }
+				plt.AddVectorField(vectors, xPositions, yPositions);
+		  }
+	 }
 
-    public class WithChangeingMagnitude : IRecipe
-    {
-        public string Category => "Plottable: Vector Field";
-        public string ID => "vectorField_angleMag";
-        public string Title => "Angle and Magnitude";
-        public string Description => "This example demonstrates how to define vectors according to a given angle and magnitude.";
+	 public class WithChangeingMagnitude : IRecipe
+	 {
+		  public string Category => "Plottable: Vector Field";
+		  public string ID => "vectorField_angleMag";
+		  public string Title => "Angle and Magnitude";
+		  public string Description => "This example demonstrates how to define vectors according to a given angle and magnitude.";
 
-        public void ExecuteRecipe(Plot plt)
-        {
-            double[] xs = DataGen.Range(-5, 6);
-            double[] ys = DataGen.Range(-5, 6);
-            Vector2[,] vectors = new Vector2[xs.Length, ys.Length];
+		  public void ExecuteRecipe (Plot plt)
+		  {
+				double[] xs = DataGen.Range(-5, 6);
+				double[] ys = DataGen.Range(-5, 6);
+				Vector2[,] vectors = new Vector2[xs.Length, ys.Length];
 
-            for (int i = 0; i < xs.Length; i++)
-            {
-                for (int j = 0; j < ys.Length; j++)
-                {
-                    double slope = -xs[i];
-                    double magnitude = Math.Abs(xs[i]);
-                    double angle = Math.Atan(slope);
+				for (int i = 0; i < xs.Length; i++)
+				{
+					 for (int j = 0; j < ys.Length; j++)
+					 {
+						  double slope = -xs[i];
+						  double magnitude = Math.Abs(xs[i]);
+						  double angle = Math.Atan(slope);
 
-                    vectors[i, j] = new Vector2(Math.Cos(angle) * magnitude, Math.Sin(angle) * magnitude);
-                }
-            }
+						  vectors[i, j] = new Vector2(Math.Cos(angle) * magnitude, Math.Sin(angle) * magnitude);
+					 }
+				}
 
-            plt.AddVectorField(vectors, xs, ys);
-        }
-    }
+				plt.AddVectorField(vectors, xs, ys);
+		  }
+	 }
 
-    public class Pendulum : IRecipe
-    {
-        public string Category => "Plottable: Vector Field";
-        public string ID => "vectorField_colormap";
-        public string Title => "Custom Colormap";
-        public string Description => "A colormap can be supplied to color arrows according to their magnitude";
+	 public class Pendulum : IRecipe
+	 {
+		  public string Category => "Plottable: Vector Field";
+		  public string ID => "vectorField_colormap";
+		  public string Title => "Custom Colormap";
+		  public string Description => "A colormap can be supplied to color arrows according to their magnitude";
 
-        public void ExecuteRecipe(Plot plt)
-        {
-            double[] xs = DataGen.Range(-5, 5, .5);
-            double[] ys = DataGen.Range(-5, 5, .5);
-            Vector2[,] vectors = new Vector2[xs.Length, ys.Length];
-            double r = 0.5;
+		  public void ExecuteRecipe (Plot plt)
+		  {
+				double[] xs = DataGen.Range(-5, 5, .5);
+				double[] ys = DataGen.Range(-5, 5, .5);
+				Vector2[,] vectors = new Vector2[xs.Length, ys.Length];
+				double r = 0.5;
 
 
-            for (int i = 0; i < xs.Length; i++)
-            {
-                for (int j = 0; j < ys.Length; j++)
-                {
-                    double x = ys[j];
-                    double y = -9.81 / r * Math.Sin(xs[i]);
+				for (int i = 0; i < xs.Length; i++)
+				{
+					 for (int j = 0; j < ys.Length; j++)
+					 {
+						  double x = ys[j];
+						  double y = -9.81 / r * Math.Sin(xs[i]);
 
-                    vectors[i, j] = new Vector2(x, y);
-                }
-            }
+						  vectors[i, j] = new Vector2(x, y);
+					 }
+				}
 
-            plt.AddVectorField(vectors, xs, ys, colormap: Drawing.Colormap.Turbo);
-            plt.XLabel("θ");
-            plt.YLabel("dθ/dt");
-        }
-    }
+				plt.AddVectorField(vectors, xs, ys, colormap: Drawing.Colormap.Turbo);
+				plt.XLabel("θ");
+				plt.YLabel("dθ/dt");
+		  }
+	 }
 
-    public class CustomScaleFactor : IRecipe
-    {
-        public string Category => "Plottable: Vector Field";
-        public string ID => "vectorField_scaleFactor";
-        public string Title => "Custom Scale Factor";
-        public string Description => "A custom scale factor can adjust the length of the arrows.";
+	 public class CustomScaleFactor : IRecipe
+	 {
+		  public string Category => "Plottable: Vector Field";
+		  public string ID => "vectorField_scaleFactor";
+		  public string Title => "Custom Scale Factor";
+		  public string Description => "A custom scale factor can adjust the length of the arrows.";
 
-        public void ExecuteRecipe(Plot plt)
-        {
-            double[] xs = DataGen.Range(-1.5, 1.5, .25);
-            double[] ys = DataGen.Range(-1.5, 1.5, .25);
-            Vector2[,] vectors = new Vector2[xs.Length, ys.Length];
+		  public void ExecuteRecipe (Plot plt)
+		  {
+				double[] xs = DataGen.Range(-1.5, 1.5, .25);
+				double[] ys = DataGen.Range(-1.5, 1.5, .25);
+				Vector2[,] vectors = new Vector2[xs.Length, ys.Length];
 
-            for (int i = 0; i < xs.Length; i++)
-            {
-                for (int j = 0; j < ys.Length; j++)
-                {
-                    double x = xs[i];
-                    double y = ys[j];
-                    var e = Math.Exp(-x * x - y * y);
-                    var dx = (1 - 2 * x * x) * e;
-                    var dy = -2 * x * y * e;
+				for (int i = 0; i < xs.Length; i++)
+				{
+					 for (int j = 0; j < ys.Length; j++)
+					 {
+						  double x = xs[i];
+						  double y = ys[j];
+						  var e = Math.Exp(-x * x - y * y);
+						  var dx = (1 - 2 * x * x) * e;
+						  var dy = -2 * x * y * e;
 
-                    vectors[i, j] = new Vector2(dx, dy);
-                }
-            }
+						  vectors[i, j] = new Vector2(dx, dy);
+					 }
+				}
 
-            plt.AddVectorField(vectors, xs, ys, scaleFactor: 0.3);
-        }
-    }
+				plt.AddVectorField(vectors, xs, ys, scaleFactor: 0.3);
+		  }
+	 }
+	 public class FancyVectorField : IRecipe
+	 {
+		  public string Category => "Plottable: Vector Field";
+		  public string ID => "vectorField_fancytips";
+		  public string Title => "Nice tips";
+		  public string Description => "Use a slower drawing method that draws tips that are proportional to the length of the arrows.";
+
+
+		  public void ExecuteRecipe (Plot plt)
+		  {
+				double[] xPositions = DataGen.Range(0, 10);
+				double[] yPositions = DataGen.Range(0, 10);
+				Vector2[,] vectors = new Vector2[xPositions.Length, yPositions.Length];
+
+				for (int x = 0; x < xPositions.Length; x++)
+					 for (int y = 0; y < yPositions.Length; y++)
+						  vectors[x, y] = new Vector2(
+								x: Math.Sin(xPositions[x]),
+								y: Math.Sin(yPositions[y]));
+
+				plt.AddVectorField(vectors, xPositions, yPositions, fancyCaps: true, anchorAtStart: true);
+		  }
+	 }
 }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/VectorField.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/VectorField.cs
@@ -3,141 +3,141 @@ using System;
 
 namespace ScottPlot.Cookbook.Recipes.Plottable
 {
-	 public class VectorFieldQuickstart : IRecipe
-	 {
-		  public string Category => "Plottable: Vector Field";
-		  public string ID => "vectorField_quickstart";
-		  public string Title => "Quickstart";
-		  public string Description => "A vector field can be useful to show data explained by differential equations";
+    public class VectorFieldQuickstart : IRecipe
+    {
+        public string Category => "Plottable: Vector Field";
+        public string ID => "vectorField_quickstart";
+        public string Title => "Quickstart";
+        public string Description => "A vector field can be useful to show data explained by differential equations";
 
-		  public void ExecuteRecipe (Plot plt)
-		  {
-				double[] xPositions = DataGen.Range(0, 10);
-				double[] yPositions = DataGen.Range(0, 10);
-				Vector2[,] vectors = new Vector2[xPositions.Length, yPositions.Length];
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[] xPositions = DataGen.Range(0, 10);
+            double[] yPositions = DataGen.Range(0, 10);
+            Vector2[,] vectors = new Vector2[xPositions.Length, yPositions.Length];
 
-				for (int x = 0; x < xPositions.Length; x++)
-					 for (int y = 0; y < yPositions.Length; y++)
-						  vectors[x, y] = new Vector2(
-								x: Math.Sin(xPositions[x]),
-								y: Math.Sin(yPositions[y]));
+            for (int x = 0; x < xPositions.Length; x++)
+                for (int y = 0; y < yPositions.Length; y++)
+                    vectors[x, y] = new Vector2(
+                          x: Math.Sin(xPositions[x]),
+                          y: Math.Sin(yPositions[y]));
 
-				plt.AddVectorField(vectors, xPositions, yPositions);
-		  }
-	 }
+            plt.AddVectorField(vectors, xPositions, yPositions);
+        }
+    }
 
-	 public class WithChangeingMagnitude : IRecipe
-	 {
-		  public string Category => "Plottable: Vector Field";
-		  public string ID => "vectorField_angleMag";
-		  public string Title => "Angle and Magnitude";
-		  public string Description => "This example demonstrates how to define vectors according to a given angle and magnitude.";
+    public class WithChangeingMagnitude : IRecipe
+    {
+        public string Category => "Plottable: Vector Field";
+        public string ID => "vectorField_angleMag";
+        public string Title => "Angle and Magnitude";
+        public string Description => "This example demonstrates how to define vectors according to a given angle and magnitude.";
 
-		  public void ExecuteRecipe (Plot plt)
-		  {
-				double[] xs = DataGen.Range(-5, 6);
-				double[] ys = DataGen.Range(-5, 6);
-				Vector2[,] vectors = new Vector2[xs.Length, ys.Length];
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[] xs = DataGen.Range(-5, 6);
+            double[] ys = DataGen.Range(-5, 6);
+            Vector2[,] vectors = new Vector2[xs.Length, ys.Length];
 
-				for (int i = 0; i < xs.Length; i++)
-				{
-					 for (int j = 0; j < ys.Length; j++)
-					 {
-						  double slope = -xs[i];
-						  double magnitude = Math.Abs(xs[i]);
-						  double angle = Math.Atan(slope);
+            for (int i = 0; i < xs.Length; i++)
+            {
+                for (int j = 0; j < ys.Length; j++)
+                {
+                    double slope = -xs[i];
+                    double magnitude = Math.Abs(xs[i]);
+                    double angle = Math.Atan(slope);
 
-						  vectors[i, j] = new Vector2(Math.Cos(angle) * magnitude, Math.Sin(angle) * magnitude);
-					 }
-				}
+                    vectors[i, j] = new Vector2(Math.Cos(angle) * magnitude, Math.Sin(angle) * magnitude);
+                }
+            }
 
-				plt.AddVectorField(vectors, xs, ys);
-		  }
-	 }
+            plt.AddVectorField(vectors, xs, ys);
+        }
+    }
 
-	 public class Pendulum : IRecipe
-	 {
-		  public string Category => "Plottable: Vector Field";
-		  public string ID => "vectorField_colormap";
-		  public string Title => "Custom Colormap";
-		  public string Description => "A colormap can be supplied to color arrows according to their magnitude";
+    public class Pendulum : IRecipe
+    {
+        public string Category => "Plottable: Vector Field";
+        public string ID => "vectorField_colormap";
+        public string Title => "Custom Colormap";
+        public string Description => "A colormap can be supplied to color arrows according to their magnitude";
 
-		  public void ExecuteRecipe (Plot plt)
-		  {
-				double[] xs = DataGen.Range(-5, 5, .5);
-				double[] ys = DataGen.Range(-5, 5, .5);
-				Vector2[,] vectors = new Vector2[xs.Length, ys.Length];
-				double r = 0.5;
-
-
-				for (int i = 0; i < xs.Length; i++)
-				{
-					 for (int j = 0; j < ys.Length; j++)
-					 {
-						  double x = ys[j];
-						  double y = -9.81 / r * Math.Sin(xs[i]);
-
-						  vectors[i, j] = new Vector2(x, y);
-					 }
-				}
-
-				plt.AddVectorField(vectors, xs, ys, colormap: Drawing.Colormap.Turbo);
-				plt.XLabel("θ");
-				plt.YLabel("dθ/dt");
-		  }
-	 }
-
-	 public class CustomScaleFactor : IRecipe
-	 {
-		  public string Category => "Plottable: Vector Field";
-		  public string ID => "vectorField_scaleFactor";
-		  public string Title => "Custom Scale Factor";
-		  public string Description => "A custom scale factor can adjust the length of the arrows.";
-
-		  public void ExecuteRecipe (Plot plt)
-		  {
-				double[] xs = DataGen.Range(-1.5, 1.5, .25);
-				double[] ys = DataGen.Range(-1.5, 1.5, .25);
-				Vector2[,] vectors = new Vector2[xs.Length, ys.Length];
-
-				for (int i = 0; i < xs.Length; i++)
-				{
-					 for (int j = 0; j < ys.Length; j++)
-					 {
-						  double x = xs[i];
-						  double y = ys[j];
-						  var e = Math.Exp(-x * x - y * y);
-						  var dx = (1 - 2 * x * x) * e;
-						  var dy = -2 * x * y * e;
-
-						  vectors[i, j] = new Vector2(dx, dy);
-					 }
-				}
-
-				plt.AddVectorField(vectors, xs, ys, scaleFactor: 0.3);
-		  }
-	 }
-	 public class FancyVectorField : IRecipe
-	 {
-		  public string Category => "Plottable: Vector Field";
-		  public string ID => "vectorField_fancytips";
-		  public string Title => "Nice tips";
-		  public string Description => "Use a slower drawing method that draws tips that are proportional to the length of the arrows.";
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[] xs = DataGen.Range(-5, 5, .5);
+            double[] ys = DataGen.Range(-5, 5, .5);
+            Vector2[,] vectors = new Vector2[xs.Length, ys.Length];
+            double r = 0.5;
 
 
-		  public void ExecuteRecipe (Plot plt)
-		  {
-				double[] xPositions = DataGen.Range(0, 10);
-				double[] yPositions = DataGen.Range(0, 10);
-				Vector2[,] vectors = new Vector2[xPositions.Length, yPositions.Length];
+            for (int i = 0; i < xs.Length; i++)
+            {
+                for (int j = 0; j < ys.Length; j++)
+                {
+                    double x = ys[j];
+                    double y = -9.81 / r * Math.Sin(xs[i]);
 
-				for (int x = 0; x < xPositions.Length; x++)
-					 for (int y = 0; y < yPositions.Length; y++)
-						  vectors[x, y] = new Vector2(
-								x: Math.Sin(xPositions[x]),
-								y: Math.Sin(yPositions[y]));
+                    vectors[i, j] = new Vector2(x, y);
+                }
+            }
 
-				plt.AddVectorField(vectors, xPositions, yPositions, fancyCaps: true, anchorAtStart: true);
-		  }
-	 }
+            plt.AddVectorField(vectors, xs, ys, colormap: Drawing.Colormap.Turbo);
+            plt.XLabel("θ");
+            plt.YLabel("dθ/dt");
+        }
+    }
+
+    public class CustomScaleFactor : IRecipe
+    {
+        public string Category => "Plottable: Vector Field";
+        public string ID => "vectorField_scaleFactor";
+        public string Title => "Custom Scale Factor";
+        public string Description => "A custom scale factor can adjust the length of the arrows.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[] xs = DataGen.Range(-1.5, 1.5, .25);
+            double[] ys = DataGen.Range(-1.5, 1.5, .25);
+            Vector2[,] vectors = new Vector2[xs.Length, ys.Length];
+
+            for (int i = 0; i < xs.Length; i++)
+            {
+                for (int j = 0; j < ys.Length; j++)
+                {
+                    double x = xs[i];
+                    double y = ys[j];
+                    var e = Math.Exp(-x * x - y * y);
+                    var dx = (1 - 2 * x * x) * e;
+                    var dy = -2 * x * y * e;
+
+                    vectors[i, j] = new Vector2(dx, dy);
+                }
+            }
+
+            plt.AddVectorField(vectors, xs, ys, scaleFactor: 0.3);
+        }
+    }
+    public class FancyVectorField : IRecipe
+    {
+        public string Category => "Plottable: Vector Field";
+        public string ID => "vectorField_fancytips";
+        public string Title => "Nice tips";
+        public string Description => "Use a slower drawing method that draws tips that are proportional to the length of the arrows.";
+
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[] xPositions = DataGen.Range(0, 10);
+            double[] yPositions = DataGen.Range(0, 10);
+            Vector2[,] vectors = new Vector2[xPositions.Length, yPositions.Length];
+
+            for (int x = 0; x < xPositions.Length; x++)
+                for (int y = 0; y < yPositions.Length; y++)
+                    vectors[x, y] = new Vector2(
+                          x: Math.Sin(xPositions[x]),
+                          y: Math.Sin(yPositions[y]));
+
+            plt.AddVectorField(vectors, xPositions, yPositions, fancyCaps: true, anchorAtStart: true);
+        }
+    }
 }


### PR DESCRIPTION
**Purpose:**
Draw nicer vector plots by skipping the Pen CustomEndCap feature and drawing the the tip of the arrows separately. 
Also, support drawing the arrows anchored at the specified x,y coordinate, instead of centering the arrows at the coordinate.

**New Functionality:**
This
![image](https://user-images.githubusercontent.com/99785/128941396-93b01f03-03f7-4fa5-b8cd-515dd3dfbec6.png)
instead of
![image](https://user-images.githubusercontent.com/99785/128941361-42605dae-594a-4b69-826f-01629892e95a.png)


The new features is optional and off by default.


```cs
        /// <summary>
        /// 
        /// </summary>
        /// <param name="vectors"></param>
        /// <param name="xs"></param>
        /// <param name="ys"></param>
        /// <param name="colormap"></param>
        /// <param name="scaleFactor"></param>
        /// <param name="defaultColor"></param>
        /// <param name="fancyCaps">Plot custom arrow heads; slower but nicer looking.</param>
        /// <param name="anchorAtStart">Draw arrow starting from the x,y coordinate, instead of centering the arrow on the x,y coordinate.</param>
        public VectorField(Vector2[,] vectors, double[] xs, double[] ys, Colormap colormap, double scaleFactor, Color defaultColor,
              bool fancyCaps = false, bool anchorAtStart = false)
        {
}
```