### PR TITLE
New plottable : `ScatterPlotDraggable`

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.31
 _In development / not yet on NuGet_
 * MultiAxis: Improved support for draggable items placed on non-primary axes (#1556, #1545) _Thanks @BambOoxX_
+* Scatter: The new `ScatterPlotDraggable` plot type is for creating scatter plots with mouse-draggable points (#1560, #1422) _Thanks @BambOoxX and @EFeru_
 
 ## ScottPlot 4.1.30
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-01-15_

--- a/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
+++ b/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
@@ -30,7 +30,7 @@ namespace ScottPlot.Plottable
         /// <summary>
         /// Cursor to display while hovering over the scatter points if dragging is enabled.
         /// </summary>
-        public ScottPlot.Cursor DragCursor => ScottPlot.Cursor.Crosshair;
+        public ScottPlot.Cursor DragCursor { get; set; } = ScottPlot.Cursor.Crosshair;
 
         /// <summary>
         /// If dragging is enabled the points cannot be dragged more negative than this position

--- a/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
+++ b/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace ScottPlot.Plottable
 {

--- a/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
+++ b/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
@@ -1,0 +1,113 @@
+using System;
+
+namespace ScottPlot.Plottable
+{
+    /// <summary>
+    /// The scatter plot renders X/Y pairs as points and/or connected lines.
+    /// Scatter plots can be extremely slow for large datasets, so use Signal plots in these situations.
+    /// </summary>
+    public class ScatterPlotDraggable : ScatterPlot, IDraggable
+    {
+        public new double[] Xs { get; private set; }
+        public new double[] Ys { get; private set; }
+        public int CurrentIndex { get; set; } = 0;
+
+        /// <summary>
+        /// Indicates whether scatter points are draggable in user controls.
+        /// </summary>
+        public bool DragEnabled { get; set; } = false;
+
+        /// <summary>
+        /// Indicates whether scatter points are horizontally draggable in user controls.
+        /// </summary>
+        public bool DragEnabledX { get; set; } = true;
+
+        /// <summary>
+        /// Indicates whether scatter points are vertically draggable in user controls.
+        /// </summary>
+        public bool DragEnabledY { get; set; } = true;
+
+        /// <summary>
+        /// Cursor to display while hovering over the scatter points if dragging is enabled.
+        /// </summary>
+        public ScottPlot.Cursor DragCursor => ScottPlot.Cursor.Crosshair;
+
+        /// <summary>
+        /// If dragging is enabled the points cannot be dragged more negative than this position
+        /// </summary>
+        public double DragXLimitMin = double.NegativeInfinity;
+
+        /// <summary>
+        /// If dragging is enabled the points cannot be dragged more positive than this position
+        /// </summary>
+        public double DragXLimitMax = double.PositiveInfinity;
+
+        /// <summary>
+        /// If dragging is enabled the points cannot be dragged more negative than this position
+        /// </summary>
+        public double DragYLimitMin = double.NegativeInfinity;
+
+        /// <summary>
+        /// If dragging is enabled the points cannot be dragged more positive than this position
+        /// </summary>
+        public double DragYLimitMax = double.PositiveInfinity;
+
+        /// <summary>
+        /// This event is invoked after the plot is dragged
+        /// </summary>
+        public event EventHandler Dragged = delegate { };
+
+        /// <summary>
+        /// Move a scatter point to a new coordinate in plot space.
+        /// </summary>
+        /// <param name="coordinateX">new X position</param>
+        /// <param name="coordinateY">new Y position</param>
+        /// <param name="fixedSize">This argument is ignored</param>
+        public void DragTo(double coordinateX, double coordinateY, bool fixedSize)
+        {
+            if (!DragEnabled)
+                return;
+
+            if (coordinateX < DragXLimitMin) coordinateX = DragXLimitMin;
+            if (coordinateX > DragXLimitMax) coordinateX = DragXLimitMax;
+            if (coordinateX < DragYLimitMin) coordinateY = DragYLimitMin;
+            if (coordinateX > DragYLimitMax) coordinateY = DragYLimitMax;
+
+            if (DragEnabledX) Xs[CurrentIndex] = coordinateX;
+            if (DragEnabledY) Ys[CurrentIndex] = coordinateY;
+
+            Dragged(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Return True if a scatter point is within a certain number of pixels (snap) to the mouse
+        /// </summary>
+        /// <param name="coordinateX">mouse position (coordinate space)</param>
+        /// <param name="coordinateY">mouse position (coordinate space)</param>
+        /// <param name="snapX">snap distance (pixels)</param>
+        /// <param name="snapY">snap distance (pixels)</param>
+        /// <returns></returns>
+        public bool IsUnderMouse(double coordinateX, double coordinateY, double snapX, double snapY)
+        {
+            bool test = false;
+            for (int i = 0; i < PointCount; i++)
+            {
+                test = Math.Abs(Ys[i] - coordinateY) <= snapY && Math.Abs(Xs[i] - coordinateX) <= snapX;
+                if (test)
+                {
+                    CurrentIndex = i;
+                    return test;
+                }
+            }
+            return test;
+        }
+
+        public ScatterPlotDraggable(double[] xs, double[] ys, double[] errorX = null, double[] errorY = null) : base(xs, ys, errorX, errorY)
+        {
+            this.Xs = xs;
+            this.Ys = ys;
+            this.XError = errorX;
+            this.YError = errorY;
+        }
+    }
+}

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Scatter.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Scatter.cs
@@ -231,20 +231,50 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
 
     public class ScatterPlotDraggable : IRecipe
     {
-        public string Category => "Plottable: Draggable Scatter Plot ";
-        public string ID => "scatter_draggable";
+        public string Category => "Plottable: Scatter Plot";
+        public string ID => "scatter_draggable_vertical";
         public string Title => "Draggable Scatter Plot";
-        public string Description => "Want to modify the scatter points interactively ? " +
-        "A ScatterPlotDraggable lets you move the points around";
+        public string Description => "Want to modify the scatter points interactively? " +
+            "A ScatterPlotDraggable lets you move the points around with the mouse. " +
+            "As you move the points around, the values in the original arrays change to " +
+            "reflect their new positions.";
 
         public void ExecuteRecipe(Plot plt)
         {
             double[] x = ScottPlot.DataGen.Consecutive(50);
             double[] y = ScottPlot.DataGen.Cos(50);
-            var scd_plot = new ScottPlot.Plottable.ScatterPlotDraggable(x, y);
-            scd_plot.DragCursor = Cursor.Crosshair;
-            scd_plot.DragEnabled = true;
-            plt.Add(scd_plot);
+
+            var scatter = new ScottPlot.Plottable.ScatterPlotDraggable(x, y)
+            {
+                DragCursor = Cursor.Crosshair,
+                DragEnabled = true,
+            };
+
+            plt.Add(scatter);
+        }
+    }
+
+    public class ScatterPlotDraggableVertical : IRecipe
+    {
+        public string Category => "Plottable: Scatter Plot";
+        public string ID => "scatter_draggable";
+        public string Title => "Draggable Scatter Plot Vertical";
+        public string Description => "You can restrict dragging to just X or Y directions.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[] x = ScottPlot.DataGen.Consecutive(50);
+            double[] y = ScottPlot.DataGen.Cos(50);
+
+            var scatter = new ScottPlot.Plottable.ScatterPlotDraggable(x, y)
+            {
+                DragCursor = Cursor.Crosshair,
+                DragEnabled = true,   // controls whether anything can be dragged
+                DragEnabledX = false, // controls whether points can be dragged horizontally 
+                DragEnabledY = true,  // controls whether points can be dragged vertically
+            };
+
+            plt.Add(scatter);
         }
     }
 }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Scatter.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Scatter.cs
@@ -234,14 +234,14 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string Category => "Plottable: Draggable Scatter Plot ";
         public string ID => "scatter_draggable";
         public string Title => "Draggable Scatter Plot";
-        public string Description => "Want to modify the scatter points interactively ? " + 
+        public string Description => "Want to modify the scatter points interactively ? " +
         "A ScatterPlotDraggable lets you move the points around";
 
         public void ExecuteRecipe(Plot plt)
         {
             double[] x = ScottPlot.DataGen.Consecutive(50);
             double[] y = ScottPlot.DataGen.Cos(50);
-            var scd_plot = new ScottPlot.Plottable.ScatterPlotDraggable(x,y);
+            var scd_plot = new ScottPlot.Plottable.ScatterPlotDraggable(x, y);
             scd_plot.DragCursor = Cursor.Crosshair;
             scd_plot.DragEnabled = true;
             plt.Add(scd_plot);

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Scatter.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Scatter.cs
@@ -228,4 +228,23 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             }
         }
     }
+
+    public class ScatterPlotDraggable : IRecipe
+    {
+        public string Category => "Plottable: Draggable Scatter Plot ";
+        public string ID => "scatter_draggable";
+        public string Title => "Draggable Scatter Plot";
+        public string Description => "Want to modify the scatter points interactively ? " + 
+        "A ScatterPlotDraggable lets you move the points around";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[] x = ScottPlot.DataGen.Consecutive(50);
+            double[] y = ScottPlot.DataGen.Cos(50);
+            var scd_plot = new ScottPlot.Plottable.ScatterPlotDraggable(x,y);
+            scd_plot.DragCursor = Cursor.Crosshair;
+            scd_plot.DragEnabled = true;
+            plt.Add(scd_plot);
+        }
+    }
 }


### PR DESCRIPTION
This PR implements the functionnalities described in #1422.
The code inherits `ScatterPlot` and `IDraggable` to reduce code duplication
Two additional options (both true by default) are provided in addition to `DragEnabled`
- `DragEnabledX` : allows to free/lock horizontal drag of the scatter points
- `DragEnabledY` : allows to free/lock vertical drag of the scatter points