### PR TITLE
SignalXY: improve support for fills with zero area

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -6,6 +6,7 @@ _In development / not yet on NuGet_
 * Ticks: Improved minor tick and minor grid line placement (#1420, #1421) _Thanks @bclehmann and @at2software_
 * Palette: Added Amber and Nero palettes (#1411, #1412) _Thanks @gauravagrwal_
 * Style: Hazel style (#1414) _Thanks @gauravagrwal_
+* SignalXY: Fixed bug affecting filled plots with zero area (#1476, #1477) _Thanks @chenxuuu_
 
 ## ScottPlot 4.1.27
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2021-10-24_

--- a/src/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot/Plottable/SignalPlotBase.cs
@@ -510,6 +510,8 @@ namespace ScottPlot.Plottable
         /// </summary>
         internal void FillToInfinity(PlotDimensions dims, Graphics gfx, float xPxStart, float xPxEnd, PointF[] linePoints, bool fillToPositiveInfinity)
         {
+            if ((int)(xPxEnd - xPxStart) == 0 || (int)dims.Height == 0)
+                return;
             float minVal = 0;
             float maxVal = (dims.DataHeight * (fillToPositiveInfinity ? -1 : 1)) + dims.DataOffsetY;
 

--- a/src/tests/PlotTypes/Signal.cs
+++ b/src/tests/PlotTypes/Signal.cs
@@ -141,5 +141,25 @@ namespace ScottPlotTests.PlotTypes
 
             TestTools.SaveFig(plt);
         }
+
+        [Test]
+        public void Test_Signal_FillBelow_ZoomOut()
+        {
+            // addresses issue #1476 where zooming far out causes the width of the
+            // fill to be zero and a hard crash
+            // https://github.com/ScottPlot/ScottPlot/issues/1476
+
+            var plt = new ScottPlot.Plot(400, 300);
+
+            var line = plt.AddSignal(ScottPlot.DataGen.RandomWalk(100));
+
+            line.FillBelow();
+
+            for (int i = 0; i < 10; i++)
+            {
+                plt.AxisZoom(.1, .1);
+                plt.Render();
+            }
+        }
     }
 }

--- a/src/tests/PlotTypes/SignalXY.cs
+++ b/src/tests/PlotTypes/SignalXY.cs
@@ -60,5 +60,27 @@ namespace ScottPlotTests.PlotTypes
             plt.SetAxisLimits(yMin: -200, yMax: 200);
             TestTools.SaveFig(plt);
         }
+
+        [Test]
+        public void Test_SignalXY_FillBelow_ZoomOut()
+        {
+            // addresses issue #1476 where zooming far out causes the width of the
+            // fill to be zero and a hard crash
+            // https://github.com/ScottPlot/ScottPlot/issues/1476
+
+            var plt = new ScottPlot.Plot(400, 300);
+
+            var line = plt.AddSignalXY(
+                xs: ScottPlot.DataGen.Consecutive(100),
+                ys: ScottPlot.DataGen.RandomWalk(100));
+
+            line.FillBelow();
+
+            for (int i = 0; i < 10; i++)
+            {
+                plt.AxisZoom(.1, .1);
+                plt.Render();
+            }
+        }
     }
 }


### PR DESCRIPTION
avoid draw 0px width or height rectangle, fix #1476