### PR TITLE
Text rendering: opt-in to ClearType (anti-alias by default)

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -3,7 +3,7 @@
 ## ScottPlot 4.1.30
 _In development / not yet on NuGet_
 * Plot: Improve values returned by `GetDataLimits()` when axis lines and spans are in use (#1415, #1505, #1532) _Thanks @EFeru_
-* Rendering: Revert default text hinting from ClearType back to AntiAliased to improve text appearance on transparent backgrounds. Users may call `Drawing.GDI.ClearType(true)` to opt-in to ClearType rendering which is superior for most situations. (#1553, #1550, #1528) _Thanks @r84r, @wangyexiang, @Elgot, @EFeru, and @saklanmazozgur_
+* Rendering: Revert default text hinting from ClearType back to AntiAliased to improve text appearance on transparent backgrounds. Users may call `ScottPlot.Drawing.GDI.ClearType(true)` to opt-in to ClearType rendering which is superior for most situations. (#1553, #1550, #1528) _Thanks @r84r, @wangyexiang, @Elgot, @EFeru, and @saklanmazozgur_
 
 ## ScottPlot 4.1.29
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-01-02_

--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.30
 _In development / not yet on NuGet_
 * Plot: Improve values returned by `GetDataLimits()` when axis lines and spans are in use (#1415, #1505, #1532) _Thanks @EFeru_
+* Rendering: Revert default text hinting from ClearType back to AntiAliased to improve text appearance on transparent backgrounds. Users may call `Drawing.GDI.ClearType(true)` to opt-in to ClearType rendering which is superior for most situations. (#1553, #1550, #1528) _Thanks @r84r, @wangyexiang, @Elgot, @EFeru, and @saklanmazozgur_
 
 ## ScottPlot 4.1.29
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-01-02_

--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -1,7 +1,10 @@
 # ScottPlot Changelog
 
-## ScottPlot 4.1.30
+## ScottPlot 4.1.31
 _In development / not yet on NuGet_
+
+## ScottPlot 4.1.30
+_Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-01-15_
 * Plot: Improve values returned by `GetDataLimits()` when axis lines and spans are in use (#1415, #1505, #1532) _Thanks @EFeru_
 * Rendering: Revert default text hinting from ClearType back to AntiAliased to improve text appearance on transparent backgrounds. Users may call `ScottPlot.Drawing.GDI.ClearType(true)` to opt-in to ClearType rendering which is superior for most situations. (#1553, #1550, #1528) _Thanks @r84r, @wangyexiang, @Elgot, @EFeru, and @saklanmazozgur_
 

--- a/src/ScottPlot/Drawing/GDI.cs
+++ b/src/ScottPlot/Drawing/GDI.cs
@@ -113,11 +113,24 @@ namespace ScottPlot.Drawing
             return Mix(colorA, colorB, fracA);
         }
 
+        /// <summary>
+        /// Controls whether ClearType (instead of the default AntiAlias) hinting will be used.
+        /// ClearType typically appears superior except when rendered above a transparent background.
+        /// </summary>
+        public static void ClearType(bool enable)
+        {
+            HighQualityTextRenderingHint = enable ? TextRenderingHint.ClearTypeGridFit : TextRenderingHint.AntiAlias;
+        }
+
+        private static TextRenderingHint HighQualityTextRenderingHint = TextRenderingHint.AntiAlias;
+
+        private static TextRenderingHint LowQualityTextRenderingHint = TextRenderingHint.SingleBitPerPixelGridFit;
+
         public static System.Drawing.Graphics Graphics(Bitmap bmp, bool lowQuality = false, double scale = 1.0)
         {
             Graphics gfx = System.Drawing.Graphics.FromImage(bmp);
             gfx.SmoothingMode = lowQuality ? SmoothingMode.HighSpeed : SmoothingMode.AntiAlias;
-            gfx.TextRenderingHint = lowQuality ? TextRenderingHint.SingleBitPerPixelGridFit : TextRenderingHint.ClearTypeGridFit;
+            gfx.TextRenderingHint = lowQuality ? LowQualityTextRenderingHint : HighQualityTextRenderingHint;
             gfx.ScaleTransform((float)scale, (float)scale);
             return gfx;
         }

--- a/src/ScottPlot/ScottPlot.csproj
+++ b/src/ScottPlot/ScottPlot.csproj
@@ -12,9 +12,9 @@
     <PackageProjectUrl>https://ScottPlot.NET</PackageProjectUrl>
     <PackageTags>plot graph data chart signal line bar heatmap scatter</PackageTags>
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
-    <Version>4.1.29</Version>
-    <AssemblyVersion>4.1.29.0</AssemblyVersion>
-    <FileVersion>4.1.29.0</FileVersion>
+    <Version>4.1.30</Version>
+    <AssemblyVersion>4.1.30.0</AssemblyVersion>
+    <FileVersion>4.1.30.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>

--- a/src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj
+++ b/src/controls/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj
@@ -15,9 +15,9 @@
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/ScottPlot/ScottPlot</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.1.29</Version>
-    <AssemblyVersion>4.1.29.0</AssemblyVersion>
-    <FileVersion>4.1.29.0</FileVersion>
+    <Version>4.1.30</Version>
+    <AssemblyVersion>4.1.30.0</AssemblyVersion>
+    <FileVersion>4.1.30.0</FileVersion>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/src/controls/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj
+++ b/src/controls/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj
@@ -14,9 +14,9 @@
     <PackageTags>plot graph data chart signal line bar heatmap scatter control interactive winforms windows forms</PackageTags>
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/ScottPlot/ScottPlot</RepositoryUrl>
-    <Version>4.1.29</Version>
-    <AssemblyVersion>4.1.29.0</AssemblyVersion>
-    <FileVersion>4.1.29.0</FileVersion>
+    <Version>4.1.30</Version>
+    <AssemblyVersion>4.1.30.0</AssemblyVersion>
+    <FileVersion>4.1.30.0</FileVersion>
     <SignAssembly>false</SignAssembly>
     <Authors>Scott Harden</Authors>
     <Company>Harden Technologies, LLC</Company>

--- a/src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj
+++ b/src/controls/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj
@@ -16,9 +16,9 @@
     <PackageTags>plot graph data chart signal line bar heatmap scatter control interactive WPF</PackageTags>
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/ScottPlot/ScottPlot</RepositoryUrl>
-    <Version>4.1.29</Version>
-    <AssemblyVersion>4.1.29.0</AssemblyVersion>
-    <FileVersion>4.1.29.0</FileVersion>
+    <Version>4.1.30</Version>
+    <AssemblyVersion>4.1.30.0</AssemblyVersion>
+    <FileVersion>4.1.30.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/src/controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/controls/ScottPlot.WinForms/FormsPlot.cs
@@ -107,7 +107,7 @@ namespace ScottPlot
 
             rtbErrorMessage.Visible = false;
             pictureBox1.BackColor = System.Drawing.Color.Transparent;
-            Plot.Style(figureBackground: BackColor);
+            Plot.Style(figureBackground: System.Drawing.Color.Transparent);
             pictureBox1.MouseWheel += PictureBox1_MouseWheel;
             RightClicked += DefaultRightClickEvent;
 

--- a/src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj
+++ b/src/controls/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj
@@ -15,9 +15,9 @@
     <PackageTags>plot graph data chart signal line bar heatmap scatter control interactive winforms windows forms</PackageTags>
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/ScottPlot/ScottPlot</RepositoryUrl>
-    <Version>4.1.29</Version>
-    <AssemblyVersion>4.1.29.0</AssemblyVersion>
-    <FileVersion>4.1.29.0</FileVersion>
+    <Version>4.1.30</Version>
+    <AssemblyVersion>4.1.30.0</AssemblyVersion>
+    <FileVersion>4.1.30.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>

--- a/src/sandbox/WinFormsApp/Form1.Designer.cs
+++ b/src/sandbox/WinFormsApp/Form1.Designer.cs
@@ -29,6 +29,7 @@
         private void InitializeComponent()
         {
             this.formsPlot1 = new ScottPlot.FormsPlot();
+            this.checkBox1 = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // formsPlot1
@@ -37,26 +38,40 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.formsPlot1.BackColor = System.Drawing.Color.Transparent;
-            this.formsPlot1.Location = new System.Drawing.Point(0, -2);
+            this.formsPlot1.Location = new System.Drawing.Point(0, 37);
             this.formsPlot1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.formsPlot1.Name = "formsPlot1";
-            this.formsPlot1.Size = new System.Drawing.Size(560, 351);
+            this.formsPlot1.Size = new System.Drawing.Size(560, 312);
             this.formsPlot1.TabIndex = 0;
+            // 
+            // checkBox1
+            // 
+            this.checkBox1.AutoSize = true;
+            this.checkBox1.Location = new System.Drawing.Point(12, 12);
+            this.checkBox1.Name = "checkBox1";
+            this.checkBox1.Size = new System.Drawing.Size(77, 19);
+            this.checkBox1.TabIndex = 1;
+            this.checkBox1.Text = "ClearType";
+            this.checkBox1.UseVisualStyleBackColor = true;
+            this.checkBox1.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
             // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(560, 349);
+            this.Controls.Add(this.checkBox1);
             this.Controls.Add(this.formsPlot1);
             this.Name = "Form1";
             this.Text = "Form1";
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
         #endregion
 
         private ScottPlot.FormsPlot formsPlot1;
+        private System.Windows.Forms.CheckBox checkBox1;
     }
 }

--- a/src/sandbox/WinFormsApp/Form1.cs
+++ b/src/sandbox/WinFormsApp/Form1.cs
@@ -15,13 +15,14 @@ namespace WinFormsApp
         public Form1()
         {
             InitializeComponent();
+            formsPlot1.Plot.AddSignal(ScottPlot.DataGen.Sin(51));
+            formsPlot1.Plot.AddSignal(ScottPlot.DataGen.Cos(51));
+            formsPlot1.Refresh();
+        }
 
-            Random rand = new(0);
-            double[] xs = ScottPlot.DataGen.Consecutive(10_000);
-            double[] ys = ScottPlot.DataGen.RandomWalk(rand, 10_000);
-            var sig1 = formsPlot1.Plot.AddSignalXY(xs, ys);
-            sig1.MarkerSize = 20;
-
+        private void checkBox1_CheckedChanged(object sender, EventArgs e)
+        {
+            ScottPlot.Drawing.GDI.ClearType(checkBox1.Checked);
             formsPlot1.Refresh();
         }
     }

--- a/src/tests/FontsTests.cs
+++ b/src/tests/FontsTests.cs
@@ -46,5 +46,27 @@ namespace ScottPlotTests
                 Assert.That(defaultFontMonospace == "Courier");
             }
         }
+
+        [Test]
+        public void Test_ClearType_Transparency()
+        {
+            ScottPlot.Plot plt = new(300, 200);
+
+            plt.Style(figureBackground: System.Drawing.Color.Transparent);
+
+            ScottPlot.Drawing.GDI.HighQualityTextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
+            TestTools.SaveFig(plt, "ClearType-Transparent");
+
+            ScottPlot.Drawing.GDI.HighQualityTextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
+            TestTools.SaveFig(plt, "AntiAlias-Transparent");
+            
+            plt.Style(figureBackground: System.Drawing.SystemColors.Control);
+
+            ScottPlot.Drawing.GDI.HighQualityTextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
+            TestTools.SaveFig(plt, "ClearType-OnGray");
+
+            ScottPlot.Drawing.GDI.HighQualityTextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
+            TestTools.SaveFig(plt, "AntiAlias-OnGray");
+        }
     }
 }

--- a/src/tests/FontsTests.cs
+++ b/src/tests/FontsTests.cs
@@ -59,7 +59,7 @@ namespace ScottPlotTests
 
             ScottPlot.Drawing.GDI.HighQualityTextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
             TestTools.SaveFig(plt, "AntiAlias-Transparent");
-            
+
             plt.Style(figureBackground: System.Drawing.SystemColors.Control);
 
             ScottPlot.Drawing.GDI.HighQualityTextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;

--- a/src/tests/FontsTests.cs
+++ b/src/tests/FontsTests.cs
@@ -54,18 +54,18 @@ namespace ScottPlotTests
 
             plt.Style(figureBackground: System.Drawing.Color.Transparent);
 
-            ScottPlot.Drawing.GDI.HighQualityTextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
+            ScottPlot.Drawing.GDI.ClearType(true);
             TestTools.SaveFig(plt, "ClearType-Transparent");
 
-            ScottPlot.Drawing.GDI.HighQualityTextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
+            ScottPlot.Drawing.GDI.ClearType(false);
             TestTools.SaveFig(plt, "AntiAlias-Transparent");
 
             plt.Style(figureBackground: System.Drawing.SystemColors.Control);
 
-            ScottPlot.Drawing.GDI.HighQualityTextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
+            ScottPlot.Drawing.GDI.ClearType(true);
             TestTools.SaveFig(plt, "ClearType-OnGray");
 
-            ScottPlot.Drawing.GDI.HighQualityTextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
+            ScottPlot.Drawing.GDI.ClearType(false);
             TestTools.SaveFig(plt, "AntiAlias-OnGray");
         }
     }


### PR DESCRIPTION
This PR sets default text rendering hint to anti-alias, revering the ClearType default set in #1496. 

This PR also exposes `ScottPlot.Drawing.GDI.ClearType()` to let the user opt-in to clear type.

Related: #1553, #1550

![screenshot-cleartype](https://user-images.githubusercontent.com/4165489/149610875-fc5d6a69-54f3-4782-9195-e877b64620e6.gif)

