### PR TITLE
Fix - Support for draggable plottables on `AxisIndex` 0 and 1

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -2,6 +2,7 @@
 
 ## ScottPlot 4.1.31
 _In development / not yet on NuGet_
+* MultiAxis: Improved support for draggable items placed on non-primary axes (#1556, #1545) _Thanks @BambOoxX_
 
 ## ScottPlot 4.1.30
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-01-15_

--- a/src/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot/Control/Backend.cs
@@ -282,16 +282,38 @@ namespace ScottPlot.Control
         /// <summary>
         /// Return the draggable plottable under the mouse cursor (or null if there isn't one)
         /// </summary>
-        private IDraggable GetDraggableUnderMouse(double pixelX, double pixelY, int snapDistancePixels = 5)
+        private IDraggable GetDraggableUnderMouse(double pixelX, double pixelY, int snapDistancePixels = 5,int xAxisIndex = 0,int yAxisIndex = 0)
         {
-            double snapWidth = Settings.XAxis.Dims.UnitsPerPx * snapDistancePixels;
-            double snapHeight = Settings.YAxis.Dims.UnitsPerPx * snapDistancePixels;
+            double xUnitsPerPx;
+            double yUnitsPerPx;
+            if (xAxisIndex == 0) 
+            {
+                xUnitsPerPx = Settings.XAxis.Dims.UnitsPerPx;
+            }
+            else
+            { 
+                xUnitsPerPx = Settings.XAxis2.Dims.UnitsPerPx;
+            }
+            if (yAxisIndex == 0) 
+            {
+                yUnitsPerPx = Settings.YAxis.Dims.UnitsPerPx;
+            }
+            else
+            { 
+                yUnitsPerPx = Settings.YAxis2.Dims.UnitsPerPx;
+
+            }
+            double snapWidth = xUnitsPerPx * snapDistancePixels;
+            double snapHeight = yUnitsPerPx * snapDistancePixels;
 
             foreach (IDraggable draggable in GetDraggables())
-                if (draggable.IsUnderMouse(Plot.GetCoordinateX((float)pixelX), Plot.GetCoordinateY((float)pixelY), snapWidth, snapHeight))
+            {
+                double xCoords = Plot.GetCoordinateX((float)pixelX, ((IPlottable)draggable).XAxisIndex);
+                double yCoords = Plot.GetCoordinateY((float)pixelY, ((IPlottable)draggable).YAxisIndex);
+                if (draggable.IsUnderMouse(xCoords, yCoords, snapWidth, snapHeight))
                     if (draggable.DragEnabled)
                         return draggable;
-
+            }
             return null;
         }
 
@@ -537,9 +559,9 @@ namespace ScottPlot.Control
         /// <summary>
         /// Return the mouse position on the plot (in coordinate space) for the latest X and Y coordinates
         /// </summary>
-        public (double x, double y) GetMouseCoordinates()
+        public (double x, double y) GetMouseCoordinates(int xAxisIndex = 0,int yAxisIndex = 0)
         {
-            (double x, double y) = Plot.GetCoordinate(MouseLocationX, MouseLocationY);
+            (double x, double y) = Plot.GetCoordinate(MouseLocationX, MouseLocationY,xAxisIndex,yAxisIndex);
             return (double.IsNaN(x) ? 0 : x, double.IsNaN(y) ? 0 : y);
         }
 

--- a/src/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot/Control/Backend.cs
@@ -282,24 +282,24 @@ namespace ScottPlot.Control
         /// <summary>
         /// Return the draggable plottable under the mouse cursor (or null if there isn't one)
         /// </summary>
-        private IDraggable GetDraggableUnderMouse(double pixelX, double pixelY, int snapDistancePixels = 5,int xAxisIndex = 0,int yAxisIndex = 0)
+        private IDraggable GetDraggableUnderMouse(double pixelX, double pixelY, int snapDistancePixels = 5, int xAxisIndex = 0, int yAxisIndex = 0)
         {
             double xUnitsPerPx;
             double yUnitsPerPx;
-            if (xAxisIndex == 0) 
+            if (xAxisIndex == 0)
             {
                 xUnitsPerPx = Settings.XAxis.Dims.UnitsPerPx;
             }
             else
-            { 
+            {
                 xUnitsPerPx = Settings.XAxis2.Dims.UnitsPerPx;
             }
-            if (yAxisIndex == 0) 
+            if (yAxisIndex == 0)
             {
                 yUnitsPerPx = Settings.YAxis.Dims.UnitsPerPx;
             }
             else
-            { 
+            {
                 yUnitsPerPx = Settings.YAxis2.Dims.UnitsPerPx;
 
             }
@@ -559,9 +559,9 @@ namespace ScottPlot.Control
         /// <summary>
         /// Return the mouse position on the plot (in coordinate space) for the latest X and Y coordinates
         /// </summary>
-        public (double x, double y) GetMouseCoordinates(int xAxisIndex = 0,int yAxisIndex = 0)
+        public (double x, double y) GetMouseCoordinates(int xAxisIndex = 0, int yAxisIndex = 0)
         {
-            (double x, double y) = Plot.GetCoordinate(MouseLocationX, MouseLocationY,xAxisIndex,yAxisIndex);
+            (double x, double y) = Plot.GetCoordinate(MouseLocationX, MouseLocationY, xAxisIndex, yAxisIndex);
             return (double.IsNaN(x) ? 0 : x, double.IsNaN(y) ? 0 : y);
         }
 

--- a/src/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot/Control/Backend.cs
@@ -284,25 +284,9 @@ namespace ScottPlot.Control
         /// </summary>
         private IDraggable GetDraggableUnderMouse(double pixelX, double pixelY, int snapDistancePixels = 5, int xAxisIndex = 0, int yAxisIndex = 0)
         {
-            double xUnitsPerPx;
-            double yUnitsPerPx;
-            if (xAxisIndex == 0)
-            {
-                xUnitsPerPx = Settings.XAxis.Dims.UnitsPerPx;
-            }
-            else
-            {
-                xUnitsPerPx = Settings.XAxis2.Dims.UnitsPerPx;
-            }
-            if (yAxisIndex == 0)
-            {
-                yUnitsPerPx = Settings.YAxis.Dims.UnitsPerPx;
-            }
-            else
-            {
-                yUnitsPerPx = Settings.YAxis2.Dims.UnitsPerPx;
+            double xUnitsPerPx = Settings.GetXAxis(xAxisIndex).Dims.UnitsPerPx;
+            double yUnitsPerPx = Settings.GetYAxis(yAxisIndex).Dims.UnitsPerPx;
 
-            }
             double snapWidth = xUnitsPerPx * snapDistancePixels;
             double snapHeight = yUnitsPerPx * snapDistancePixels;
 

--- a/src/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot/Control/Backend.cs
@@ -285,18 +285,20 @@ namespace ScottPlot.Control
         /// <summary>
         /// Return the draggable plottable under the mouse cursor (or null if there isn't one)
         /// </summary>
-        private IDraggable GetDraggableUnderMouse(double pixelX, double pixelY, int snapDistancePixels = 5, int xAxisIndex = 0, int yAxisIndex = 0)
+        private IDraggable GetDraggableUnderMouse(double pixelX, double pixelY, int snapDistancePixels = 5)
         {
-            double xUnitsPerPx = Settings.GetXAxis(xAxisIndex).Dims.UnitsPerPx;
-            double yUnitsPerPx = Settings.GetYAxis(yAxisIndex).Dims.UnitsPerPx;
-
-            double snapWidth = xUnitsPerPx * snapDistancePixels;
-            double snapHeight = yUnitsPerPx * snapDistancePixels;
 
             foreach (IDraggable draggable in GetEnabledDraggables())
             {
-                double xCoords = Plot.GetCoordinateX((float)pixelX, ((IPlottable)draggable).XAxisIndex);
-                double yCoords = Plot.GetCoordinateY((float)pixelY, ((IPlottable)draggable).YAxisIndex);
+                int xAxisIndex = ((IPlottable)draggable).XAxisIndex;
+                int yAxisIndex = ((IPlottable)draggable).YAxisIndex;
+                double xUnitsPerPx = Settings.GetXAxis(xAxisIndex).Dims.UnitsPerPx;
+                double yUnitsPerPx = Settings.GetYAxis(yAxisIndex).Dims.UnitsPerPx;
+
+                double snapWidth = xUnitsPerPx * snapDistancePixels;
+                double snapHeight = yUnitsPerPx * snapDistancePixels;
+                double xCoords = Plot.GetCoordinateX((float)pixelX, xAxisIndex);
+                double yCoords = Plot.GetCoordinateY((float)pixelY, yAxisIndex);
                 if (draggable.IsUnderMouse(xCoords, yCoords, snapWidth, snapHeight))
                     return draggable;
             }

--- a/src/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot/Control/Backend.cs
@@ -274,10 +274,13 @@ namespace ScottPlot.Control
         }
 
         /// <summary>
-        /// Return a copy of the list of draggable plottables
+        /// Return a copy of the list of draggable plottables with dragging enabled
         /// </summary>
-        private IDraggable[] GetDraggables() =>
-            Settings.Plottables.Where(x => x is IDraggable).Select(x => (IDraggable)x).ToArray();
+        private IDraggable[] GetEnabledDraggables() => Settings.Plottables
+            .Where(x => x is IDraggable)
+            .Select(x => (IDraggable)x)
+            .Where(x => x.DragEnabled)
+            .ToArray();
 
         /// <summary>
         /// Return the draggable plottable under the mouse cursor (or null if there isn't one)
@@ -290,13 +293,12 @@ namespace ScottPlot.Control
             double snapWidth = xUnitsPerPx * snapDistancePixels;
             double snapHeight = yUnitsPerPx * snapDistancePixels;
 
-            foreach (IDraggable draggable in GetDraggables())
+            foreach (IDraggable draggable in GetEnabledDraggables())
             {
                 double xCoords = Plot.GetCoordinateX((float)pixelX, ((IPlottable)draggable).XAxisIndex);
                 double yCoords = Plot.GetCoordinateY((float)pixelY, ((IPlottable)draggable).YAxisIndex);
                 if (draggable.IsUnderMouse(xCoords, yCoords, snapWidth, snapHeight))
-                    if (draggable.DragEnabled)
-                        return draggable;
+                    return draggable;
             }
             return null;
         }

--- a/src/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot/Control/Backend.cs
@@ -282,24 +282,24 @@ namespace ScottPlot.Control
         /// <summary>
         /// Return the draggable plottable under the mouse cursor (or null if there isn't one)
         /// </summary>
-        private IDraggable GetDraggableUnderMouse(double pixelX, double pixelY, int snapDistancePixels = 5, int xAxisIndex = 0, int yAxisIndex = 0)
+        private IDraggable GetDraggableUnderMouse(double pixelX, double pixelY, int snapDistancePixels = 5,int xAxisIndex = 0,int yAxisIndex = 0)
         {
             double xUnitsPerPx;
             double yUnitsPerPx;
-            if (xAxisIndex == 0)
+            if (xAxisIndex == 0) 
             {
                 xUnitsPerPx = Settings.XAxis.Dims.UnitsPerPx;
             }
             else
-            {
+            { 
                 xUnitsPerPx = Settings.XAxis2.Dims.UnitsPerPx;
             }
-            if (yAxisIndex == 0)
+            if (yAxisIndex == 0) 
             {
                 yUnitsPerPx = Settings.YAxis.Dims.UnitsPerPx;
             }
             else
-            {
+            { 
                 yUnitsPerPx = Settings.YAxis2.Dims.UnitsPerPx;
 
             }
@@ -559,9 +559,9 @@ namespace ScottPlot.Control
         /// <summary>
         /// Return the mouse position on the plot (in coordinate space) for the latest X and Y coordinates
         /// </summary>
-        public (double x, double y) GetMouseCoordinates(int xAxisIndex = 0, int yAxisIndex = 0)
+        public (double x, double y) GetMouseCoordinates(int xAxisIndex = 0,int yAxisIndex = 0)
         {
-            (double x, double y) = Plot.GetCoordinate(MouseLocationX, MouseLocationY, xAxisIndex, yAxisIndex);
+            (double x, double y) = Plot.GetCoordinate(MouseLocationX, MouseLocationY,xAxisIndex,yAxisIndex);
             return (double.IsNaN(x) ? 0 : x, double.IsNaN(y) ? 0 : y);
         }
 

--- a/src/ScottPlot/Control/EventProcess/Events/PlottableDragEvent.cs
+++ b/src/ScottPlot/Control/EventProcess/Events/PlottableDragEvent.cs
@@ -30,8 +30,8 @@ namespace ScottPlot.Control.EventProcess.Events
 
         public void ProcessEvent()
         {
-            double xCoord = Plot.GetCoordinateX(X, ((IPlottable)PlottableBeingDragged).XAxisIndex);
-            double yCoord = Plot.GetCoordinateY(Y, ((IPlottable)PlottableBeingDragged).YAxisIndex);
+            double xCoord = Plot.GetCoordinateX(X,((IPlottable)PlottableBeingDragged).XAxisIndex);
+            double yCoord = Plot.GetCoordinateY(Y,((IPlottable)PlottableBeingDragged).YAxisIndex);
             PlottableBeingDragged.DragTo(xCoord, yCoord, fixedSize: ShiftDown);
         }
     }

--- a/src/ScottPlot/Control/EventProcess/Events/PlottableDragEvent.cs
+++ b/src/ScottPlot/Control/EventProcess/Events/PlottableDragEvent.cs
@@ -30,8 +30,8 @@ namespace ScottPlot.Control.EventProcess.Events
 
         public void ProcessEvent()
         {
-            double xCoord = Plot.GetCoordinateX(X);
-            double yCoord = Plot.GetCoordinateY(Y);
+            double xCoord = Plot.GetCoordinateX(X,((IPlottable)PlottableBeingDragged).XAxisIndex);
+            double yCoord = Plot.GetCoordinateY(Y,((IPlottable)PlottableBeingDragged).YAxisIndex);
             PlottableBeingDragged.DragTo(xCoord, yCoord, fixedSize: ShiftDown);
         }
     }

--- a/src/ScottPlot/Control/EventProcess/Events/PlottableDragEvent.cs
+++ b/src/ScottPlot/Control/EventProcess/Events/PlottableDragEvent.cs
@@ -30,8 +30,8 @@ namespace ScottPlot.Control.EventProcess.Events
 
         public void ProcessEvent()
         {
-            double xCoord = Plot.GetCoordinateX(X,((IPlottable)PlottableBeingDragged).XAxisIndex);
-            double yCoord = Plot.GetCoordinateY(Y,((IPlottable)PlottableBeingDragged).YAxisIndex);
+            double xCoord = Plot.GetCoordinateX(X, ((IPlottable)PlottableBeingDragged).XAxisIndex);
+            double yCoord = Plot.GetCoordinateY(Y, ((IPlottable)PlottableBeingDragged).YAxisIndex);
             PlottableBeingDragged.DragTo(xCoord, yCoord, fixedSize: ShiftDown);
         }
     }

--- a/src/ScottPlot/Plot/Plot.Axis.cs
+++ b/src/ScottPlot/Plot/Plot.Axis.cs
@@ -294,27 +294,13 @@ namespace ScottPlot
         /// </summary>
         /// <param name="xPixel">horizontal pixel location</param>
         /// <param name="yPixel">vertical pixel location</param>
+        /// <param name="xAxisIndex">index of the horizontal axis to use</param>
+        /// <param name="yAxisIndex">index of the vertical axis to use</param>
         /// <returns>point in coordinate space</returns>
         public (double x, double y) GetCoordinate(float xPixel, float yPixel, int xAxisIndex = 0, int yAxisIndex = 0)
         {
-            double xCoordinate;
-            double yCoordinate;
-            if (xAxisIndex == 0)
-            {
-                xCoordinate = settings.XAxis.Dims.GetUnit(xPixel);
-            }
-            else
-            {
-                xCoordinate = settings.XAxis2.Dims.GetUnit(xPixel);
-            };
-            if (yAxisIndex == 0)
-            {
-                yCoordinate = settings.YAxis.Dims.GetUnit(yPixel);
-            }
-            else
-            {
-                yCoordinate = settings.YAxis2.Dims.GetUnit(yPixel);
-            };
+            double xCoordinate = settings.GetXAxis(xAxisIndex).Dims.GetUnit(xPixel);
+            double yCoordinate = settings.GetYAxis(yAxisIndex).Dims.GetUnit(yPixel);
             return (xCoordinate, yCoordinate);
         }
 
@@ -322,34 +308,18 @@ namespace ScottPlot
         /// Return the X position (in coordinate space) for the given pixel column
         /// </summary>
         /// <param name="xPixel">horizontal pixel location</param>
+        /// <param name="xAxisIndex">index of the horizontal axis to use</param>
         /// <returns>horizontal position in coordinate space</returns>
-        public double GetCoordinateX(float xPixel, int xAxisIndex = 0)
-        {
-            if (xAxisIndex == 0)
-            {
-                return settings.XAxis.Dims.GetUnit(xPixel);
-            }
-            else
-            {
-                return settings.XAxis2.Dims.GetUnit(xPixel);
-            };
-        }
+        public double GetCoordinateX(float xPixel, int xAxisIndex = 0) => settings.GetXAxis(xAxisIndex).Dims.GetUnit(xPixel);
+
         /// <summary>
         /// Return the Y position (in coordinate space) for the given pixel row
         /// </summary>
         /// <param name="yPixel">vertical pixel location</param>
+        /// <param name="yAxisIndex">index of the vertical axis to use</param>
         /// <returns>vertical position in coordinate space</returns>
-        public double GetCoordinateY(float yPixel, int yAxisIndex = 0)
-        {
-            if (yAxisIndex == 0)
-            {
-                return settings.YAxis.Dims.GetUnit(yPixel);
-            }
-            else
-            {
-                return settings.YAxis2.Dims.GetUnit(yPixel);
-            };
-        }
+        public double GetCoordinateY(float yPixel, int yAxisIndex = 0) => settings.GetYAxis(yAxisIndex).Dims.GetUnit(yPixel);
+
         /// <summary>
         /// Return the pixel for the given point in coordinate space
         /// </summary>

--- a/src/ScottPlot/Plot/Plot.Axis.cs
+++ b/src/ScottPlot/Plot/Plot.Axis.cs
@@ -1,4 +1,4 @@
-﻿/* 
+/* 
  * This file contains code related to Axes including:
  *   - Unit/Pixel conversions
  *   - Configuring axis limits and boundaries
@@ -295,23 +295,61 @@ namespace ScottPlot
         /// <param name="xPixel">horizontal pixel location</param>
         /// <param name="yPixel">vertical pixel location</param>
         /// <returns>point in coordinate space</returns>
-        public (double x, double y) GetCoordinate(float xPixel, float yPixel) =>
-            (settings.XAxis.Dims.GetUnit(xPixel), settings.YAxis.Dims.GetUnit(yPixel));
+        public (double x, double y) GetCoordinate(float xPixel, float yPixel, int xAxisIndex = 0, int yAxisIndex = 0)
+        {
+            double xCoordinate;
+            double yCoordinate;
+            if (xAxisIndex == 0)
+            {
+                xCoordinate =  settings.XAxis.Dims.GetUnit(xPixel);
+            } 
+            else
+            {
+                xCoordinate = settings.XAxis2.Dims.GetUnit(xPixel);
+            };
+            if (yAxisIndex == 0)
+            {
+                yCoordinate =  settings.YAxis.Dims.GetUnit(yPixel);
+            } 
+            else
+            {
+                yCoordinate = settings.YAxis2.Dims.GetUnit(yPixel);
+            };
+            return (xCoordinate,yCoordinate);
+        }
 
         /// <summary>
         /// Return the X position (in coordinate space) for the given pixel column
         /// </summary>
         /// <param name="xPixel">horizontal pixel location</param>
         /// <returns>horizontal position in coordinate space</returns>
-        public double GetCoordinateX(float xPixel) => settings.XAxis.Dims.GetUnit(xPixel);
-
+        public double GetCoordinateX(float xPixel, int xAxisIndex = 0)
+        {
+            if (xAxisIndex == 0)
+            {
+                return settings.XAxis.Dims.GetUnit(xPixel);
+            } 
+            else
+            {
+                return settings.XAxis2.Dims.GetUnit(xPixel);
+            };
+        }
         /// <summary>
         /// Return the Y position (in coordinate space) for the given pixel row
         /// </summary>
         /// <param name="yPixel">vertical pixel location</param>
         /// <returns>vertical position in coordinate space</returns>
-        public double GetCoordinateY(float yPixel) => settings.YAxis.Dims.GetUnit(yPixel);
-
+        public double GetCoordinateY(float yPixel, int yAxisIndex = 0)
+        {
+            if (yAxisIndex == 0)
+            {
+                return settings.YAxis.Dims.GetUnit(yPixel);
+            }
+            else
+            {
+                return settings.YAxis2.Dims.GetUnit(yPixel);
+            };
+        }
         /// <summary>
         /// Return the pixel for the given point in coordinate space
         /// </summary>

--- a/src/ScottPlot/Plot/Plot.Axis.cs
+++ b/src/ScottPlot/Plot/Plot.Axis.cs
@@ -1,4 +1,4 @@
-/* 
+﻿/* 
  * This file contains code related to Axes including:
  *   - Unit/Pixel conversions
  *   - Configuring axis limits and boundaries
@@ -301,21 +301,21 @@ namespace ScottPlot
             double yCoordinate;
             if (xAxisIndex == 0)
             {
-                xCoordinate =  settings.XAxis.Dims.GetUnit(xPixel);
-            } 
+                xCoordinate = settings.XAxis.Dims.GetUnit(xPixel);
+            }
             else
             {
                 xCoordinate = settings.XAxis2.Dims.GetUnit(xPixel);
             };
             if (yAxisIndex == 0)
             {
-                yCoordinate =  settings.YAxis.Dims.GetUnit(yPixel);
-            } 
+                yCoordinate = settings.YAxis.Dims.GetUnit(yPixel);
+            }
             else
             {
                 yCoordinate = settings.YAxis2.Dims.GetUnit(yPixel);
             };
-            return (xCoordinate,yCoordinate);
+            return (xCoordinate, yCoordinate);
         }
 
         /// <summary>
@@ -328,7 +328,7 @@ namespace ScottPlot
             if (xAxisIndex == 0)
             {
                 return settings.XAxis.Dims.GetUnit(xPixel);
-            } 
+            }
             else
             {
                 return settings.XAxis2.Dims.GetUnit(xPixel);

--- a/src/ScottPlot/Plot/Plot.Axis.cs
+++ b/src/ScottPlot/Plot/Plot.Axis.cs
@@ -1,4 +1,4 @@
-/* 
+﻿/* 
  * This file contains code related to Axes including:
  *   - Unit/Pixel conversions
  *   - Configuring axis limits and boundaries
@@ -301,21 +301,21 @@ namespace ScottPlot
             double yCoordinate;
             if (xAxisIndex == 0)
             {
-                xCoordinate =  settings.XAxis.Dims.GetUnit(xPixel);
-            } 
+                xCoordinate = settings.XAxis.Dims.GetUnit(xPixel);
+            }
             else
             {
                 xCoordinate = settings.XAxis2.Dims.GetUnit(xPixel);
             };
             if (yAxisIndex == 0)
             {
-                yCoordinate =  settings.YAxis.Dims.GetUnit(yPixel);
-            } 
+                yCoordinate = settings.YAxis.Dims.GetUnit(yPixel);
+            }
             else
             {
                 yCoordinate = settings.YAxis2.Dims.GetUnit(yPixel);
             };
-            return (xCoordinate,yCoordinate);
+            return (xCoordinate, yCoordinate);
         }
 
         /// <summary>
@@ -328,7 +328,7 @@ namespace ScottPlot
             if (xAxisIndex == 0)
             {
                 return settings.XAxis.Dims.GetUnit(xPixel);
-            } 
+            }
             else
             {
                 return settings.XAxis2.Dims.GetUnit(xPixel);
@@ -356,22 +356,22 @@ namespace ScottPlot
         /// <param name="x">horizontal coordinate</param>
         /// <param name="y">vertical coordinate</param>
         /// <returns>pixel location</returns>
-        public (float xPixel, float yPixel) GetPixel(double x, double y) =>
-            (settings.XAxis.Dims.GetPixel(x), settings.YAxis.Dims.GetPixel(y));
+        public (float xPixel, float yPixel) GetPixel(double x, double y, int xAxisIndex = 0, int yAxisIndex = 0) =>
+                    (GetPixelX(x), GetPixelY(y));
 
         /// <summary>
         /// Return the horizontal pixel location given position in coordinate space
         /// </summary>
         /// <param name="x">horizontal coordinate</param>
         /// <returns>horizontal pixel position</returns>
-        public float GetPixelX(double x) => settings.XAxis.Dims.GetPixel(x);
+        public float GetPixelX(double x, int xAxisIndex = 0) => xAxisIndex == 0 ? settings.XAxis.Dims.GetPixel(x) : settings.XAxis2.Dims.GetPixel(x);
 
         /// <summary>
         /// Return the vertical pixel location given position in coordinate space
         /// </summary>
         /// <param name="y">vertical coordinate</param>
         /// <returns>vertical pixel position</returns>
-        public float GetPixelY(double y) => settings.YAxis.Dims.GetPixel(y);
+        public float GetPixelY(double y, int yAxisIndex = 0) => yAxisIndex == 0 ? settings.XAxis.Dims.GetPixel(y) : settings.XAxis2.Dims.GetPixel(y);
 
         #endregion
 

--- a/src/ScottPlot/Plot/Plot.Axis.cs
+++ b/src/ScottPlot/Plot/Plot.Axis.cs
@@ -1,4 +1,4 @@
-﻿/* 
+/* 
  * This file contains code related to Axes including:
  *   - Unit/Pixel conversions
  *   - Configuring axis limits and boundaries
@@ -301,21 +301,21 @@ namespace ScottPlot
             double yCoordinate;
             if (xAxisIndex == 0)
             {
-                xCoordinate = settings.XAxis.Dims.GetUnit(xPixel);
-            }
+                xCoordinate =  settings.XAxis.Dims.GetUnit(xPixel);
+            } 
             else
             {
                 xCoordinate = settings.XAxis2.Dims.GetUnit(xPixel);
             };
             if (yAxisIndex == 0)
             {
-                yCoordinate = settings.YAxis.Dims.GetUnit(yPixel);
-            }
+                yCoordinate =  settings.YAxis.Dims.GetUnit(yPixel);
+            } 
             else
             {
                 yCoordinate = settings.YAxis2.Dims.GetUnit(yPixel);
             };
-            return (xCoordinate, yCoordinate);
+            return (xCoordinate,yCoordinate);
         }
 
         /// <summary>
@@ -328,7 +328,7 @@ namespace ScottPlot
             if (xAxisIndex == 0)
             {
                 return settings.XAxis.Dims.GetUnit(xPixel);
-            }
+            } 
             else
             {
                 return settings.XAxis2.Dims.GetUnit(xPixel);
@@ -356,22 +356,22 @@ namespace ScottPlot
         /// <param name="x">horizontal coordinate</param>
         /// <param name="y">vertical coordinate</param>
         /// <returns>pixel location</returns>
-        public (float xPixel, float yPixel) GetPixel(double x, double y, int xAxisIndex = 0, int yAxisIndex = 0) =>
-                    (GetPixelX(x), GetPixelY(y));
+        public (float xPixel, float yPixel) GetPixel(double x, double y) =>
+            (settings.XAxis.Dims.GetPixel(x), settings.YAxis.Dims.GetPixel(y));
 
         /// <summary>
         /// Return the horizontal pixel location given position in coordinate space
         /// </summary>
         /// <param name="x">horizontal coordinate</param>
         /// <returns>horizontal pixel position</returns>
-        public float GetPixelX(double x, int xAxisIndex = 0) => xAxisIndex == 0 ? settings.XAxis.Dims.GetPixel(x) : settings.XAxis2.Dims.GetPixel(x);
+        public float GetPixelX(double x) => settings.XAxis.Dims.GetPixel(x);
 
         /// <summary>
         /// Return the vertical pixel location given position in coordinate space
         /// </summary>
         /// <param name="y">vertical coordinate</param>
         /// <returns>vertical pixel position</returns>
-        public float GetPixelY(double y, int yAxisIndex = 0) => yAxisIndex == 0 ? settings.XAxis.Dims.GetPixel(y) : settings.XAxis2.Dims.GetPixel(y);
+        public float GetPixelY(double y) => settings.YAxis.Dims.GetPixel(y);
 
         #endregion
 

--- a/src/controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/controls/ScottPlot.WinForms/FormsPlot.cs
@@ -117,7 +117,7 @@ namespace ScottPlot
         /// <summary>
         /// Return the mouse position on the plot (in coordinate space) for the latest X and Y coordinates
         /// </summary>
-        public (double x, double y) GetMouseCoordinates(int xAxisIndex = 0,int yAxisIndex = 0) => Backend.GetMouseCoordinates(xAxisIndex,yAxisIndex);
+        public (double x, double y) GetMouseCoordinates(int xAxisIndex = 0, int yAxisIndex = 0) => Backend.GetMouseCoordinates(xAxisIndex, yAxisIndex);
 
         /// <summary>
         /// Return the mouse position (in pixel space) for the last observed mouse position

--- a/src/controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/controls/ScottPlot.WinForms/FormsPlot.cs
@@ -117,7 +117,7 @@ namespace ScottPlot
         /// <summary>
         /// Return the mouse position on the plot (in coordinate space) for the latest X and Y coordinates
         /// </summary>
-        public (double x, double y) GetMouseCoordinates(int xAxisIndex = 0, int yAxisIndex = 0) => Backend.GetMouseCoordinates(xAxisIndex, yAxisIndex);
+        public (double x, double y) GetMouseCoordinates(int xAxisIndex = 0,int yAxisIndex = 0) => Backend.GetMouseCoordinates(xAxisIndex,yAxisIndex);
 
         /// <summary>
         /// Return the mouse position (in pixel space) for the last observed mouse position

--- a/src/controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/controls/ScottPlot.WinForms/FormsPlot.cs
@@ -117,7 +117,7 @@ namespace ScottPlot
         /// <summary>
         /// Return the mouse position on the plot (in coordinate space) for the latest X and Y coordinates
         /// </summary>
-        public (double x, double y) GetMouseCoordinates() => Backend.GetMouseCoordinates();
+        public (double x, double y) GetMouseCoordinates(int xAxisIndex = 0,int yAxisIndex = 0) => Backend.GetMouseCoordinates(xAxisIndex,yAxisIndex);
 
         /// <summary>
         /// Return the mouse position (in pixel space) for the last observed mouse position

--- a/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/MultiAxisLock.cs
+++ b/src/demo/ScottPlot.Demo.WinForms/WinFormsDemos/MultiAxisLock.cs
@@ -18,25 +18,49 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
         public MultiAxisLock()
         {
             InitializeComponent();
+
             Random rand = new Random();
+            double[] data1 = DataGen.RandomWalk(rand, 100, mult: 1);
+            double[] data2 = DataGen.RandomWalk(rand, 100, mult: 10);
+            double[] data3 = DataGen.RandomWalk(rand, 100, mult: 100);
+            double avg1 = data1.Sum() / data1.Length;
+            double avg2 = data2.Sum() / data2.Length;
+            double avg3 = data3.Sum() / data3.Length;
 
-            // Add 3 signals each with a different vertical axis index.
-            // Each signal defaults to X axis index 0 so their horizontal axis will be shared.
-
-            var plt1 = formsPlot1.Plot.AddSignal(DataGen.RandomWalk(rand, 100, mult: 1));
+            // Add signals specifying the vertical axis index for each
+            var plt1 = formsPlot1.Plot.AddSignal(data1);
             plt1.YAxisIndex = 0;
             plt1.LineWidth = 3;
             plt1.Color = Color.Magenta;
 
-            var plt2 = formsPlot1.Plot.AddSignal(DataGen.RandomWalk(rand, 100, mult: 10));
+            var plt2 = formsPlot1.Plot.AddSignal(data2);
             plt2.YAxisIndex = 1;
             plt2.LineWidth = 3;
             plt2.Color = Color.Green;
 
-            var plt3 = formsPlot1.Plot.AddSignal(DataGen.RandomWalk(rand, 100, mult: 100));
+            var plt3 = formsPlot1.Plot.AddSignal(data3);
             plt3.YAxisIndex = 2;
             plt3.LineWidth = 3;
             plt3.Color = Color.Navy;
+
+            // Add draggable horizontal lines specifying the vertical axis index for each
+            var hline1 = formsPlot1.Plot.AddHorizontalLine(avg1);
+            hline1.DragEnabled = true;
+            hline1.Color = plt1.Color;
+            hline1.LineStyle = LineStyle.Dash;
+            hline1.YAxisIndex = 0;
+
+            var hline2 = formsPlot1.Plot.AddHorizontalLine(avg2);
+            hline2.DragEnabled = true;
+            hline2.Color = plt2.Color;
+            hline2.LineStyle = LineStyle.Dash;
+            hline2.YAxisIndex = 1;
+
+            var hline3 = formsPlot1.Plot.AddHorizontalLine(avg3);
+            hline3.DragEnabled = true;
+            hline3.Color = plt3.Color;
+            hline3.LineStyle = LineStyle.Dash;
+            hline3.YAxisIndex = 2;
 
             // The horizontal axis is shared by these signal plots (XAxisIndex defaults to 0)
             formsPlot1.Plot.XAxis.Label("Horizontal Axis");
@@ -58,6 +82,8 @@ namespace ScottPlot.Demo.WinForms.WinFormsDemos
             // adjust axis limits to fit the data once before locking them based on initial check state
             formsPlot1.Plot.AxisAuto();
             SetLocks();
+
+            formsPlot1.Refresh();
         }
 
         private void SetLocks()


### PR DESCRIPTION
- Former behavior only worked for `AxisIndex` 0

This PR is related to the discussion on #1545 

There is still work to generalize this to other axis indexes, but I don't know to reach other axes at the moment.