### PR TITLE
 IRenderable and IPlottable.Render with Graphics object for clean printouts

### DIFF
--- a/src/ScottPlot/Drawing/GDI.cs
+++ b/src/ScottPlot/Drawing/GDI.cs
@@ -94,6 +94,7 @@ namespace ScottPlot.Drawing
             return gfx;
         }
 
+
         public static System.Drawing.Graphics Graphics(Bitmap bmp, PlotDimensions dims, bool lowQuality = false, bool clipToDataArea = true)
         {
             Graphics gfx = Graphics(bmp, lowQuality, dims.ScaleFactor);
@@ -111,6 +112,30 @@ namespace ScottPlot.Drawing
             }
 
             return gfx;
+        }
+
+        public static void ClipToDataArea(this Graphics gfx, PlotDimensions dims, bool clipToDataArea = true, bool lowQuality = false)
+        {
+            gfx.TextRenderingHint = lowQuality ? TextRenderingHint.SingleBitPerPixelGridFit : TextRenderingHint.AntiAliasGridFit;
+
+            if (gfx.Transform.OffsetX != dims.OffsetX || gfx.Transform.OffsetY != dims.OffsetY)
+                gfx.TranslateTransform(dims.OffsetX, dims.OffsetY);
+
+            if (clipToDataArea)
+            {
+                /* These dimensions are withdrawn by 1 pixel to leave room for a 1px wide data frame.
+                 * Rounding is intended to exactly match rounding used when frame placement is determined.
+                 */
+                float left = (int)Math.Round(dims.DataOffsetX) + 1;
+                float top = (int)Math.Round(dims.DataOffsetY) + 1;
+                float width = (int)Math.Round(dims.DataWidth) - 1;
+                float height = (int)Math.Round(dims.DataHeight) - 1;
+                gfx.Clip = new Region(new RectangleF(left, top, width, height));
+            }
+            else
+            {
+                gfx.ResetClip();
+            }
         }
 
         public static System.Drawing.Pen Pen(System.Drawing.Color color, double width = 1, LineStyle lineStyle = LineStyle.Solid, bool rounded = false)

--- a/src/ScottPlot/Plot/Plot.cs
+++ b/src/ScottPlot/Plot/Plot.cs
@@ -16,12 +16,22 @@ namespace ScottPlot
         /// <summary>
         /// Plot image width (pixels)
         /// </summary>
-        public float Width { get => settings.Width; set => Resize(value, settings.Height); }
+        public float Width { get => settings.Width; set => Resize(value, settings.Height, settings.OffsetX, settings.OffsetY); }
 
         /// <summary>
         /// Plot image height (pixels)
         /// </summary>
-        public float Height { get => settings.Height; set => Resize(settings.Width, value); }
+        public float Height { get => settings.Height; set => Resize(settings.Width, value, settings.OffsetX, settings.OffsetY); }
+
+        /// <summary>
+        /// Plot image Offset (pixels)
+        /// </summary>
+        public float OffsetX { get => settings.Width; set => Resize(settings.Width, settings.Height, value, settings.OffsetY); }
+
+        /// <summary>
+        /// Plot image Offset (pixels)
+        /// </summary>
+        public float OffsetY { get => settings.Height; set => Resize(settings.Width, settings.Height, settings.OffsetX, value); }
 
         /// <summary>
         /// A ScottPlot stores data in plottable objects and draws it on a bitmap when Render() is called
@@ -187,7 +197,9 @@ namespace ScottPlot
         /// </summary>
         /// <param name="width">width (pixels) for future renders</param>
         /// <param name="height">height (pixels) for future renders</param>
-        public void Resize(float width, float height) => settings.Resize(width, height);
+        /// <param name="x">Offset X (pixels) for future renders</param>
+        /// <param name="y">Offset Y (pixels) for future renders</param>
+        public void Resize(float width, float height, float x = 0, float y = 0) => settings.Resize(width, height, x, y);
 
         /// <summary>
         /// Return a new color from the Pallette based on the number of plottables already in the plot.

--- a/src/ScottPlot/PlotDimensions.cs
+++ b/src/ScottPlot/PlotDimensions.cs
@@ -10,6 +10,8 @@ namespace ScottPlot
         // plot dimensions
         public readonly float Width;
         public readonly float Height;
+        public readonly float OffsetX;
+        public readonly float OffsetY;
         public readonly float DataWidth;
         public readonly float DataHeight;
         public readonly float DataOffsetX;
@@ -42,11 +44,12 @@ namespace ScottPlot
         public double GetCoordinateX(float pixel) => (pixel - DataOffsetX) / PxPerUnitX + XMin;
         public double GetCoordinateY(float pixel) => DataHeight - ((pixel - YMin) * PxPerUnitY);
 
-        public PlotDimensions(SizeF figureSize, SizeF dataSize, PointF dataOffset,
+        public PlotDimensions(SizeF figureSize, PointF figureOffset, SizeF dataSize, PointF dataOffset,
             (double xMin, double xMax, double yMin, double yMax) axisLimits,
             double scaleFactor)
         {
             (Width, Height) = (figureSize.Width, figureSize.Height);
+            (OffsetX, OffsetY) = (figureOffset.X, figureOffset.Y);
             (DataWidth, DataHeight) = (dataSize.Width, dataSize.Height);
             (DataOffsetX, DataOffsetY) = (dataOffset.X, dataOffset.Y);
             (XMin, XMax, YMin, YMax) = (axisLimits.xMin, axisLimits.xMax, axisLimits.yMin, axisLimits.yMax);

--- a/src/ScottPlot/Plottable/Annotation.cs
+++ b/src/ScottPlot/Plottable/Annotation.cs
@@ -55,12 +55,11 @@ namespace ScottPlot.Plottable
 
         // TODO: the negative coordiante thing is silly. Use alignment fields to control this behavior.
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (!IsVisible)
                 return;
-
-            using var gfx = GDI.Graphics(bmp, dims, lowQuality, false);
+            gfx.ClipToDataArea(dims);
             using var font = GDI.Font(Font);
             using var fontBrush = new SolidBrush(Font.Color);
             using var shadowBrush = new SolidBrush(ShadowColor);

--- a/src/ScottPlot/Plottable/ArrowCoordinated.cs
+++ b/src/ScottPlot/Plottable/ArrowCoordinated.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ScottPlot.Drawing;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -111,12 +112,11 @@ namespace ScottPlot.Plottable
                 throw new InvalidOperationException("Base and Tip coordinates must be finite");
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (IsVisible == false)
                 return;
-
-            using Graphics gfx = Drawing.GDI.Graphics(bmp, dims, lowQuality);
+            gfx.ClipToDataArea(dims);
             using Pen penLine = Drawing.GDI.Pen(Color, LineWidth, LineStyle, true);
 
             Pixel basePixel = dims.GetPixel(Base);

--- a/src/ScottPlot/Plottable/AxisLine.cs
+++ b/src/ScottPlot/Plottable/AxisLine.cs
@@ -128,20 +128,20 @@ namespace ScottPlot.Plottable
                 throw new NullReferenceException(nameof(PositionFormatter));
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (!IsVisible)
                 return;
 
-            RenderLine(dims, bmp, lowQuality);
+            RenderLine(dims, gfx);
 
             if (PositionLabel)
-                RenderPositionLabel(dims, bmp, lowQuality);
+                RenderPositionLabel(dims, gfx);
         }
 
-        public void RenderLine(PlotDimensions dims, Bitmap bmp, bool lowQuality)
+        public void RenderLine(PlotDimensions dims, Graphics gfx)
         {
-            using var gfx = GDI.Graphics(bmp, dims, lowQuality);
+            gfx.ClipToDataArea(dims);
             using var pen = GDI.Pen(Color, LineWidth, LineStyle, true);
 
             if (IsHorizontal)
@@ -168,9 +168,9 @@ namespace ScottPlot.Plottable
             }
         }
 
-        private void RenderPositionLabel(PlotDimensions dims, Bitmap bmp, bool lowQuality)
+        private void RenderPositionLabel(PlotDimensions dims, Graphics gfx)
         {
-            using var gfx = GDI.Graphics(bmp, dims, lowQuality, clipToDataArea: false);
+            gfx.ClipToDataArea(dims, false);
             using var pen = GDI.Pen(Color, LineWidth, LineStyle, true);
 
             using var fnt = GDI.Font(PositionLabelFont);

--- a/src/ScottPlot/Plottable/AxisSpan.cs
+++ b/src/ScottPlot/Plottable/AxisSpan.cs
@@ -207,9 +207,9 @@ namespace ScottPlot.Plottable
             return new RectangleF(left, top, width, height);
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
-            using (var gfx = GDI.Graphics(bmp, dims, lowQuality))
+            gfx.ClipToDataArea(dims);
             using (var brush = GDI.Brush(Color))
             {
                 RectangleF rect = GetClippedRectangle(dims);

--- a/src/ScottPlot/Plottable/BarPlot.cs
+++ b/src/ScottPlot/Plottable/BarPlot.cs
@@ -34,9 +34,9 @@ namespace ScottPlot.Plottable
             ValueOffsets = yOffsets ?? DataGen.Zeros(ys.Length);
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
-            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
+            gfx.ClipToDataArea(dims);
             for (int barIndex = 0; barIndex < Values.Length; barIndex++)
             {
                 if (Orientation == Orientation.Vertical)

--- a/src/ScottPlot/Plottable/BubblePlot.cs
+++ b/src/ScottPlot/Plottable/BubblePlot.cs
@@ -109,12 +109,12 @@ namespace ScottPlot.Plottable
             }
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (IsVisible == false)
                 return;
 
-            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
+            gfx.ClipToDataArea(dims);
             using Brush brush = GDI.Brush(Color.Magenta);
             using Pen pen = GDI.Pen(Color.Black);
 

--- a/src/ScottPlot/Plottable/ClevelandDotPlot.cs
+++ b/src/ScottPlot/Plottable/ClevelandDotPlot.cs
@@ -180,9 +180,9 @@ namespace ScottPlot.Plottable
         // NOTE: These render methods contains a lot of code and complexity not required to render this plot type.
         // TODO: Delete as much of this code as possible and simplify the render methods.
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
-            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
+            gfx.ClipToDataArea(dims);
             for (int barIndex = 0; barIndex < Values.Length; barIndex++)
             {
                 if (Orientation == Orientation.Vertical)

--- a/src/ScottPlot/Plottable/Colorbar.cs
+++ b/src/ScottPlot/Plottable/Colorbar.cs
@@ -192,14 +192,14 @@ namespace ScottPlot.Plottable
         public Bitmap GetBitmap(int width, int height, bool vertical = true) =>
             Colormap.Colorbar(Colormap, width, height, vertical, MinColor, MaxColor);
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (BmpScale is null)
                 UpdateBitmap();
 
-            RectangleF colorbarRect = RenderColorbar(dims, bmp);
+            RectangleF colorbarRect = RenderColorbar(dims, gfx);
 
-            RenderTicks(dims, bmp, lowQuality, colorbarRect);
+            RenderTicks(dims, gfx, colorbarRect);
         }
 
         /// <summary>
@@ -233,7 +233,7 @@ namespace ScottPlot.Plottable
             return ticks;
         }
 
-        private RectangleF RenderColorbar(PlotDimensions dims, Bitmap bmp)
+        private RectangleF RenderColorbar(PlotDimensions dims, Graphics gfx)
         {
             float scaleLeftPad = 10;
 
@@ -241,7 +241,7 @@ namespace ScottPlot.Plottable
             SizeF size = new(Width, dims.DataHeight);
             RectangleF rect = new(location, size);
 
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality: true, clipToDataArea: false))
+            gfx.ClipToDataArea(dims, false, true);
             using (var pen = GDI.Pen(Color.Black))
             {
                 gfx.DrawImage(BmpScale, location.X, location.Y, size.Width, size.Height + 1);
@@ -251,13 +251,13 @@ namespace ScottPlot.Plottable
             return rect;
         }
 
-        private void RenderTicks(PlotDimensions dims, Bitmap bmp, bool lowQuality, RectangleF colorbarRect)
+        private void RenderTicks(PlotDimensions dims, Graphics gfx, RectangleF colorbarRect)
         {
             float tickLeftPx = colorbarRect.Right;
             float tickRightPx = tickLeftPx + TickMarkLength;
             float tickLabelPx = tickRightPx + 2;
 
-            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality, false);
+            gfx.ClipToDataArea(dims, false);
             using var tickMarkPen = GDI.Pen(TickMarkColor, TickMarkWidth);
             using var tickLabelBrush = GDI.Brush(TickLabelFont.Color);
             using var tickFont = GDI.Font(TickLabelFont);

--- a/src/ScottPlot/Plottable/CoordinatedHeatmap.cs
+++ b/src/ScottPlot/Plottable/CoordinatedHeatmap.cs
@@ -9,10 +9,9 @@ namespace ScottPlot.Plottable
     [Obsolete("This plot type has been deprecated. Min/max and interpolation settings are exposed in the regular Heatmap.")]
     public class CoordinatedHeatmap : Heatmap
     {
-        protected override void RenderHeatmap(PlotDimensions dims, Bitmap bmp, bool lowQuality)
+        protected override void RenderHeatmap(PlotDimensions dims, Graphics gfx)
         {
-            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
-
+            gfx.ClipToDataArea(dims);
             gfx.InterpolationMode = Interpolation;
             gfx.PixelOffsetMode = PixelOffsetMode.Half;
 

--- a/src/ScottPlot/Plottable/CoxcombPlot.cs
+++ b/src/ScottPlot/Plottable/CoxcombPlot.cs
@@ -73,7 +73,7 @@ namespace ScottPlot.Plottable
             FillColors = fillColors;
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             int numCategories = Normalized.Length;
             PointF origin = new PointF(dims.GetPixelX(0), dims.GetPixelY(0));
@@ -81,11 +81,10 @@ namespace ScottPlot.Plottable
             double maxRadiusPixels = new double[] { dims.PxPerUnitX, dims.PxPerUnitX }.Min();
             double maxDiameterPixels = maxRadiusPixels * 2;
 
-
-            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
+            gfx.ClipToDataArea(dims);
             using SolidBrush sliceFillBrush = (SolidBrush)GDI.Brush(Color.Black);
 
-            RenderAxis(gfx, dims, bmp, lowQuality);
+            RenderAxis(gfx, dims);
 
             double start = -90;
             for (int i = 0; i < numCategories; i++)
@@ -106,7 +105,7 @@ namespace ScottPlot.Plottable
             }
         }
 
-        private void RenderAxis(Graphics gfx, PlotDimensions dims, Bitmap bmp, bool lowQuality)
+        private void RenderAxis(Graphics gfx, PlotDimensions dims)
         {
             double[,] Norm = new double[Normalized.Length, 1];
             for (int i = 0; i < Normalized.Length; i++)
@@ -132,7 +131,7 @@ namespace ScottPlot.Plottable
                 ImagePlacement = ImagePlacement.Inside
             };
 
-            axis.Render(dims, bmp, lowQuality);
+            axis.Render(dims, gfx);
         }
 
         private static double[] Normalize(double[] values)

--- a/src/ScottPlot/Plottable/Crosshair.cs
+++ b/src/ScottPlot/Plottable/Crosshair.cs
@@ -132,13 +132,13 @@ namespace ScottPlot.Plottable
 
         public void ValidateData(bool deep = false) { }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (IsVisible == false)
                 return;
 
-            HorizontalLine.Render(dims, bmp, lowQuality);
-            VerticalLine.Render(dims, bmp, lowQuality);
+            HorizontalLine.Render(dims, gfx);
+            VerticalLine.Render(dims, gfx);
         }
 
         [Obsolete("Use VerticalLine.PositionFormatter()")]

--- a/src/ScottPlot/Plottable/FinancePlot.cs
+++ b/src/ScottPlot/Plottable/FinancePlot.cs
@@ -151,12 +151,12 @@ namespace ScottPlot.Plottable
             return new AxisLimits(limits[0], limits[1], limits[2], limits[3]);
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (Candle)
-                RenderCandles(dims, bmp, lowQuality);
+                RenderCandles(dims, gfx);
             else
-                RenderOhlc(dims, bmp, lowQuality);
+                RenderOhlc(dims, gfx);
         }
 
         public void ValidateData(bool deepValidation = false)
@@ -173,11 +173,11 @@ namespace ScottPlot.Plottable
             }
         }
 
-        private void RenderCandles(PlotDimensions dims, Bitmap bmp, bool lowQuality)
+        private void RenderCandles(PlotDimensions dims, Graphics gfx)
         {
             double fractionalTickWidth = .7;
 
-            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
+            gfx.ClipToDataArea(dims);
             using Pen pen = new Pen(Color.Magenta);
             using SolidBrush brush = new SolidBrush(Color.Magenta);
             for (int i = 0; i < OHLCs.Count; i++)
@@ -237,11 +237,11 @@ namespace ScottPlot.Plottable
             }
         }
 
-        private void RenderOhlc(PlotDimensions dims, Bitmap bmp, bool lowQuality)
+        private void RenderOhlc(PlotDimensions dims, Graphics gfx)
         {
             double fractionalTickWidth = .7;
 
-            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
+            gfx.ClipToDataArea(dims);
             using Pen pen = new Pen(Color.Magenta);
             for (int i = 0; i < OHLCs.Count; i++)
             {

--- a/src/ScottPlot/Plottable/FunctionPlot.cs
+++ b/src/ScottPlot/Plottable/FunctionPlot.cs
@@ -51,7 +51,7 @@ namespace ScottPlot.Plottable
 
         public int PointCount { get; private set; }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             List<double> xList = new List<double>();
             List<double> yList = new List<double>();
@@ -92,7 +92,7 @@ namespace ScottPlot.Plottable
                 MarkerShape = MarkerShape.none,
                 LineStyle = LineStyle
             };
-            scatter.Render(dims, bmp, lowQuality);
+            scatter.Render(dims, gfx);
         }
 
         public void ValidateData(bool deepValidation = false)

--- a/src/ScottPlot/Plottable/Heatmap.cs
+++ b/src/ScottPlot/Plottable/Heatmap.cs
@@ -311,15 +311,14 @@ namespace ScottPlot.Plottable
                     throw new ArgumentException("Heatmaps may be unreliable for arrays with more than 10 million values");
             }
         }
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
-            RenderHeatmap(dims, bmp, lowQuality);
+            RenderHeatmap(dims, gfx);
         }
 
-        protected virtual void RenderHeatmap(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        protected virtual void RenderHeatmap(PlotDimensions dims, Graphics gfx)
         {
-            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
-
+            gfx.ClipToDataArea(dims);
             gfx.InterpolationMode = Interpolation;
             gfx.PixelOffsetMode = PixelOffsetMode.Half;
 

--- a/src/ScottPlot/Plottable/IPlottable.cs
+++ b/src/ScottPlot/Plottable/IPlottable.cs
@@ -1,9 +1,11 @@
-﻿namespace ScottPlot.Plottable
+﻿using System.Drawing;
+
+namespace ScottPlot.Plottable
 {
     public interface IPlottable
     {
         bool IsVisible { get; set; }
-        void Render(PlotDimensions dims, System.Drawing.Bitmap bmp, bool lowQuality = false);
+        void Render(PlotDimensions dims, Graphics gfx);
 
         int XAxisIndex { get; set; }
         int YAxisIndex { get; set; }

--- a/src/ScottPlot/Plottable/Image.cs
+++ b/src/ScottPlot/Plottable/Image.cs
@@ -59,12 +59,12 @@ namespace ScottPlot.Plottable
             };
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             PointF defaultPoint = new PointF(dims.GetPixelX(X), dims.GetPixelY(Y));
             PointF textLocationPoint = (Rotation == 0) ? TextLocation(defaultPoint) : defaultPoint;
 
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            gfx.ClipToDataArea(dims);
             using (var framePen = new Pen(BorderColor, BorderSize * 2))
             {
                 gfx.TranslateTransform((int)textLocationPoint.X, (int)textLocationPoint.Y);

--- a/src/ScottPlot/Plottable/LollipopPlot.cs
+++ b/src/ScottPlot/Plottable/LollipopPlot.cs
@@ -68,9 +68,9 @@ namespace ScottPlot.Plottable
         // NOTE: These render methods contains a lot of code and complexity not required to render this plot type.
         // TODO: Delete as much of this code as possible and simplify the render methods.
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
-            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
+            gfx.ClipToDataArea(dims);
             for (int barIndex = 0; barIndex < Values.Length; barIndex++)
             {
                 if (Orientation == Orientation.Vertical)

--- a/src/ScottPlot/Plottable/MarkerPlot.cs
+++ b/src/ScottPlot/Plottable/MarkerPlot.cs
@@ -58,14 +58,13 @@ namespace ScottPlot.Plottable
             Validate.AssertIsReal(nameof(Y), Y);
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (!IsVisible)
                 return;
 
             PointF point = new(dims.GetPixelX(X), dims.GetPixelY(Y));
 
-            using Graphics gfx = Drawing.GDI.Graphics(bmp, lowQuality);
             MarkerTools.DrawMarker(gfx, point, MarkerShape, (float)MarkerSize, Color);
         }
     }

--- a/src/ScottPlot/Plottable/PiePlot.cs
+++ b/src/ScottPlot/Plottable/PiePlot.cs
@@ -80,9 +80,9 @@ namespace ScottPlot.Plottable
             // TODO: ensure the length of colors and group names matches expected length
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            gfx.ClipToDataArea(dims);
             using (Pen backgroundPen = GDI.Pen(BackgroundColor))
             using (Pen outlinePen = GDI.Pen(OutlineColor, OutlineSize))
             using (Brush sliceFillBrush = GDI.Brush(Color.Black))

--- a/src/ScottPlot/Plottable/Polygon.cs
+++ b/src/ScottPlot/Plottable/Polygon.cs
@@ -89,13 +89,13 @@ namespace ScottPlot.Plottable
             }
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             PointF[] points = new PointF[Xs.Length];
             for (int i = 0; i < Xs.Length; i++)
                 points[i] = new PointF(dims.GetPixelX(Xs[i]), dims.GetPixelY(Ys[i]));
 
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            gfx.ClipToDataArea(dims);
             using (Brush fillBrush = GDI.Brush(FillColor, HatchColor, HatchStyle))
             using (Pen outlinePen = GDI.Pen(LineColor, (float)LineWidth))
             {

--- a/src/ScottPlot/Plottable/Polygons.cs
+++ b/src/ScottPlot/Plottable/Polygons.cs
@@ -134,9 +134,9 @@ namespace ScottPlot.Plottable
             return (maxX - minX > smallerThenPixelX || maxY - minY > smallerThenPixelY);
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            gfx.ClipToDataArea(dims);
             using (Brush brush = GDI.Brush(FillColor, HatchColor, HatchStyle))
             using (Pen pen = GDI.Pen(LineColor, LineWidth))
             {

--- a/src/ScottPlot/Plottable/PopulationPlot.cs
+++ b/src/ScottPlot/Plottable/PopulationPlot.cs
@@ -107,7 +107,7 @@ namespace ScottPlot.Plottable
             return new AxisLimits(positionMin, positionMax, minValue, maxValue);
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             Random rand = new Random(0);
             double groupWidth = .8;
@@ -145,30 +145,30 @@ namespace ScottPlot.Plottable
                             throw new NotImplementedException();
                     }
 
-                    Scatter(dims, bmp, lowQuality, population, rand, popLeft, popWidth, series.color, ScatterOutlineColor, 128, scatterPos);
+                    Scatter(dims, gfx, population, rand, popLeft, popWidth, series.color, ScatterOutlineColor, 128, scatterPos);
 
                     if (DistributionCurve)
-                        Distribution(dims, bmp, lowQuality, population, rand, popLeft, popWidth, DistributionCurveColor, scatterPos, DistributionCurveLineStyle);
+                        Distribution(dims, gfx, population, rand, popLeft, popWidth, DistributionCurveColor, scatterPos, DistributionCurveLineStyle);
 
                     switch (DataBoxStyle)
                     {
                         case BoxStyle.BarMeanStdErr:
-                            Bar(dims, bmp, lowQuality, population, rand, popLeft, popWidth, series.color, boxPos, useStdErr: true);
+                            Bar(dims, gfx, population, rand, popLeft, popWidth, series.color, boxPos, useStdErr: true);
                             break;
                         case BoxStyle.BarMeanStDev:
-                            Bar(dims, bmp, lowQuality, population, rand, popLeft, popWidth, series.color, boxPos, useStdErr: false);
+                            Bar(dims, gfx, population, rand, popLeft, popWidth, series.color, boxPos, useStdErr: false);
                             break;
                         case BoxStyle.BoxMeanStdevStderr:
-                            Box(dims, bmp, lowQuality, population, rand, popLeft, popWidth, series.color, boxPos, BoxFormat.StdevStderrMean);
+                            Box(dims, gfx, population, rand, popLeft, popWidth, series.color, boxPos, BoxFormat.StdevStderrMean);
                             break;
                         case BoxStyle.BoxMedianQuartileOutlier:
-                            Box(dims, bmp, lowQuality, population, rand, popLeft, popWidth, series.color, boxPos, BoxFormat.OutlierQuartileMedian);
+                            Box(dims, gfx, population, rand, popLeft, popWidth, series.color, boxPos, BoxFormat.OutlierQuartileMedian);
                             break;
                         case BoxStyle.MeanAndStderr:
-                            MeanAndError(dims, bmp, lowQuality, population, rand, popLeft, popWidth, series.color, boxPos, useStdErr: true);
+                            MeanAndError(dims, gfx, population, rand, popLeft, popWidth, series.color, boxPos, useStdErr: true);
                             break;
                         case BoxStyle.MeanAndStdev:
-                            MeanAndError(dims, bmp, lowQuality, population, rand, popLeft, popWidth, series.color, boxPos, useStdErr: false);
+                            MeanAndError(dims, gfx, population, rand, popLeft, popWidth, series.color, boxPos, useStdErr: false);
                             break;
                         default:
                             throw new NotImplementedException();
@@ -179,7 +179,7 @@ namespace ScottPlot.Plottable
 
         public enum Position { Hide, Center, Left, Right }
 
-        private static void Scatter(PlotDimensions dims, Bitmap bmp, bool lowQuality, Population pop, Random rand,
+        private static void Scatter(PlotDimensions dims, Graphics gfx, Population pop, Random rand,
             double popLeft, double popWidth, Color fillColor, Color edgeColor, byte alpha, Position position)
         {
             // adjust edges to accomodate special positions
@@ -194,7 +194,7 @@ namespace ScottPlot.Plottable
 
             float radius = 5;
 
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            gfx.ClipToDataArea(dims);
             using (Pen penEdge = GDI.Pen(Color.FromArgb(alpha, edgeColor)))
             using (Brush brushFill = GDI.Brush(Color.FromArgb(alpha, fillColor)))
             {
@@ -208,7 +208,7 @@ namespace ScottPlot.Plottable
             }
         }
 
-        private static void Distribution(PlotDimensions dims, Bitmap bmp, bool lowQuality, Population pop, Random rand,
+        private static void Distribution(PlotDimensions dims, Graphics gfx, Population pop, Random rand,
             double popLeft, double popWidth, Color color, Position position, LineStyle lineStyle)
         {
             // adjust edges to accomodate special positions
@@ -234,14 +234,14 @@ namespace ScottPlot.Plottable
                 points[i] = new PointF(x, y);
             }
 
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            gfx.ClipToDataArea(dims);
             using (Pen pen = GDI.Pen(color, 1, lineStyle, true))
             {
                 gfx.DrawLines(pen, points);
             }
         }
 
-        private static void MeanAndError(PlotDimensions dims, Bitmap bmp, bool lowQuality, Population pop, Random rand,
+        private static void MeanAndError(PlotDimensions dims, Graphics gfx, Population pop, Random rand,
             double popLeft, double popWidth, Color color, Position position, bool useStdErr = false)
         {
             // adjust edges to accomodate special positions
@@ -273,7 +273,7 @@ namespace ScottPlot.Plottable
             double capPx2 = dims.GetPixelX(centerX + capWidth / 2);
             float radius = 5;
 
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            gfx.ClipToDataArea(dims);
             using (Pen pen = GDI.Pen(color, 2))
             using (Brush brush = GDI.Brush(color))
             {
@@ -284,7 +284,7 @@ namespace ScottPlot.Plottable
             }
         }
 
-        private static void Bar(PlotDimensions dims, Bitmap bmp, bool lowQuality, Population pop, Random rand,
+        private static void Bar(PlotDimensions dims, Graphics gfx, Population pop, Random rand,
             double popLeft, double popWidth, Color color, Position position, bool useStdErr = false)
         {
             // adjust edges to accomodate special positions
@@ -325,7 +325,7 @@ namespace ScottPlot.Plottable
 
             RectangleF rect = new RectangleF((float)leftPx, (float)yPxTop, (float)(rightPx - leftPx), (float)(yPxBase - yPxTop));
 
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            gfx.ClipToDataArea(dims);
             using (Pen pen = GDI.Pen(Color.Black))
             using (Brush brush = GDI.Brush(color))
             {
@@ -340,7 +340,7 @@ namespace ScottPlot.Plottable
         public enum BoxFormat { StdevStderrMean, OutlierQuartileMedian }
         public enum HorizontalAlignment { Left, Center, Right }
 
-        private static void Box(PlotDimensions dims, Bitmap bmp, bool lowQuality, Population pop, Random rand,
+        private static void Box(PlotDimensions dims, Graphics gfx, Population pop, Random rand,
             double popLeft, double popWidth, Color color, Position position, BoxFormat boxFormat,
             HorizontalAlignment errorAlignment = HorizontalAlignment.Right)
         {
@@ -413,7 +413,7 @@ namespace ScottPlot.Plottable
                     throw new NotImplementedException();
             }
 
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            gfx.ClipToDataArea(dims);
             using (Pen pen = GDI.Pen(Color.Black))
             using (Brush brush = GDI.Brush(color))
             {

--- a/src/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot/Plottable/RadarPlot.cs
@@ -240,7 +240,7 @@ namespace ScottPlot.Plottable
 
         public int PointCount { get => Norm.Length; }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             int numGroups = Norm.GetUpperBound(0) + 1;
             int numCategories = Norm.GetUpperBound(1) + 1;
@@ -248,7 +248,7 @@ namespace ScottPlot.Plottable
             double minScale = new double[] { dims.PxPerUnitX, dims.PxPerUnitX }.Min();
             PointF origin = new PointF(dims.GetPixelX(0), dims.GetPixelY(0));
 
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            gfx.ClipToDataArea(dims);
             using (Pen pen = GDI.Pen(WebColor, OutlineWidth))
             using (Brush brush = GDI.Brush(Color.Black))
             using (StringFormat sf = new StringFormat() { LineAlignment = StringAlignment.Center })
@@ -256,7 +256,7 @@ namespace ScottPlot.Plottable
             using (System.Drawing.Font font = GDI.Font(Font))
             using (Brush fontBrush = GDI.Brush(Font.Color))
             {
-                RenderAxis(gfx, dims, bmp, lowQuality);
+                RenderAxis(gfx, dims);
 
                 for (int i = 0; i < numGroups; i++)
                 {
@@ -279,7 +279,7 @@ namespace ScottPlot.Plottable
                 ? new StarAxisTick(location, NormMaxes.Select(x => x * location).ToArray())
                 : new StarAxisTick(location, NormMax);
 
-        private void RenderAxis(Graphics gfx, PlotDimensions dims, Bitmap bmp, bool lowQuality)
+        private void RenderAxis(Graphics gfx, PlotDimensions dims)
         {
             double[] tickLocations = new[] { 0.25, 0.5, 1 };
             StarAxisTick[] ticks = tickLocations.Select(x => GetTick(x)).ToArray();
@@ -300,7 +300,7 @@ namespace ScottPlot.Plottable
                 ImagePlacement = ImagePlacement.Outside
             };
 
-            axis.Render(dims, bmp, lowQuality);
+            axis.Render(dims, gfx);
         }
     }
 }

--- a/src/ScottPlot/Plottable/RadialGaugePlot.cs
+++ b/src/ScottPlot/Plottable/RadialGaugePlot.cs
@@ -249,7 +249,7 @@ namespace ScottPlot.Plottable
             return new AxisLimits(-radius, radius, -radius, radius);
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             ValidateData();
 
@@ -261,7 +261,7 @@ namespace ScottPlot.Plottable
                 mode: GaugeMode);
 
             PointF centerPixel = new(dims.GetPixelX(0), dims.GetPixelY(0));
-            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
+            gfx.ClipToDataArea(dims);
 
             float pxPerUnit = (float)Math.Min(dims.PxPerUnitX, dims.PxPerUnitY);
             float gaugeWidthPx = pxPerUnit / (GaugeCount * ((float)SpaceFraction + 1));

--- a/src/ScottPlot/Plottable/ScaleBar.cs
+++ b/src/ScottPlot/Plottable/ScaleBar.cs
@@ -50,9 +50,9 @@ namespace ScottPlot.Plottable
                 throw new InvalidOperationException("Width and Height cannot be Infinity");
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
-            using (var gfx = GDI.Graphics(bmp, dims, lowQuality))
+            gfx.ClipToDataArea(dims);
             using (var font = GDI.Font(Font))
             using (var fontBrush = new SolidBrush(Font.Color))
             using (var linePen = new Pen(LineColor, LineWidth))

--- a/src/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot/Plottable/ScatterPlot.cs
@@ -212,12 +212,12 @@ namespace ScottPlot.Plottable
                 yMax: limits[3] + OffsetY);
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (IsVisible == false)
                 return;
 
-            using (var gfx = GDI.Graphics(bmp, dims, lowQuality))
+            gfx.ClipToDataArea(dims);
             using (var penLine = GDI.Pen(Color, LineWidth, LineStyle, true))
             using (var penLineError = GDI.Pen(Color, ErrorLineWidth, LineStyle.Solid, true))
             {

--- a/src/ScottPlot/Plottable/ScatterPlotHighlight.cs
+++ b/src/ScottPlot/Plottable/ScatterPlotHighlight.cs
@@ -14,7 +14,7 @@ namespace ScottPlot.Plottable
         public ScatterPlotHighlight(double[] xs, double[] ys, double[] xErr = null, double[] yErr = null) :
                                     base(xs, ys, xErr, yErr) => HighlightClear();
 
-        public new void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false) => throw new NotImplementedException();
+        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false) => throw new NotImplementedException();
         public void HighlightClear() => throw new NotImplementedException();
         public (double x, double y, int index) HighlightPoint(int index) => throw new NotImplementedException();
         public (double x, double y, int index) HighlightPointNearestX(double x) => throw new NotImplementedException();

--- a/src/ScottPlot/Plottable/ScatterPlotList.cs
+++ b/src/ScottPlot/Plottable/ScatterPlotList.cs
@@ -98,13 +98,13 @@ namespace ScottPlot.Plottable
             return new AxisLimits(xMin, xMax, yMin, yMax);
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             PointF[] points = new PointF[Count];
             for (int i = 0; i < Count; i++)
                 points[i] = new PointF(dims.GetPixelX(Xs[i]), dims.GetPixelY(Ys[i]));
 
-            using (var gfx = GDI.Graphics(bmp, dims, lowQuality))
+            gfx.ClipToDataArea(dims);
             using (var linePen = GDI.Pen(Color, LineWidth, LineStyle, true))
             {
                 if (LineStyle != LineStyle.None && LineWidth > 0 && Count > 1)

--- a/src/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot/Plottable/SignalPlotBase.cs
@@ -733,9 +733,9 @@ namespace ScottPlot.Plottable
             return new LegendItem[] { singleLegendItem };
         }
 
-        public virtual void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public virtual void Render(PlotDimensions dims, Graphics gfx)
         {
-            using var gfx = GDI.Graphics(bmp, dims, lowQuality);
+            gfx.ClipToDataArea(dims);
             using var brush = GDI.Brush(Color);
             using var penLD = GDI.Pen(Color, (float)LineWidth, LineStyle, true);
             using var penHD = GDI.Pen(Color, (float)LineWidth, LineStyle.Solid, true);

--- a/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -309,7 +309,7 @@ namespace ScottPlot.Plottable
         /// </summary>
         /// <param name="x">X position in plot space</param>
         /// <returns></returns>
-        private new (double x, TY y, int index) GetPointNearestX(double x)
+        private new(double x, TY y, int index) GetPointNearestX(double x)
         {
             throw new NotImplementedException();
         }

--- a/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -103,9 +103,9 @@ namespace ScottPlot.Plottable
             }
         }
 
-        public override void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public override void Render(PlotDimensions dims, Graphics gfx)
         {
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            gfx.ClipToDataArea(dims);
             using (var brush = new SolidBrush(Color))
             using (var penHD = GDI.Pen(Color, (float)LineWidth, LineStyle, true))
             {
@@ -309,7 +309,7 @@ namespace ScottPlot.Plottable
         /// </summary>
         /// <param name="x">X position in plot space</param>
         /// <returns></returns>
-        private new(double x, TY y, int index) GetPointNearestX(double x)
+        private new (double x, TY y, int index) GetPointNearestX(double x)
         {
             throw new NotImplementedException();
         }

--- a/src/ScottPlot/Plottable/Text.cs
+++ b/src/ScottPlot/Plottable/Text.cs
@@ -46,12 +46,12 @@ namespace ScottPlot.Plottable
                 throw new InvalidOperationException("text cannot be null or whitespace");
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (string.IsNullOrWhiteSpace(Label) || IsVisible == false)
                 return;
 
-            using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
+            gfx.ClipToDataArea(dims);
             using (var font = GDI.Font(Font))
             using (var fontBrush = new SolidBrush(Font.Color))
             using (var frameBrush = new SolidBrush(BackgroundColor))

--- a/src/ScottPlot/Plottable/Tooltip.cs
+++ b/src/ScottPlot/Plottable/Tooltip.cs
@@ -49,12 +49,12 @@ namespace ScottPlot.Plottable
                 throw new InvalidOperationException("Y must be a real number");
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (!IsVisible)
                 return;
 
-            using (var gfx = GDI.Graphics(bmp, dims, lowQuality, clipToDataArea: true))
+            gfx.ClipToDataArea(dims);
             using (var font = GDI.Font(Font))
             using (var fillBrush = GDI.Brush(FillColor))
             using (var fontBrush = GDI.Brush(Font.Color))

--- a/src/ScottPlot/Plottable/VectorField.cs
+++ b/src/ScottPlot/Plottable/VectorField.cs
@@ -108,12 +108,12 @@ namespace ScottPlot.Plottable
 
         public int PointCount { get => Vectors.Length; }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (IsVisible == false)
                 return;
 
-            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
+            gfx.ClipToDataArea(dims);
 
             ArrowStyle.Render(dims, gfx, Xs, Ys, Vectors, VectorColors);
         }

--- a/src/ScottPlot/Renderable/Axis.cs
+++ b/src/ScottPlot/Renderable/Axis.cs
@@ -121,7 +121,7 @@ namespace ScottPlot.Renderable
         /// <summary>
         /// Render all components of this axis onto the given Bitmap
         /// </summary>
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (IsVisible == false)
                 return;
@@ -132,12 +132,10 @@ namespace ScottPlot.Renderable
             AxisLabel.PixelSize = PixelSize;
             AxisLine.PixelOffset = PixelOffset;
 
-            using (var gfx = GDI.Graphics(bmp, dims, lowQuality, false))
-            {
-                AxisTicks.Render(dims, bmp, lowQuality);
-                AxisLabel.Render(dims, bmp, lowQuality);
-                AxisLine.Render(dims, bmp, lowQuality);
-            }
+            gfx.ClipToDataArea(dims, false);
+            AxisTicks.Render(dims, gfx);
+            AxisLabel.Render(dims, gfx);
+            AxisLine.Render(dims, gfx);
         }
 
         /// <summary>

--- a/src/ScottPlot/Renderable/AxisDimensions.cs
+++ b/src/ScottPlot/Renderable/AxisDimensions.cs
@@ -15,6 +15,11 @@ namespace ScottPlot.Renderable
         public float FigureSizePx { get; private set; }
 
         /// <summary>
+        /// Offset of the data area (in pixels) relative to the left or top edge of the figure.
+        /// </summary>
+        public float OffsetPx { get; private set; }
+
+        /// <summary>
         /// Side of just the data area (in pixels).
         /// The data area is the inner rectangle that displays plots.
         /// </summary>
@@ -152,11 +157,18 @@ namespace ScottPlot.Renderable
         /// <summary>
         /// Resize/reposition this axis according to the given pixel units
         /// </summary>
-        public void Resize(float figureSizePx, float? dataSizePx = null, float? dataOffsetPx = null)
+        public void Resize(float figureSizePx, float figureOffsetPx, float? dataSizePx = null, float? dataOffsetPx = null)
         {
             FigureSizePx = figureSizePx;
-            DataSizePx = dataSizePx ?? DataSizePx;
-            DataOffsetPx = dataOffsetPx ?? DataOffsetPx;
+            OffsetPx = figureOffsetPx;
+            if (dataSizePx != null)
+            {
+                DataSizePx = dataSizePx ?? DataSizePx;
+            }
+            if (dataOffsetPx != null)
+            {
+                DataOffsetPx = dataOffsetPx ?? DataOffsetPx;
+            }
         }
 
         /// <summary>

--- a/src/ScottPlot/Renderable/AxisLabel.cs
+++ b/src/ScottPlot/Renderable/AxisLabel.cs
@@ -80,12 +80,12 @@ namespace ScottPlot.Renderable
             }
         }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (IsVisible == false || (string.IsNullOrWhiteSpace(Label) && ImageLabel == null))
                 return;
 
-            using var gfx = GDI.Graphics(bmp, dims, lowQuality, false);
+            gfx.ClipToDataArea(dims, false);
             (float x, float y) = GetAxisCenter(dims);
 
             if (ImageLabel is null)

--- a/src/ScottPlot/Renderable/AxisLine.cs
+++ b/src/ScottPlot/Renderable/AxisLine.cs
@@ -14,12 +14,12 @@ namespace ScottPlot.Renderable
         public Edge Edge;
         public float PixelOffset;
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (IsVisible == false)
                 return;
 
-            using (var gfx = GDI.Graphics(bmp, dims, lowQuality, false))
+            gfx.ClipToDataArea(dims, false);
             using (var pen = GDI.Pen(Color, Width))
             {
                 float left = dims.DataOffsetX;

--- a/src/ScottPlot/Renderable/AxisTicks.cs
+++ b/src/ScottPlot/Renderable/AxisTicks.cs
@@ -54,13 +54,12 @@ namespace ScottPlot.Renderable
 
         // TODO: store the TickCollection in the Axis module, not in the Ticks module.
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (!IsVisible)
                 return;
 
-            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality, false);
-
+            gfx.ClipToDataArea(dims, false);
             double[] visibleMajorTicks = TickCollection.GetVisibleMajorTicks(dims)
                 .Select(t => t.Position)
                 .ToArray();

--- a/src/ScottPlot/Renderable/AxisTicksRender.cs
+++ b/src/ScottPlot/Renderable/AxisTicksRender.cs
@@ -94,13 +94,13 @@ namespace ScottPlot.Renderable
                         float x = dims.GetPixelX(visibleMajorTicks[i].Position);
                         float y = dims.DataOffsetY + dims.DataHeight + MajorTickLength;
 
-                        gfx.TranslateTransform(x, y);
+                        //gfx.TranslateTransform(x, y);
                         gfx.RotateTransform(-rotation);
                         sf.Alignment = rotation == 0 ? StringAlignment.Center : StringAlignment.Far;
                         if (rulerMode) sf.Alignment = StringAlignment.Near;
                         sf.LineAlignment = rotation == 0 ? StringAlignment.Near : StringAlignment.Center;
-                        gfx.DrawString(visibleMajorTicks[i].Label, font, brush, 0, 0, sf);
-                        gfx.ResetTransform();
+                        gfx.DrawString(visibleMajorTicks[i].Label, font, brush, x, y, sf);
+                        //gfx.ResetTransform();
                     }
                     break;
 
@@ -110,13 +110,13 @@ namespace ScottPlot.Renderable
                         float x = dims.GetPixelX(visibleMajorTicks[i].Position);
                         float y = dims.DataOffsetY - MajorTickLength;
 
-                        gfx.TranslateTransform(x, y);
+                        //gfx.TranslateTransform(x, y);
                         gfx.RotateTransform(-rotation);
                         sf.Alignment = rotation == 0 ? StringAlignment.Center : StringAlignment.Near;
                         if (rulerMode) sf.Alignment = StringAlignment.Near;
                         sf.LineAlignment = rotation == 0 ? StringAlignment.Far : StringAlignment.Center;
-                        gfx.DrawString(visibleMajorTicks[i].Label, font, brush, 0, 0, sf);
-                        gfx.ResetTransform();
+                        gfx.DrawString(visibleMajorTicks[i].Label, font, brush, x, y, sf);
+                        //gfx.ResetTransform();
                     }
                     break;
 
@@ -126,7 +126,7 @@ namespace ScottPlot.Renderable
                         float x = dims.DataOffsetX - PixelOffset - MajorTickLength;
                         float y = dims.GetPixelY(visibleMajorTicks[i].Position);
 
-                        gfx.TranslateTransform(x, y);
+                        //gfx.TranslateTransform(x, y);
                         gfx.RotateTransform(-rotation);
                         sf.Alignment = StringAlignment.Far;
                         sf.LineAlignment = rulerMode ? StringAlignment.Far : StringAlignment.Center;
@@ -135,8 +135,8 @@ namespace ScottPlot.Renderable
                             sf.Alignment = StringAlignment.Center;
                             sf.LineAlignment = StringAlignment.Far;
                         }
-                        gfx.DrawString(visibleMajorTicks[i].Label, font, brush, 0, 0, sf);
-                        gfx.ResetTransform();
+                        gfx.DrawString(visibleMajorTicks[i].Label, font, brush, x, y, sf);
+                        //gfx.ResetTransform();
                     }
                     break;
 
@@ -146,7 +146,7 @@ namespace ScottPlot.Renderable
                         float x = dims.DataOffsetX + PixelOffset + MajorTickLength + dims.DataWidth;
                         float y = dims.GetPixelY(visibleMajorTicks[i].Position);
 
-                        gfx.TranslateTransform(x, y);
+                        //gfx.TranslateTransform(x, y);
                         gfx.RotateTransform(-rotation);
                         sf.Alignment = StringAlignment.Near;
                         sf.LineAlignment = rulerMode ? StringAlignment.Far : StringAlignment.Center;
@@ -155,8 +155,8 @@ namespace ScottPlot.Renderable
                             sf.Alignment = StringAlignment.Center;
                             sf.LineAlignment = StringAlignment.Near;
                         }
-                        gfx.DrawString(visibleMajorTicks[i].Label, font, brush, 0, 0, sf);
-                        gfx.ResetTransform();
+                        gfx.DrawString(visibleMajorTicks[i].Label, font, brush, x, y, sf);
+                        //gfx.ResetTransform();
                     }
                     break;
 

--- a/src/ScottPlot/Renderable/DataBackground.cs
+++ b/src/ScottPlot/Renderable/DataBackground.cs
@@ -11,9 +11,9 @@ namespace ScottPlot.Renderable
         public Color Color { get; set; } = Color.White;
         public bool IsVisible { get; set; } = true;
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
-            using (var gfx = GDI.Graphics(bmp, dims, lowQuality: true, false))
+            gfx.ClipToDataArea(dims, false, true);
             using (var brush = GDI.Brush(Color))
             {
                 var dataRect = new RectangleF(x: dims.DataOffsetX, y: dims.DataOffsetY, width: dims.DataWidth, height: dims.DataHeight);

--- a/src/ScottPlot/Renderable/FigureBackground.cs
+++ b/src/ScottPlot/Renderable/FigureBackground.cs
@@ -8,12 +8,10 @@ namespace ScottPlot.Renderable
         public Color Color { get; set; } = Color.White;
         public bool IsVisible { get; set; } = true;
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
-            using (var gfx = GDI.Graphics(bmp, dims, lowQuality: true, false))
-            {
-                gfx.Clear(Color);
-            }
+            gfx.ClipToDataArea(dims, false, true);
+            gfx.Clear(Color);
         }
     }
 }

--- a/src/ScottPlot/Renderable/IRenderable.cs
+++ b/src/ScottPlot/Renderable/IRenderable.cs
@@ -10,6 +10,6 @@ namespace ScottPlot.Renderable
     public interface IRenderable
     {
         bool IsVisible { get; set; }
-        void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false);
+        void Render(PlotDimensions dims, Graphics gfx);
     }
 }

--- a/src/ScottPlot/Renderable/Legend.cs
+++ b/src/ScottPlot/Renderable/Legend.cs
@@ -37,12 +37,12 @@ namespace ScottPlot.Renderable
         private float SymbolPad { get { return Font.Size / 3; } }
         private float MarkerWidth { get { return Font.Size / 2; } }
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (IsVisible is false || LegendItems is null || LegendItems.Length == 0)
                 return;
 
-            using (var gfx = GDI.Graphics(bmp, dims, lowQuality, false))
+            gfx.ClipToDataArea(dims, false);
             using (var font = GDI.Font(Font))
             {
                 var (maxLabelWidth, maxLabelHeight, width, height) = GetDimensions(gfx, LegendItems, font);

--- a/src/ScottPlot/Renderable/Message.cs
+++ b/src/ScottPlot/Renderable/Message.cs
@@ -61,12 +61,12 @@ namespace ScottPlot.Renderable
 
         public bool IsVisible { get; set; } = false;
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (!IsVisible || string.IsNullOrWhiteSpace(Text))
                 return;
 
-            using (var gfx = GDI.Graphics(bmp, dims, lowQuality, false))
+            gfx.ClipToDataArea(dims, false);
             using (var font = GDI.Font(FontName, FontSize, FontBold))
             using (var fontBrush = new SolidBrush(FontColor))
             using (var fillBrush = new SolidBrush(FillColor))

--- a/src/ScottPlot/Renderable/ZoomRectangle.cs
+++ b/src/ScottPlot/Renderable/ZoomRectangle.cs
@@ -19,12 +19,12 @@ namespace ScottPlot.Renderable
         public void Set(float x, float y, float width, float height) =>
             (X, Y, Width, Height, IsVisible) = (x, y, width, height, true);
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             if (!IsVisible)
                 return;
 
-            using (var gfx = GDI.Graphics(bmp, dims, lowQuality: true, false))
+            gfx.ClipToDataArea(dims, false, true);
             using (var fillBrush = GDI.Brush(FillColor))
             using (var borderPen = GDI.Pen(BorderColor))
             {

--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -127,6 +127,16 @@ namespace ScottPlot
         public int Height => (int)YAxis.Dims.FigureSizePx;
 
         /// <summary>
+        /// Width of the figure (in pixels)
+        /// </summary>
+        public int OffsetX => (int)XAxis.Dims.OffsetPx;
+
+        /// <summary>
+        /// Height of the figure (in pixels)
+        /// </summary>
+        public int OffsetY => (int)YAxis.Dims.OffsetPx;
+
+        /// <summary>
         /// Default padding to use when AxisAuto() or Margins() is called without a specified margin
         /// </summary>
         public double MarginsX = .05;
@@ -151,6 +161,7 @@ namespace ScottPlot
 
             // determine figure dimensions based on primary X and Y axis
             var figureSize = new SizeF(XAxis.Dims.FigureSizePx, YAxis.Dims.FigureSizePx);
+            var figureOffset = new PointF(XAxis.Dims.OffsetPx, YAxis.Dims.OffsetPx);
             var dataSize = new SizeF(XAxis.Dims.DataSizePx, YAxis.Dims.DataSizePx);
             var dataOffset = new PointF(XAxis.Dims.DataOffsetPx, YAxis.Dims.DataOffsetPx);
 
@@ -159,16 +170,16 @@ namespace ScottPlot
             (double yMin, double yMax) = yAxis.Dims.RationalLimits();
             var limits = (xMin, xMax, yMin, yMax);
 
-            return new PlotDimensions(figureSize, dataSize, dataOffset, limits, scaleFactor);
+            return new PlotDimensions(figureSize, figureOffset, dataSize, dataOffset, limits, scaleFactor);
         }
 
         /// <summary>
-        /// Set the default size for rendering images
+        /// Set the default size and offset for rendering images
         /// </summary>
-        public void Resize(float width, float height)
+        public void Resize(float width, float height, float X = 0, float Y = 0)
         {
             foreach (Axis axis in Axes)
-                axis.Dims.Resize(axis.IsHorizontal ? width : height);
+                axis.Dims.Resize(axis.IsHorizontal ? width : height, axis.IsHorizontal ? X : Y);
         }
 
         /// <summary>
@@ -511,9 +522,9 @@ namespace ScottPlot
             foreach (Axis axis in Axes)
             {
                 if (axis.IsHorizontal)
-                    axis.Dims.Resize(Width, XAxis.Dims.DataSizePx, XAxis.Dims.DataOffsetPx);
+                    axis.Dims.Resize(Width, OffsetX, XAxis.Dims.DataSizePx, XAxis.Dims.DataOffsetPx);
                 else
-                    axis.Dims.Resize(Height, YAxis.Dims.DataSizePx, YAxis.Dims.DataOffsetPx);
+                    axis.Dims.Resize(Height, OffsetY, YAxis.Dims.DataSizePx, YAxis.Dims.DataOffsetPx);
             }
         }
 
@@ -560,7 +571,7 @@ namespace ScottPlot
             var figSize = new SizeF(Width, Height);
 
             // first-pass tick calculation based on full image size 
-            var dimsFull = new PlotDimensions(figSize, figSize, new PointF(0, 0), limits, scaleFactor: 1);
+            var dimsFull = new PlotDimensions(figSize, new PointF(0, 0), figSize, new PointF(0, 0), limits, scaleFactor: 1);
 
             foreach (var axis in Axes)
             {
@@ -578,9 +589,10 @@ namespace ScottPlot
 
             // now recalculate ticks based on new layout
             var dataSize = new SizeF(XAxis.Dims.DataSizePx, YAxis.Dims.DataSizePx);
+            var figureOffset = new PointF(XAxis.Dims.OffsetPx, YAxis.Dims.OffsetPx);
             var dataOffset = new PointF(XAxis.Dims.DataOffsetPx, YAxis.Dims.DataOffsetPx);
 
-            var dims3 = new PlotDimensions(figSize, dataSize, dataOffset, limits, scaleFactor: 1.0);
+            var dims3 = new PlotDimensions(figSize, figureOffset, dataSize, dataOffset, limits, scaleFactor: 1.0);
             foreach (var axis in Axes)
             {
                 bool isMatchingXAxis = axis.IsHorizontal && axis.AxisIndex == xAxisIndex;

--- a/src/ScottPlot/StarAxis.cs
+++ b/src/ScottPlot/StarAxis.cs
@@ -95,7 +95,7 @@ namespace ScottPlot
         public int XAxisIndex { get; set; } = 0;
         public int YAxisIndex { get; set; } = 0;
 
-        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        public void Render(PlotDimensions dims, Graphics gfx)
         {
             double sweepAngle = 2 * Math.PI / NumberOfSpokes;
             double minScale = new double[] { dims.PxPerUnitX, dims.PxPerUnitX }.Min();


### PR DESCRIPTION
Hi,

I refactored the IRenderable and IPlottable Render function to work directly on a Graphics object insted of a bitmap. This allows to use the Graphics object during printing and render directly on the printer. This improves the print result a lot. 

[ScottPlotClear.pdf](https://github.com/ScottPlot/ScottPlot/files/7684122/ScottPlotClear.pdf)
[ScottPlotBlurry.pdf](https://github.com/ScottPlot/ScottPlot/files/7684124/ScottPlotBlurry.pdf)

I have implemented this for myself because I need a clean printout. Maybe it is also interesting for others. If not feel free to decline the request. Since it's my first request, I ask to be lenient with me and possibly ask for a small hint what I can do better. 

- IRenderable.Render and IPlottable.Render changed to _void Render(PlotDimensions dims, Graphics gfx)_

- OffsetX + OffsetY Added to Settings --> Adds an offset for the entire plot in Graphics object (need for printing at other coordinates than 0:0 )

- ClipToDataArea() used to clip drawing to data area of the plot, set quality and transform coordinates according to OffsetX/OffsetY