### PR TITLE
ScatterPlot: Fix YError data limit bug

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -4,6 +4,7 @@
 * Ticks: Improve placement when axis scale lock is enabled (#1229, #1197)
 * Plot: `SetViewLimits()` replaced by `SetOuterViewLimits()` and `SetInnerViewLimits()` (#1197) _Thanks @noob765_
 * Plot: `EqualScaleMode` (an enumeration accepted by `AxisScaleLock()`) now has `PreserveSmallest` and `PreserveLargest` members to indicate which axis to prioritize when adjusting zoom level. The new default is `PreserveSmallest` which prevents data from falling off the edge of the plot when resizing. (#1197) _Thanks @noob765_
+* Scatter Plot: Fixed bug affecting plots where `YError` is set but `XError` is not (#1237, #1238) _Thanks @simmdan_
 
 ## ScottPlot 4.1.17
 * Improved `RadarPlot.Update()` default arguments (#1097) _Thanks @arthurits_

--- a/src/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot/Plottable/ScatterPlot.cs
@@ -184,7 +184,7 @@ namespace ScottPlot.Plottable
             }
             else
             {
-                var YsAndError = Ys.Zip(XError, (y, e) => (y, e)).Skip(from).Take(to - from + 1);
+                var YsAndError = Ys.Zip(YError, (y, e) => (y, e)).Skip(from).Take(to - from + 1);
                 limits[2] = YsAndError.Min(p => p.y - p.e);
                 limits[3] = YsAndError.Max(p => p.y + p.e);
             }

--- a/src/tests/PlottableRenderTests/Scatter.cs
+++ b/src/tests/PlottableRenderTests/Scatter.cs
@@ -69,6 +69,24 @@ namespace ScottPlotTests.PlottableRenderTests
         }
 
         [Test]
+        public void Test_Scatter_ChangeOnlyYErrorData()
+        {
+            var plt = new ScottPlot.Plot();
+
+            // set errorY but NOT errorX
+            double[] xs = { 1, 2, 3, 4 };
+            double[] ys = { 1, 4, 9, 16 };
+            double[] yErr = { .5, .5, 1, 1 };
+            var splt = new ScatterPlot(xs, ys, errorY: yErr) { };
+
+            plt.Add(splt);
+            var bmp = TestTools.GetLowQualityBitmap(plt);
+            Console.WriteLine(new MeanPixel(bmp));
+
+            Assert.That(bmp != null);
+        }
+
+        [Test]
         public void Test_Scatter_LineWidth()
         {
             var plt = new ScottPlot.Plot();


### PR DESCRIPTION
**Purpose:**
Fixes bug #1237.   

**New Functionality:**
It appears that there was a copy/paste from the XError to the YError section of the GetAxisLimits method on ScatterPlot.  Some of the code was fixed to have y instead of x, but one case was missed.

Test that illustrates the issue (if the other change is backed out) is included in this PR.