### PR TITLE
CI: build all packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,31 +72,31 @@ jobs:
 
       - name: 📦 Package ScottPlot
         run: |
-          dotnet restore src/ScottPlot/ScottPlot.csproj --configuration Release
+          dotnet restore src/ScottPlot/ScottPlot.csproj
           dotnet build src/ScottPlot/ScottPlot.csproj --configuration Release
           dotnet pack src/ScottPlot/ScottPlot.csproj --configuration Release
 
       - name: 📦 Package ScottPlot.WinForms
         run: |
-          dotnet restore src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj --configuration Release
+          dotnet restore src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj
           dotnet build src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj --configuration Release
           dotnet pack src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj --configuration Release
 
       - name: 📦 Package ScottPlot.WPF
         run: |
-          dotnet restore src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj --configuration Release
+          dotnet restore src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj
           dotnet build src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj --configuration Release
           dotnet pack src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj --configuration Release
 
       - name: 📦 Package ScottPlot.Avalonia
         run: |
-          dotnet restore src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj --configuration Release
+          dotnet restore src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj
           dotnet build src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj --configuration Release
           dotnet pack src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj --configuration Release
 
       - name: 📦 Package ScottPlot.Eto
         run: |
-          dotnet restore src/controls/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj --configuration Release
+          dotnet restore src/controls/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj
           dotnet build src/controls/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj --configuration Release
           dotnet pack src/controls/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj --configuration Release
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,29 +9,9 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  build:
-    runs-on: windows-latest
-    name: Build Solution
-    steps:
-      - name: 🛒 Checkout
-        uses: actions/checkout@v2
-      - name: 🐢 Set up MSBuild
-        uses: microsoft/setup-msbuild@v1.1
-      - name: ✨ Set up .NET 6.0
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: "6.0.x"
-          include-prerelease: true
-      - name: 🚚 Restore
-        working-directory: src
-        run: dotnet restore
-      - name: 🐌 MSBuild
-        working-directory: src
-        run: msbuild -property:Configuration=Release -verbosity:minimal
-
   format:
     runs-on: windows-latest
-    name: Check Formatting
+    name: ✒️ Check Formatting
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v2
@@ -57,7 +37,7 @@ jobs:
           - os: macos-latest
             osName: MacOS
     runs-on: ${{ matrix.os }}
-    name: Test on ${{ matrix.osName }}
+    name: 🧪 Test on ${{ matrix.osName }}
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v2
@@ -80,7 +60,7 @@ jobs:
         run: dotnet test --configuration Release
 
   package:
-    name: Package
+    name: 📦 Create NuGet Packages
     runs-on: windows-latest
     steps:
       - name: 🛒 Checkout
@@ -89,15 +69,53 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: "6.0.x"
-      - name: 🚚 Restore
-        run: dotnet restore src
+
       - name: 📦 Package ScottPlot
-        run: dotnet pack src/ScottPlot/ScottPlot.csproj --configuration Release
+        run: |
+          dotnet restore src/ScottPlot/ScottPlot.csproj --configuration Release
+          dotnet build src/ScottPlot/ScottPlot.csproj --configuration Release
+          dotnet pack src/ScottPlot/ScottPlot.csproj --configuration Release
+
       - name: 📦 Package ScottPlot.WinForms
-        run: dotnet pack src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj --configuration Release
+        run: |
+          dotnet restore src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj --configuration Release
+          dotnet build src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj --configuration Release
+          dotnet pack src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj --configuration Release
+
       - name: 📦 Package ScottPlot.WPF
-        run: dotnet pack src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj --configuration Release
+        run: |
+          dotnet restore src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj --configuration Release
+          dotnet build src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj --configuration Release
+          dotnet pack src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj --configuration Release
+
       - name: 📦 Package ScottPlot.Avalonia
-        run: dotnet pack src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj --configuration Release
+        run: |
+          dotnet restore src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj --configuration Release
+          dotnet build src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj --configuration Release
+          dotnet pack src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj --configuration Release
+
       - name: 📦 Package ScottPlot.Eto
-        run: dotnet pack src/controls/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj --configuration Release
+        run: |
+          dotnet restore src/controls/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj --configuration Release
+          dotnet build src/controls/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj --configuration Release
+          dotnet pack src/controls/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj --configuration Release
+
+  build:
+    runs-on: windows-latest
+    name: 🛠️ Build Entire Solution
+    steps:
+      - name: 🛒 Checkout
+        uses: actions/checkout@v2
+      - name: 🐢 Set up MSBuild
+        uses: microsoft/setup-msbuild@v1.1
+      - name: ✨ Set up .NET 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "6.0.x"
+          include-prerelease: true
+      - name: 🚚 Restore
+        working-directory: src
+        run: dotnet restore
+      - name: 🐌 MSBuild
+        working-directory: src
+        run: msbuild -property:Configuration=Release -verbosity:minimal

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,3 +78,26 @@ jobs:
       - name: 🧪 Test
         working-directory: src/tests
         run: dotnet test --configuration Release
+
+  package:
+    name: Package
+    runs-on: windows-latest
+    steps:
+      - name: 🛒 Checkout
+        uses: actions/checkout@v2
+      - name: ✨ Setup .NET 6
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "6.0.x"
+      - name: 🚚 Restore
+        run: dotnet restore src
+      - name: 📦 Package ScottPlot
+        run: dotnet pack src/ScottPlot/ScottPlot.csproj --configuration Release
+      - name: 📦 Package ScottPlot.WinForms
+        run: dotnet pack src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj --configuration Release
+      - name: 📦 Package ScottPlot.WPF
+        run: dotnet pack src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj --configuration Release
+      - name: 📦 Package ScottPlot.Avalonia
+        run: dotnet pack src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj --configuration Release
+      - name: 📦 Package ScottPlot.Eto
+        run: dotnet pack src/controls/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj --configuration Release

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -5,41 +5,62 @@ on:
 
 jobs:
   deploy:
-    name: Package and Deploy
+    name: 🚀 Publish Packages
     runs-on: windows-latest
     steps:
       - name: 🛒 Checkout
         uses: actions/checkout@v2
-      - name: 🐢 Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.0.3
-      - name: ✨ Setup .NET 5.0
-        uses: actions/setup-dotnet@v1
+
       - name: ✨ Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: "6.0.x"
+
       - name: 🛠️ Setup NuGet
         uses: nuget/setup-nuget@v1
         with:
           nuget-api-key: ${{ secrets.NUGET_API_KEY }}
-      - name: 🚚 Restore
-        working-directory: src/tests
-        run: dotnet restore
-      - name: 🛠️ Build
-        working-directory: src/tests
-        run: dotnet build --configuration Release
-      - name: 📦 Pack
+
+      - name: 🚀 Publish ScottPlot
         run: |
+          dotnet restore src/ScottPlot/ScottPlot.csproj
+          dotnet build src/ScottPlot/ScottPlot.csproj --configuration Release
           dotnet pack src/ScottPlot/ScottPlot.csproj --configuration Release
+          nuget push "src\ScottPlot\bin\Release\*.nupkg" -SkipDuplicate -Source https://api.nuget.org/v3/index.json
+
+      - name: 🚀 Publish ScottPlot.WinForms
+        run: |
+          dotnet restore src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj
+          dotnet build src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj --configuration Release
           dotnet pack src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj --configuration Release
+          nuget push "src\controls\ScottPlot.WinForms\bin\Release\*.nupkg" -SkipDuplicate -Source https://api.nuget.org/v3/index.json
+
+      - name: 🚀 Publish ScottPlot.WPF
+        run: |
+          dotnet restore src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj
+          dotnet build src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj --configuration Release
           dotnet pack src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj --configuration Release
+          nuget push "src\controls\ScottPlot.WPF\bin\Release\*.nupkg" -SkipDuplicate -Source https://api.nuget.org/v3/index.json
+
+      - name: 🚀 Publish ScottPlot.Avalonia
+        run: |
+          dotnet restore src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj
+          dotnet build src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj --configuration Release
           dotnet pack src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj --configuration Release
+          nuget push "src\controls\ScottPlot.Avalonia\bin\Release\*.nupkg" -SkipDuplicate -Source https://api.nuget.org/v3/index.json
+
+      - name: 🚀 Publish ScottPlot.Eto
+        run: |
+          dotnet restore src/controls/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj
+          dotnet build src/controls/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj --configuration Release
           dotnet pack src/controls/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj --configuration Release
-      - name: 💾 Store
+          nuget push "src\controls\ScottPlot.Eto\bin\Release\*.nupkg" -SkipDuplicate -Source https://api.nuget.org/v3/index.json
+
+      - name: 💾 Store Packages
         uses: actions/upload-artifact@v2
         with:
           name: ScottPlot-Packages
-          retention-days: 30
+          retention-days: 1
           path: |
             src/ScottPlot/bin/Release/*.nupkg
             src/ScottPlot/bin/Release/*.snupkg
@@ -51,10 +72,3 @@ jobs:
             src/controls/ScottPlot.Avalonia/bin/Release/*.snupkg
             src/controls/ScottPlot.Eto/bin/Release/*.nupkg
             src/controls/ScottPlot.Eto/bin/Release/*.snupkg
-      - name: 🚀 Publish
-        run: |
-          nuget push "src\ScottPlot\bin\Release\*.nupkg" -SkipDuplicate -Source https://api.nuget.org/v3/index.json
-          nuget push "src\controls\ScottPlot.WinForms\bin\Release\*.nupkg" -SkipDuplicate -Source https://api.nuget.org/v3/index.json
-          nuget push "src\controls\ScottPlot.WPF\bin\Release\*.nupkg" -SkipDuplicate -Source https://api.nuget.org/v3/index.json
-          nuget push "src\controls\ScottPlot.Avalonia\bin\Release\*.nupkg" -SkipDuplicate -Source https://api.nuget.org/v3/index.json
-          nuget push "src\controls\ScottPlot.Eto\bin\Release\*.nupkg" -SkipDuplicate -Source https://api.nuget.org/v3/index.json

--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -4,7 +4,7 @@
 _In development / not yet on NuGet_
 
 ## ScottPlot 4.1.28
-_Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-01-01_
+_Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-01-01_
 * Eto Control: New ScottPlot control for the Eto GUI framework (#1425, #1438) _Thanks @rafntor_
 * Radar Plot: `OutlineWidth` now allows customization of the line around radar plots (#1426, #1277) _Thanks @Rayffer_
 * Ticks: Improved minor tick and minor grid line placement (#1420, #1421) _Thanks @bclehmann and @at2software_


### PR DESCRIPTION
Something changed in GitHub packages and the Avalonia package will not build and was not able to be deployed.

This wasn't noticed previously because only the deployment action (not the CI action) built packages routinely.

This PR adds a package building step to the CI pipeline.