### PR TITLE
Radar: ShowCategoryLabels

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -2,6 +2,7 @@
 
 ## ScottPlot 4.1.21
 * Legend: Throw an exception if `RenderLegend()` is called on a plot with no labeled plottables (#1257)
+* Radar: Improved support for category labels. (#1261, #1262) _Thanks @Rayffer_
 
 ## ScottPlot 4.1.20
 * Ticks: Fixed bug where corner labels would not render when multiplier or offset notation is in use (#1252, #1253) _Thanks @@DavidBergstromSWE_

--- a/src/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot/Plottable/RadarPlot.cs
@@ -76,6 +76,11 @@ namespace ScottPlot.Plottable
         public bool ShowAxisValues { get; set; } = true;
 
         /// <summary>
+        /// If true, each category name will be written in text at every corner of the radar
+        /// </summary>
+        public bool ShowCategoryLabels { get; set; } = true;
+
+        /// <summary>
         /// Controls rendering style of the concentric circles (ticks) of the web
         /// </summary>
         public RadarAxis AxisType { get; set; } = RadarAxis.Circle;
@@ -273,7 +278,7 @@ namespace ScottPlot.Plottable
                 NumberOfSpokes = Norm.GetLength(1),
                 AxisType = AxisType,
                 WebColor = WebColor,
-                ShowCategoryLabels = IndependentAxes,
+                ShowCategoryLabels = ShowCategoryLabels,
                 LabelEachSpoke = IndependentAxes,
                 ShowAxisValues = ShowAxisValues,
                 Graphics = gfx


### PR DESCRIPTION
**Purpose:**
This pull request intends to give RadarPlot users the option to show category labels instead of it being shown when IndependentAxes property is set to true. Solves #1261

**New Functionality:**
There is no new functionality apart from giving the RadarPlot users direct control whether to show category labels or not.