### PR TITLE
Plot: BenchmarkTimes()

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -24,6 +24,7 @@ _In development / not yet on NuGet_
 * Text: Improved support for rotated text and background fills using custom alignments (#1417, #1516) _Thanks @riquich and @AndXaf_
 * Text: Added options for custom borders (#1417, #1516) _Thanks @AndXaf and @MachineFossil_
 * Plot: New `RemoveAxis()` method allows users to remove axes placed by `AddAxis()` (#1458) _Thanks @gobikulandaisamy_
+* Benchmark: `Plot.BenchmarkTimes()` now returns an array of recent frame render times (#1493, #1491) _Thanks @anose001_
 
 ## ScottPlot 4.1.27
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2021-10-24_

--- a/src/ScottPlot/Plot/Plot.cs
+++ b/src/ScottPlot/Plot/Plot.cs
@@ -287,6 +287,12 @@ namespace ScottPlot
         }
 
         /// <summary>
+        /// Return an array of times for the last several renders.
+        /// The last element of the array is the most recently rendered frame time.
+        /// </summary>
+        public double[] BenchmarkTimes() => settings.BenchmarkMessage.GetRenderTimes();
+
+        /// <summary>
         /// Configure legend visibility and location. 
         /// Optionally you can further customize the legend by interacting with the object it returns.
         /// </summary>

--- a/src/ScottPlot/Renderable/Message.cs
+++ b/src/ScottPlot/Renderable/Message.cs
@@ -2,6 +2,7 @@
 using ScottPlot.Drawing;
 using System.Diagnostics;
 using System.Drawing;
+using System.Collections.Generic;
 
 namespace ScottPlot.Renderable
 {
@@ -12,12 +13,26 @@ namespace ScottPlot.Renderable
         public double Hz { get { return (MSec > 0) ? 1000.0 / MSec : 0; } }
         public string Message { get => $"Rendered in {MSec:00.00} ms ({Hz:0000.00} Hz)"; }
 
+        private int MaxRenderTimes = 100;
+        private List<double> RenderTimes = new();
+
         public void Restart() => Sw.Restart();
         public void Stop()
         {
             Sw.Stop();
+
+            RenderTimes.Add(Sw.Elapsed.TotalMilliseconds);
+            while (RenderTimes.Count > MaxRenderTimes)
+                RenderTimes.RemoveAt(0);
+
             Text = Message;
         }
+
+        /// <summary>
+        /// Returns an array of render times (in milliseconds) of the last several renders.
+        /// The most recent renders are at the end of the array.
+        /// </summary>
+        public double[] GetRenderTimes() => RenderTimes.ToArray();
 
         public BenchmarkMessage()
         {


### PR DESCRIPTION
`Plot.BenchmarkTimes()` now returns an array of recent frame render times suitable for averaging

resolves #1493