### PR TITLE
Improved tick label rotation

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -28,6 +28,7 @@
 * Axes: Added `LockLimits()` to control pan/zoom manipulation so individual axes can be manipulated in multi-axis plots. See demo application for example. (#1179, #1210) _Thanks @kkaiser41_
 * Vector Plot: Add additional options to customize arrowhead style and position. See cookbook for examples. (#1202) _Thanks @hhubschle_
 * Finance Plot: Fixed bug affecting plots with no data points (#1200) _Thanks @Maoyao233_
+* Ticks: Improve display of rotated ticks on secondary axes (#1201) _Thanks @gigios_
 
 ## ScottPlot 4.1.16
 * Made it easier to use custom color palettes (see cookbook) (#1058, #1082) _Thanks @EmanuelFeru_

--- a/src/ScottPlot/Renderable/AxisTicksRender.cs
+++ b/src/ScottPlot/Renderable/AxisTicksRender.cs
@@ -80,100 +80,77 @@ namespace ScottPlot.Renderable
             if (tc.tickLabels is null || tc.tickLabels.Length == 0)
                 return;
 
-            using (var font = GDI.Font(tickFont))
-            using (var brush = GDI.Brush(tickFont.Color))
-            using (var sf = GDI.StringFormat())
+            using var font = GDI.Font(tickFont);
+            using var brush = GDI.Brush(tickFont.Color);
+            using var sf = GDI.StringFormat();
+
+            if (edge == Edge.Bottom)
             {
-                // TODO: Refactor to improve rotated tick label rendering:
-                //  1) rotation should always be assumed
-                //  2) a separate function should translate/rotate/render/reset
-                //  3) all edges should support rotation
-                if (edge == Edge.Bottom)
+                for (int i = 0; i < tc.tickPositionsMajor.Length; i++)
                 {
-                    if (rotation == 0)
-                    {
-                        sf.Alignment = rulerMode ? StringAlignment.Near : StringAlignment.Center;
-                        sf.LineAlignment = StringAlignment.Near;
-                        for (int i = 0; i < tc.tickPositionsMajor.Length; i++)
-                            gfx.DrawString(tc.tickLabels[i], font, brush, format: sf,
-                                x: dims.GetPixelX(tc.tickPositionsMajor[i]),
-                                y: dims.DataOffsetY + dims.DataHeight + PixelOffset + MajorTickLength);
+                    float x = dims.GetPixelX(tc.tickPositionsMajor[i]);
+                    float y = dims.DataOffsetY + dims.DataHeight + MajorTickLength;
 
-                        sf.Alignment = StringAlignment.Far;
-                        gfx.DrawString(tc.CornerLabel, font, brush, format: sf,
-                            x: dims.DataOffsetX + dims.DataWidth,
-                            y: dims.DataOffsetY + dims.DataHeight + MajorTickLength + tc.LargestLabelHeight);
-                    }
-                    else
-                    {
-                        for (int i = 0; i < tc.tickPositionsMajor.Length; i++)
-                        {
-                            float x = dims.GetPixelX(tc.tickPositionsMajor[i]);
-                            float y = dims.DataOffsetY + dims.DataHeight + MajorTickLength + 3;
-
-                            gfx.TranslateTransform(x, y);
-                            gfx.RotateTransform(-rotation);
-                            sf.Alignment = StringAlignment.Far;
-                            sf.LineAlignment = StringAlignment.Center;
-                            gfx.DrawString(tc.tickLabels[i], font, brush, 0, 0, sf);
-                            gfx.ResetTransform();
-                        }
-                    }
-                }
-                else if (edge == Edge.Top)
-                {
-                    sf.Alignment = rulerMode ? StringAlignment.Near : StringAlignment.Center;
-                    sf.LineAlignment = StringAlignment.Far;
-                    for (int i = 0; i < tc.tickPositionsMajor.Length; i++)
-                        gfx.DrawString(tc.tickLabels[i], font, brush, format: sf,
-                            x: dims.GetPixelX(tc.tickPositionsMajor[i]),
-                            y: dims.DataOffsetY - PixelOffset - MajorTickLength);
-                }
-                else if (edge == Edge.Left)
-                {
-                    if (rotation == 0)
-                    {
-                        sf.LineAlignment = rulerMode ? StringAlignment.Far : StringAlignment.Center;
-                        sf.Alignment = StringAlignment.Far;
-                        for (int i = 0; i < tc.tickPositionsMajor.Length; i++)
-                            gfx.DrawString(tc.tickLabels[i], font, brush, format: sf,
-                                x: dims.DataOffsetX - PixelOffset - MajorTickLength,
-                                y: dims.GetPixelY(tc.tickPositionsMajor[i]));
-
-                        sf.LineAlignment = StringAlignment.Far;
-                        sf.Alignment = StringAlignment.Near;
-                        gfx.DrawString(tc.CornerLabel, font, brush, dims.DataOffsetX, dims.DataOffsetY, sf);
-                    }
-                    else
-                    {
-                        for (int i = 0; i < tc.tickPositionsMajor.Length; i++)
-                        {
-                            float x = dims.DataOffsetX - PixelOffset - MajorTickLength;
-                            float y = dims.GetPixelY(tc.tickPositionsMajor[i]);
-
-                            gfx.TranslateTransform(x, y);
-                            gfx.RotateTransform(-rotation);
-                            sf.Alignment = StringAlignment.Far;
-                            sf.LineAlignment = StringAlignment.Center;
-                            gfx.DrawString(tc.tickLabels[i], font, brush, 0, 0, sf);
-                            gfx.ResetTransform();
-                        }
-                    }
-                }
-                else if (edge == Edge.Right)
-                {
-                    sf.LineAlignment = rulerMode ? StringAlignment.Far : StringAlignment.Center;
-                    sf.Alignment = StringAlignment.Near;
-                    for (int i = 0; i < tc.tickPositionsMajor.Length; i++)
-                        gfx.DrawString(tc.tickLabels[i], font, brush, format: sf,
-                            x: dims.DataOffsetX + PixelOffset + MajorTickLength + dims.DataWidth,
-                            y: dims.GetPixelY(tc.tickPositionsMajor[i]));
-                }
-                else
-                {
-                    throw new NotImplementedException();
+                    gfx.TranslateTransform(x, y);
+                    gfx.RotateTransform(-rotation);
+                    sf.Alignment = rotation == 0 ? StringAlignment.Center : StringAlignment.Far;
+                    if (rulerMode) sf.Alignment = StringAlignment.Near;
+                    sf.LineAlignment = rotation == 0 ? StringAlignment.Near : StringAlignment.Center;
+                    gfx.DrawString(tc.tickLabels[i], font, brush, 0, 0, sf);
+                    gfx.ResetTransform();
                 }
             }
+            else if (edge == Edge.Top)
+            {
+                for (int i = 0; i < tc.tickPositionsMajor.Length; i++)
+                {
+                    float x = dims.GetPixelX(tc.tickPositionsMajor[i]);
+                    float y = dims.DataOffsetY - MajorTickLength;
+
+                    gfx.TranslateTransform(x, y);
+                    gfx.RotateTransform(-rotation);
+                    sf.Alignment = rotation == 0 ? StringAlignment.Center : StringAlignment.Near;
+                    if (rulerMode) sf.Alignment = StringAlignment.Near;
+                    sf.LineAlignment = rotation == 0 ? StringAlignment.Far : StringAlignment.Center;
+                    gfx.DrawString(tc.tickLabels[i], font, brush, 0, 0, sf);
+                    gfx.ResetTransform();
+                }
+            }
+            else if (edge == Edge.Left)
+            {
+                for (int i = 0; i < tc.tickPositionsMajor.Length; i++)
+                {
+                    float x = dims.DataOffsetX - PixelOffset - MajorTickLength;
+                    float y = dims.GetPixelY(tc.tickPositionsMajor[i]);
+
+                    gfx.TranslateTransform(x, y);
+                    gfx.RotateTransform(-rotation);
+                    sf.Alignment = StringAlignment.Far;
+                    sf.LineAlignment = rulerMode ? StringAlignment.Far : StringAlignment.Center;
+                    gfx.DrawString(tc.tickLabels[i], font, brush, 0, 0, sf);
+                    gfx.ResetTransform();
+                }
+            }
+            else if (edge == Edge.Right)
+            {
+                for (int i = 0; i < tc.tickPositionsMajor.Length; i++)
+                {
+                    float x = dims.DataOffsetX + PixelOffset + MajorTickLength + dims.DataWidth;
+                    float y = dims.GetPixelY(tc.tickPositionsMajor[i]);
+
+                    gfx.TranslateTransform(x, y);
+                    gfx.RotateTransform(-rotation);
+                    sf.Alignment = StringAlignment.Near;
+                    sf.LineAlignment = rulerMode ? StringAlignment.Far : StringAlignment.Center;
+                    gfx.DrawString(tc.tickLabels[i], font, brush, 0, 0, sf);
+                    gfx.ResetTransform();
+                }
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+
         }
     }
 }

--- a/src/tests/Axis/RotatedTicks.cs
+++ b/src/tests/Axis/RotatedTicks.cs
@@ -1,0 +1,44 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlotTests.Axis
+{
+    class RotatedTicks
+    {
+        [Test]
+        public void Test_Rotated_AllAxes()
+        {
+            var plt = new ScottPlot.Plot(400, 300);
+
+            plt.XAxis2.Ticks(true);
+            plt.YAxis2.Ticks(true);
+            TestTools.SaveFig(plt, "1");
+
+            plt.XAxis.TickLabelStyle(rotation: 45);
+            plt.XAxis2.TickLabelStyle(rotation: 45);
+            plt.YAxis.TickLabelStyle(rotation: 45);
+            plt.YAxis2.TickLabelStyle(rotation: 45);
+            TestTools.SaveFig(plt, "2");
+        }
+
+        [Test]
+        public void Test_Ruler_AllAxes()
+        {
+            var plt = new ScottPlot.Plot(400, 300);
+
+            plt.XAxis2.Ticks(true);
+            plt.YAxis2.Ticks(true);
+
+            plt.XAxis.RulerMode(true);
+            plt.XAxis2.RulerMode(true);
+            plt.YAxis.RulerMode(true);
+            plt.YAxis2.RulerMode(true);
+
+            TestTools.SaveFig(plt);
+        }
+    }
+}


### PR DESCRIPTION
fixes #1201

```cs
plt.YAxis2.TickLabelStyle(rotation: 45);
```

default | rotated | ruler
---|---|---
![image](https://user-images.githubusercontent.com/4165489/130548528-ab167428-c745-4bc5-aea9-38d7fbe5df0c.png)|![image](https://user-images.githubusercontent.com/4165489/130548549-9f588c6d-fc2f-4fa6-95cc-ab9d90d3e1ca.png)|![image](https://user-images.githubusercontent.com/4165489/130548557-d290fe07-2bf9-474e-ab12-44fa478bcc03.png)
