### PR TITLE
Always generate at least 2 major ticks (#1420)

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -2,6 +2,9 @@
 
 ## ScottPlot 4.1.28
 _In development / not yet on NuGet_
+* Ticks: Improved minor tick and minor grid line placement (#1420, #1421) _Thanks @bclehmann and @at2software_
+* Palette: Added Amber and Nero palettes (#1411, #1412) _Thanks @gauravagrwal_
+* Style: Hazel style (#1414) _Thanks @gauravagrwal_
 
 ## ScottPlot 4.1.27
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2021-10-24_

--- a/src/ScottPlot/Renderable/AxisTicks.cs
+++ b/src/ScottPlot/Renderable/AxisTicks.cs
@@ -9,6 +9,7 @@ using ScottPlot.Ticks;
 using ScottPlot.Drawing;
 using System;
 using System.Drawing;
+using System.Linq;
 
 namespace ScottPlot.Renderable
 {
@@ -60,20 +61,28 @@ namespace ScottPlot.Renderable
 
             using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality, false);
 
+            double[] visibleMajorTicks = TickCollection.GetVisibleMajorTicks(dims)
+                .Select(t => t.Position)
+                .ToArray();
+
+            double[] visibleMinorTicks = TickCollection.GetVisibleMinorTicks(dims)
+                .Select(t => t.Position)
+                .ToArray();
+
             if (MajorTickVisible)
-                AxisTicksRender.RenderTickMarks(dims, gfx, TickCollection.tickPositionsMajor, RulerMode ? MajorTickLength * 4 : MajorTickLength, MajorTickColor, Edge, PixelOffset);
+                AxisTicksRender.RenderTickMarks(dims, gfx, visibleMajorTicks, RulerMode ? MajorTickLength * 4 : MajorTickLength, MajorTickColor, Edge, PixelOffset);
 
             if (TickLabelVisible)
                 AxisTicksRender.RenderTickLabels(dims, gfx, TickCollection, TickLabelFont, Edge, TickLabelRotation, RulerMode, PixelOffset, MajorTickLength, MinorTickLength);
 
             if (MinorTickVisible)
-                AxisTicksRender.RenderTickMarks(dims, gfx, TickCollection.tickPositionsMinor, MinorTickLength, MinorTickColor, Edge, PixelOffset);
+                AxisTicksRender.RenderTickMarks(dims, gfx, visibleMinorTicks, MinorTickLength, MinorTickColor, Edge, PixelOffset);
 
             if (MajorGridVisible)
-                AxisTicksRender.RenderGridLines(dims, gfx, TickCollection.tickPositionsMajor, MajorGridStyle, MajorGridColor, MajorGridWidth, Edge);
+                AxisTicksRender.RenderGridLines(dims, gfx, visibleMajorTicks, MajorGridStyle, MajorGridColor, MajorGridWidth, Edge);
 
             if (MinorGridVisible)
-                AxisTicksRender.RenderGridLines(dims, gfx, TickCollection.tickPositionsMinor, MinorGridStyle, MinorGridColor, MinorGridWidth, Edge);
+                AxisTicksRender.RenderGridLines(dims, gfx, visibleMinorTicks, MinorGridStyle, MinorGridColor, MinorGridWidth, Edge);
         }
     }
 }

--- a/src/ScottPlot/Renderable/AxisTicksRender.cs
+++ b/src/ScottPlot/Renderable/AxisTicksRender.cs
@@ -84,12 +84,14 @@ namespace ScottPlot.Renderable
             using var brush = GDI.Brush(tickFont.Color);
             using var sf = GDI.StringFormat();
 
+            Tick[] visibleMajorTicks = tc.GetVisibleMajorTicks(dims);
+
             switch (edge)
             {
                 case Edge.Bottom:
-                    for (int i = 0; i < tc.tickPositionsMajor.Length; i++)
+                    for (int i = 0; i < visibleMajorTicks.Length; i++)
                     {
-                        float x = dims.GetPixelX(tc.tickPositionsMajor[i]);
+                        float x = dims.GetPixelX(visibleMajorTicks[i].Position);
                         float y = dims.DataOffsetY + dims.DataHeight + MajorTickLength;
 
                         gfx.TranslateTransform(x, y);
@@ -97,15 +99,15 @@ namespace ScottPlot.Renderable
                         sf.Alignment = rotation == 0 ? StringAlignment.Center : StringAlignment.Far;
                         if (rulerMode) sf.Alignment = StringAlignment.Near;
                         sf.LineAlignment = rotation == 0 ? StringAlignment.Near : StringAlignment.Center;
-                        gfx.DrawString(tc.tickLabels[i], font, brush, 0, 0, sf);
+                        gfx.DrawString(visibleMajorTicks[i].Label, font, brush, 0, 0, sf);
                         gfx.ResetTransform();
                     }
                     break;
 
                 case Edge.Top:
-                    for (int i = 0; i < tc.tickPositionsMajor.Length; i++)
+                    for (int i = 0; i < visibleMajorTicks.Length; i++)
                     {
-                        float x = dims.GetPixelX(tc.tickPositionsMajor[i]);
+                        float x = dims.GetPixelX(visibleMajorTicks[i].Position);
                         float y = dims.DataOffsetY - MajorTickLength;
 
                         gfx.TranslateTransform(x, y);
@@ -113,16 +115,16 @@ namespace ScottPlot.Renderable
                         sf.Alignment = rotation == 0 ? StringAlignment.Center : StringAlignment.Near;
                         if (rulerMode) sf.Alignment = StringAlignment.Near;
                         sf.LineAlignment = rotation == 0 ? StringAlignment.Far : StringAlignment.Center;
-                        gfx.DrawString(tc.tickLabels[i], font, brush, 0, 0, sf);
+                        gfx.DrawString(visibleMajorTicks[i].Label, font, brush, 0, 0, sf);
                         gfx.ResetTransform();
                     }
                     break;
 
                 case Edge.Left:
-                    for (int i = 0; i < tc.tickPositionsMajor.Length; i++)
+                    for (int i = 0; i < visibleMajorTicks.Length; i++)
                     {
                         float x = dims.DataOffsetX - PixelOffset - MajorTickLength;
-                        float y = dims.GetPixelY(tc.tickPositionsMajor[i]);
+                        float y = dims.GetPixelY(visibleMajorTicks[i].Position);
 
                         gfx.TranslateTransform(x, y);
                         gfx.RotateTransform(-rotation);
@@ -133,16 +135,16 @@ namespace ScottPlot.Renderable
                             sf.Alignment = StringAlignment.Center;
                             sf.LineAlignment = StringAlignment.Far;
                         }
-                        gfx.DrawString(tc.tickLabels[i], font, brush, 0, 0, sf);
+                        gfx.DrawString(visibleMajorTicks[i].Label, font, brush, 0, 0, sf);
                         gfx.ResetTransform();
                     }
                     break;
 
                 case Edge.Right:
-                    for (int i = 0; i < tc.tickPositionsMajor.Length; i++)
+                    for (int i = 0; i < visibleMajorTicks.Length; i++)
                     {
                         float x = dims.DataOffsetX + PixelOffset + MajorTickLength + dims.DataWidth;
-                        float y = dims.GetPixelY(tc.tickPositionsMajor[i]);
+                        float y = dims.GetPixelY(visibleMajorTicks[i].Position);
 
                         gfx.TranslateTransform(x, y);
                         gfx.RotateTransform(-rotation);
@@ -153,7 +155,7 @@ namespace ScottPlot.Renderable
                             sf.Alignment = StringAlignment.Center;
                             sf.LineAlignment = StringAlignment.Near;
                         }
-                        gfx.DrawString(tc.tickLabels[i], font, brush, 0, 0, sf);
+                        gfx.DrawString(visibleMajorTicks[i].Label, font, brush, 0, 0, sf);
                         gfx.ResetTransform();
                     }
                     break;

--- a/src/ScottPlot/ScottPlot.csproj
+++ b/src/ScottPlot/ScottPlot.csproj
@@ -12,9 +12,9 @@
     <PackageProjectUrl>https://ScottPlot.NET</PackageProjectUrl>
     <PackageTags>plot graph data chart signal line bar heatmap scatter</PackageTags>
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
-    <Version>4.1.27</Version>
-    <AssemblyVersion>4.1.27.0</AssemblyVersion>
-    <FileVersion>4.1.27.0</FileVersion>
+    <Version>4.1.28</Version>
+    <AssemblyVersion>4.1.28.0</AssemblyVersion>
+    <FileVersion>4.1.28.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>

--- a/src/ScottPlot/Ticks/TickCollection.cs
+++ b/src/ScottPlot/Ticks/TickCollection.cs
@@ -544,5 +544,48 @@ namespace ScottPlot.Ticks
         {
             return GetMajorTicks().Concat(GetMinorTicks()).ToArray();
         }
+
+        public Tick[] GetVisibleMajorTicks(PlotDimensions dims)
+        {
+            double high, low;
+            if (Orientation == AxisOrientation.Vertical)
+            {
+                low = dims.YMin - dims.UnitsPerPxY; // add an extra pixel to capture the edge tick
+                high = dims.YMax + dims.UnitsPerPxY; // add an extra pixel to capture the edge tick
+            }
+            else
+            {
+                low = dims.XMin - dims.UnitsPerPxX; // add an extra pixel to capture the edge tick
+                high = dims.XMax + dims.UnitsPerPxX; // add an extra pixel to capture the edge tick
+            }
+
+            return GetMajorTicks()
+                .Where(t => t.Position >= low && t.Position <= high)
+                .ToArray();
+        }
+
+        public Tick[] GetVisibleMinorTicks(PlotDimensions dims)
+        {
+            double high, low;
+            if (Orientation == AxisOrientation.Vertical)
+            {
+                low = dims.YMin - dims.UnitsPerPxY; // add an extra pixel to capture the edge tick
+                high = dims.YMax + dims.UnitsPerPxY; // add an extra pixel to capture the edge tick
+            }
+            else
+            {
+                low = dims.XMin - dims.UnitsPerPxX; // add an extra pixel to capture the edge tick
+                high = dims.XMax + dims.UnitsPerPxX; // add an extra pixel to capture the edge tick
+            }
+
+            return GetMinorTicks()
+                .Where(t => t.Position >= low && t.Position <= high)
+                .ToArray();
+        }
+
+        public Tick[] GetVisibleTicks(PlotDimensions dims)
+        {
+            return GetVisibleMajorTicks(dims).Concat(GetVisibleMinorTicks(dims)).ToArray();
+        }
     }
 }

--- a/src/ScottPlot/Ticks/TickCollection.cs
+++ b/src/ScottPlot/Ticks/TickCollection.cs
@@ -277,7 +277,13 @@ namespace ScottPlot.Ticks
             }
 
             if (IntegerPositionsOnly)
+            {
+                int firstTick = (int)tickPositionsMajor[0];
                 tickPositionsMajor = tickPositionsMajor.Where(x => x == (int)x).Distinct().ToArray();
+
+                if (tickPositionsMajor.Length < 2)
+                    tickPositionsMajor = new double[] { firstTick - 1, firstTick, firstTick + 1 };
+            }
 
             (tickLabels, CornerLabel) = GetPrettyTickLabels(
                     tickPositionsMajor,

--- a/src/ScottPlot/Ticks/TickCollection.cs
+++ b/src/ScottPlot/Ticks/TickCollection.cs
@@ -268,6 +268,9 @@ namespace ScottPlot.Ticks
                                            .Where(x => low <= x && x <= high)
                                            .ToArray();
 
+            if (tickPositionsMajor.Length < 2)
+                tickPositionsMajor = new double[] { tickPositionsMajor.Length > 0 ? tickPositionsMajor[0] : low - firstTickOffset, low - firstTickOffset + tickSpacing };
+
             if (IntegerPositionsOnly)
                 tickPositionsMajor = tickPositionsMajor.Where(x => x == (int)x).Distinct().ToArray();
 

--- a/src/ScottPlot/Ticks/TickCollection.cs
+++ b/src/ScottPlot/Ticks/TickCollection.cs
@@ -269,7 +269,12 @@ namespace ScottPlot.Ticks
                                            .ToArray();
 
             if (tickPositionsMajor.Length < 2)
-                tickPositionsMajor = new double[] { tickPositionsMajor.Length > 0 ? tickPositionsMajor[0] : low - firstTickOffset, low - firstTickOffset + tickSpacing };
+            {
+                double tickBelow = low - firstTickOffset;
+                double firstTick = tickPositionsMajor.Length > 0 ? tickPositionsMajor[0] : tickBelow;
+                double nextTick = tickBelow + tickSpacing;
+                tickPositionsMajor = new double[] { firstTick, nextTick };
+            }
 
             if (IntegerPositionsOnly)
                 tickPositionsMajor = tickPositionsMajor.Where(x => x == (int)x).Distinct().ToArray();

--- a/src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj
+++ b/src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj
@@ -15,9 +15,9 @@
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/ScottPlot/ScottPlot</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.1.27</Version>
-    <AssemblyVersion>4.1.27.0</AssemblyVersion>
-    <FileVersion>4.1.27.0</FileVersion>
+    <Version>4.1.28</Version>
+    <AssemblyVersion>4.1.28.0</AssemblyVersion>
+    <FileVersion>4.1.28.0</FileVersion>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj
+++ b/src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj
@@ -16,9 +16,9 @@
     <PackageTags>plot graph data chart signal line bar heatmap scatter control interactive WPF</PackageTags>
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/ScottPlot/ScottPlot</RepositoryUrl>
-    <Version>4.1.27</Version>
-    <AssemblyVersion>4.1.27.0</AssemblyVersion>
-    <FileVersion>4.1.27.0</FileVersion>
+    <Version>4.1.28</Version>
+    <AssemblyVersion>4.1.28.0</AssemblyVersion>
+    <FileVersion>4.1.28.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj
+++ b/src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj
@@ -15,9 +15,9 @@
     <PackageTags>plot graph data chart signal line bar heatmap scatter control interactive winforms windows forms</PackageTags>
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/ScottPlot/ScottPlot</RepositoryUrl>
-    <Version>4.1.27</Version>
-    <AssemblyVersion>4.1.27.0</AssemblyVersion>
-    <FileVersion>4.1.27.0</FileVersion>
+    <Version>4.1.28</Version>
+    <AssemblyVersion>4.1.28.0</AssemblyVersion>
+    <FileVersion>4.1.28.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
**Purpose:** #1420 

Note that this will create minor ticks even if there are no major ticks on-screen (but the minor ticks may be above or below the drawn area).

## Examples
### 1 major tick visible
![image](https://user-images.githubusercontent.com/8635304/140000209-44f68461-51dd-4f9a-9962-3e4d78540982.png)

### 0 major ticks visible
![image](https://user-images.githubusercontent.com/8635304/140000230-09df9e57-b4b5-4f29-8219-b3fbc6bb7aa5.png)

### 0 major or minor ticks visible (zoomed in between minor ticks)
![image](https://user-images.githubusercontent.com/8635304/140000260-d8d399c6-bf24-4873-b3a7-b2e24abbc40e.png)
