### PR TITLE
Palette: Tsitsulin (25-colors)

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -8,6 +8,7 @@
   * `ColorblindFriendly` modeled after [Wong 2011](https://www.nature.com/articles/nmeth.1618.pdf) (#1312) _Thanks @arthurits_
   * `Dark` 8-color palette LCD and print friendly (#1313) _Thanks @arthurits_
   * `DarkPastel` 8-color palette of LCD and print-friendly colors (#1314) _Thanks @arthurits_
+  * `Tsitsulin` 25-color optimal qualitative palette ([described here](http://tsitsul.in/blog/coloropt)) by [Anton Tsitsulin](http://tsitsul.in) (#1318) _Thanks @arthurits_
 
 ## ScottPlot 4.1.23
 * NuGet: use deterministic builds, add source link support, and include compiler flags (#1285)

--- a/src/ScottPlot/Palette.cs
+++ b/src/ScottPlot/Palette.cs
@@ -24,7 +24,7 @@ namespace ScottPlot
         public static ScottPlot.Drawing.Palette OneHalfDark => new(new ScottPlot.Drawing.Colorsets.OneHalfDark());
         public static ScottPlot.Drawing.Palette PolarNight => new(new ScottPlot.Drawing.Colorsets.PolarNight());
         public static ScottPlot.Drawing.Palette SnowStorm => new(new ScottPlot.Drawing.Colorsets.Snowstorm());
-        public static ScottPlot.Drawing.Palette xgfs24 => new(new ScottPlot.Drawing.Colorsets.xgfs25());
+        public static ScottPlot.Drawing.Palette xgfs25 => new(new ScottPlot.Drawing.Colorsets.xgfs25());
 
         /// <summary>
         /// Create a new color palette from an array of HTML colors
@@ -63,7 +63,7 @@ namespace ScottPlot.Drawing
         public static Palette OneHalfDark => new(new Colorsets.OneHalfDark());
         public static Palette PolarNight => new(new Colorsets.PolarNight());
         public static Palette SnowStorm => new(new Colorsets.Snowstorm());
-        public static Palette xgfs24 => new(new Colorsets.xgfs25());
+        public static Palette xgfs25 => new(new Colorsets.xgfs25());
 
         private readonly IPalette cset;
         public readonly string Name;

--- a/src/ScottPlot/Palette.cs
+++ b/src/ScottPlot/Palette.cs
@@ -24,7 +24,7 @@ namespace ScottPlot
         public static ScottPlot.Drawing.Palette OneHalfDark => new(new ScottPlot.Drawing.Colorsets.OneHalfDark());
         public static ScottPlot.Drawing.Palette PolarNight => new(new ScottPlot.Drawing.Colorsets.PolarNight());
         public static ScottPlot.Drawing.Palette SnowStorm => new(new ScottPlot.Drawing.Colorsets.Snowstorm());
-        public static ScottPlot.Drawing.Palette xgfs25 => new(new ScottPlot.Drawing.Colorsets.xgfs25());
+        public static ScottPlot.Drawing.Palette xgfs25 => new(new ScottPlot.Drawing.Colorsets.Tsitsulin());
 
         /// <summary>
         /// Create a new color palette from an array of HTML colors
@@ -63,7 +63,7 @@ namespace ScottPlot.Drawing
         public static Palette OneHalfDark => new(new Colorsets.OneHalfDark());
         public static Palette PolarNight => new(new Colorsets.PolarNight());
         public static Palette SnowStorm => new(new Colorsets.Snowstorm());
-        public static Palette xgfs25 => new(new Colorsets.xgfs25());
+        public static Palette xgfs25 => new(new Colorsets.Tsitsulin());
 
         private readonly IPalette cset;
         public readonly string Name;

--- a/src/ScottPlot/Palette.cs
+++ b/src/ScottPlot/Palette.cs
@@ -24,6 +24,7 @@ namespace ScottPlot
         public static ScottPlot.Drawing.Palette OneHalfDark => new(new ScottPlot.Drawing.Colorsets.OneHalfDark());
         public static ScottPlot.Drawing.Palette PolarNight => new(new ScottPlot.Drawing.Colorsets.PolarNight());
         public static ScottPlot.Drawing.Palette SnowStorm => new(new ScottPlot.Drawing.Colorsets.Snowstorm());
+        public static ScottPlot.Drawing.Palette xgfs24 => new(new ScottPlot.Drawing.Colorsets.xgfs25());
 
         /// <summary>
         /// Create a new color palette from an array of HTML colors
@@ -62,6 +63,7 @@ namespace ScottPlot.Drawing
         public static Palette OneHalfDark => new(new Colorsets.OneHalfDark());
         public static Palette PolarNight => new(new Colorsets.PolarNight());
         public static Palette SnowStorm => new(new Colorsets.Snowstorm());
+        public static Palette xgfs24 => new(new Colorsets.xgfs25());
 
         private readonly IPalette cset;
         public readonly string Name;

--- a/src/ScottPlot/Palettes/Tsitsulin.cs
+++ b/src/ScottPlot/Palettes/Tsitsulin.cs
@@ -1,12 +1,10 @@
-﻿/* A 25-color pelette based on Anton Tsitsulin's 12-color palette discussed:
- * http://tsitsul.in/blog/coloropt/
- * At the time the license file was accessed (2021-09-03) in the github address:
+﻿/* A 25-color pelette based on Anton Tsitsulin's 12-color palette
+ * http://tsitsul.in/blog/coloropt
  * https://github.com/xgfs/coloropt
- * the original work was released under a MIT License.
  */
 namespace ScottPlot.Drawing.Colorsets
 {
-    class xgfs25 : HexColorset, IPalette
+    class Tsitsulin : HexColorset, IPalette
     {
         public override string[] hexColors => new string[]
         {

--- a/src/ScottPlot/Palettes/xgfs25.cs
+++ b/src/ScottPlot/Palettes/xgfs25.cs
@@ -1,0 +1,22 @@
+﻿/* A 25-color pelette based on Anton Tsitsulin's 12-color palette discussed:
+ * http://tsitsul.in/blog/coloropt/
+ * At the time the license file was accessed (2021-09-03) in the github address:
+ * https://github.com/xgfs/coloropt
+ * the original work was released under a MIT License.
+ */
+namespace ScottPlot.Drawing.Colorsets
+{
+    class xgfs25 : HexColorset, IPalette
+    {
+        public override string[] hexColors => new string[]
+        {
+            "#ebac23", "#b80058", "#008cf9", "#006e00", "#00bbad",
+            "#d163e6", "#b24502", "#ff9287", "#5954d6", "#00c6f8",
+            "#878500", "#00a76c",
+            "#f6da9c", "#ff5caa", "#8accff", "#4bff4b", "#6efff4",
+            "#edc1f5", "#feae7c", "#ffc8c3", "#bdbbef", "#bdf2ff",
+            "#fffc43", "#65ffc8",
+            "#aaaaaa",
+        };
+    }
+}


### PR DESCRIPTION
**New Contributors:**
Please review [CONTRIBUTING.md](https://github.com/swharden/ScottPlot/blob/master/CONTRIBUTING.md)

**Hacktoberfest Participants:**
Check-out the [Hacktoberfest 2021](https://github.com/ScottPlot/ScottPlot/issues/1274) page

**Purpose:**
* A qualitative 25-color palette based on Anton Tsitsulin (@xgfs)'s 12-color palette discussed [in his blog](http://tsitsul.in/blog/coloropt/).
 * Regarding copyright and any related issue, I contacted Anton (September, 2nd) and he graciously allowed the use of his color palettes. We quickly agreed that a specific written license would be appropriate and he graciously added a license note stating: _specifically, assume public domain license on the colors_. At the time the license file was accessed (September 3rd, 2021) in the corresponding [github repo](https://github.com/xgfs/coloropt), the original work was released under a MIT License.
* This palette uses Anton's original 12-color palette, plus a lighter version of the same 12 colors, plus a grey color. Although it's not recommended to plot many series in the same graph, this palette could come in handy should there be such a need.
* The main difference with palette `Category20` is that, instead of every second color being a lighter version of the color before it (which could make it difficult to distinguish between colors), in this one the darker colors are used first and the lighter colors later, and therefore the light colors are only used when plotting several series.

![Xgfs25](https://user-images.githubusercontent.com/63915486/135746251-10a5f1c9-c54e-47d7-b2a6-c0f09bdf7a5d.png)