### PR TITLE
Controls: Reduce render warnings and add Refresh() method

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.21
 * Legend: Throw an exception if `RenderLegend()` is called on a plot with no labeled plottables (#1257)
 * Radar: Improved support for category labels. (#1261, #1262) _Thanks @Rayffer_
+* Controls: Now have a `Refresh()` method as an alias of `Render()` for manually redrawing the plot and updating the image on the screen. Using `Render()` in user controls is more similar to similar plotting libraries and less likely to be confused with `Plot.Render()` in documentation and warning messages. (#1264, #1270, #1263, #1245, #1165)
 
 ## ScottPlot 4.1.20
 * Ticks: Fixed bug where corner labels would not render when multiplier or offset notation is in use (#1252, #1253) _Thanks @@DavidBergstromSWE_

--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -4,6 +4,7 @@
 * Legend: Throw an exception if `RenderLegend()` is called on a plot with no labeled plottables (#1257)
 * Radar: Improved support for category labels. (#1261, #1262) _Thanks @Rayffer_
 * Controls: Now have a `Refresh()` method as an alias of `Render()` for manually redrawing the plot and updating the image on the screen. Using `Render()` in user controls is more similar to similar plotting libraries and less likely to be confused with `Plot.Render()` in documentation and warning messages. (#1264, #1270, #1263, #1245, #1165)
+* Controls: Decreased visibility of the render warning (introduced in ScottPlot 4.1.19) by allowing it only to appear when the debugger is attached (#1165, #1264)
 * Radial Gaugue Plot: Fixed divide-by-zero bug affecting normalized gauges (#1272) _Thanks @arthurits_
 
 ## ScottPlot 4.1.20

--- a/src/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot/Control/Backend.cs
@@ -355,7 +355,10 @@ namespace ScottPlot.Control
             RenderCount += 1;
             PlottablesIdentifierAtLastRender = Settings.PlottablesIdentifier;
 
-            if (WasManuallyRendered == false && Settings.Plottables.Count > 0 && Configuration.WarnIfRenderNotCalledManually)
+            if (WasManuallyRendered == false &&
+                Settings.Plottables.Count > 0 &&
+                Configuration.WarnIfRenderNotCalledManually &&
+                Debugger.IsAttached)
             {
                 string message = $"ScottPlot {Plot.Version} WARNING:\n" +
                     $"{ControlName}.Refresh() must be called\n" +

--- a/src/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot/Control/Backend.cs
@@ -355,7 +355,7 @@ namespace ScottPlot.Control
             RenderCount += 1;
             PlottablesIdentifierAtLastRender = Settings.PlottablesIdentifier;
 
-            if (WasManuallyRendered == false && Configuration.WarnIfRenderNotCalledManually)
+            if (WasManuallyRendered == false && Settings.Plottables.Count > 0 && Configuration.WarnIfRenderNotCalledManually)
             {
                 string message = $"ScottPlot {Plot.Version} WARNING:\n" +
                     $"{ControlName}.Render() must be called at least once\n" +

--- a/src/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot/Control/Backend.cs
@@ -358,9 +358,9 @@ namespace ScottPlot.Control
             if (WasManuallyRendered == false && Settings.Plottables.Count > 0 && Configuration.WarnIfRenderNotCalledManually)
             {
                 string message = $"ScottPlot {Plot.Version} WARNING:\n" +
-                    $"{ControlName}.Render() must be called at least once\n" +
-                    $"after adding or removing plottable objects.";
-                Debug.WriteLine(message);
+                    $"{ControlName}.Refresh() must be called\n" +
+                    $"after modifying the plot or its data.";
+                Debug.WriteLine(message.Replace("\n", " "));
                 AddErrorMessage(Bmp, message);
             }
 

--- a/src/ScottPlot/Control/Configuration.cs
+++ b/src/ScottPlot/Control/Configuration.cs
@@ -136,6 +136,6 @@ namespace ScottPlot.Control
         /// Now that the timer-based auto-render functionality has been removed users must manually call Render() at least once.
         /// This option controls whether a warning message is shown if the user did not call Render() manually.
         /// </summary>
-        public bool WarnIfRenderNotCalledManually = true;
+        public bool WarnIfRenderNotCalledManually { get; set; } = true;
     }
 }

--- a/src/controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
+++ b/src/controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
@@ -107,10 +107,10 @@ namespace ScottPlot.Avalonia
             Backend.RenderRequest(renderType);
         }
 
-        [Obsolete("This method is deprecated. Call Refresh() instead.")]
+        // TODO: mark this obsolete in ScottPlot 5.0 (favor Refresh)
         public void Render(bool lowQuality = false) => Refresh(lowQuality);
 
-        [Obsolete("This method is deprecated. Call RefreshRequest() instead.")]
+        // TODO: mark this obsolete in ScottPlot 5.0 (favor Refresh)
         public void RenderRequest(RenderType renderType = RenderType.LowQualityThenHighQualityDelayed) => RefreshRequest(renderType);
 
         private Task SetImagePlot(Func<Ava.Media.Imaging.Bitmap> getBmp)

--- a/src/controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
+++ b/src/controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
@@ -96,16 +96,22 @@ namespace ScottPlot.Avalonia
         public (float x, float y) GetMousePixel() => Backend.GetMousePixel();
         public void Reset() => Backend.Reset((float)this.Bounds.Width, (float)this.Bounds.Height);
         public void Reset(Plot newPlot) => Backend.Reset((float)this.Bounds.Width, (float)this.Bounds.Height, newPlot);
-        public void Render(bool lowQuality = false)
+        public void Refresh(bool lowQuality = false)
         {
             Backend.WasManuallyRendered = true;
             Backend.Render(lowQuality);
         }
-        public void RenderRequest(RenderType renderType = RenderType.LowQualityThenHighQualityDelayed)
+        public void RefreshRequest(RenderType renderType = RenderType.LowQualityThenHighQualityDelayed)
         {
             Backend.WasManuallyRendered = true;
             Backend.RenderRequest(renderType);
         }
+
+        [Obsolete("This method is deprecated. Call Refresh() instead.")]
+        public void Render(bool lowQuality = false) => Refresh(lowQuality);
+
+        [Obsolete("This method is deprecated. Call RefreshRequest() instead.")]
+        public void RenderRequest(RenderType renderType = RenderType.LowQualityThenHighQualityDelayed) => RefreshRequest(renderType);
 
         private Task SetImagePlot(Func<Ava.Media.Imaging.Bitmap> getBmp)
         {
@@ -242,7 +248,7 @@ namespace ScottPlot.Avalonia
         public void DefaultRightClickEvent(object sender, EventArgs e) => GetDefaultContextMenu().Open(this);
         private void RightClickMenu_Copy_Click(object sender, EventArgs e) => throw new NotImplementedException();
         private void RightClickMenu_Help_Click(object sender, EventArgs e) => new HelpWindow().Show();
-        private void RightClickMenu_AutoAxis_Click(object sender, EventArgs e) { Plot.AxisAuto(); Render(); }
+        private void RightClickMenu_AutoAxis_Click(object sender, EventArgs e) { Plot.AxisAuto(); Refresh(); }
         private async void RightClickMenu_SaveImage_Click(object sender, EventArgs e)
         {
             SaveFileDialog savefile = new SaveFileDialog { InitialFileName = "ScottPlot.png" };
@@ -289,7 +295,7 @@ namespace ScottPlot.Avalonia
             if (e.Property.Name == "Bounds")
             {
                 Backend.Resize((float)Bounds.Width, (float)Bounds.Height, useDelayedRendering: true);
-                Render();
+                Refresh();
             }
         }
     }

--- a/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
+++ b/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
@@ -143,21 +143,27 @@ namespace ScottPlot
         /// Re-render the plot and update the image displayed by this control.
         /// </summary>
         /// <param name="lowQuality">disable anti-aliasing to produce faster (but lower quality) plots</param>
-        public void Render(bool lowQuality = false)
+        public void Refresh(bool lowQuality = false)
         {
             Backend.WasManuallyRendered = true;
             Backend.Render(lowQuality);
         }
 
+        [Obsolete("This method is deprecated. Call Refresh() instead.")]
+        public void Render(bool lowQuality = false) => Refresh(lowQuality);
+
         /// <summary>
-        /// Request the control re-render the next time it is available.
+        /// Request the control to refresh the next time it is available.
         /// This method does not block the calling thread.
         /// </summary>
-        public void RenderRequest(RenderType renderType = RenderType.LowQualityThenHighQualityDelayed)
+        public void RefreshRequest(RenderType renderType = RenderType.LowQualityThenHighQualityDelayed)
         {
             Backend.WasManuallyRendered = true;
             Backend.RenderRequest(renderType);
         }
+
+        [Obsolete("This method is deprecated. Call RefreshRequest() instead.")]
+        public void RenderRequest(RenderType renderType = RenderType.LowQualityThenHighQualityDelayed) => RefreshRequest(renderType);
 
         private void OnBitmapChanged(object sender, EventArgs e) => PlotImage.Source = BmpImageFromBmp(Backend.GetLatestBitmap());
         private void OnBitmapUpdated(object sender, EventArgs e) => PlotImage.Source = BmpImageFromBmp(Backend.GetLatestBitmap());
@@ -239,7 +245,7 @@ namespace ScottPlot
         private void RightClickMenu_Copy_Click(object sender, EventArgs e) => System.Windows.Clipboard.SetImage(BmpImageFromBmp(Backend.GetLatestBitmap()));
         private void RightClickMenu_Help_Click(object sender, EventArgs e) => new WPF.HelpWindow().Show();
         private void RightClickMenu_OpenInNewWindow_Click(object sender, EventArgs e) => new WpfPlotViewer(Plot).Show();
-        private void RightClickMenu_AutoAxis_Click(object sender, EventArgs e) { Plot.AxisAuto(); Render(); }
+        private void RightClickMenu_AutoAxis_Click(object sender, EventArgs e) { Plot.AxisAuto(); Refresh(); }
         private void RightClickMenu_SaveImage_Click(object sender, EventArgs e)
         {
             var sfd = new SaveFileDialog

--- a/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
+++ b/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
@@ -83,7 +83,7 @@ namespace ScottPlot
             {
                 try
                 {
-                    Backend.WasManuallyRendered = true;
+                    Configuration.WarnIfRenderNotCalledManually = false;
                     Plot.Title($"ScottPlot {Plot.Version}");
                     Plot.Render();
                 }

--- a/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
+++ b/src/controls/ScottPlot.WPF/WpfPlot.xaml.cs
@@ -149,7 +149,11 @@ namespace ScottPlot
             Backend.Render(lowQuality);
         }
 
-        [Obsolete("This method is deprecated. Call Refresh() instead.")]
+        // TODO: mark this obsolete in ScottPlot 5.0 (favor Refresh)
+        /// <summary>
+        /// Re-render the plot and update the image displayed by this control.
+        /// </summary>
+        /// <param name="lowQuality">disable anti-aliasing to produce faster (but lower quality) plots</param>
         public void Render(bool lowQuality = false) => Refresh(lowQuality);
 
         /// <summary>
@@ -162,7 +166,11 @@ namespace ScottPlot
             Backend.RenderRequest(renderType);
         }
 
-        [Obsolete("This method is deprecated. Call RefreshRequest() instead.")]
+        // TODO: mark this obsolete in ScottPlot 5.0 (favor Refresh)
+        /// <summary>
+        /// Request the control to refresh the next time it is available.
+        /// This method does not block the calling thread.
+        /// </summary>
         public void RenderRequest(RenderType renderType = RenderType.LowQualityThenHighQualityDelayed) => RefreshRequest(renderType);
 
         private void OnBitmapChanged(object sender, EventArgs e) => PlotImage.Source = BmpImageFromBmp(Backend.GetLatestBitmap());

--- a/src/controls/ScottPlot.WPF/WpfPlotViewer.xaml.cs
+++ b/src/controls/ScottPlot.WPF/WpfPlotViewer.xaml.cs
@@ -26,7 +26,7 @@ namespace ScottPlot
             Title = windowTitle;
 
             wpfPlot1.Reset(plot);
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
     }
 }

--- a/src/controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/controls/ScottPlot.WinForms/FormsPlot.cs
@@ -147,7 +147,12 @@ namespace ScottPlot
             Backend.Render(lowQuality, skipIfCurrentlyRendering);
         }
 
-        [Obsolete("This method is deprecated. Call Refresh() instead.")]
+        // TODO: mark this obsolete in ScottPlot 5.0 (favor Refresh)
+        /// <summary>
+        /// Re-render the plot and update the image displayed by this control.
+        /// </summary>
+        /// <param name="lowQuality">disable anti-aliasing to produce faster (but lower quality) plots</param>
+        /// <param name="skipIfCurrentlyRendering"></param>
         public void Render(bool lowQuality = false, bool skipIfCurrentlyRendering = false)
             => Refresh(lowQuality, skipIfCurrentlyRendering);
 
@@ -161,7 +166,11 @@ namespace ScottPlot
             Backend.RenderRequest(renderType);
         }
 
-        [Obsolete("This method is deprecated. Call RefreshRequest() instead.")]
+        // TODO: mark this obsolete in ScottPlot 5.0 (favor Refresh)
+        /// <summary>
+        /// Request the control to refresh the next time it is available.
+        /// This method does not block the calling thread.
+        /// </summary>
         public void RenderRequest(RenderType renderType = RenderType.LowQualityThenHighQualityDelayed) =>
             RefreshRequest(renderType);
 

--- a/src/controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/controls/ScottPlot.WinForms/FormsPlot.cs
@@ -12,7 +12,7 @@ namespace ScottPlot
     {
         /// <summary>
         /// This is the plot displayed by the user control.
-        /// After modifying it you may need to call Render() to request the plot be redrawn on the screen.
+        /// After modifying it you may need to call Refresh() to request the plot be redrawn on the screen.
         /// </summary>
         public Plot Plot => Backend.Plot;
 
@@ -140,22 +140,30 @@ namespace ScottPlot
         /// </summary>
         /// <param name="lowQuality">disable anti-aliasing to produce faster (but lower quality) plots</param>
         /// <param name="skipIfCurrentlyRendering"></param>
-        public void Render(bool lowQuality = false, bool skipIfCurrentlyRendering = false)
+        public void Refresh(bool lowQuality = false, bool skipIfCurrentlyRendering = false)
         {
             Application.DoEvents();
             Backend.WasManuallyRendered = true;
             Backend.Render(lowQuality, skipIfCurrentlyRendering);
         }
 
+        [Obsolete("This method is deprecated. Call Refresh() instead.")]
+        public void Render(bool lowQuality = false, bool skipIfCurrentlyRendering = false)
+            => Refresh(lowQuality, skipIfCurrentlyRendering);
+
         /// <summary>
-        /// Request the control re-render the next time it is available.
+        /// Request the control to refresh the next time it is available.
         /// This method does not block the calling thread.
         /// </summary>
-        public void RenderRequest(RenderType renderType = RenderType.LowQualityThenHighQualityDelayed)
+        public void RefreshRequest(RenderType renderType = RenderType.LowQualityThenHighQualityDelayed)
         {
             Backend.WasManuallyRendered = true;
             Backend.RenderRequest(renderType);
         }
+
+        [Obsolete("This method is deprecated. Call RefreshRequest() instead.")]
+        public void RenderRequest(RenderType renderType = RenderType.LowQualityThenHighQualityDelayed) =>
+            RefreshRequest(renderType);
 
         private void FormsPlot_Load(object sender, EventArgs e) { OnSizeChanged(null, null); }
         private void OnBitmapUpdated(object sender, EventArgs e) { Application.DoEvents(); pictureBox1.Invalidate(); }
@@ -195,7 +203,7 @@ namespace ScottPlot
         public void DefaultRightClickEvent(object sender, EventArgs e) => DefaultRightClickMenu.Show(System.Windows.Forms.Cursor.Position);
         private void RightClickMenu_Copy_Click(object sender, EventArgs e) => Clipboard.SetImage(Plot.Render());
         private void RightClickMenu_Help_Click(object sender, EventArgs e) => new FormHelp().Show();
-        private void RightClickMenu_AutoAxis_Click(object sender, EventArgs e) { Plot.AxisAuto(); Render(); }
+        private void RightClickMenu_AutoAxis_Click(object sender, EventArgs e) { Plot.AxisAuto(); Refresh(); }
         private void RightClickMenu_OpenInNewWindow_Click(object sender, EventArgs e) => new FormsPlotViewer(Plot).Show();
         private void RightClickMenu_SaveImage_Click(object sender, EventArgs e)
         {

--- a/src/controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/controls/ScottPlot.WinForms/FormsPlot.cs
@@ -74,7 +74,7 @@ namespace ScottPlot
             {
                 try
                 {
-                    Backend.WasManuallyRendered = true;
+                    Configuration.WarnIfRenderNotCalledManually = false;
                     Plot.Title($"ScottPlot {Plot.Version}");
                     Plot.Render();
                 }

--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/AvaloniaConfig.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/AvaloniaConfig.axaml.cs
@@ -24,7 +24,7 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
 
             avaPlot1.Plot.AddScatter(dataXs, dataSin);
             avaPlot1.Plot.AddScatter(dataXs, dataCos);
-            avaPlot1.Render();
+            avaPlot1.Refresh();
 
         }
 
@@ -43,10 +43,10 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
         private void VerticalUnlock(object sender, RoutedEventArgs e) { if (avaPlot1 is null) return; avaPlot1.Configuration.LockVerticalAxis = false; }
         private void HorizontalLock(object sender, RoutedEventArgs e) { if (avaPlot1 is null) return; avaPlot1.Configuration.LockHorizontalAxis = true; }
         private void HorizontalUnlock(object sender, RoutedEventArgs e) { if (avaPlot1 is null) return; avaPlot1.Configuration.LockHorizontalAxis = false; }
-        private void EqualAxisLock(object sender, RoutedEventArgs e) { if (avaPlot1 is null) return; avaPlot1.Plot.AxisScaleLock(true); avaPlot1.Render(); }
+        private void EqualAxisLock(object sender, RoutedEventArgs e) { if (avaPlot1 is null) return; avaPlot1.Plot.AxisScaleLock(true); avaPlot1.Refresh(); }
         private void EqualAxisUnlock(object sender, RoutedEventArgs e) { if (avaPlot1 is null) return; avaPlot1.Plot.AxisScaleLock(false); }
-        private void DoubleClickBenchmarkEnable(object sender, RoutedEventArgs e) { if (avaPlot1 is null) return; avaPlot1.Configuration.DoubleClickBenchmark = true; avaPlot1.Render(); }
-        private void DoubleClickBenchmarkDisable(object sender, RoutedEventArgs e) { if (avaPlot1 is null) return; avaPlot1.Configuration.DoubleClickBenchmark = false; avaPlot1.Render(); }
+        private void DoubleClickBenchmarkEnable(object sender, RoutedEventArgs e) { if (avaPlot1 is null) return; avaPlot1.Configuration.DoubleClickBenchmark = true; avaPlot1.Refresh(); }
+        private void DoubleClickBenchmarkDisable(object sender, RoutedEventArgs e) { if (avaPlot1 is null) return; avaPlot1.Configuration.DoubleClickBenchmark = false; avaPlot1.Refresh(); }
 
         private void RightClickMenuEnable(object sender, RoutedEventArgs e)
         {

--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/AxisLimits.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/AxisLimits.axaml.cs
@@ -19,7 +19,7 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
             wpfPlot1.Plot.AddSignal(DataGen.Cos(51));
             wpfPlot1.Plot.AxisAuto();
             wpfPlot1.Plot.SetOuterViewLimits(0, 50, -1, 1);
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
 
         }
 

--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/Layout.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/Layout.axaml.cs
@@ -48,7 +48,7 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
             avaPlot1.Plot.Layout(left: 20, top: 50, bottom: 100, right: 20);
             //avaPlot1.Configure(recalculateLayoutOnMouseUp: false);
 
-            avaPlot1.Render();
+            avaPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/LinkedPlots.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/LinkedPlots.axaml.cs
@@ -26,10 +26,10 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
             AvaPlots = new AvaPlot[] { avaPlot1, avaPlot2 };
 
             avaPlot1.Plot.AddScatter(dataXs, dataSin);
-            avaPlot1.Render();
+            avaPlot1.Refresh();
 
             avaPlot2.Plot.AddScatter(dataXs, dataCos);
-            avaPlot2.Render();
+            avaPlot2.Refresh();
         }
 
         private void InitializeComponent()
@@ -50,7 +50,7 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
                 // disable this briefly to avoid infinite loop
                 ap.Configuration.AxesChangedEventEnabled = false;
                 ap.Plot.SetAxisLimits(newAxisLimits);
-                ap.Render();
+                ap.Refresh();
                 ap.Configuration.AxesChangedEventEnabled = true;
             }
         }

--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/LiveDataFixed.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/LiveDataFixed.axaml.cs
@@ -68,7 +68,7 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
 
         void Render(object sender, EventArgs e)
         {
-            avaPlot1.Render();
+            avaPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/LiveDataGrowing.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/LiveDataGrowing.axaml.cs
@@ -90,7 +90,7 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
         {
             if (AutoAxisCheckbox.IsChecked == true)
                 avaPlot1.Plot.AxisAuto();
-            avaPlot1.Render();
+            avaPlot1.Refresh();
         }
 
         private void DisableAutoAxis(object sender, RoutedEventArgs e)

--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/MouseTracker.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/MouseTracker.axaml.cs
@@ -22,7 +22,7 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
 
             avaPlot1.Plot.AddSignal(DataGen.RandomWalk(null, 100));
             Crosshair = avaPlot1.Plot.AddCrosshair(0, 0);
-            avaPlot1.Render();
+            avaPlot1.Refresh();
 
             avaPlot1.PointerMoved += OnMouseMove;
             avaPlot1.PointerLeave += OnMouseLeave;
@@ -50,7 +50,7 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
             Crosshair.X = coordinateX;
             Crosshair.Y = coordinateY;
 
-            avaPlot1.Render();
+            avaPlot1.Refresh();
         }
 
         private void OnMouseEnter(object sender, PointerEventArgs e)
@@ -69,7 +69,7 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
             this.Find<TextBlock>("YCoordinateLabel").Text = "--";
 
             Crosshair.IsVisible = false;
-            avaPlot1.Render();
+            avaPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/MultiAxisLock.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/MultiAxisLock.axaml.cs
@@ -54,7 +54,6 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
     {
         private readonly ScottPlot.Renderable.Axis YAxis3;
         private readonly AvaPlot avaPlot1;
-        private bool initialized = false;
         private readonly MultiAxisLockViewModel viewModel;
 
         public MultiAxisLock()
@@ -108,10 +107,10 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
             avaPlot1.Plot.AxisAuto();
             CheckChanged();
         }
+
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-            initialized = true;
         }
 
         private void CheckChanged()

--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/PlotInScrollViewer.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/PlotInScrollViewer.axaml.cs
@@ -24,7 +24,7 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
 
                 //avaPlot.Configure(enableScrollWheelZoom: false, enableRightClickMenu: false);
 
-                avaPlot.Render();
+                avaPlot.Refresh();
             }
 
         }

--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/RightClickMenu.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/RightClickMenu.axaml.cs
@@ -28,7 +28,7 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
 
             avaPlot1.Plot.AddSignal(DataGen.Sin(51));
             avaPlot1.Plot.AddSignal(DataGen.Cos(51));
-            avaPlot1.Render();
+            avaPlot1.Refresh();
 
             List<ContextMenuItem> contextMenu = new List<ContextMenuItem>
             {
@@ -58,14 +58,14 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
             Random rand = new Random();
             avaPlot1.Plot.AddSignal(DataGen.Sin(51, phase: rand.NextDouble() * 1000));
             avaPlot1.Plot.AxisAuto();
-            avaPlot1.Render();
+            avaPlot1.Refresh();
         }
 
         private void ClearPlot()
         {
             avaPlot1.Plot.Clear();
             avaPlot1.Plot.AxisAuto();
-            avaPlot1.Render();
+            avaPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/ShowValueOnHover.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/ShowValueOnHover.axaml.cs
@@ -61,7 +61,7 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
             if (LastHighlightedIndex != pointIndex)
             {
                 LastHighlightedIndex = pointIndex;
-                avaPlot1.Render();
+                avaPlot1.Refresh();
             }
 
             // update the GUI to describe the highlighted point

--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/ToggleVisibility.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/ToggleVisibility.axaml.cs
@@ -30,7 +30,7 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
             vline1 = avaPlot1.Plot.AddVerticalLine(0);
             vline2 = avaPlot1.Plot.AddVerticalLine(50);
 
-            avaPlot1.Render();
+            avaPlot1.Refresh();
 
             this.Find<CheckBox>("sineCheckbox").Checked += SinShow;
             this.Find<CheckBox>("sineCheckbox").Unchecked += SinHide;
@@ -51,28 +51,28 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
         {
             if (avaPlot1 is null) return;
             sinPlot.IsVisible = false;
-            avaPlot1.Render();
+            avaPlot1.Refresh();
         }
 
         private void SinShow(object sender, RoutedEventArgs e)
         {
             if (avaPlot1 is null) return;
             sinPlot.IsVisible = true;
-            avaPlot1.Render();
+            avaPlot1.Refresh();
         }
 
         private void CosShow(object sender, RoutedEventArgs e)
         {
             if (avaPlot1 is null) return;
             cosPlot.IsVisible = true;
-            avaPlot1.Render();
+            avaPlot1.Refresh();
         }
 
         private void CosHide(object sender, RoutedEventArgs e)
         {
             if (avaPlot1 is null) return;
             cosPlot.IsVisible = false;
-            avaPlot1.Render();
+            avaPlot1.Refresh();
         }
 
         private void LinesShow(object sender, RoutedEventArgs e)
@@ -80,7 +80,7 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
             if (avaPlot1 is null) return;
             vline1.IsVisible = true;
             vline2.IsVisible = true;
-            avaPlot1.Render();
+            avaPlot1.Refresh();
         }
 
         private void LinesHide(object sender, RoutedEventArgs e)
@@ -88,7 +88,7 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
             if (avaPlot1 is null) return;
             vline1.IsVisible = false;
             vline2.IsVisible = false;
-            avaPlot1.Render();
+            avaPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/TransparentBackground.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/TransparentBackground.axaml.cs
@@ -26,7 +26,7 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
 
             avaPlot1.Plot.Style(figureBackground: System.Drawing.Color.Transparent);
             avaPlot1.Plot.Style(dataBackground: System.Drawing.Color.Transparent);
-            avaPlot1.Render();
+            avaPlot1.Refresh();
         }
 
         private void InitializeComponent()

--- a/src/demo/ScottPlot.Demo.Avalonia/CookbookControl.axaml.cs
+++ b/src/demo/ScottPlot.Demo.Avalonia/CookbookControl.axaml.cs
@@ -60,7 +60,7 @@ namespace ScottPlot.Demo.Avalonia
             imagePlot1.IsVisible = false;
             avaPlot1.IsVisible = true;
             recipe.ExecuteRecipe(avaPlot1.Plot);
-            avaPlot1.Render();
+            avaPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.WPF/CookbookControl.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/CookbookControl.xaml.cs
@@ -36,7 +36,7 @@ namespace ScottPlot.Demo.WPF
 
             wpfPlot1.Reset();
             recipe.ExecuteRecipe(wpfPlot1.Plot);
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.WPF/WpfDemos/AxisLimits.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/WpfDemos/AxisLimits.xaml.cs
@@ -26,7 +26,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             wpfPlot1.Plot.AddSignal(DataGen.Cos(51));
             wpfPlot1.Plot.AxisAuto();
             wpfPlot1.Plot.SetOuterViewLimits(0, 50, -1, 1);
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.WPF/WpfDemos/Layout.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/WpfDemos/Layout.xaml.cs
@@ -44,7 +44,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             wpfPlot1.Plot.AxisAuto();
             wpfPlot1.Plot.Layout(left: 20, top: 50, bottom: 100, right: 20);
 
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.WPF/WpfDemos/LinkedPlots.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/WpfDemos/LinkedPlots.xaml.cs
@@ -29,8 +29,8 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             WpfPlots = new WpfPlot[] { wpfPlot1, wpfPlot2 };
 
             // perform an initial render
-            wpfPlot1.Render();
-            wpfPlot2.Render();
+            wpfPlot1.Refresh();
+            wpfPlot2.Refresh();
         }
 
         private void AxesChanged(object sender, EventArgs e)
@@ -46,7 +46,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
                 // disable events briefly to prevent an infinite loop
                 wp.Configuration.AxesChangedEventEnabled = false;
                 wp.Plot.SetAxisLimits(newAxisLimits);
-                wp.Render();
+                wp.Refresh();
                 wp.Configuration.AxesChangedEventEnabled = true;
             }
         }

--- a/src/demo/ScottPlot.Demo.WPF/WpfDemos/LiveDataFixed.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/WpfDemos/LiveDataFixed.xaml.cs
@@ -37,7 +37,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             wpfPlot1.Plot.AddSignal(liveData);
             wpfPlot1.Plot.AxisAutoX(margin: 0);
             wpfPlot1.Plot.SetAxisLimits(yMin: -1, yMax: 2.5);
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
 
             // create a traditional timer to update the data
             _updateDataTimer = new Timer(_ => UpdateData(), null, 0, 5);
@@ -67,7 +67,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
 
         void Render(object sender, EventArgs e)
         {
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.WPF/WpfDemos/LiveDataGrowing.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/WpfDemos/LiveDataGrowing.xaml.cs
@@ -35,7 +35,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             signalPlot = wpfPlot1.Plot.AddSignal(data);
             wpfPlot1.Plot.YLabel("Value");
             wpfPlot1.Plot.XLabel("Sample Number");
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
 
             // create a timer to modify the data
             _updateDataTimer = new DispatcherTimer();
@@ -82,7 +82,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
         {
             if (AutoAxisCheckbox.IsChecked == true)
                 wpfPlot1.Plot.AxisAuto();
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
 
         private void DisableAutoAxis(object sender, RoutedEventArgs e)

--- a/src/demo/ScottPlot.Demo.WPF/WpfDemos/ManyPlots.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/WpfDemos/ManyPlots.xaml.cs
@@ -24,7 +24,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             this.rowIndex = rowIndex;
             wpfPlot = new WpfPlot();
             wpfPlot.Reset(plt);
-            wpfPlot.Render();
+            wpfPlot.Refresh();
         }
     }
 

--- a/src/demo/ScottPlot.Demo.WPF/WpfDemos/MouseTracker.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/WpfDemos/MouseTracker.xaml.cs
@@ -25,7 +25,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             InitializeComponent();
             wpfPlot1.Plot.AddSignal(DataGen.RandomWalk(null, 100));
             Crosshair = wpfPlot1.Plot.AddCrosshair(0, 0);
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
 
         private void OnMouseMove(object sender, MouseEventArgs e)
@@ -44,7 +44,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             Crosshair.X = coordinateX;
             Crosshair.Y = coordinateY;
 
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
 
         private void wpfPlot1_MouseEnter(object sender, MouseEventArgs e)
@@ -62,7 +62,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             YCoordinateLabel.Content = "--";
 
             Crosshair.IsVisible = false;
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.WPF/WpfDemos/MultiAxisLock.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/WpfDemos/MultiAxisLock.xaml.cs
@@ -70,7 +70,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
 
             // adjust axis limits to fit the data once before locking them
             WpfPlot1.Plot.AxisAuto();
-            WpfPlot1.Render();
+            WpfPlot1.Refresh();
             CheckChanged(null, null);
         }
 

--- a/src/demo/ScottPlot.Demo.WPF/WpfDemos/PlotInScrollViewer.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/WpfDemos/PlotInScrollViewer.xaml.cs
@@ -31,9 +31,9 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             wpfPlot3.Plot.AddSignal(DataGen.RandomWalk(Rand, 50));
 
             // perform an initial render for each control
-            wpfPlot1.Render();
-            wpfPlot2.Render();
-            wpfPlot3.Render();
+            wpfPlot1.Refresh();
+            wpfPlot2.Refresh();
+            wpfPlot3.Refresh();
         }
 
         private void ScrollViewer_PreviewMouseWheel(object sender, MouseWheelEventArgs e)

--- a/src/demo/ScottPlot.Demo.WPF/WpfDemos/RightClickMenu.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/WpfDemos/RightClickMenu.xaml.cs
@@ -32,7 +32,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             wpfPlot1.RightClicked += DeployCustomMenu;
 
             // perform an initial render
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
 
         private void DeployCustomMenu(object sender, EventArgs e)

--- a/src/demo/ScottPlot.Demo.WPF/WpfDemos/ShowValueOnHover.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/WpfDemos/ShowValueOnHover.xaml.cs
@@ -41,7 +41,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             HighlightedPoint.IsVisible = false;
 
             // perform an initial render
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
 
         private void wpfPlot1_MouseMove(object sender, MouseEventArgs e)
@@ -60,7 +60,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             if (LastHighlightedIndex != pointIndex)
             {
                 LastHighlightedIndex = pointIndex;
-                wpfPlot1.Render();
+                wpfPlot1.Refresh();
             }
 
             // update the GUI to describe the highlighted point

--- a/src/demo/ScottPlot.Demo.WPF/WpfDemos/ToggleVisibility.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/WpfDemos/ToggleVisibility.xaml.cs
@@ -35,35 +35,35 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             vline1 = wpfPlot1.Plot.AddVerticalLine(0);
             vline2 = wpfPlot1.Plot.AddVerticalLine(50);
 
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
 
         private void SinHide(object sender, RoutedEventArgs e)
         {
             if (wpfPlot1 is null) return;
             sinPlot.IsVisible = false;
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
 
         private void SinShow(object sender, RoutedEventArgs e)
         {
             if (wpfPlot1 is null) return;
             sinPlot.IsVisible = true;
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
 
         private void CosShow(object sender, RoutedEventArgs e)
         {
             if (wpfPlot1 is null) return;
             cosPlot.IsVisible = true;
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
 
         private void CosHide(object sender, RoutedEventArgs e)
         {
             if (wpfPlot1 is null) return;
             cosPlot.IsVisible = false;
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
 
         private void LinesShow(object sender, RoutedEventArgs e)
@@ -71,7 +71,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             if (wpfPlot1 is null) return;
             vline1.IsVisible = true;
             vline2.IsVisible = true;
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
 
         private void LinesHide(object sender, RoutedEventArgs e)
@@ -79,7 +79,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             if (wpfPlot1 is null) return;
             vline1.IsVisible = false;
             vline2.IsVisible = false;
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.WPF/WpfDemos/TransparentBackground.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/WpfDemos/TransparentBackground.xaml.cs
@@ -32,7 +32,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
 
             wpfPlot1.Plot.Style(figureBackground: System.Drawing.Color.Transparent);
             wpfPlot1.Plot.Style(dataBackground: System.Drawing.Color.Transparent);
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.WPF/WpfDemos/WpfConfig.xaml.cs
+++ b/src/demo/ScottPlot.Demo.WPF/WpfDemos/WpfConfig.xaml.cs
@@ -22,7 +22,7 @@ namespace ScottPlot.Demo.WPF.WpfDemos
             InitializeComponent();
             wpfPlot1.Plot.AddSignal(DataGen.Sin(51));
             wpfPlot1.Plot.AddSignal(DataGen.Cos(51));
-            wpfPlot1.Render();
+            wpfPlot1.Refresh();
         }
 
         // TODO: use proper binding (perhaps with the configuration object itself?)
@@ -36,10 +36,10 @@ namespace ScottPlot.Demo.WPF.WpfDemos
         private void VerticalUnlock(object sender, RoutedEventArgs e) { if (wpfPlot1 is null) return; wpfPlot1.Configuration.LockVerticalAxis = false; }
         private void HorizontalLock(object sender, RoutedEventArgs e) { if (wpfPlot1 is null) return; wpfPlot1.Configuration.LockHorizontalAxis = true; }
         private void HorizontalUnlock(object sender, RoutedEventArgs e) { if (wpfPlot1 is null) return; wpfPlot1.Configuration.LockHorizontalAxis = false; }
-        private void EqualAxisLock(object sender, RoutedEventArgs e) { if (wpfPlot1 is null) return; wpfPlot1.Plot.AxisScaleLock(true); wpfPlot1.Render(); }
+        private void EqualAxisLock(object sender, RoutedEventArgs e) { if (wpfPlot1 is null) return; wpfPlot1.Plot.AxisScaleLock(true); wpfPlot1.Refresh(); }
         private void EqualAxisUnlock(object sender, RoutedEventArgs e) { if (wpfPlot1 is null) return; wpfPlot1.Plot.AxisScaleLock(false); }
-        private void DoubleClickBenchmarkEnable(object sender, RoutedEventArgs e) { if (wpfPlot1 is null) return; wpfPlot1.Configuration.DoubleClickBenchmark = true; wpfPlot1.Render(); }
-        private void DoubleClickBenchmarkDisable(object sender, RoutedEventArgs e) { if (wpfPlot1 is null) return; wpfPlot1.Configuration.DoubleClickBenchmark = false; wpfPlot1.Render(); }
+        private void DoubleClickBenchmarkEnable(object sender, RoutedEventArgs e) { if (wpfPlot1 is null) return; wpfPlot1.Configuration.DoubleClickBenchmark = true; wpfPlot1.Refresh(); }
+        private void DoubleClickBenchmarkDisable(object sender, RoutedEventArgs e) { if (wpfPlot1 is null) return; wpfPlot1.Configuration.DoubleClickBenchmark = false; wpfPlot1.Refresh(); }
 
         private void RightClickMenuEnable(object sender, RoutedEventArgs e)
         {

--- a/src/demo/ScottPlot.Demo.WinForms/FormCookbook.cs
+++ b/src/demo/ScottPlot.Demo.WinForms/FormCookbook.cs
@@ -59,7 +59,7 @@ namespace ScottPlot.Demo.WinForms
 
             formsPlot1.Reset();
             recipe.ExecuteRecipe(formsPlot1.Plot);
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/AxisLimits.cs
+++ b/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/AxisLimits.cs
@@ -19,7 +19,7 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
             formsPlot1.Plot.AddSignal(DataGen.Cos(51));
             formsPlot1.Plot.AxisAuto();
             formsPlot1.Plot.SetOuterViewLimits(0, 50, -1, 1);
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/FormsPlotConfig.cs
+++ b/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/FormsPlotConfig.cs
@@ -27,7 +27,7 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
             formsPlot1.Plot.AddScatter(dataXs, dataSin);
             formsPlot1.Plot.AddScatter(dataXs, dataCos);
 
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
 
         private void cbPannable_CheckedChanged(object sender, EventArgs e)
@@ -62,7 +62,7 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
         private void cbEqualAxes_CheckedChanged(object sender, EventArgs e)
         {
             formsPlot1.Plot.AxisScaleLock(cbEqualAxes.Checked);
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
 
         private void cbDoubleClickBenchmark_CheckedChanged(object sender, EventArgs e)

--- a/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/LinkedPlots.cs
+++ b/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/LinkedPlots.cs
@@ -35,7 +35,7 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
                 // disable events briefly to avoid an infinite loop
                 fp.Configuration.AxesChangedEventEnabled = false;
                 fp.Plot.SetAxisLimits(newAxisLimits);
-                fp.Render();
+                fp.Refresh();
                 fp.Configuration.AxesChangedEventEnabled = true;
             }
         }

--- a/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/LiveDataIncoming.cs
+++ b/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/LiveDataIncoming.cs
@@ -65,7 +65,7 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
         {
             if (cbAutoAxis.Checked)
                 formsPlot1.Plot.AxisAuto();
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
 
         private void cbAutoAxis_CheckedChanged(object sender, EventArgs e)

--- a/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/LiveDataUpdate.cs
+++ b/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/LiveDataUpdate.cs
@@ -70,7 +70,7 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
 
         private void timerRender_Tick(object sender, EventArgs e)
         {
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
 
         private void runCheckbox_CheckedChanged(object sender, EventArgs e)

--- a/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/MouseTracker.cs
+++ b/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/MouseTracker.cs
@@ -35,7 +35,7 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
             Crosshair.X = coordinateX;
             Crosshair.Y = coordinateY;
 
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
 
         private void formsPlot1_MouseEnter(object sender, EventArgs e)
@@ -54,7 +54,7 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
             YCoordinateLabel.Text = $"--";
 
             Crosshair.IsVisible = false;
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/RightClickMenu.cs
+++ b/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/RightClickMenu.cs
@@ -22,7 +22,7 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
 
             formsPlot1.Plot.AddSignal(DataGen.Sin(51));
             formsPlot1.Plot.AddSignal(DataGen.Cos(51));
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
 
         private void CustomRightClickEvent(object sender, EventArgs e)
@@ -39,14 +39,14 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
             double[] data = DataGen.Sin(51, phase: rand.NextDouble() * 1000);
             formsPlot1.Plot.AddSignal(data);
             formsPlot1.Plot.AxisAuto();
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
 
         private void ClearPlot(object sender, EventArgs e)
         {
             formsPlot1.Plot.Clear();
             formsPlot1.Plot.AxisAuto();
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/ShowValueOnHover2.cs
+++ b/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/ShowValueOnHover2.cs
@@ -46,7 +46,7 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
             if (LastHighlightedIndex != pointIndex)
             {
                 LastHighlightedIndex = pointIndex;
-                formsPlot1.Render();
+                formsPlot1.Refresh();
             }
 
             // update the GUI to describe the highlighted point

--- a/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/ToggleVisibility.cs
+++ b/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/ToggleVisibility.cs
@@ -33,26 +33,26 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
             vline1 = formsPlot1.Plot.AddVerticalLine(0);
             vline2 = formsPlot1.Plot.AddVerticalLine(50);
 
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
 
         private void cbSin_CheckedChanged(object sender, EventArgs e)
         {
             sinPlot.IsVisible = cbSin.Checked;
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
 
         private void cbCos_CheckedChanged(object sender, EventArgs e)
         {
             cosPlot.IsVisible = cbCos.Checked;
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
 
         private void cbLines_CheckedChanged(object sender, EventArgs e)
         {
             vline1.IsVisible = cbLines.Checked;
             vline2.IsVisible = cbLines.Checked;
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
     }
 }

--- a/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/TransparentBackground.cs
+++ b/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/TransparentBackground.cs
@@ -72,14 +72,14 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
             }
 
             BackgroundImage = bmp;
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
 
         private void SetBackground(Color bgcolor)
         {
             BackgroundImage = null;
             BackColor = bgcolor;
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
     }
 }

--- a/src/sandbox/WinFormsApp/Form1.cs
+++ b/src/sandbox/WinFormsApp/Form1.cs
@@ -21,7 +21,7 @@ namespace WinFormsApp
             double[] xs = ScottPlot.DataGen.Random(rand, pointCount);
             double[] ys = ScottPlot.DataGen.Random(rand, pointCount);
             formsPlot1.Plot.AddScatter(xs, ys);
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
     }
 }

--- a/src/sandbox/WinFormsFrameworkApp/Form1.cs
+++ b/src/sandbox/WinFormsFrameworkApp/Form1.cs
@@ -16,7 +16,7 @@ namespace WinFormsFrameworkApp
             formsPlot1.Plot.AddLine(-1e5, -1e10, 1e5, 1e10);
             formsPlot1.Plot.XAxis.TickLabelNotation(multiplier: true);
             formsPlot1.Plot.YAxis.TickLabelNotation(multiplier: true);
-            formsPlot1.Render();
+            formsPlot1.Refresh();
         }
     }
 }

--- a/src/sandbox/WpfApp/MainWindow.xaml.cs
+++ b/src/sandbox/WpfApp/MainWindow.xaml.cs
@@ -14,7 +14,7 @@ namespace WpfApp
 
             WpfPlot1.Plot.AddSignal(ScottPlot.DataGen.Sin(51));
             WpfPlot1.Plot.AddSignal(ScottPlot.DataGen.Cos(51));
-            WpfPlot1.Render();
+            WpfPlot1.Refresh();
         }
     }
 }


### PR DESCRIPTION
This PR adds a `Refresh()` method to ScottPlot controls as a recommended replacement for `Render()` to avoid confusion between the method with the same name in the `Plot` class. 

Related to #1263, #1245, and #1165. Resolves #1264.