### PR TITLE
Arrow plot type

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -8,6 +8,7 @@
 * Controls: Fix bug where middle-click-drag zoom rectangle would persist if combined with scroll wheel events (#1226) _Thanks @Elgot_
 * Scatter Plot: Fixed bug affecting plots where `YError` is set but `XError` is not (#1237, #1238) _Thanks @simmdan_
 * Palette: Added `Microcharts` colorset (#1235) _Thanks @arthurits_
+* Arrow: New plot type for rendering arrows on plots. Arrowhead functionality of scatter plots has been deprecated. (#1241, #1240)
 
 ## ScottPlot 4.1.17
 * Improved `RadarPlot.Update()` default arguments (#1097) _Thanks @arthurits_

--- a/src/ScottPlot/Coordinate.cs
+++ b/src/ScottPlot/Coordinate.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace ScottPlot
+{
+    /// <summary>
+    /// Describes an X/Y position in coordinate space
+    /// </summary>
+    public class Coordinate
+    {
+        public double X;
+        public double Y;
+
+        public Coordinate(double x, double y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        /// <summary>
+        /// True as lone as neither coordinate is NaN or Infinity
+        /// </summary>
+        public bool IsFinite()
+        {
+            return
+                !double.IsNaN(X) &&
+                !double.IsNaN(Y) &&
+                !double.IsInfinity(X) &&
+                !double.IsInfinity(Y);
+        }
+
+        /// <summary>
+        /// Return the distance to another coordinate (in coordinate units)
+        /// </summary>
+        public double Distance(Coordinate other)
+        {
+            double dX = Math.Abs(other.X - X);
+            double dY = Math.Abs(other.Y - Y);
+            return Math.Sqrt(dX * dX + dY * dY);
+        }
+    }
+}

--- a/src/ScottPlot/Enums/ArrowAnchor.cs
+++ b/src/ScottPlot/Enums/ArrowAnchor.cs
@@ -1,0 +1,20 @@
+﻿namespace ScottPlot
+{
+    public enum ArrowAnchor
+    {
+        /// <summary>
+        /// X/Y coordinates define the base of the arrow
+        /// </summary>
+        Base,
+
+        /// <summary>
+        /// X/Y coordinates define the center of the arrow
+        /// </summary>
+        Center,
+
+        /// <summary>
+        /// X/Y coordinates define the tip of the arrow
+        /// </summary>
+        Tip,
+    }
+}

--- a/src/ScottPlot/Markers.cs
+++ b/src/ScottPlot/Markers.cs
@@ -31,6 +31,8 @@ namespace ScottPlot
     {
         public static void DrawMarker(Graphics gfx, PointF pixelLocation, MarkerShape shape, float size, Color color)
         {
+            if (size == 0 || shape == MarkerShape.none)
+                return;
 
             Pen pen = new Pen(color);
 

--- a/src/ScottPlot/Pixel.cs
+++ b/src/ScottPlot/Pixel.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace ScottPlot
+{
+    /// <summary>
+    /// Describes an X/Y position in pixel space
+    /// </summary>
+    public class Pixel
+    {
+        public float X;
+        public float Y;
+
+        public Pixel(float x, float y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        /// <summary>
+        /// True as lone as neither coordinate is NaN or Infinity
+        /// </summary>
+        public bool IsFinite()
+        {
+            return
+                !double.IsNaN(X) &&
+                !double.IsNaN(Y) &&
+                !double.IsInfinity(X) &&
+                !double.IsInfinity(Y);
+        }
+
+        /// <summary>
+        /// Return the distance to another pixel (in pixel units)
+        /// </summary>
+        public float Distance(Pixel other)
+        {
+            double dX = Math.Abs(other.X - X);
+            double dY = Math.Abs(other.Y - Y);
+            return (float)Math.Sqrt(dX * dX + dY * dY);
+        }
+    }
+}

--- a/src/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot/Plot/Plot.Add.cs
@@ -36,8 +36,9 @@ namespace ScottPlot
         /// <summary>
         /// Display an arrow pointing to a spot in coordinate space
         /// </summary>
-        public ScatterPlot AddArrow(double xTip, double yTip, double xBase, double yBase, float lineWidth = 5, Color? color = null)
+        public ArrowCoordinated AddArrow(double xTip, double yTip, double xBase, double yBase, float lineWidth = 5, Color? color = null)
         {
+            /*
             double[] xs = { xBase, xTip };
             double[] ys = { yBase, yTip };
             var plottable = new ScatterPlot(xs, ys)
@@ -47,6 +48,12 @@ namespace ScottPlot
                 Color = color ?? GetNextColor(),
                 ArrowheadLength = 3,
                 ArrowheadWidth = 3
+            };
+            */
+            var plottable = new ArrowCoordinated(xBase, yBase, xTip, yTip)
+            {
+                LineWidth = lineWidth,
+                Color = color ?? GetNextColor(),
             };
             Add(plottable);
             return plottable;

--- a/src/ScottPlot/PlotDimensions.cs
+++ b/src/ScottPlot/PlotDimensions.cs
@@ -34,8 +34,11 @@ namespace ScottPlot
         public readonly double UnitsPerPxX;
         public readonly double UnitsPerPxY;
 
+        public Pixel GetPixel(Coordinate coordinate) => new Pixel(GetPixelX(coordinate.X), GetPixelY(coordinate.Y));
         public float GetPixelX(double position) => (float)(DataOffsetX + ((position - XMin) * PxPerUnitX));
         public float GetPixelY(double position) => (float)(DataOffsetY + ((YMax - position) * PxPerUnitY));
+
+        public Coordinate GetCoordinate(Pixel pixel) => new Coordinate(GetCoordinateX(pixel.X), GetCoordinateY(pixel.Y));
         public double GetCoordinateX(float pixel) => (pixel - DataOffsetX) / PxPerUnitX + XMin;
         public double GetCoordinateY(float pixel) => DataHeight - ((pixel - YMin) * PxPerUnitY);
 

--- a/src/ScottPlot/Plottable/ArrowCoordinated.cs
+++ b/src/ScottPlot/Plottable/ArrowCoordinated.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Plottable
+{
+    /// <summary>
+    /// An arrow with X/Y coordinates for the base and the tip
+    /// </summary>
+    public class ArrowCoordinated : IPlottable
+    {
+        /// <summary>
+        /// Location of the arrow base in coordinate space
+        /// </summary>
+        public readonly Coordinate Base = new(0, 0);
+
+        /// <summary>
+        /// Location of the arrow base in coordinate space
+        /// </summary>
+        public readonly Coordinate Tip = new(0, 0);
+
+        /// <summary>
+        /// Color of the arrow and arrowhead
+        /// </summary>
+        public Color Color = Color.Black;
+
+        /// <summary>
+        /// Thickness of the arrow line
+        /// </summary>
+        public double LineWidth = 2;
+
+        /// <summary>
+        /// Style of the arrow line
+        /// </summary>
+        public LineStyle LineStyle = LineStyle.Solid;
+
+        /// <summary>
+        /// Label to appear in the legend
+        /// </summary>
+        public string Label;
+
+        /// <summary>
+        /// Width of the arrowhead (pixels)
+        /// </summary>
+        public double ArrowheadWidth = 3;
+
+        /// <summary>
+        /// Height of the arrowhead (pixels)
+        /// </summary>
+        public double ArrowheadLength = 3;
+
+        /// <summary>
+        /// The arrow will be lengthened to ensure it is at least this size on the screen
+        /// </summary>
+        public float MinimumLengthPixels = 0;
+
+        /// <summary>
+        /// Marker to be drawn at the base (if MarkerSize > 0)
+        /// </summary>
+        public MarkerShape MarkerShape = MarkerShape.filledCircle;
+
+        /// <summary>
+        /// Size of marker (in pixels) to draw at the base
+        /// </summary>
+        public float MarkerSize = 0;
+
+        public bool IsVisible { get; set; } = true;
+        public int XAxisIndex { get; set; } = 0;
+        public int YAxisIndex { get; set; } = 0;
+
+        public ArrowCoordinated(Coordinate arrowBase, Coordinate arrowTip)
+        {
+            Base.X = arrowBase.X;
+            Base.Y = arrowTip.Y;
+            Tip.X = arrowTip.X;
+            Tip.Y = arrowTip.Y;
+        }
+
+        public ArrowCoordinated(double xBase, double yBase, double xTip, double yTip)
+        {
+            Base.X = xBase;
+            Base.Y = yBase;
+            Tip.X = xTip;
+            Tip.Y = yTip;
+        }
+
+        public AxisLimits GetAxisLimits()
+        {
+            double xMin = Math.Min(Base.X, Tip.X);
+            double xMax = Math.Max(Base.X, Tip.X);
+            double yMin = Math.Min(Base.Y, Tip.Y);
+            double yMax = Math.Max(Base.Y, Tip.Y);
+            return new AxisLimits(xMin, xMax, yMin, yMax);
+        }
+
+        public LegendItem[] GetLegendItems()
+        {
+            var item = new LegendItem()
+            {
+                label = Label
+            };
+            return new LegendItem[] { item };
+        }
+
+        public void ValidateData(bool deep = false)
+        {
+            if (!Base.IsFinite() || !Tip.IsFinite())
+                throw new InvalidOperationException("Base and Tip coordinates must be finite");
+        }
+
+        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        {
+            if (IsVisible == false)
+                return;
+
+            using Graphics gfx = Drawing.GDI.Graphics(bmp, dims, lowQuality);
+            using Pen penLine = Drawing.GDI.Pen(Color, LineWidth, LineStyle, true);
+
+            Pixel basePixel = dims.GetPixel(Base);
+            Pixel tipPixel = dims.GetPixel(Tip);
+
+            float lengthPixels = basePixel.Distance(tipPixel);
+            if (lengthPixels < MinimumLengthPixels)
+            {
+                float expandBy = MinimumLengthPixels / lengthPixels;
+                float dX = tipPixel.X - basePixel.X;
+                float dY = tipPixel.Y - basePixel.Y;
+                basePixel.X = tipPixel.X - dX * expandBy;
+                basePixel.Y = tipPixel.Y - dY * expandBy;
+            }
+
+            MarkerTools.DrawMarker(gfx, new(basePixel.X, basePixel.Y), MarkerShape, MarkerSize, Color);
+
+            penLine.CustomEndCap = new System.Drawing.Drawing2D.AdjustableArrowCap((float)ArrowheadWidth, (float)ArrowheadLength, true);
+            penLine.StartCap = System.Drawing.Drawing2D.LineCap.Flat;
+            gfx.DrawLine(penLine, basePixel.X, basePixel.Y, tipPixel.X, tipPixel.Y);
+        }
+    }
+}

--- a/src/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot/Plottable/ScatterPlot.cs
@@ -44,8 +44,14 @@ namespace ScottPlot.Plottable
         public float ErrorCapSize = 3;
         public float MarkerSize = 5;
         public bool StepDisplay = false;
+
+        [Obsolete("Scatter plot arrowheads have been deprecated. Use the Arrow plot type instead.", true)]
         public bool IsArrow { get => ArrowheadWidth > 0 && ArrowheadLength > 0; }
+
+        [Obsolete("Scatter plot arrowheads have been deprecated. Use the Arrow plot type instead.", true)]
         public float ArrowheadWidth = 0;
+
+        [Obsolete("Scatter plot arrowheads have been deprecated. Use the Arrow plot type instead.", true)]
         public float ArrowheadLength = 0;
 
         // TODO: think about better/additional API ?
@@ -269,12 +275,6 @@ namespace ScottPlot.Plottable
                     }
                     else
                     {
-                        if (IsArrow)
-                        {
-                            penLine.CustomEndCap = new AdjustableArrowCap(ArrowheadWidth, ArrowheadLength, true);
-                            penLine.StartCap = LineCap.Flat;
-                        }
-
                         gfx.DrawLines(penLine, points);
                     }
                 }

--- a/src/ScottPlot/Plottable/VectorField.cs
+++ b/src/ScottPlot/Plottable/VectorField.cs
@@ -15,29 +15,18 @@ namespace ScottPlot.Plottable
         private readonly double[] Ys;
         private readonly Vector2[,] Vectors;
         private readonly Color[] VectorColors;
-        public readonly Renderable.ArrowStyle ArrowStyle = new();
         public string Label;
         public bool IsVisible { get; set; } = true;
         public int XAxisIndex { get; set; } = 0;
         public int YAxisIndex { get; set; } = 0;
 
-        [Obsolete("use ArrowStyle.Anchor", true)]
-        public ArrowAnchor Anchor;
-
-        [Obsolete("use ArrowStyle.ScaledArrowheads", true)]
-        public bool ScaledArrowheads;
-
-        [Obsolete("use ArrowStyle.ScaledArrowheadWidth", true)]
-        public double ScaledArrowheadWidth;
-
-        [Obsolete("use ArrowStyle.ScaledArrowheadLength", true)]
-        public double ScaledArrowheadLength;
-
-        [Obsolete("use ArrowStyle.MarkerShape", true)]
-        public MarkerShape MarkerShape = MarkerShape.filledCircle;
-
-        [Obsolete("use ArrowStyle.MarkerSize", true)]
-        public float MarkerSize = 0;
+        private readonly Renderable.ArrowStyle ArrowStyle = new();
+        public ArrowAnchor Anchor { get => ArrowStyle.Anchor; set => ArrowStyle.Anchor = value; }
+        public bool ScaledArrowheads { get => ArrowStyle.ScaledArrowheads; set => ArrowStyle.ScaledArrowheads = value; }
+        public double ScaledArrowheadWidth { get => ArrowStyle.ScaledArrowheadWidth; set => ArrowStyle.ScaledArrowheadWidth = value; }
+        public double ScaledArrowheadLength { get => ArrowStyle.ScaledArrowheadLength; set => ArrowStyle.ScaledArrowheadLength = value; }
+        public MarkerShape MarkerShape { get => ArrowStyle.MarkerShape; set => ArrowStyle.MarkerShape = value; }
+        public float MarkerSize { get => ArrowStyle.MarkerSize; set => ArrowStyle.MarkerSize = value; }
 
         public VectorField(Vector2[,] vectors, double[] xs, double[] ys, Colormap colormap, double scaleFactor, Color defaultColor)
         {

--- a/src/ScottPlot/Plottable/VectorField.cs
+++ b/src/ScottPlot/Plottable/VectorField.cs
@@ -2,7 +2,6 @@
 using ScottPlot.Statistics;
 using System;
 using System.Drawing;
-using System.Drawing.Drawing2D;
 using System.Linq;
 
 namespace ScottPlot.Plottable
@@ -12,47 +11,32 @@ namespace ScottPlot.Plottable
     /// </summary>
     public class VectorField : IPlottable
     {
-        // data
         private readonly double[] Xs;
         private readonly double[] Ys;
         private readonly Vector2[,] Vectors;
         private readonly Color[] VectorColors;
-
+        public readonly Renderable.ArrowStyle ArrowStyle = new();
         public string Label;
         public bool IsVisible { get; set; } = true;
         public int XAxisIndex { get; set; } = 0;
         public int YAxisIndex { get; set; } = 0;
 
-        public enum VectorAnchor { Base, Center, Tip, }
+        [Obsolete("use ArrowStyle.Anchor", true)]
+        public ArrowAnchor Anchor;
 
-        /// <summary>
-        /// Describes which part of the vector line will be placed at the data coordinates.
-        /// </summary>
-        public VectorAnchor Anchor = VectorAnchor.Center;
-
-        /// <summary>
-        /// If enabled arrowheads will be drawn as lines scaled to each vector's magnitude.
-        /// </summary>
+        [Obsolete("use ArrowStyle.ScaledArrowheads", true)]
         public bool ScaledArrowheads;
 
-        /// <summary>
-        /// When using scaled arrowheads this defines the width of the arrow relative to the vector line's length.
-        /// </summary>
-        public double ScaledArrowheadWidth = 0.15;
+        [Obsolete("use ArrowStyle.ScaledArrowheadWidth", true)]
+        public double ScaledArrowheadWidth;
 
-        /// <summary>
-        /// When using scaled arrowheads this defines length of the arrowhead relative to the vector line's length.
-        /// </summary>
-        public double ScaledArrowheadLength = 0.5;
+        [Obsolete("use ArrowStyle.ScaledArrowheadLength", true)]
+        public double ScaledArrowheadLength;
 
-        /// <summary>
-        /// Marker drawn at each coordinate
-        /// </summary>
+        [Obsolete("use ArrowStyle.MarkerShape", true)]
         public MarkerShape MarkerShape = MarkerShape.filledCircle;
 
-        /// <summary>
-        /// Size of markers to be drawn at each coordinate
-        /// </summary>
+        [Obsolete("use ArrowStyle.MarkerSize", true)]
         public float MarkerSize = 0;
 
         public VectorField(Vector2[,] vectors, double[] xs, double[] ys, Colormap colormap, double scaleFactor, Color defaultColor)
@@ -113,109 +97,13 @@ namespace ScottPlot.Plottable
 
         public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
         {
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
-            using (Pen pen = GDI.Pen(Color.Black))
-            {
-                float tipScale = (float)Math.Sqrt(ScaledArrowheadLength * ScaledArrowheadLength + ScaledArrowheadWidth * ScaledArrowheadWidth);
-                float headAngle = (float)Math.Atan2(ScaledArrowheadWidth, ScaledArrowheadLength);
+            if (IsVisible == false)
+                return;
 
-                if (!ScaledArrowheads)
-                    pen.CustomEndCap = new AdjustableArrowCap(2, 2);
+            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
 
-                for (int i = 0; i < Xs.Length; i++)
-                {
-                    for (int j = 0; j < Ys.Length; j++)
-                    {
-                        Vector2 v = Vectors[i, j];
-                        float tailX, tailY, endX, endY;
-
-                        switch (Anchor)
-                        {
-                            case VectorAnchor.Base:
-                                tailX = dims.GetPixelX(Xs[i]);
-                                tailY = dims.GetPixelY(Ys[j]);
-                                endX = dims.GetPixelX(Xs[i] + v.X);
-                                endY = dims.GetPixelY(Ys[j] + v.Y);
-                                break;
-                            case VectorAnchor.Center:
-                                tailX = dims.GetPixelX(Xs[i] - v.X / 2);
-                                tailY = dims.GetPixelY(Ys[j] - v.Y / 2);
-                                endX = dims.GetPixelX(Xs[i] + v.X / 2);
-                                endY = dims.GetPixelY(Ys[j] + v.Y / 2);
-                                break;
-                            case VectorAnchor.Tip:
-                                tailX = dims.GetPixelX(Xs[i] - v.X);
-                                tailY = dims.GetPixelY(Ys[j] - v.Y);
-                                endX = dims.GetPixelX(Xs[i]);
-                                endY = dims.GetPixelY(Ys[j]);
-                                break;
-                            default:
-                                throw new NotImplementedException("unsupported anchor type");
-                        }
-
-                        pen.Color = VectorColors[i * Ys.Length + j];
-                        if (ScaledArrowheads)
-                            DrawFancyArrow(gfx, pen, tailX, tailY, endX, endY, headAngle, tipScale);
-                        else
-                            gfx.DrawLine(pen, tailX, tailY, endX, endY);
-
-                        if (MarkerShape != MarkerShape.none && MarkerSize > 0)
-                        {
-                            PointF markerPoint = new PointF(dims.GetPixelX(Xs[i]), dims.GetPixelY(Ys[j]));
-                            MarkerTools.DrawMarker(gfx, markerPoint, MarkerShape, MarkerSize, pen.Color);
-                        }
-                    }
-                }
-            }
+            ArrowStyle.Render(dims, gfx, Xs, Ys, Vectors, VectorColors);
         }
-
-        /// <summary>
-        /// Draw arrow with tips without using CustomEndCap.
-        /// </summary>
-        /// <param name="gfx"></param>
-        /// <param name="pen"></param>
-        /// <param name="baseX"></param>
-        /// <param name="baseY"></param>
-        /// <param name="tipX"></param>
-        /// <param name="tipY"></param>
-        /// <param name="headAngle">Determines how 'pointy' the tip is.</param>
-        /// <param name="tipScale">Length of tip part, relative to total length.</param>
-        private void DrawFancyArrow(
-           Graphics gfx, Pen pen,
-           float baseX,
-           float baseY,
-           float tipX,
-           float tipY,
-           float headAngle,
-           float tipScale)
-        {
-            var dx = tipX - baseX;
-            var dy = tipY - baseY;
-            var arrowAngle = (float)Math.Atan2(dy, dx);
-            var sinA1 = (float)Math.Sin(headAngle - arrowAngle);
-            var cosA1 = (float)Math.Cos(headAngle - arrowAngle);
-            var sinA2 = (float)Math.Sin(headAngle + arrowAngle);
-            var cosA2 = (float)Math.Cos(headAngle + arrowAngle);
-            var len = (float)Math.Sqrt(dx * dx + dy * dy);
-            var hypLen = len * tipScale;
-
-            var corner1X = tipX - hypLen * cosA1;
-            var corner1Y = tipY + hypLen * sinA1;
-            var corner2X = tipX - hypLen * cosA2;
-            var corner2Y = tipY - hypLen * sinA2;
-
-            PointF[] arrowPoints =
-            {
-                new PointF(baseX, baseY),
-                new PointF(tipX, tipY),
-                new PointF(corner1X, corner1Y),
-                new PointF(tipX, tipY),
-                new PointF(corner2X, corner2Y),
-            };
-            gfx.DrawLines(pen, arrowPoints);
-        }
-
-
 
         public override string ToString()
         {

--- a/src/ScottPlot/Plottable/VectorField.cs
+++ b/src/ScottPlot/Plottable/VectorField.cs
@@ -21,11 +21,35 @@ namespace ScottPlot.Plottable
         public int YAxisIndex { get; set; } = 0;
 
         private readonly Renderable.ArrowStyle ArrowStyle = new();
+
+        /// <summary>
+        /// Describes which part of the vector line will be placed at the data coordinates.
+        /// </summary>
         public ArrowAnchor Anchor { get => ArrowStyle.Anchor; set => ArrowStyle.Anchor = value; }
+
+        /// <summary>
+        /// If enabled arrowheads will be drawn as lines scaled to each vector's magnitude.
+        /// </summary>
         public bool ScaledArrowheads { get => ArrowStyle.ScaledArrowheads; set => ArrowStyle.ScaledArrowheads = value; }
+
+        /// <summary>
+        /// When using scaled arrowheads this defines the width of the arrow relative to the vector line's length.
+        /// </summary>
         public double ScaledArrowheadWidth { get => ArrowStyle.ScaledArrowheadWidth; set => ArrowStyle.ScaledArrowheadWidth = value; }
+
+        /// <summary>
+        /// When using scaled arrowheads this defines length of the arrowhead relative to the vector line's length.
+        /// </summary>
         public double ScaledArrowheadLength { get => ArrowStyle.ScaledArrowheadLength; set => ArrowStyle.ScaledArrowheadLength = value; }
+
+        /// <summary>
+        /// Marker drawn at each coordinate
+        /// </summary>
         public MarkerShape MarkerShape { get => ArrowStyle.MarkerShape; set => ArrowStyle.MarkerShape = value; }
+
+        /// <summary>
+        /// Size of markers to be drawn at each coordinate
+        /// </summary>
         public float MarkerSize { get => ArrowStyle.MarkerSize; set => ArrowStyle.MarkerSize = value; }
 
         public VectorField(Vector2[,] vectors, double[] xs, double[] ys, Colormap colormap, double scaleFactor, Color defaultColor)

--- a/src/ScottPlot/Renderable/ArrowStyle.cs
+++ b/src/ScottPlot/Renderable/ArrowStyle.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Renderable
+{
+    public class ArrowStyle
+    {
+        /// <summary>
+        /// Describes which part of the vector line will be placed at the data coordinates.
+        /// </summary>
+        public ArrowAnchor Anchor = ArrowAnchor.Center;
+
+        /// <summary>
+        /// If enabled arrowheads will be drawn as lines scaled to each vector's magnitude.
+        /// </summary>
+        public bool ScaledArrowheads;
+
+        /// <summary>
+        /// When using scaled arrowheads this defines the width of the arrow relative to the vector line's length.
+        /// </summary>
+        public double ScaledArrowheadWidth = 0.15;
+
+        /// <summary>
+        /// When using scaled arrowheads this defines length of the arrowhead relative to the vector line's length.
+        /// </summary>
+        public double ScaledArrowheadLength = 0.5;
+
+        /// <summary>
+        /// Marker drawn at each coordinate
+        /// </summary>
+        public MarkerShape MarkerShape = MarkerShape.filledCircle;
+
+        /// <summary>
+        /// Size of markers to be drawn at each coordinate
+        /// </summary>
+        public float MarkerSize = 0;
+
+        public (float tipScale, float headAngle) GetTipDimensions()
+        {
+            float tipScale = (float)Math.Sqrt(ScaledArrowheadLength * ScaledArrowheadLength + ScaledArrowheadWidth * ScaledArrowheadWidth);
+            float headAngle = (float)Math.Atan2(ScaledArrowheadWidth, ScaledArrowheadLength);
+            return (tipScale, headAngle);
+        }
+
+        /// <summary>
+        /// Render an evenly-spaced 2D vector field.
+        /// </summary>
+        public void Render(PlotDimensions dims, Graphics gfx, double[] xs, double[] ys, Statistics.Vector2[,] vectors, Color[] colors)
+        {
+            (float tipScale, float headAngle) = GetTipDimensions(); // precalculate angles for fancy arrows
+
+            using Pen pen = Drawing.GDI.Pen(Color.Black);
+            if (!ScaledArrowheads)
+                pen.CustomEndCap = new System.Drawing.Drawing2D.AdjustableArrowCap(2, 2);
+
+            for (int i = 0; i < xs.Length; i++)
+            {
+                for (int j = 0; j < ys.Length; j++)
+                {
+                    Statistics.Vector2 v = vectors[i, j];
+                    float tailX, tailY, endX, endY;
+
+                    switch (Anchor)
+                    {
+                        case ArrowAnchor.Base:
+                            tailX = dims.GetPixelX(xs[i]);
+                            tailY = dims.GetPixelY(ys[j]);
+                            endX = dims.GetPixelX(xs[i] + v.X);
+                            endY = dims.GetPixelY(ys[j] + v.Y);
+                            break;
+                        case ArrowAnchor.Center:
+                            tailX = dims.GetPixelX(xs[i] - v.X / 2);
+                            tailY = dims.GetPixelY(ys[j] - v.Y / 2);
+                            endX = dims.GetPixelX(xs[i] + v.X / 2);
+                            endY = dims.GetPixelY(ys[j] + v.Y / 2);
+                            break;
+                        case ArrowAnchor.Tip:
+                            tailX = dims.GetPixelX(xs[i] - v.X);
+                            tailY = dims.GetPixelY(ys[j] - v.Y);
+                            endX = dims.GetPixelX(xs[i]);
+                            endY = dims.GetPixelY(ys[j]);
+                            break;
+                        default:
+                            throw new NotImplementedException("unsupported anchor type");
+                    }
+
+                    pen.Color = colors[i * ys.Length + j];
+                    if (ScaledArrowheads)
+                        DrawFancyArrow(gfx, pen, tailX, tailY, endX, endY, headAngle, tipScale);
+                    else
+                        gfx.DrawLine(pen, tailX, tailY, endX, endY);
+
+                    if (MarkerShape != MarkerShape.none && MarkerSize > 0)
+                    {
+                        PointF markerPoint = new PointF(dims.GetPixelX(xs[i]), dims.GetPixelY(ys[j]));
+                        MarkerTools.DrawMarker(gfx, markerPoint, MarkerShape, MarkerSize, pen.Color);
+                    }
+                }
+            }
+        }
+        
+        private void DrawFancyArrow(Graphics gfx, Pen pen, float x1, float y1, float x2, float y2, float headAngle, float tipScale)
+        {
+            var dx = x2 - x1;
+            var dy = y2 - y1;
+            var arrowAngle = (float)Math.Atan2(dy, dx);
+            var sinA1 = (float)Math.Sin(headAngle - arrowAngle);
+            var cosA1 = (float)Math.Cos(headAngle - arrowAngle);
+            var sinA2 = (float)Math.Sin(headAngle + arrowAngle);
+            var cosA2 = (float)Math.Cos(headAngle + arrowAngle);
+            var len = (float)Math.Sqrt(dx * dx + dy * dy);
+            var hypLen = len * tipScale;
+
+            var corner1X = x2 - hypLen * cosA1;
+            var corner1Y = y2 + hypLen * sinA1;
+            var corner2X = x2 - hypLen * cosA2;
+            var corner2Y = y2 - hypLen * sinA2;
+
+            PointF[] arrowPoints =
+            {
+                new PointF(x1, y1),
+                new PointF(x2, y2),
+                new PointF(corner1X, corner1Y),
+                new PointF(x2, y2),
+                new PointF(corner2X, corner2Y),
+            };
+            gfx.DrawLines(pen, arrowPoints);
+        }
+    }
+}

--- a/src/ScottPlot/Renderable/ArrowStyle.cs
+++ b/src/ScottPlot/Renderable/ArrowStyle.cs
@@ -30,6 +30,16 @@ namespace ScottPlot.Renderable
         public double ScaledArrowheadLength = 0.5;
 
         /// <summary>
+        /// Size of the arrowhead if custom/scaled arrowheads are not in use
+        /// </summary>
+        public float NonScaledArrowheadWidth = 2;
+
+        /// <summary>
+        /// Size of the arrowhead if custom/scaled arrowheads are not in use
+        /// </summary>
+        public float NonScaledArrowheadLength = 2;
+
+        /// <summary>
         /// Marker drawn at each coordinate
         /// </summary>
         public MarkerShape MarkerShape = MarkerShape.filledCircle;
@@ -55,7 +65,7 @@ namespace ScottPlot.Renderable
 
             using Pen pen = Drawing.GDI.Pen(Color.Black);
             if (!ScaledArrowheads)
-                pen.CustomEndCap = new System.Drawing.Drawing2D.AdjustableArrowCap(2, 2);
+                pen.CustomEndCap = new System.Drawing.Drawing2D.AdjustableArrowCap(NonScaledArrowheadWidth, NonScaledArrowheadLength);
 
             for (int i = 0; i < xs.Length; i++)
             {
@@ -102,7 +112,7 @@ namespace ScottPlot.Renderable
                 }
             }
         }
-        
+
         private void DrawFancyArrow(Graphics gfx, Pen pen, float x1, float y1, float x2, float y2, float headAngle, float tipScale)
         {
             var dx = x2 - x1;

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Arrow.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Arrow.cs
@@ -6,25 +6,35 @@
         public string ID => "plottable_arrow_quickstart";
         public string Title => "Arrows";
         public string Description =>
-            "Arrows point to specific locations on the plot. " +
-            "Arrows are actually just scatter plots with two points and an arrowhead.";
+            "Arrows point to specific locations on the plot. ";
 
         public void ExecuteRecipe(Plot plt)
         {
             // plot some sample data
             plt.AddSignal(DataGen.Sin(51));
-            plt.AddSignal(DataGen.Cos(51));
 
             // add arrows using coordinates
             plt.AddArrow(25, 0, 27, .2);
-            plt.AddArrow(27, -.25, 23, -.5, lineWidth: 10);
+
+            // you can define a minimum length so the line persists even when zooming out
+            var arrow2 = plt.AddArrow(27, -.25, 23, -.5);
+            arrow2.Color = System.Drawing.Color.Red;
+            arrow2.MinimumLengthPixels = 100;
 
             // the shape of the arrowhead can be adjusted
             var skinny = plt.AddArrow(12, 1, 12, .5);
-            skinny.ArrowheadLength *= 2;
+            skinny.Color = System.Drawing.Color.Green;
+            skinny.ArrowheadLength = 5;
+            skinny.ArrowheadWidth = 2;
 
             var fat = plt.AddArrow(20, .6, 20, 1);
-            fat.ArrowheadWidth *= 2; ;
+            fat.Color = System.Drawing.Color.Blue;
+            fat.ArrowheadLength = 2;
+            fat.ArrowheadWidth = 5;
+
+            // a marker can be drawn at the base of the arrow
+            var arrow3 = plt.AddArrow(30, -.58, 35, -.4);
+            arrow3.MarkerSize = 15;
         }
     }
 }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/VectorField.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/VectorField.cs
@@ -138,9 +138,9 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                           y: Math.Sin(yPositions[y]));
 
             var vf = plt.AddVectorField(vectors, xPositions, yPositions);
-            vf.ArrowStyle.ScaledArrowheads = true;
-            vf.ArrowStyle.Anchor = ArrowAnchor.Base;
-            vf.ArrowStyle.MarkerSize = 3;
+            vf.ScaledArrowheads = true;
+            vf.Anchor = ArrowAnchor.Base;
+            vf.MarkerSize = 3;
         }
     }
 }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/VectorField.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/VectorField.cs
@@ -117,13 +117,13 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             plt.AddVectorField(vectors, xs, ys, scaleFactor: 0.3);
         }
     }
+
     public class FancyVectorField : IRecipe
     {
         public string Category => "Plottable: Vector Field";
         public string ID => "vectorField_fancytips";
         public string Title => "Scaled Arrowheads";
         public string Description => "Use a slower drawing method that draws tips that are proportional to the length of the arrows.";
-
 
         public void ExecuteRecipe(Plot plt)
         {
@@ -138,9 +138,9 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                           y: Math.Sin(yPositions[y]));
 
             var vf = plt.AddVectorField(vectors, xPositions, yPositions);
-            vf.ScaledArrowheads = true;
-            vf.Anchor = ScottPlot.Plottable.VectorField.VectorAnchor.Base;
-            vf.MarkerSize = 3;
+            vf.ArrowStyle.ScaledArrowheads = true;
+            vf.ArrowStyle.Anchor = ArrowAnchor.Base;
+            vf.ArrowStyle.MarkerSize = 3;
         }
     }
 }

--- a/src/tests/PlotTypes/Arrow.cs
+++ b/src/tests/PlotTypes/Arrow.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlotTests.PlotTypes
+{
+    class Arrow
+    {
+        [Test]
+        public void Test_Arrow_Render()
+        {
+            var plt = new ScottPlot.Plot(400, 300);
+            var arrow1 = plt.AddArrow(1, 2, 3, 4);
+            var arrow2 = plt.AddArrow(1 + 2, 2, 3 + 2, 4);
+            arrow2.MinimumLengthPixels = 100;
+            plt.SetAxisLimits(-10, 10, -10, 10);
+            TestTools.SaveFig(plt);
+        }
+    }
+}

--- a/src/tests/PlottableRenderTests/Scatter.cs
+++ b/src/tests/PlottableRenderTests/Scatter.cs
@@ -267,35 +267,6 @@ namespace ScottPlotTests.PlottableRenderTests
         }
 
         [Test]
-        public void Test_Scatter_Arrow()
-        {
-            var plt = new ScottPlot.Plot();
-
-            // start with default settings
-            double[] xs = { 1, 2, 3, 4 };
-            double[] ys = { 1, 4, 9, 16 };
-            var splt = new ScatterPlot(xs, ys) { };
-
-            plt.Add(splt);
-            var bmp1 = TestTools.GetLowQualityBitmap(plt);
-
-            // change the plottable
-            splt.ArrowheadLength = 5;
-            splt.ArrowheadWidth = 5;
-            var bmp2 = TestTools.GetLowQualityBitmap(plt);
-
-            // measure what changed
-            //TestTools.SaveFig(bmp1, "1");
-            //TestTools.SaveFig(bmp2, "2");
-            var before = new MeanPixel(bmp1);
-            var after = new MeanPixel(bmp2);
-            Console.WriteLine($"Before: {before}");
-            Console.WriteLine($"After: {after}");
-
-            Assert.That(after.IsDarkerThan(before));
-        }
-
-        [Test]
         public void Test_Scatter_Color()
         {
             var plt = new ScottPlot.Plot();


### PR DESCRIPTION
* abstracts styling/rendering of arrows in the VectorField plot type
* creates `ScottPlot.Coordinate` and `ScottPlot.Pixel` types
* creates a new `ArrowCoordinated` plot type
* deprecates arrow functionality from scatter plots

This PR resolves #1228 and #1241