### PR TITLE
New plottables - `DraggableMarkerPlot` and `DraggableMarkerPlotInVector`

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.31
 _In development / not yet on NuGet_
 * MultiAxis: Improved support for draggable items placed on non-primary axes (#1556, #1545) _Thanks @BambOoxX_
+* Marker: New plot types `DraggableMarkerPlot` and `DraggableMarkerPlotInVector` give users options to add mouse-interactive markers to plots (#1558) _Thanks @BambOoxX_
 
 ## ScottPlot 4.1.30
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-01-15_

--- a/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
+++ b/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
@@ -44,16 +44,6 @@ namespace ScottPlot.Plottable
         public event EventHandler Dragged = delegate { };
 
         /// <summary>
-        /// The lower bound of the axis line.
-        /// </summary>
-        public double Min = double.NegativeInfinity;
-
-        /// <summary>
-        /// The upper bound of the axis line.
-        /// </summary>
-        public double Max = double.PositiveInfinity;
-
-        /// <summary>
         /// Move the line to a new coordinate in plot space.
         /// </summary>
         /// <param name="coordinateX">new X position</param>
@@ -82,7 +72,6 @@ namespace ScottPlot.Plottable
         /// <param name="snapY">snap distance (pixels)</param>
         /// <returns></returns>
         public bool IsUnderMouse(double coordinateX, double coordinateY, double snapX, double snapY) => Math.Abs(Y - coordinateY) <= snapY && Math.Abs(X - coordinateX) <= snapX;
-
     }
 
     public class DraggableMarkerPlotInVector : ScatterPlot, IDraggable

--- a/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
+++ b/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
@@ -6,6 +6,9 @@ using ScottPlot.Drawing;
 
 namespace ScottPlot.Plottable
 {
+    /// <summary>
+    /// This plot type displays a marker at a point that can be dragged with the mouse.
+    /// </summary>
     public class DraggableMarkerPlot : MarkerPlot, IDraggable
     {
         /// <summary>
@@ -74,6 +77,10 @@ namespace ScottPlot.Plottable
         public bool IsUnderMouse(double coordinateX, double coordinateY, double snapX, double snapY) => Math.Abs(Y - coordinateY) <= snapY && Math.Abs(X - coordinateX) <= snapX;
     }
 
+    /// <summary>
+    /// This plot type displays a marker at a point that can be dragged with the mouse,
+    /// but when dragged it "snapps" to specific X/Y coordinates defined by two arrays of values.
+    /// </summary>
     public class DraggableMarkerPlotInVector : IDraggable, IPlottable
     {
         public bool IsVisible { get; set; } = true;

--- a/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
+++ b/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
@@ -16,7 +16,7 @@ namespace ScottPlot.Plottable
         /// <summary>
         /// Cursor to display while hovering over this line if dragging is enabled.
         /// </summary>
-        public Cursor DragCursor => Cursor.Crosshair;
+        public Cursor DragCursor => Cursor.Hand;
 
         /// <summary>
         /// If dragging is enabled the line cannot be dragged more negative than this position

--- a/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
+++ b/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
@@ -115,16 +115,6 @@ namespace ScottPlot.Plottable
         /// </summary>
         public event EventHandler Dragged = delegate { };
 
-        /// <summary>
-        /// The lower bound of the axis line.
-        /// </summary>
-        public double Min = double.NegativeInfinity;
-
-        /// <summary>
-        /// The upper bound of the axis line.
-        /// </summary>
-        public double Max = double.PositiveInfinity;
-
         public new void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
         {
             if (!IsVisible)

--- a/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
+++ b/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
@@ -1,0 +1,316 @@
+﻿using System;
+using System.Linq;
+using System.Drawing;
+using System.Diagnostics;
+
+namespace ScottPlot.Plottable
+{
+    public class DraggableMarkerPlot : IDraggable, IPlottable
+    {
+        public bool IsVisible { get; set; } = true;
+        public int XAxisIndex { get; set; } = 0;
+        public int YAxisIndex { get; set; } = 0;
+
+        /// <summary>
+        /// Horizontal position in coordinate space
+        /// </summary>
+        public double X { get; set; }
+
+        /// <summary>
+        /// Vertical position in coordinate space
+        /// </summary>
+        public double Y { get; set; }
+
+        /// <summary>
+        /// Marker to draw at this point
+        /// </summary>
+        public MarkerShape MarkerShape { get; set; } = MarkerShape.filledCircle;
+
+        /// <summary>
+        /// Size of the marker in pixel units
+        /// </summary>
+        public double MarkerSize { get; set; } = 10;
+
+        /// <summary>
+        /// Color of the marker to display at this point
+        /// </summary>
+        public Color Color { get; set; } = Color.Black;
+
+        /// <summary>
+        /// Text to appear in the legend (if populated)
+        /// </summary>
+        public string Label { get; set; }
+
+        /// <summary>
+        /// Indicates whether this line is draggable in user controls.
+        /// </summary>
+        public bool DragEnabled { get; set; } = false;
+
+        /// <summary>
+        /// Cursor to display while hovering over this line if dragging is enabled.
+        /// </summary>
+        public Cursor DragCursor => Cursor.Crosshair;
+
+        /// <summary>
+        /// If dragging is enabled the line cannot be dragged more negative than this position
+        /// </summary>
+        public double DragXLimitMin = double.NegativeInfinity;
+
+        /// <summary>
+        /// If dragging is enabled the line cannot be dragged more positive than this position
+        /// </summary>
+        public double DragXLimitMax = double.PositiveInfinity;
+
+        /// <summary>
+        /// If dragging is enabled the line cannot be dragged more negative than this position
+        /// </summary>
+        public double DragYLimitMin = double.NegativeInfinity;
+
+        /// <summary>
+        /// If dragging is enabled the line cannot be dragged more positive than this position
+        /// </summary>
+        public double DragYLimitMax = double.PositiveInfinity;
+
+        /// <summary>
+        /// This event is invoked after the line is dragged
+        /// </summary>
+        public event EventHandler Dragged = delegate { };
+
+        /// <summary>
+        /// The lower bound of the axis line.
+        /// </summary>
+        public double Min = double.NegativeInfinity;
+
+        /// <summary>
+        /// The upper bound of the axis line.
+        /// </summary>
+        public double Max = double.PositiveInfinity;
+
+        public AxisLimits GetAxisLimits() => new AxisLimits(X, X, Y, Y);
+
+        public void ValidateData(bool deep = false)
+        {
+            Validate.AssertIsReal(nameof(X), X);
+            Validate.AssertIsReal(nameof(Y), Y);
+        }
+
+        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        {
+            if (!IsVisible)
+                return;
+
+            PointF point = new PointF(dims.GetPixelX(X), dims.GetPixelY(Y));
+
+            Graphics gfx = ScottPlot.Drawing.GDI.Graphics(bmp, dims, lowQuality);
+            MarkerTools.DrawMarker(gfx, point, MarkerShape, (float)MarkerSize, Color);
+        }
+
+        /// <summary>
+        /// Move the line to a new coordinate in plot space.
+        /// </summary>
+        /// <param name="coordinateX">new X position</param>
+        /// <param name="coordinateY">new Y position</param>
+        /// <param name="fixedSize">This argument is ignored</param>
+        public void DragTo(double coordinateX, double coordinateY, bool fixedSize)
+        {
+            if (!DragEnabled)
+                return;
+
+            if (coordinateX < DragXLimitMin) coordinateX = DragXLimitMin;
+            if (coordinateX > DragXLimitMax) coordinateX = DragXLimitMax;
+            if (coordinateX < DragYLimitMin) coordinateY = DragYLimitMin;
+            if (coordinateX > DragYLimitMax) coordinateY = DragYLimitMax;
+            X = coordinateX;
+            Y = coordinateY;
+            Dragged(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Return True if the line is within a certain number of pixels (snap) to the mouse
+        /// </summary>
+        /// <param name="coordinateX">mouse position (coordinate space)</param>
+        /// <param name="coordinateY">mouse position (coordinate space)</param>
+        /// <param name="snapX">snap distance (pixels)</param>
+        /// <param name="snapY">snap distance (pixels)</param>
+        /// <returns></returns>
+        public bool IsUnderMouse(double coordinateX, double coordinateY, double snapX, double snapY) => Math.Abs(Y - coordinateY) <= snapY && Math.Abs(X - coordinateX) <= snapX;
+
+        public LegendItem[] GetLegendItems()
+        {
+            var singleItem = new LegendItem()
+            {
+                label = Label,
+                markerShape = MarkerShape,
+                markerSize = MarkerSize,
+                color = Color
+            };
+            return new LegendItem[] { singleItem };
+        }
+    }
+
+    public class DraggableMarkerPlotInVector : IDraggable, IPlottable
+    {
+        public bool IsVisible { get; set; } = true;
+        public int XAxisIndex { get; set; } = 0;
+        public int YAxisIndex { get; set; } = 0;
+
+        /// <summary>
+        /// Horizontal position in coordinate space
+        /// </summary>
+        public double[] Xs { get; set; }
+
+        /// <summary>
+        /// Vertical position in coordinate space
+        /// </summary>
+        public double[] Ys { get; set; }
+
+        public int PointCount => Xs.Length;
+
+        public int CurrentIndex { get; set; } = 0;
+        /// <summary>
+        /// Marker to draw at this point
+        /// </summary>
+        public MarkerShape MarkerShape { get; set; } = MarkerShape.filledCircle;
+
+        /// <summary>
+        /// Size of the marker in pixel units
+        /// </summary>
+        public double MarkerSize { get; set; } = 10;
+
+        /// <summary>
+        /// Color of the marker to display at this point
+        /// </summary>
+        public Color Color { get; set; } = Color.Black;
+
+        /// <summary>
+        /// Text to appear in the legend (if populated)
+        /// </summary>
+        public string Label { get; set; }
+
+        /// <summary>
+        /// Indicates whether this line is draggable in user controls.
+        /// </summary>
+        public bool DragEnabled { get; set; } = false;
+
+        /// <summary>
+        /// Cursor to display while hovering over this line if dragging is enabled.
+        /// </summary>
+        public Cursor DragCursor => Cursor.Crosshair;
+
+        /// <summary>
+        /// If dragging is enabled the line cannot be dragged more negative than this position
+        /// </summary>
+        public double DragXLimitMin = double.NegativeInfinity;
+
+        /// <summary>
+        /// If dragging is enabled the line cannot be dragged more positive than this position
+        /// </summary>
+        public double DragXLimitMax = double.PositiveInfinity;
+
+        /// <summary>
+        /// If dragging is enabled the line cannot be dragged more negative than this position
+        /// </summary>
+        public double DragYLimitMin = double.NegativeInfinity;
+
+        /// <summary>
+        /// If dragging is enabled the line cannot be dragged more positive than this position
+        /// </summary>
+        public double DragYLimitMax = double.PositiveInfinity;
+
+        /// <summary>
+        /// This event is invoked after the line is dragged
+        /// </summary>
+        public event EventHandler Dragged = delegate { };
+
+        /// <summary>
+        /// The lower bound of the axis line.
+        /// </summary>
+        public double Min = double.NegativeInfinity;
+
+        /// <summary>
+        /// The upper bound of the axis line.
+        /// </summary>
+        public double Max = double.PositiveInfinity;
+
+        public AxisLimits GetAxisLimits() => new AxisLimits(Xs.Min(), Xs.Max(), Ys.Min(), Ys.Max());
+
+        public void ValidateData(bool deep = false)
+        {
+            Debug.Assert(CurrentIndex >= 0 && CurrentIndex <= PointCount - 1, $"CurrentIndex property is out of bounds, it should be in the [0 - {PointCount - 1} range");
+            Debug.Assert(CurrentIndex <= Xs.Length - 1);
+            Validate.AssertHasElements(nameof(Xs), Xs);
+            Validate.AssertHasElements(nameof(Ys), Ys);
+            Validate.AssertEqualLength("", Xs, Ys);
+            if (deep)
+            {
+                Validate.AssertAllReal(nameof(Xs), Xs);
+                Validate.AssertAllReal(nameof(Ys), Ys);
+            }
+        }
+
+        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        {
+            if (!IsVisible)
+                return;
+
+            PointF point = new PointF(dims.GetPixelX(Xs[CurrentIndex]), dims.GetPixelY(Ys[CurrentIndex]));
+
+            Graphics gfx = ScottPlot.Drawing.GDI.Graphics(bmp, dims, lowQuality);
+            MarkerTools.DrawMarker(gfx, point, MarkerShape, (float)MarkerSize, Color);
+        }
+
+        /// <summary>
+        /// Move the line to a new coordinate in plot space.
+        /// </summary>
+        /// <param name="coordinateX">new X position</param>
+        /// <param name="coordinateY">new Y position</param>
+        /// <param name="fixedSize">This argument is ignored</param>
+        public void DragTo(double coordinateX, double coordinateY, bool fixedSize)
+        {
+            if (!DragEnabled)
+                return;
+
+            if (coordinateX < DragXLimitMin) coordinateX = DragXLimitMin;
+            if (coordinateX > DragXLimitMax) coordinateX = DragXLimitMax;
+            if (coordinateX < DragYLimitMin) coordinateY = DragYLimitMin;
+            if (coordinateX > DragYLimitMax) coordinateY = DragYLimitMax;
+
+            var distancessq = new double[PointCount];
+            for (int i = 0; i < PointCount; i++)
+            {
+                distancessq[i] = Math.Pow(Xs[i] - coordinateX, 2) + Math.Pow(Ys[i] - coordinateY, 2);
+            }
+            for (int i = 0; i < PointCount; i++)
+            {
+                if (distancessq[i] < distancessq[CurrentIndex])
+                {
+                    CurrentIndex = i;
+                }
+            }
+
+            Dragged(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Return True if the line is within a certain number of pixels (snap) to the mouse
+        /// </summary>
+        /// <param name="coordinateX">mouse position (coordinate space)</param>
+        /// <param name="coordinateY">mouse position (coordinate space)</param>
+        /// <param name="snapX">snap distance (pixels)</param>
+        /// <param name="snapY">snap distance (pixels)</param>
+        /// <returns></returns>
+        public bool IsUnderMouse(double coordinateX, double coordinateY, double snapX, double snapY) => Math.Abs(Ys[CurrentIndex] - coordinateY) <= snapY && Math.Abs(Xs[CurrentIndex] - coordinateX) <= snapX;
+
+        public LegendItem[] GetLegendItems()
+        {
+            var singleItem = new LegendItem()
+            {
+                label = Label,
+                markerShape = MarkerShape,
+                markerSize = MarkerSize,
+                color = Color
+            };
+            return new LegendItem[] { singleItem };
+        }
+    }
+}

--- a/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
+++ b/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
@@ -16,7 +16,7 @@ namespace ScottPlot.Plottable
         /// <summary>
         /// Cursor to display while hovering over this line if dragging is enabled.
         /// </summary>
-        public Cursor DragCursor => Cursor.Hand;
+        public Cursor DragCursor { get; set; } = Cursor.Hand;
 
         /// <summary>
         /// If dragging is enabled the line cannot be dragged more negative than this position

--- a/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
+++ b/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Drawing;
 using System.Diagnostics;
@@ -9,42 +9,42 @@ namespace ScottPlot.Plottable
     public class DraggableMarkerPlot : MarkerPlot, IDraggable
     {
         /// <summary>
-        /// Indicates whether this line is draggable in user controls.
+        /// Indicates whether this marker is draggable in user controls.
         /// </summary>
         public bool DragEnabled { get; set; } = true;
 
         /// <summary>
-        /// Cursor to display while hovering over this line if dragging is enabled.
+        /// Cursor to display while hovering over this marker if dragging is enabled.
         /// </summary>
         public Cursor DragCursor { get; set; } = Cursor.Hand;
 
         /// <summary>
-        /// If dragging is enabled the line cannot be dragged more negative than this position
+        /// If dragging is enabled the marker cannot be dragged more negative than this position
         /// </summary>
         public double DragXLimitMin = double.NegativeInfinity;
 
         /// <summary>
-        /// If dragging is enabled the line cannot be dragged more positive than this position
+        /// If dragging is enabled the marker cannot be dragged more positive than this position
         /// </summary>
         public double DragXLimitMax = double.PositiveInfinity;
 
         /// <summary>
-        /// If dragging is enabled the line cannot be dragged more negative than this position
+        /// If dragging is enabled the marker cannot be dragged more negative than this position
         /// </summary>
         public double DragYLimitMin = double.NegativeInfinity;
 
         /// <summary>
-        /// If dragging is enabled the line cannot be dragged more positive than this position
+        /// If dragging is enabled the marker cannot be dragged more positive than this position
         /// </summary>
         public double DragYLimitMax = double.PositiveInfinity;
 
         /// <summary>
-        /// This event is invoked after the line is dragged
+        /// This event is invoked after the marker is dragged
         /// </summary>
         public event EventHandler Dragged = delegate { };
 
         /// <summary>
-        /// Move the line to a new coordinate in plot space.
+        /// Move the marker to a new coordinate in plot space.
         /// </summary>
         /// <param name="coordinateX">new X position</param>
         /// <param name="coordinateY">new Y position</param>
@@ -64,7 +64,7 @@ namespace ScottPlot.Plottable
         }
 
         /// <summary>
-        /// Return True if the line is within a certain number of pixels (snap) to the mouse
+        /// Return True if the marker is within a certain number of pixels (snap) to the mouse
         /// </summary>
         /// <param name="coordinateX">mouse position (coordinate space)</param>
         /// <param name="coordinateY">mouse position (coordinate space)</param>
@@ -81,37 +81,37 @@ namespace ScottPlot.Plottable
         public int CurrentIndex { get; set; } = 0;
 
         /// <summary>
-        /// Indicates whether this line is draggable in user controls.
+        /// Indicates whether this marker on the scatter plot is draggable in user controls.
         /// </summary>
         public bool DragEnabled { get; set; } = true;
 
         /// <summary>
-        /// Cursor to display while hovering over this line if dragging is enabled.
+        /// Cursor to display while hovering over this marker on the scatter plot if dragging is enabled.
         /// </summary>
         public Cursor DragCursor => Cursor.Crosshair;
 
         /// <summary>
-        /// If dragging is enabled the line cannot be dragged more negative than this position
+        /// If dragging is enabled the marker on the scatter plot cannot be dragged more negative than this position
         /// </summary>
         public double DragXLimitMin = double.NegativeInfinity;
 
         /// <summary>
-        /// If dragging is enabled the line cannot be dragged more positive than this position
+        /// If dragging is enabled the marker on the scatter plot cannot be dragged more positive than this position
         /// </summary>
         public double DragXLimitMax = double.PositiveInfinity;
 
         /// <summary>
-        /// If dragging is enabled the line cannot be dragged more negative than this position
+        /// If dragging is enabled the marker on the scatter plot cannot be dragged more negative than this position
         /// </summary>
         public double DragYLimitMin = double.NegativeInfinity;
 
         /// <summary>
-        /// If dragging is enabled the line cannot be dragged more positive than this position
+        /// If dragging is enabled the marker on the scatter plot cannot be dragged more positive than this position
         /// </summary>
         public double DragYLimitMax = double.PositiveInfinity;
 
         /// <summary>
-        /// This event is invoked after the line is dragged
+        /// This event is invoked after the marker on the scatter plot is dragged
         /// </summary>
         public event EventHandler Dragged = delegate { };
 

--- a/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
+++ b/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
@@ -11,7 +11,7 @@ namespace ScottPlot.Plottable
         /// <summary>
         /// Indicates whether this line is draggable in user controls.
         /// </summary>
-        public bool DragEnabled { get; set; } = false;
+        public bool DragEnabled { get; set; } = true;
 
         /// <summary>
         /// Cursor to display while hovering over this line if dragging is enabled.
@@ -94,7 +94,7 @@ namespace ScottPlot.Plottable
         /// <summary>
         /// Indicates whether this line is draggable in user controls.
         /// </summary>
-        public bool DragEnabled { get; set; } = false;
+        public bool DragEnabled { get; set; } = true;
 
         /// <summary>
         /// Cursor to display while hovering over this line if dragging is enabled.

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Marker.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Marker.cs
@@ -48,8 +48,31 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                 MarkerShape = MarkerShape.filledDiamond,
                 MarkerSize = 25,
             };
-
             plt.Add(myDraggableMarker);
+        }
+    }
+
+    public class MarkerDraggableInVector : IRecipe
+    {
+        public string Category => "Plottable: Marker";
+        public string ID => "marker_draggableinvector";
+        public string Title => "Draggable Marker in a vector";
+        public string Description =>
+            "A special type of marker which can be dragged with the mouse, but only in a given dataset not on the whole plot. " +
+            "This is practical if you want to show the properties of a specific data point without always following the mouse movement, as in the \"Show Value on Hover\" example";
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[] xs = DataGen.Consecutive(50);
+            double[] ys = DataGen.Random(new Random(0), 50);
+
+            var myDraggableMarkerInVector = new ScottPlot.Plottable.DraggableMarkerPlotInVector();
+            myDraggableMarkerInVector.Xs = xs;
+            myDraggableMarkerInVector.Ys = ys;
+            myDraggableMarkerInVector.DragEnabled = true;
+            myDraggableMarkerInVector.IsVisible = true;
+            myDraggableMarkerInVector.Color = Color.Red;
+            plt.AddScatter(xs, ys);
+            plt.Add(myDraggableMarkerInVector);
         }
     }
 }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Marker.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Marker.cs
@@ -56,23 +56,32 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
     {
         public string Category => "Plottable: Marker";
         public string ID => "marker_draggableinvector";
-        public string Title => "Draggable Marker in a vector";
+        public string Title => "Draggable Marker Snap";
         public string Description =>
-            "A special type of marker which can be dragged with the mouse, but only in a given dataset not on the whole plot. " +
-            "This is practical if you want to show the properties of a specific data point without always following the mouse movement, as in the \"Show Value on Hover\" example";
+            "This is a type of marker which can be dragged with the mouse, " +
+            "but is restricted to to X/Y positions defined by two arrays.";
         public void ExecuteRecipe(Plot plt)
         {
+            // create random data and display it with a scatter plot
             double[] xs = DataGen.Consecutive(50);
             double[] ys = DataGen.Random(new Random(0), 50);
+            plt.AddScatter(xs, ys, label: "data");
 
-            var myDraggableMarkerInVector = new ScottPlot.Plottable.DraggableMarkerPlotInVector();
-            myDraggableMarkerInVector.Xs = xs;
-            myDraggableMarkerInVector.Ys = ys;
-            myDraggableMarkerInVector.DragEnabled = true;
-            myDraggableMarkerInVector.IsVisible = true;
-            myDraggableMarkerInVector.Color = Color.Red;
-            plt.AddScatter(xs, ys);
-            plt.Add(myDraggableMarkerInVector);
+            // add a draggable marker that "snaps" to data values in that scatter plot
+            var dmpv = new ScottPlot.Plottable.DraggableMarkerPlotInVector()
+            {
+                Xs = xs,
+                Ys = ys,
+                DragEnabled = true,
+                IsVisible = true,
+                MarkerSize = 15,
+                MarkerShape = MarkerShape.filledDiamond,
+                Color = Color.Magenta,
+                Label = "marker",
+            };
+            plt.Add(dmpv);
+
+            plt.Legend();
         }
     }
 }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Marker.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Marker.cs
@@ -27,4 +27,29 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             }
         }
     }
+
+    public class MarkerDraggable : IRecipe
+    {
+        public string Category => "Plottable: Marker";
+        public string ID => "marker_draggable";
+        public string Title => "Draggable Marker";
+        public string Description =>
+            "A special type of marker exists which allows dragging with the mouse.";
+        public void ExecuteRecipe(Plot plt)
+        {
+            plt.AddSignal(ScottPlot.DataGen.Sin(51));
+            plt.AddSignal(ScottPlot.DataGen.Cos(51));
+
+            var myDraggableMarker = new ScottPlot.Plottable.DraggableMarkerPlot()
+            {
+                X = 25,
+                Y = .57,
+                Color = Color.Magenta,
+                MarkerShape = MarkerShape.filledDiamond,
+                MarkerSize = 25,
+            };
+
+            plt.Add(myDraggableMarker);
+        }
+    }
 }


### PR DESCRIPTION
- `DraggableMarkerPlot` is a `MarkerPlot` that can be dragged through a `Plot`. This can serve as a *static* way to pinpoint a location on the axes. By *static* I mean that does not move with the mouse unless dragged
- `DraggableMarkerPlotInVector` behaves somewhat similar to as `ScatterPlot` that in addition has a draggable point. When you drag the point, it goes to the coordinates in the vector closest to the mouse position.
