### PR TITLE
Fix - `MouseZoomRect` affects all axes

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.31
 _In development / not yet on NuGet_
 * MultiAxis: Improved support for draggable items placed on non-primary axes (#1556, #1545) _Thanks @BambOoxX_
+* Controls: Improved middle-click-drag zoom rectangle support for plots with multiple axes (#1559, #1537) _Thanks @BambOoxX_
 
 ## ScottPlot 4.1.30
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-01-15_

--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -495,9 +495,9 @@ namespace ScottPlot
 
             if (finalize)
             {
+                ZoomRectangle.Clear();
                 foreach (Axis axis in Axes)
                 {
-                    ZoomRectangle.Clear();
                     if (axis.IsHorizontal)
                     {
                         double x1 = axis.Dims.GetUnit(left);

--- a/src/ScottPlot/Settings.cs
+++ b/src/ScottPlot/Settings.cs
@@ -495,12 +495,22 @@ namespace ScottPlot
 
             if (finalize)
             {
-                double x1 = XAxis.Dims.GetUnit(left);
-                double x2 = XAxis.Dims.GetUnit(right);
-                double y1 = YAxis.Dims.GetUnit(bottom);
-                double y2 = YAxis.Dims.GetUnit(top);
-                ZoomRectangle.Clear();
-                AxisSet(x1, x2, y1, y2);
+                foreach (Axis axis in Axes)
+                {
+                    ZoomRectangle.Clear();
+                    if (axis.IsHorizontal)
+                    {
+                        double x1 = axis.Dims.GetUnit(left);
+                        double x2 = axis.Dims.GetUnit(right);
+                        axis.Dims.SetAxis(x1, x2);
+                    }
+                    else
+                    {
+                        double y1 = axis.Dims.GetUnit(bottom);
+                        double y2 = axis.Dims.GetUnit(top);
+                        axis.Dims.SetAxis(y1, y2);
+                    }
+                }
             }
             else
             {


### PR DESCRIPTION
This PR fixes #1537 to preserve the aspect ratio between axes during a Zoom.
In fact, the current behavior seems in contradiction with the fact that by default axes limits are free and should (to my understanding) be affected in the same manner by the drag zoom, regardless of the axis.
