### PR TITLE
Ticks: disabling log scaling should disable integer rounding

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -25,6 +25,7 @@ _In development / not yet on NuGet_
 * Text: Added options for custom borders (#1417, #1516) _Thanks @AndXaf and @MachineFossil_
 * Plot: New `RemoveAxis()` method allows users to remove axes placed by `AddAxis()` (#1458) _Thanks @gobikulandaisamy_
 * Benchmark: `Plot.BenchmarkTimes()` now returns an array of recent frame render times (#1493, #1491) _Thanks @anose001_
+* Ticks: Disabling log-scaled minor ticks now disables tick label integer rounding (#1419) _Thanks @at2software_
 
 ## ScottPlot 4.1.27
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2021-10-24_

--- a/src/ScottPlot/Renderable/Axis.cs
+++ b/src/ScottPlot/Renderable/Axis.cs
@@ -387,9 +387,16 @@ namespace ScottPlot.Renderable
         /// </summary>
         public void MinorLogScale(bool enable, bool roundMajorTicks = true)
         {
-            AxisTicks.TickCollection.MinorTickDistribution = enable ? MinorTickDistribution.log : MinorTickDistribution.even;
-            if (roundMajorTicks)
+            if (enable)
+            {
+                AxisTicks.TickCollection.MinorTickDistribution = MinorTickDistribution.log;
                 AxisTicks.TickCollection.IntegerPositionsOnly = roundMajorTicks;
+            }
+            else
+            {
+                AxisTicks.TickCollection.MinorTickDistribution = MinorTickDistribution.even;
+                AxisTicks.TickCollection.IntegerPositionsOnly = false;
+            }
         }
 
         /// <summary>

--- a/src/tests/Axis/LogAxis.cs
+++ b/src/tests/Axis/LogAxis.cs
@@ -94,5 +94,27 @@ namespace ScottPlotTests.Axis
             foreach (ScottPlot.Ticks.Tick tick in plt.YAxis.GetTicks())
                 Console.WriteLine(tick);
         }
+
+        [Test]
+        public void Test_Log_Unset()
+        {
+            var plt = new ScottPlot.Plot();
+            var bmp1 = plt.Render();
+            double[] ticks1 = plt.YAxis.GetTicks().Select(x => x.Position).ToArray();
+
+            plt.YAxis.MinorLogScale(true);
+            var bmp2 = plt.Render();
+            double[] ticks2 = plt.YAxis.GetTicks().Select(x => x.Position).ToArray();
+
+            plt.YAxis.MinorLogScale(false);
+            var bmp3 = plt.Render();
+            double[] ticks3 = plt.YAxis.GetTicks().Select(x => x.Position).ToArray();
+
+            Assert.AreNotEqual(ticks1.Length, ticks2.Length);
+            Assert.AreEqual(ticks1.Length, ticks3.Length);
+
+            for (int i = 0; i < ticks1.Length; i++)
+                Assert.AreEqual(ticks1[i], ticks3[i]);
+        }
     }
 }


### PR DESCRIPTION
fixes #1419