### PR TITLE
Plot.RemoveAxis()

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -23,6 +23,7 @@ _In development / not yet on NuGet_
 * Rendering: Improved support for scaled plots when passing scale as a `Plot.Render()` argument (#1416) _Thanks @Andreas_
 * Text: Improved support for rotated text and background fills using custom alignments (#1417, #1516) _Thanks @riquich and @AndXaf_
 * Text: Added options for custom borders (#1417, #1516) _Thanks @AndXaf and @MachineFossil_
+* Plot: New `RemoveAxis()` method allows users to remove axes placed by `AddAxis()` (#1458) _Thanks @gobikulandaisamy_
 
 ## ScottPlot 4.1.27
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2021-10-24_

--- a/src/ScottPlot/Plot/Plot.Axis.cs
+++ b/src/ScottPlot/Plot/Plot.Axis.cs
@@ -277,6 +277,14 @@ namespace ScottPlot
             return axis;
         }
 
+        /// <summary>
+        /// Remove the a specific axis from the plot
+        /// </summary>
+        public void RemoveAxis(Renderable.Axis axis)
+        {
+            settings.Axes.Remove(axis);
+        }
+
         #endregion
 
         #region coordinate/pixel conversions

--- a/src/tests/Axis/MultiAxis.cs
+++ b/src/tests/Axis/MultiAxis.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlotTests.Axis
+{
+    internal class MultiAxis
+    {
+        [Test]
+        public void Test_RemoveAxis_Works()
+        {
+            var plt = new ScottPlot.Plot(600, 400);
+            plt.AddSignal(ScottPlot.DataGen.Sin(51));
+            plt.AddSignal(ScottPlot.DataGen.Cos(51));
+
+            var extraAxis = plt.AddAxis(ScottPlot.Renderable.Edge.Left, axisIndex: 2);
+            TestTools.SaveFig(plt, "a");
+
+            plt.RemoveAxis(extraAxis);
+            TestTools.SaveFig(plt, "b");
+        }
+    }
+}


### PR DESCRIPTION
```cs
var plt = new ScottPlot.Plot(600, 400);
plt.AddSignal(ScottPlot.DataGen.Sin(51));
plt.AddSignal(ScottPlot.DataGen.Cos(51));

var extraAxis = plt.AddAxis(ScottPlot.Renderable.Edge.Left, axisIndex: 2);
plt.SaveFig("a.png");

plt.RemoveAxis(extraAxis);
plt.SaveFig("b.png");
```

additional axis | removed
---|---
![image](https://user-images.githubusercontent.com/4165489/147839763-64833f69-7b60-4506-aaa8-d5db4499bfb6.png)|![image](https://user-images.githubusercontent.com/4165489/147839765-b393e8d5-4591-4530-85c5-ac7104cb7d03.png)

resolves #1458