### PR TITLE
csproj: improve TargetFrameworks

### DIFF
--- a/src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj
+++ b/src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net461;net472;net48;netcoreapp3.1;net5.0-windows;net6.0-windows;</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <AssemblyName>ScottPlot.WPF</AssemblyName>
     <OutputType>Library</OutputType>

--- a/src/controls/ScottPlot.WPF/ScottPlot.WPF.csproj
+++ b/src/controls/ScottPlot.WPF/ScottPlot.WPF.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows;net5.0-windows;net461;</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj
+++ b/src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net461;net472;net48;netcoreapp3.1;net5.0-windows;net6.0-windows;</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <AssemblyName>ScottPlot.WinForms</AssemblyName>
     <RootNamespace>ScottPlot</RootNamespace>

--- a/src/demo/ScottPlot.Demo.Eto/Eto.Forms Demo.csproj
+++ b/src/demo/ScottPlot.Demo.Eto/Eto.Forms Demo.csproj
@@ -9,6 +9,7 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <ApplicationIcon>icon.ico</ApplicationIcon>
+		<NoWarn>NU1701</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/sandbox/EtoApp/EtoApp.csproj
+++ b/src/sandbox/EtoApp/EtoApp.csproj
@@ -8,6 +8,7 @@
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
+		<NoWarn>NU1701</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
* Adds more targets and adjusts target order to improve support in .NET 6 and VS 2022
* Also silences Eto warnings about dependency version mismatches (#1438)

resolves #1500