### PR TITLE
Add options to invert tick mark direction

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -12,6 +12,7 @@ _In development / not yet on NuGet_
 * Population plot: Population plots `DataFormat` now have a `DataFormat` member that displays individual data points on top of a bar graph representing their mean and variance (#1440) Thanks _@Syntaxrabbit_
 * SignalXY: Fixed bug affecting filled plots with zero area (#1476, #1477) _Thanks @chenxuuu_
 * Cookbook: Added example showing how to place markers colored according to a colormap displayed in a colorbar (#1461) _Thanks @obnews_
+* Ticks: Added option to invert tick mark direction (#1489, #1475) _Thanks @wangyexiang_
 
 ## ScottPlot 4.1.27
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2021-10-24_

--- a/src/ScottPlot/Renderable/Axis.cs
+++ b/src/ScottPlot/Renderable/Axis.cs
@@ -292,6 +292,14 @@ namespace ScottPlot.Renderable
         }
 
         /// <summary>
+        /// Control whether tick marks point outward or inward
+        /// </summary>
+        public void TickMarkDirection(bool outward)
+        {
+            AxisTicks.TicksExtendOutward = outward;
+        }
+
+        /// <summary>
         /// Set the culture to use for unit-to-string tick mark conversion
         /// </summary>
         public void SetCulture(System.Globalization.CultureInfo culture) => AxisTicks.TickCollection.Culture = culture;

--- a/src/ScottPlot/Renderable/AxisTicks.cs
+++ b/src/ScottPlot/Renderable/AxisTicks.cs
@@ -22,6 +22,7 @@ namespace ScottPlot.Renderable
         public bool TickLabelVisible = true;
         public float TickLabelRotation = 0;
         public Drawing.Font TickLabelFont = new Drawing.Font() { Size = 11 };
+        public bool TicksExtendOutward = true;
 
         // major tick/grid styling
         public bool MajorTickVisible = true;
@@ -76,10 +77,22 @@ namespace ScottPlot.Renderable
                 AxisTicksRender.RenderGridLines(dims, gfx, visibleMinorTicks, MinorGridStyle, MinorGridColor, MinorGridWidth, Edge);
 
             if (MinorTickVisible)
-                AxisTicksRender.RenderTickMarks(dims, gfx, visibleMinorTicks, MinorTickLength, MinorTickColor, Edge, PixelOffset);
+            {
+                float tickLength = TicksExtendOutward ? MinorTickLength : -MinorTickLength;
+                AxisTicksRender.RenderTickMarks(dims, gfx, visibleMinorTicks, tickLength, MinorTickColor, Edge, PixelOffset);
+            }
 
             if (MajorTickVisible)
-                AxisTicksRender.RenderTickMarks(dims, gfx, visibleMajorTicks, RulerMode ? MajorTickLength * 4 : MajorTickLength, MajorTickColor, Edge, PixelOffset);
+            {
+                float tickLength = MajorTickLength;
+
+                if (RulerMode)
+                    tickLength *= 4;
+
+                tickLength = TicksExtendOutward ? tickLength : -tickLength;
+
+                AxisTicksRender.RenderTickMarks(dims, gfx, visibleMajorTicks, tickLength, MajorTickColor, Edge, PixelOffset);
+            }
 
             if (TickLabelVisible)
                 AxisTicksRender.RenderTickLabels(dims, gfx, TickCollection, TickLabelFont, Edge, TickLabelRotation, RulerMode, PixelOffset, MajorTickLength, MinorTickLength);

--- a/src/ScottPlot/Renderable/AxisTicks.cs
+++ b/src/ScottPlot/Renderable/AxisTicks.cs
@@ -69,20 +69,20 @@ namespace ScottPlot.Renderable
                 .Select(t => t.Position)
                 .ToArray();
 
-            if (MajorTickVisible)
-                AxisTicksRender.RenderTickMarks(dims, gfx, visibleMajorTicks, RulerMode ? MajorTickLength * 4 : MajorTickLength, MajorTickColor, Edge, PixelOffset);
-
-            if (TickLabelVisible)
-                AxisTicksRender.RenderTickLabels(dims, gfx, TickCollection, TickLabelFont, Edge, TickLabelRotation, RulerMode, PixelOffset, MajorTickLength, MinorTickLength);
-
-            if (MinorTickVisible)
-                AxisTicksRender.RenderTickMarks(dims, gfx, visibleMinorTicks, MinorTickLength, MinorTickColor, Edge, PixelOffset);
-
             if (MajorGridVisible)
                 AxisTicksRender.RenderGridLines(dims, gfx, visibleMajorTicks, MajorGridStyle, MajorGridColor, MajorGridWidth, Edge);
 
             if (MinorGridVisible)
                 AxisTicksRender.RenderGridLines(dims, gfx, visibleMinorTicks, MinorGridStyle, MinorGridColor, MinorGridWidth, Edge);
+
+            if (MinorTickVisible)
+                AxisTicksRender.RenderTickMarks(dims, gfx, visibleMinorTicks, MinorTickLength, MinorTickColor, Edge, PixelOffset);
+
+            if (MajorTickVisible)
+                AxisTicksRender.RenderTickMarks(dims, gfx, visibleMajorTicks, RulerMode ? MajorTickLength * 4 : MajorTickLength, MajorTickColor, Edge, PixelOffset);
+
+            if (TickLabelVisible)
+                AxisTicksRender.RenderTickLabels(dims, gfx, TickCollection, TickLabelFont, Edge, TickLabelRotation, RulerMode, PixelOffset, MajorTickLength, MinorTickLength);
         }
     }
 }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/AxisAdvanced.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/AxisAdvanced.cs
@@ -481,4 +481,23 @@ namespace ScottPlot.Cookbook.Recipes
             plt.YAxis.TickLabelFormat(customTickFormatter);
         }
     }
+
+    class TickMarksInvertDirection : IRecipe
+    {
+        public string Category => "Advanced Axis Features";
+        public string ID => "ticks_invert_tick_mark_direction";
+        public string Title => "Invert tick mark direction";
+        public string Description =>
+            "Tick marks can be outward (default) or inverted to appear as " +
+            "inward lines relative to the edge of the plot area.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            plt.AddSignal(DataGen.Sin(51));
+            plt.AddSignal(DataGen.Cos(51));
+
+            plt.XAxis.TickMarkDirection(outward: false);
+            plt.YAxis.TickMarkDirection(outward: false);
+        }
+    }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4165489/147177112-4358bdf0-e9ba-4907-8616-80708cf6d526.png)

```cs
plt.XAxis.TickMarkDirection(outward: false);
plt.YAxis.TickMarkDirection(outward: false);
```

Resolves #1475