### PR TITLE
Text: improve alignment

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -21,6 +21,8 @@ _In development / not yet on NuGet_
 * Image: New `Scale` property allows customization of image size (#1406)
 * Axis: `Plot.GetDataLimits()` returns the boundaries of all data from all visible plottables regardless of the current axis limits (#1415) _Thanks @EFeru_
 * Rendering: Improved support for scaled plots when passing scale as a `Plot.Render()` argument (#1416) _Thanks @Andreas_
+* Text: Improved support for rotated text and background fills using custom alignments (#1417, #1516) _Thanks @riquich and @AndXaf_
+* Text: Added options for custom borders (#1417, #1516) _Thanks @AndXaf and @MachineFossil_
 
 ## ScottPlot 4.1.27
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2021-10-24_

--- a/src/ScottPlot/Drawing/GDI.cs
+++ b/src/ScottPlot/Drawing/GDI.cs
@@ -71,6 +71,33 @@ namespace ScottPlot.Drawing
             return size;
         }
 
+        private static (float x, float y) AlignmentFraction(Alignment alignment)
+        {
+            return alignment switch
+            {
+                Alignment.UpperLeft => (0, 0),
+                Alignment.UpperRight => (1, 0),
+                Alignment.UpperCenter => (.5f, 0),
+                Alignment.MiddleLeft => (0, .5f),
+                Alignment.MiddleCenter => (.5f, .5f),
+                Alignment.MiddleRight => (1, .5f),
+                Alignment.LowerLeft => (0, 1),
+                Alignment.LowerRight => (1, 1),
+                Alignment.LowerCenter => (.5f, 1),
+                _ => throw new NotImplementedException(),
+            };
+        }
+
+        /// <summary>
+        /// Return the X and Y distance (pixels) necessary to translate the canvas for the given text/font/alignment
+        /// </summary>
+        public static (float dX, float dY) TranslateString(string text, Font font)
+        {
+            SizeF stringSize = MeasureString(text, font);
+            (float xFrac, float yFrac) = AlignmentFraction(font.Alignment);
+            return (stringSize.Width * xFrac, stringSize.Height * yFrac);
+        }
+
         public static System.Drawing.Color Mix(System.Drawing.Color colorA, System.Drawing.Color colorB, double fracA)
         {
             byte r = (byte)((colorA.R * (1 - fracA)) + colorB.R * fracA);

--- a/src/ScottPlot/Plottable/Text.cs
+++ b/src/ScottPlot/Plottable/Text.cs
@@ -29,6 +29,8 @@ namespace ScottPlot.Plottable
         public bool FontBold { set => Font.Bold = value; }
         public Alignment Alignment { set => Font.Alignment = value; }
         public float Rotation { set => Font.Rotation = value; }
+        public float BorderSize { get; set; } = 0;
+        public Color BorderColor { get; set; } = Color.Black;
         public float PixelOffsetX { get; set; } = 0;
         public float PixelOffsetY { get; set; } = 0;
 
@@ -57,6 +59,7 @@ namespace ScottPlot.Plottable
             using (var font = GDI.Font(Font))
             using (var fontBrush = new SolidBrush(Font.Color))
             using (var frameBrush = new SolidBrush(BackgroundColor))
+            using (var outlinePen = new Pen(BorderColor, BorderSize))
             {
                 float pixelX = dims.GetPixelX(X) + PixelOffsetX;
                 float pixelY = dims.GetPixelY(Y) - PixelOffsetY;
@@ -72,6 +75,8 @@ namespace ScottPlot.Plottable
                 {
                     RectangleF stringRect = new(0, 0, stringSize.Width, stringSize.Height);
                     gfx.FillRectangle(frameBrush, stringRect);
+                    if (BorderSize > 0)
+                        gfx.DrawRectangle(outlinePen, stringRect.X, stringRect.Y, stringRect.Width, stringRect.Height);
                 }
 
                 gfx.DrawString(Label, font, fontBrush, new PointF(0, 0));

--- a/src/ScottPlot/Plottable/Text.cs
+++ b/src/ScottPlot/Plottable/Text.cs
@@ -65,14 +65,16 @@ namespace ScottPlot.Plottable
                 gfx.TranslateTransform(pixelX, pixelY);
                 gfx.RotateTransform(Font.Rotation);
 
+                (float dX, float dY) = GDI.TranslateString(Label, Font);
+                gfx.TranslateTransform(-dX, -dY);
+
                 if (BackgroundFill)
                 {
-                    RectangleF stringRect = new RectangleF(0, 0, stringSize.Width, stringSize.Height);
+                    RectangleF stringRect = new(0, 0, stringSize.Width, stringSize.Height);
                     gfx.FillRectangle(frameBrush, stringRect);
                 }
 
-                StringFormat sf = GDI.StringFormat(Font.Alignment);
-                gfx.DrawString(Label, font, fontBrush, new PointF(0, 0), sf);
+                gfx.DrawString(Label, font, fontBrush, new PointF(0, 0));
 
                 GDI.ResetTransformPreservingScale(gfx, dims);
             }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Text.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Text.cs
@@ -34,42 +34,31 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string ID => "text_alignment";
         public string Title => "Text Alignment and Rotation";
         public string Description =>
-            "Advanced options are available to customize rotation and alignment. " +
-            "Note that if rotation is used, alignment is ignored.";
+            "Alignment indicates which corner is placed at the X/Y coordinate.";
 
         public void ExecuteRecipe(Plot plt)
         {
-            int pointCount = 51;
-            double[] x = DataGen.Consecutive(pointCount);
-            double[] sin = DataGen.Sin(pointCount);
-            double[] cos = DataGen.Cos(pointCount);
+            ScottPlot.Alignment[] alignments = (ScottPlot.Alignment[])Enum.GetValues(typeof(ScottPlot.Alignment));
 
-            plt.AddScatter(x, sin);
-            plt.AddScatter(x, cos);
+            for (int i = 0; i < alignments.Length; i++)
+            {
+                double frac = (double)i / alignments.Length;
+                double x = Math.Sin(frac * Math.PI * 2);
+                double y = Math.Cos(frac * Math.PI * 2);
 
-            plt.AddPoint(25, 0.8, color: Color.Green);
-            var t1 = plt.AddText(" Important Point (1)", 25, 0.8, 16, Color.Green);
+                var txt = plt.AddText(alignments[i].ToString(), x, y);
+                txt.Alignment = alignments[i];
+                txt.Font.Color = Color.Black; ;
+                txt.BackgroundColor = Color.LightSteelBlue;
+                txt.BackgroundFill = true;
+                txt.Rotation = 5;
+                txt.BorderSize = 2;
+                txt.BorderColor = Color.Navy;
 
-            plt.AddPoint(30, 0.3, color: Color.Black, size: 15);
-            var t2 = plt.AddText(" Default alignment (2)", 30, 0.3, 16);
+                plt.AddPoint(x, y, Color.Red, 10);
+            }
 
-            plt.AddPoint(30, 0, color: Color.Black, size: 15);
-            var t3 = plt.AddText("Middle center (3)", 30, 0, 16);
-            t3.Alignment = Alignment.MiddleCenter;
-
-            plt.AddPoint(30, -0.3, color: Color.Black, size: 15);
-            var t4 = plt.AddText("Upper left (4)", 30, -0.3, 16);
-            t4.Alignment = Alignment.UpperLeft;
-
-            plt.AddPoint(5, -.5, color: Color.Blue, size: 15);
-            var t5 = plt.AddText(" Rotated Text (5)", 5, -.5, 16);
-            t5.Rotation = -30;
-
-            var t6 = plt.AddText(" Filled Background (6)", 15, -.6, 16);
-            t6.Color = Color.Red;
-            t6.FontBold = true;
-            t6.BackgroundFill = true;
-            t6.BackgroundColor = Color.LightBlue;
+            plt.Margins(.5, .2);
         }
     }
 

--- a/src/tests/PlotTypes/Text.cs
+++ b/src/tests/PlotTypes/Text.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlotTests.PlotTypes
+{
+    public class Text
+    {
+        [Test]
+        public void Test_Text_Alignment()
+        {
+            ScottPlot.Alignment[] alignments = (ScottPlot.Alignment[])Enum.GetValues(typeof(ScottPlot.Alignment));
+
+            var plt = new ScottPlot.Plot(400, 300);
+
+            for (int i = 0; i < alignments.Length; i++)
+            {
+                double frac = (double)i / alignments.Length;
+                double x = Math.Sin(frac * Math.PI * 2);
+                double y = Math.Cos(frac * Math.PI * 2);
+
+                var txt = plt.AddText(alignments[i].ToString(), x, y);
+                txt.Alignment = alignments[i];
+                txt.Font.Color = System.Drawing.Color.Black; ;
+                txt.BackgroundColor = System.Drawing.Color.LightSteelBlue;
+                txt.BackgroundFill = true;
+
+                plt.AddPoint(x, y, System.Drawing.Color.Black);
+            }
+
+            plt.Frameless();
+            plt.Margins(.5, .2);
+            TestTools.SaveFig(plt);
+        }
+    }
+}

--- a/src/tests/PlotTypes/Text.cs
+++ b/src/tests/PlotTypes/Text.cs
@@ -28,12 +28,14 @@ namespace ScottPlotTests.PlotTypes
                 txt.BackgroundColor = System.Drawing.Color.LightSteelBlue;
                 txt.BackgroundFill = true;
                 txt.Rotation = 5;
+                txt.BorderSize = 2;
+                txt.BorderColor = System.Drawing.Color.Navy;
 
                 plt.AddPoint(x, y, System.Drawing.Color.Black);
             }
 
             plt.Frameless();
-            plt.Margins(.5, .5);
+            plt.Margins(.5, .2);
             TestTools.SaveFig(plt);
         }
     }

--- a/src/tests/PlotTypes/Text.cs
+++ b/src/tests/PlotTypes/Text.cs
@@ -27,12 +27,13 @@ namespace ScottPlotTests.PlotTypes
                 txt.Font.Color = System.Drawing.Color.Black; ;
                 txt.BackgroundColor = System.Drawing.Color.LightSteelBlue;
                 txt.BackgroundFill = true;
+                txt.Rotation = 5;
 
                 plt.AddPoint(x, y, System.Drawing.Color.Black);
             }
 
             plt.Frameless();
-            plt.Margins(.5, .2);
+            plt.Margins(.5, .5);
             TestTools.SaveFig(plt);
         }
     }


### PR DESCRIPTION
before | after
---|---
![image](https://user-images.githubusercontent.com/4165489/147800460-6be17760-728f-4ef3-8119-79302213a09a.png)|![image](https://user-images.githubusercontent.com/4165489/147801321-e59e5e1c-1608-4721-8e19-436620dbdb3b.png)

fixes #1417