### PR TITLE
refresh after loading plot viewer

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.22
 * Coxcomb Plots: Added support for image labels (#1265, #1275) _Thanks @Rayffer_
 * Palette: Added overloads for `GetColor()` and `GetColors()` to support transparency
+* Plot Viewer: fixed bug causing render warning to appear in WinForms and Avalonia plot viewers (#1265, #1238) _Thanks @bukkideme, @Nexus452, and @bclehmann_
 
 ## ScottPlot 4.1.21
 * Legend: Throw an exception if `RenderLegend()` is called on a plot with no labeled plottables (#1257)

--- a/src/controls/ScottPlot.Avalonia/AvaPlotViewer.axaml.cs
+++ b/src/controls/ScottPlot.Avalonia/AvaPlotViewer.axaml.cs
@@ -23,7 +23,7 @@ namespace ScottPlot.Avalonia
 
             plot.Resize(windowWidth, windowHeight);
             this.Find<AvaPlot>("avaPlot1").Reset(plot);
-            this.Find<AvaPlot>("avaPlot1").Refresh(plot);
+            this.Find<AvaPlot>("avaPlot1").Refresh();
         }
 
         private void InitializeComponent()

--- a/src/controls/ScottPlot.Avalonia/AvaPlotViewer.axaml.cs
+++ b/src/controls/ScottPlot.Avalonia/AvaPlotViewer.axaml.cs
@@ -23,6 +23,7 @@ namespace ScottPlot.Avalonia
 
             plot.Resize(windowWidth, windowHeight);
             this.Find<AvaPlot>("avaPlot1").Reset(plot);
+            this.Find<AvaPlot>("avaPlot1").Refresh(plot);
         }
 
         private void InitializeComponent()

--- a/src/controls/ScottPlot.WinForms/FormsPlotViewer.cs
+++ b/src/controls/ScottPlot.WinForms/FormsPlotViewer.cs
@@ -20,6 +20,7 @@ namespace ScottPlot
             Text = windowTitle;
 
             formsPlot1.Reset(plot);
+            formsPlot1.Refresh();
         }
     }
 }

--- a/src/sandbox/WinFormsFrameworkApp/Form1.Designer.cs
+++ b/src/sandbox/WinFormsFrameworkApp/Form1.Designer.cs
@@ -29,24 +29,25 @@ namespace WinFormsFrameworkApp
         /// </summary>
         private void InitializeComponent()
         {
-            this.formsPlot1 = new ScottPlot.FormsPlot();
+            this.button1 = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
-            // formsPlot1
+            // button1
             // 
-            this.formsPlot1.BackColor = System.Drawing.Color.Transparent;
-            this.formsPlot1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.formsPlot1.Location = new System.Drawing.Point(0, 0);
-            this.formsPlot1.Name = "formsPlot1";
-            this.formsPlot1.Size = new System.Drawing.Size(548, 303);
-            this.formsPlot1.TabIndex = 0;
+            this.button1.Location = new System.Drawing.Point(139, 78);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(75, 23);
+            this.button1.TabIndex = 0;
+            this.button1.Text = "button1";
+            this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += new System.EventHandler(this.button1_Click);
             // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(548, 303);
-            this.Controls.Add(this.formsPlot1);
+            this.Controls.Add(this.button1);
             this.Name = "Form1";
             this.Text = "ScottPlot Sandbox - WinForms (.NET Framework)";
             this.ResumeLayout(false);
@@ -55,7 +56,7 @@ namespace WinFormsFrameworkApp
 
         #endregion
 
-        private ScottPlot.FormsPlot formsPlot1;
+        private System.Windows.Forms.Button button1;
     }
 }
 

--- a/src/sandbox/WinFormsFrameworkApp/Form1.cs
+++ b/src/sandbox/WinFormsFrameworkApp/Form1.cs
@@ -1,6 +1,4 @@
-﻿using ScottPlot;
-using ScottPlot.Plottable;
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms;
@@ -12,11 +10,16 @@ namespace WinFormsFrameworkApp
         public Form1()
         {
             InitializeComponent();
+        }
 
-            formsPlot1.Plot.AddLine(-1e5, -1e10, 1e5, 1e10);
-            formsPlot1.Plot.XAxis.TickLabelNotation(multiplier: true);
-            formsPlot1.Plot.YAxis.TickLabelNotation(multiplier: true);
-            formsPlot1.Refresh();
+        private void button1_Click(object sender, EventArgs e)
+        {
+            Random rand = new Random();
+            var plt = new ScottPlot.Plot();
+            plt.AddSignal(ScottPlot.DataGen.RandomWalk(rand, 100));
+
+            var v = new ScottPlot.FormsPlotViewer(plt);
+            v.Show();
         }
     }
 }


### PR DESCRIPTION
Fixes bug caused by plot viewers not calling `Refresh()` after resetting the plot.

Interestingly the WpfPlot already made this call, so the fix affects only FormsPlot and AvaPlot.

Fixes #1283 and fixes #1264