### PR TITLE
RadialGaugue plot: division by zero

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -3,9 +3,10 @@
 ## ScottPlot 4.1.21
 * Legend: Throw an exception if `RenderLegend()` is called on a plot with no labeled plottables (#1257)
 * Radar: Improved support for category labels. (#1261, #1262) _Thanks @Rayffer_
+* Radial Gaugue Plot: Fixed divide-by-zero bug affecting normalized gauges (#1272) _Thanks @arthurits_
 
 ## ScottPlot 4.1.20
-* Ticks: Fixed bug where corner labels would not render when multiplier or offset notation is in use (#1252, #1253) _Thanks @@DavidBergstromSWE_
+* Ticks: Fixed bug where corner labels would not render when multiplier or offset notation is in use (#1252, #1253) _Thanks @DavidBergstromSWE_
 
 ## ScottPlot 4.1.19
 * Controls: Fixed bug where render warning message is not hidden if `RenderRequest()` is called (#1165) _Thanks @gigios_

--- a/src/ScottPlot/Plottable/RadialGaugePlot.cs
+++ b/src/ScottPlot/Plottable/RadialGaugePlot.cs
@@ -181,7 +181,10 @@ namespace ScottPlot.Plottable
             double angleSum = angleStart;
             for (int i = 0; i < gaugeCount; i++)
             {
-                double angleSwept = angleRange * values[i] / scaleRange;
+                double angleSwept = 0;
+                if (scaleRange > 0)
+                    angleSwept = angleRange * values[i] / scaleRange;
+
                 if (!clockwise)
                     angleSwept *= -1;
 


### PR DESCRIPTION
**Purpose:**
Avoid division by zero when computing rotational angles.

https://github.com/ScottPlot/ScottPlot/blob/83b3da7ad94779780c59eda9cc02d4552c4d931c/src/ScottPlot/Plottable/RadialGaugePlot.cs#L184

**New Functionality:**
Sometimes, the values fed to RadialGauge plot could be equal to 0. That would be the case when the user is plotting data from a sensor and, for some reason, no data is received (all values would be 0). In that case, division by zero must be avoided and a value of 0 degrees must be assigned to each gauge.

```cs
double angleSwept = 0;
if (scaleRange > 0)
    angleSwept = angleRange * values[i] / scaleRange;
```