### PR TITLE
Demo (Avalonia): Multi-Axis Lock

### DIFF
--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/MultiAxisLock.axaml
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/MultiAxisLock.axaml
@@ -1,0 +1,42 @@
+﻿<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:ScottPlot="clr-namespace:ScottPlot.Avalonia;assembly=ScottPlot.Avalonia"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        x:Class="ScottPlot.Demo.Avalonia.AvaloniaDemos.MultiAxisLock"
+        Title="Multi-Axis Lock" 
+        Height="400"
+        Width="600">
+    <DockPanel LastChildFill="True">
+        <WrapPanel DockPanel.Dock="Top">
+            <CheckBox 
+                Content="Primary" 
+                Margin="5"
+                FontWeight="SemiBold"
+                IsChecked="{Binding Primary}"
+                Foreground="Magenta"
+                x:Name="PrimaryCheckbox"
+                />
+            
+            <CheckBox 
+                Content="Secondary" 
+                Margin="5"
+                FontWeight="SemiBold"
+                IsChecked="{Binding Secondary}"
+                Foreground="Green"
+                x:Name="SecondaryCheckbox"
+                />
+            
+            <CheckBox 
+                Content="Tertiary" 
+                Margin="5" 
+                FontWeight="SemiBold"
+                IsChecked="{Binding Tertiary}"
+                Foreground="Navy"
+                x:Name="TertiaryCheckbox"
+                />
+        </WrapPanel>
+		<ScottPlot:AvaPlot Name="AvaPlot1"/>
+    </DockPanel>
+</Window>

--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/MultiAxisLock.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/MultiAxisLock.axaml.cs
@@ -8,122 +8,122 @@ using System;
 
 namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
 {
-	public class MultiAxisLockViewModel
-	{
-		private bool _primary = true;
-		public bool Primary
-		{
-			get => _primary; set
-			{
-				_primary = value;
-				_onChange();
-			}
-		}
-		private bool _secondary = true;
+    public class MultiAxisLockViewModel
+    {
+        private bool _primary = true;
+        public bool Primary
+        {
+            get => _primary; set
+            {
+                _primary = value;
+                _onChange();
+            }
+        }
+        private bool _secondary = true;
 
-		public bool Secondary
-		{
-			get => _secondary; set
-			{
-				_secondary = value;
-				_onChange();
-			}
-		}
-		private bool _tertiary = true;
+        public bool Secondary
+        {
+            get => _secondary; set
+            {
+                _secondary = value;
+                _onChange();
+            }
+        }
+        private bool _tertiary = true;
 
-		public bool Tertiary
-		{
-			get => _tertiary; set
-			{
-				_tertiary = value;
-				_onChange();
-			}
-		}
-		private Action _onChange;
+        public bool Tertiary
+        {
+            get => _tertiary; set
+            {
+                _tertiary = value;
+                _onChange();
+            }
+        }
+        private Action _onChange;
 
-		public MultiAxisLockViewModel(Action onChange)
-		{
-			_onChange = onChange;
-		}
+        public MultiAxisLockViewModel(Action onChange)
+        {
+            _onChange = onChange;
+        }
 
-	}
-	/// <summary>
-	/// Interaction logic for MultiAxisLock.axaml
-	/// </summary>
-	public class MultiAxisLock : Window
-	{
-		private readonly ScottPlot.Renderable.Axis YAxis3;
-		private readonly AvaPlot avaPlot1;
-		private bool initialized = false;
-		private readonly MultiAxisLockViewModel viewModel;
+    }
+    /// <summary>
+    /// Interaction logic for MultiAxisLock.axaml
+    /// </summary>
+    public class MultiAxisLock : Window
+    {
+        private readonly ScottPlot.Renderable.Axis YAxis3;
+        private readonly AvaPlot avaPlot1;
+        private bool initialized = false;
+        private readonly MultiAxisLockViewModel viewModel;
 
-		public MultiAxisLock()
-		{
-			InitializeComponent();
+        public MultiAxisLock()
+        {
+            InitializeComponent();
 #if DEBUG
-			this.AttachDevTools();
+            this.AttachDevTools();
 #endif
-			viewModel = new MultiAxisLockViewModel(() => this.CheckChanged());
-			this.DataContext = viewModel;
-			avaPlot1 = this.Find<AvaPlot>("AvaPlot1");
+            viewModel = new MultiAxisLockViewModel(() => this.CheckChanged());
+            this.DataContext = viewModel;
+            avaPlot1 = this.Find<AvaPlot>("AvaPlot1");
 
-			Random rand = new Random();
+            Random rand = new Random();
 
-			// Add 3 signals each with a different vertical axis index.
-			// Each signal defaults to X axis index 0 so their horizontal axis will be shared.
+            // Add 3 signals each with a different vertical axis index.
+            // Each signal defaults to X axis index 0 so their horizontal axis will be shared.
 
-			var plt1 = avaPlot1.Plot.AddSignal(DataGen.RandomWalk(rand, 100, mult: 1));
-			plt1.YAxisIndex = 0;
-			plt1.LineWidth = 3;
-			plt1.Color = System.Drawing.Color.Magenta;
+            var plt1 = avaPlot1.Plot.AddSignal(DataGen.RandomWalk(rand, 100, mult: 1));
+            plt1.YAxisIndex = 0;
+            plt1.LineWidth = 3;
+            plt1.Color = System.Drawing.Color.Magenta;
 
-			var plt2 = avaPlot1.Plot.AddSignal(DataGen.RandomWalk(rand, 100, mult: 10));
-			plt2.YAxisIndex = 1;
-			plt2.LineWidth = 3;
-			plt2.Color = System.Drawing.Color.Green;
+            var plt2 = avaPlot1.Plot.AddSignal(DataGen.RandomWalk(rand, 100, mult: 10));
+            plt2.YAxisIndex = 1;
+            plt2.LineWidth = 3;
+            plt2.Color = System.Drawing.Color.Green;
 
-			var plt3 = avaPlot1.Plot.AddSignal(DataGen.RandomWalk(rand, 100, mult: 100));
-			plt3.YAxisIndex = 2;
-			plt3.LineWidth = 3;
-			plt3.Color = System.Drawing.Color.Navy;
+            var plt3 = avaPlot1.Plot.AddSignal(DataGen.RandomWalk(rand, 100, mult: 100));
+            plt3.YAxisIndex = 2;
+            plt3.LineWidth = 3;
+            plt3.Color = System.Drawing.Color.Navy;
 
-			// The horizontal axis is shared by these signal plots (XAxisIndex defaults to 0)
-			avaPlot1.Plot.XAxis.Label("Horizontal Axis");
+            // The horizontal axis is shared by these signal plots (XAxisIndex defaults to 0)
+            avaPlot1.Plot.XAxis.Label("Horizontal Axis");
 
-			// Customize the primary (left) and secondary (right) axes
-			avaPlot1.Plot.YAxis.Color(System.Drawing.Color.Magenta);
-			avaPlot1.Plot.YAxis.Label("Primary Axis");
-			avaPlot1.Plot.YAxis2.Color(System.Drawing.Color.Green);
-			avaPlot1.Plot.YAxis2.Label("Secondary Axis");
+            // Customize the primary (left) and secondary (right) axes
+            avaPlot1.Plot.YAxis.Color(System.Drawing.Color.Magenta);
+            avaPlot1.Plot.YAxis.Label("Primary Axis");
+            avaPlot1.Plot.YAxis2.Color(System.Drawing.Color.Green);
+            avaPlot1.Plot.YAxis2.Label("Secondary Axis");
 
-			// the secondary (right) axis ticks are hidden by default so enable them
-			avaPlot1.Plot.YAxis2.Ticks(true);
+            // the secondary (right) axis ticks are hidden by default so enable them
+            avaPlot1.Plot.YAxis2.Ticks(true);
 
-			// Create an additional vertical axis and customize it
-			YAxis3 = avaPlot1.Plot.AddAxis(Renderable.Edge.Left, 2);
-			YAxis3.Color(System.Drawing.Color.Navy);
-			YAxis3.Label("Tertiary Axis");
+            // Create an additional vertical axis and customize it
+            YAxis3 = avaPlot1.Plot.AddAxis(Renderable.Edge.Left, 2);
+            YAxis3.Color(System.Drawing.Color.Navy);
+            YAxis3.Label("Tertiary Axis");
 
-			// adjust axis limits to fit the data once before locking them
-			avaPlot1.Plot.AxisAuto();
-			CheckChanged();
-		}
-		private void InitializeComponent()
-		{
-			AvaloniaXamlLoader.Load(this);
-			initialized = true;
-		}
+            // adjust axis limits to fit the data once before locking them
+            avaPlot1.Plot.AxisAuto();
+            CheckChanged();
+        }
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+            initialized = true;
+        }
 
-		private void CheckChanged()
-		{
-			if (avaPlot1 is null)
-			{
-				return;
-			}
+        private void CheckChanged()
+        {
+            if (avaPlot1 is null)
+            {
+                return;
+            }
 
-			avaPlot1.Plot.YAxis.LockLimits(!viewModel.Primary);
-			avaPlot1.Plot.YAxis2.LockLimits(!viewModel.Secondary);
-			YAxis3.LockLimits(!viewModel.Tertiary);
-		}
-	}
+            avaPlot1.Plot.YAxis.LockLimits(!viewModel.Primary);
+            avaPlot1.Plot.YAxis2.LockLimits(!viewModel.Secondary);
+            YAxis3.LockLimits(!viewModel.Tertiary);
+        }
+    }
 }

--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/MultiAxisLock.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/MultiAxisLock.axaml.cs
@@ -1,0 +1,129 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+using ScottPlot.Avalonia;
+using System;
+
+namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
+{
+	public class MultiAxisLockViewModel
+	{
+		private bool _primary = true;
+		public bool Primary
+		{
+			get => _primary; set
+			{
+				_primary = value;
+				_onChange();
+			}
+		}
+		private bool _secondary = true;
+
+		public bool Secondary
+		{
+			get => _secondary; set
+			{
+				_secondary = value;
+				_onChange();
+			}
+		}
+		private bool _tertiary = true;
+
+		public bool Tertiary
+		{
+			get => _tertiary; set
+			{
+				_tertiary = value;
+				_onChange();
+			}
+		}
+		private Action _onChange;
+
+		public MultiAxisLockViewModel(Action onChange)
+		{
+			_onChange = onChange;
+		}
+
+	}
+	/// <summary>
+	/// Interaction logic for MultiAxisLock.axaml
+	/// </summary>
+	public class MultiAxisLock : Window
+	{
+		private readonly ScottPlot.Renderable.Axis YAxis3;
+		private readonly AvaPlot avaPlot1;
+		private bool initialized = false;
+		private readonly MultiAxisLockViewModel viewModel;
+
+		public MultiAxisLock()
+		{
+			InitializeComponent();
+#if DEBUG
+			this.AttachDevTools();
+#endif
+			viewModel = new MultiAxisLockViewModel(() => this.CheckChanged());
+			this.DataContext = viewModel;
+			avaPlot1 = this.Find<AvaPlot>("AvaPlot1");
+
+			Random rand = new Random();
+
+			// Add 3 signals each with a different vertical axis index.
+			// Each signal defaults to X axis index 0 so their horizontal axis will be shared.
+
+			var plt1 = avaPlot1.Plot.AddSignal(DataGen.RandomWalk(rand, 100, mult: 1));
+			plt1.YAxisIndex = 0;
+			plt1.LineWidth = 3;
+			plt1.Color = System.Drawing.Color.Magenta;
+
+			var plt2 = avaPlot1.Plot.AddSignal(DataGen.RandomWalk(rand, 100, mult: 10));
+			plt2.YAxisIndex = 1;
+			plt2.LineWidth = 3;
+			plt2.Color = System.Drawing.Color.Green;
+
+			var plt3 = avaPlot1.Plot.AddSignal(DataGen.RandomWalk(rand, 100, mult: 100));
+			plt3.YAxisIndex = 2;
+			plt3.LineWidth = 3;
+			plt3.Color = System.Drawing.Color.Navy;
+
+			// The horizontal axis is shared by these signal plots (XAxisIndex defaults to 0)
+			avaPlot1.Plot.XAxis.Label("Horizontal Axis");
+
+			// Customize the primary (left) and secondary (right) axes
+			avaPlot1.Plot.YAxis.Color(System.Drawing.Color.Magenta);
+			avaPlot1.Plot.YAxis.Label("Primary Axis");
+			avaPlot1.Plot.YAxis2.Color(System.Drawing.Color.Green);
+			avaPlot1.Plot.YAxis2.Label("Secondary Axis");
+
+			// the secondary (right) axis ticks are hidden by default so enable them
+			avaPlot1.Plot.YAxis2.Ticks(true);
+
+			// Create an additional vertical axis and customize it
+			YAxis3 = avaPlot1.Plot.AddAxis(Renderable.Edge.Left, 2);
+			YAxis3.Color(System.Drawing.Color.Navy);
+			YAxis3.Label("Tertiary Axis");
+
+			// adjust axis limits to fit the data once before locking them
+			avaPlot1.Plot.AxisAuto();
+			CheckChanged();
+		}
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+			initialized = true;
+		}
+
+		private void CheckChanged()
+		{
+			if (avaPlot1 is null)
+			{
+				return;
+			}
+
+			avaPlot1.Plot.YAxis.LockLimits(!viewModel.Primary);
+			avaPlot1.Plot.YAxis2.LockLimits(!viewModel.Secondary);
+			YAxis3.LockLimits(!viewModel.Tertiary);
+		}
+	}
+}

--- a/src/demo/ScottPlot.Demo.Avalonia/MainWindow.axaml
+++ b/src/demo/ScottPlot.Demo.Avalonia/MainWindow.axaml
@@ -54,8 +54,8 @@
 							</TextBlock>
 						</Button>
 						<TextBlock >
-              Simple examples that demonstrate the primary features of ScottPlot
-            </TextBlock>
+							Simple examples that demonstrate the primary features of ScottPlot
+						</TextBlock>
 					</DockPanel>
 				</StackPanel>
 			</Border>
@@ -72,8 +72,8 @@
 								</TextBlock>
 							</Button>
 							<TextBlock >
-                Create a ScottPlot programmatically then display it in an interactive window
-              </TextBlock>
+								Create a ScottPlot programmatically then display it in an interactive window
+							</TextBlock>
 						</DockPanel>
 
 						<DockPanel>
@@ -83,8 +83,8 @@
 								</TextBlock>
 							</Button>
 							<TextBlock >
-                Display the position under the mouse cursor
-              </TextBlock>
+								Display the position under the mouse cursor
+							</TextBlock>
 						</DockPanel>
 
 						<DockPanel>
@@ -105,8 +105,8 @@
 								</TextBlock>
 							</Button>
 							<TextBlock >
-                Advanced styling and behavior customization
-              </TextBlock>
+								Advanced styling and behavior customization
+							</TextBlock>
 						</DockPanel>
 
 						<DockPanel>
@@ -116,8 +116,8 @@
 								</TextBlock>
 							</Button>
 							<TextBlock >
-                Link the axes of two plots together so adjusting one changes the other
-              </TextBlock>
+								Link the axes of two plots together so adjusting one changes the other
+							</TextBlock>
 						</DockPanel>
 
 						<DockPanel>
@@ -127,8 +127,8 @@
 								</TextBlock>
 							</Button>
 							<TextBlock >
-                Display live data from a fixed-length array that continuously changes
-              </TextBlock>
+								Display live data from a fixed-length array that continuously changes
+							</TextBlock>
 						</DockPanel>
 
 						<DockPanel>
@@ -138,8 +138,8 @@
 								</TextBlock>
 							</Button>
 							<TextBlock >
-                Display live data that grows with time
-              </TextBlock>
+								Display live data that grows with time
+							</TextBlock>
 						</DockPanel>
 
 						<DockPanel>
@@ -149,8 +149,8 @@
 								</TextBlock>
 							</Button>
 							<TextBlock >
-                Display the value of the data point nearest the cursor
-              </TextBlock>
+								Display the value of the data point nearest the cursor
+							</TextBlock>
 						</DockPanel>
 
 						<DockPanel>
@@ -160,8 +160,8 @@
 								</TextBlock>
 							</Button>
 							<TextBlock >
-                Demonstrate a control with a transparent background
-              </TextBlock>
+								Demonstrate a control with a transparent background
+							</TextBlock>
 						</DockPanel>
 
 						<!-- I think doing this in Avalonia means a rewrite and I barely understand templates
@@ -184,8 +184,8 @@
 								</TextBlock>
 							</Button>
 							<TextBlock >
-                Display a custom menu (or perform a different action) when the control is right-clicked
-              </TextBlock>
+								Display a custom menu (or perform a different action) when the control is right-clicked
+							</TextBlock>
 						</DockPanel>
 
 						<DockPanel>
@@ -195,8 +195,8 @@
 								</TextBlock>
 							</Button>
 							<TextBlock >
-                Display multiple plots in a scrolling control
-              </TextBlock>
+								Display multiple plots in a scrolling control
+							</TextBlock>
 						</DockPanel>
 
 						<DockPanel>
@@ -217,8 +217,19 @@
 								</TextBlock>
 							</Button>
 							<TextBlock>
-                Demonstrate how axis boundaries can be used to constrain axis limits in interactive plots
-              </TextBlock>
+								Demonstrate how axis boundaries can be used to constrain axis limits in interactive plots
+							</TextBlock>
+						</DockPanel>
+
+						<DockPanel>
+							<Button DockPanel.Dock="Left" Name="LaunchMultiAxisLockButton">
+								<TextBlock TextAlignment="Center">
+									MultiAxisLock
+								</TextBlock>
+							</Button>
+							<TextBlock>
+								Selectively pan/zoom individual axes in multi-axis plots
+							</TextBlock>
 						</DockPanel>
 
 					</StackPanel>

--- a/src/demo/ScottPlot.Demo.Avalonia/MainWindow.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/MainWindow.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using ScottPlot.Avalonia;
+using System;
 
 namespace ScottPlot.Demo.Avalonia
 {
@@ -29,9 +30,10 @@ namespace ScottPlot.Demo.Avalonia
             this.Find<Button>("LaunchPlotInAScrollViewerButton").Click += LaunchPlotInAScrollViewer;
             this.Find<Button>("LaunchAxisLimitsButton").Click += LaunchAxisLimits;
             this.Find<Button>("LaunchLayoutButton").Click += LaunchLayout;
+            this.Find<Button>("LaunchMultiAxisLockButton").Click += LaunchMultiAxisLock;
         }
 
-        public void InitializeComponent()
+		public void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
         }
@@ -114,6 +116,12 @@ namespace ScottPlot.Demo.Avalonia
         public void LaunchLayout(object sender, RoutedEventArgs e)
         {
             new AvaloniaDemos.Layout().ShowDialog(this);
+        }	
+        public void LaunchMultiAxisLock(object sender, RoutedEventArgs e)
+		{
+            new AvaloniaDemos.MultiAxisLock().ShowDialog(this);
         }
+
+
     }
 }

--- a/src/demo/ScottPlot.Demo.Avalonia/MainWindow.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/MainWindow.axaml.cs
@@ -33,7 +33,7 @@ namespace ScottPlot.Demo.Avalonia
             this.Find<Button>("LaunchMultiAxisLockButton").Click += LaunchMultiAxisLock;
         }
 
-		public void InitializeComponent()
+        public void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
         }
@@ -116,9 +116,9 @@ namespace ScottPlot.Demo.Avalonia
         public void LaunchLayout(object sender, RoutedEventArgs e)
         {
             new AvaloniaDemos.Layout().ShowDialog(this);
-        }	
+        }
         public void LaunchMultiAxisLock(object sender, RoutedEventArgs e)
-		{
+        {
             new AvaloniaDemos.MultiAxisLock().ShowDialog(this);
         }
 


### PR DESCRIPTION
**New Contributors:**
please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Purpose:**
#1210

**New Functionality:**
Adds multi-axis lock demo for Avalonia. There are some bigger changes from the WPF version as Avalonians normally do MVVM with observables, often with `INotifyPropertyChanged`, not event handlers. This is because event handlers can be fired before the data context is updated. So generally event handlers are used only for code-behind where you're setting the value in the handler. I think most Avalonia users use something like ReactiveUI so their viewmodels are less verbose.