### PR TITLE
Fix bug on `GetDataLimits` when plot is empty

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -6,6 +6,7 @@ _In development / not yet on NuGet_
 * Legend: `GetBitmap()` returns a transparent image instead of throwing an exception if there are no items in the legend (#1578) _Thanks @BambOoxX_
 * Legend: Added `Count`, `HasItems`, and `GetItems()` so users can inspect legend contents to if/how they want to display it (#1578) _Thanks @BambOoxX_
 * Plot: Exposed `GetDraggable()` to allow users to retrieve the plotted objects at specific pixel positions (#1578) _Thanks @BambOoxX_
+* Axis Limits: Improved handling of axis limits for plots containing no data (#1581) _Thanks @EFeru_
 
 ## ScottPlot 4.1.31
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-01-17_

--- a/src/ScottPlot/Plot/Plot.Axis.cs
+++ b/src/ScottPlot/Plot/Plot.Axis.cs
@@ -379,6 +379,15 @@ namespace ScottPlot
                 }
             }
 
+            if (double.IsPositiveInfinity(xMin))
+                xMin = double.NegativeInfinity;
+            if (double.IsNegativeInfinity(xMax))
+                xMax = double.PositiveInfinity;
+            if (double.IsPositiveInfinity(yMin))
+                yMin = double.NegativeInfinity;
+            if (double.IsNegativeInfinity(yMax))
+                yMax = double.PositiveInfinity;
+
             return new AxisLimits(xMin, xMax, yMin, yMax);
         }
 


### PR DESCRIPTION
When plot is empty meaning no `plottable in GetPlottables()` then the returned limits have the initial values:
https://github.com/ScottPlot/ScottPlot/blob/a214b94102c107db3799197655b5255c464c7eda/src/ScottPlot/Plot/Plot.Axis.cs#L355-L358

Now, if the user calls:
```cs
AxisLimits limits = formsPlot1.Plot.GetDataLimits();
formsPlot1.Plot.SetOuterViewLimits(limits.XMin, limits.XMax, limits.YMin, limits.YMax);
```
if is not possible to interract with the plot anymore (zoom, pan, etc.) beacause the limits set are flipped. This PR fixes the returned limits to the correct ones.