### PR TITLE
WIP : Attempt to constrain drag to adjacent points

### DIFF
--- a/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
+++ b/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
@@ -96,7 +96,7 @@ namespace ScottPlot.Plottable
                 if (DragEnabledY && DragBoxedY)
                 {
                     if (SortedCurrentIndex < PointCount && coordinateY > YsSorted[SortedCurrentIndex + 1]) coordinateY = YsSorted[SortedCurrentIndex + 1];
-                    if (SortedCurrentIndex > 0 && coordinateY < YsSorted[SortedCurrentIndex - 1]) coordinateY = YsSorted[SortedCurrentIndex - 1];   
+                    if (SortedCurrentIndex > 0 && coordinateY < YsSorted[SortedCurrentIndex - 1]) coordinateY = YsSorted[SortedCurrentIndex - 1];
                 }
 
                 if (DragEnabledX)

--- a/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
+++ b/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
@@ -80,7 +80,7 @@ namespace ScottPlot.Plottable
         {
             if (!DragEnabled)
                 return;
-
+            if (CurrentIndex > PointCount - 1) CurrentIndex = PointCount - 1;
             if (coordinateX < DragXLimitMin) coordinateX = DragXLimitMin;
             if (coordinateX > DragXLimitMax) coordinateX = DragXLimitMax;
             if (coordinateX < DragYLimitMin) coordinateY = DragYLimitMin;

--- a/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
+++ b/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
@@ -103,12 +103,12 @@ namespace ScottPlot.Plottable
                 if (DragEnabledX)
                 {
                     Xs[CurrentIndex] = coordinateX;
-                    Xs[SortedCurrentIndex] = coordinateX;
+                    XsSorted[SortedCurrentIndex] = coordinateX;
                 }
                 if (DragEnabledY)
                 {
                     Ys[CurrentIndex] = coordinateY;
-                    Ys[SortedCurrentIndex] = coordinateY;
+                    YsSorted[SortedCurrentIndex] = coordinateY;
                 }
             }
 

--- a/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
+++ b/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Linq;
 
 namespace ScottPlot.Plottable
 {
@@ -139,17 +140,19 @@ namespace ScottPlot.Plottable
 
         public ScatterPlotDraggable(double[] xs, double[] ys, double[] errorX = null, double[] errorY = null) : base(xs, ys, errorX, errorY)
         {
-            Xs = xs;
-            Ys = ys;
-            XError = errorX;
-            YError = errorY;
+            //Xs = xs;
+            //Ys = ys;
+            //XError = errorX;
+            //YError = errorY;
+            int[] permutationinds = Enumerable.Range(0, PointCount).ToArray();
+            Array.Sort<int>(permutationinds, (a, b) => Xs[a].CompareTo(Xs[b]));
             XsSorted = new double[PointCount];
-            Xs.CopyTo(XsSorted, 0);
-            Array.Sort(XsSorted);
             YsSorted = new double[PointCount];
-            Ys.CopyTo(YsSorted, 0);
-            Array.Sort(YsSorted);
-
+            for (int i = 0;i<PointCount; i++)
+            {
+                XsSorted[i] = Xs[permutationinds[i]];
+                YsSorted[i] = Ys[permutationinds[i]];
+            }
         }
     }
 }

--- a/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
+++ b/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 
 namespace ScottPlot.Plottable
@@ -85,18 +85,18 @@ namespace ScottPlot.Plottable
             if (DragEnabled)
             {
                 int SortedCurrentIndex = Array.IndexOf(XsSorted, Xs[CurrentIndex]);
-
                 if (DragEnabledX && DragBoxedX)
                 {
-                    if (SortedCurrentIndex < PointCount && coordinateX > XsSorted[SortedCurrentIndex + 1]) coordinateX = XsSorted[SortedCurrentIndex + 1];
-                    if (SortedCurrentIndex > 0 && coordinateX < XsSorted[SortedCurrentIndex - 1]) coordinateX = XsSorted[SortedCurrentIndex - 1];
+                    double lower_bound = SortedCurrentIndex == 0 ? XsSorted[0] : XsSorted[SortedCurrentIndex - 1];
+                    double upper_bound = SortedCurrentIndex == PointCount - 1 ? XsSorted[PointCount - 1] : XsSorted[SortedCurrentIndex + 1];
+                    coordinateX = CompareToBox(coordinateX, lower_bound, upper_bound);
                 }
                 if (DragEnabledY && DragBoxedY)
                 {
-                    if (SortedCurrentIndex < PointCount && coordinateY > YsSorted[SortedCurrentIndex + 1]) coordinateY = YsSorted[SortedCurrentIndex + 1];
-                    if (SortedCurrentIndex > 0 && coordinateY < YsSorted[SortedCurrentIndex - 1]) coordinateY = YsSorted[SortedCurrentIndex - 1];
+                    double lower_bound = SortedCurrentIndex == 0 ? YsSorted[0] : YsSorted[SortedCurrentIndex - 1];
+                    double upper_bound = SortedCurrentIndex == PointCount - 1 ? YsSorted[PointCount - 1] : YsSorted[SortedCurrentIndex + 1];
+                    coordinateY = CompareToBox(coordinateY, lower_bound, upper_bound);
                 }
-
                 if (DragEnabledX)
                 {
                     Xs[CurrentIndex] = coordinateX;
@@ -110,6 +110,26 @@ namespace ScottPlot.Plottable
             }
 
             Dragged(this, EventArgs.Empty);
+        }
+
+        private (double, double) SwapBoundsIfNeeded(double lower_bound, double upper_bound)
+        {
+            if (upper_bound < lower_bound)
+            {
+                return (upper_bound, lower_bound);
+            }
+            else
+            {
+                return (lower_bound, upper_bound);
+            }
+        }
+
+        private double CompareToBox(double coordinate, double lower_bound, double upper_bound)
+        {
+            (lower_bound, upper_bound) = SwapBoundsIfNeeded(lower_bound, upper_bound);
+            if (coordinate >= upper_bound) return upper_bound;
+            if (coordinate <= lower_bound) return lower_bound;
+            return coordinate;
         }
 
         /// <summary>
@@ -141,7 +161,7 @@ namespace ScottPlot.Plottable
             Array.Sort<int>(permutationinds, (a, b) => Xs[a].CompareTo(Xs[b]));
             XsSorted = new double[PointCount];
             YsSorted = new double[PointCount];
-            for (int i = 0;i<PointCount; i++)
+            for (int i = 0; i < PointCount; i++)
             {
                 XsSorted[i] = Xs[permutationinds[i]];
                 YsSorted[i] = Ys[permutationinds[i]];

--- a/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
+++ b/src/ScottPlot/Plottable/ScatterPlotDraggable.cs
@@ -9,12 +9,9 @@ namespace ScottPlot.Plottable
     /// </summary>
     public class ScatterPlotDraggable : ScatterPlot, IDraggable
     {
-        public new double[] Xs { get; private set; }
-        public new double[] Ys { get; private set; }
         public int CurrentIndex { get; set; } = 0;
         public double[] XsSorted { get; private set; }
         public double[] YsSorted { get; private set; }
-
         /// <summary>
         /// Indicates whether scatter points are draggable in user controls.
         /// </summary>
@@ -140,10 +137,6 @@ namespace ScottPlot.Plottable
 
         public ScatterPlotDraggable(double[] xs, double[] ys, double[] errorX = null, double[] errorY = null) : base(xs, ys, errorX, errorY)
         {
-            //Xs = xs;
-            //Ys = ys;
-            //XError = errorX;
-            //YError = errorY;
             int[] permutationinds = Enumerable.Range(0, PointCount).ToArray();
             Array.Sort<int>(permutationinds, (a, b) => Xs[a].CompareTo(Xs[b]));
             XsSorted = new double[PointCount];

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Scatter.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Scatter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Text;
@@ -272,6 +272,30 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                 DragEnabled = true,   // controls whether anything can be dragged
                 DragEnabledX = false, // controls whether points can be dragged horizontally 
                 DragEnabledY = true,  // controls whether points can be dragged vertically
+            };
+
+            plt.Add(scatter);
+        }
+    }
+
+    public class ScatterPlotDraggableBoxed : IRecipe
+    {
+        public string Category => "Plottable: Scatter Plot";
+        public string ID => "scatter_draggable_boxed";
+        public string Title => "Draggable Scatter Plot with box constraint";
+        public string Description => "You can restrict dragging to adjacent points (separately in X and Y).";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[] x = ScottPlot.DataGen.Consecutive(50);
+            double[] y = ScottPlot.DataGen.Cos(50);
+
+            var scatter = new ScottPlot.Plottable.ScatterPlotDraggable(x, y)
+            {
+                DragCursor = Cursor.Crosshair,
+                DragEnabled = true,   // controls whether anything can be dragged
+                DragBoxedX = true, // controls whether dragging in constrained to the adjacent points in X
+                DragBoxedY = true, // controls whether dragging in constrained to the adjacent points in Y
             };
 
             plt.Add(scatter);

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Scatter.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Scatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Text;
@@ -298,6 +298,8 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                 DragBoxedY = true, // controls whether dragging in constrained to the adjacent points in Y
             };
 
+            var vspan = plt.AddVerticalSpan(y[29], y[31], Color.Red);
+            var hspan = plt.AddHorizontalSpan(x[29], x[31], Color.Red);
             plt.Add(scatter);
         }
     }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Scatter.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Scatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Text;
@@ -232,7 +232,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
     public class ScatterPlotDraggable : IRecipe
     {
         public string Category => "Plottable: Scatter Plot";
-        public string ID => "scatter_draggable_vertical";
+        public string ID => "scatter_draggable";
         public string Title => "Draggable Scatter Plot";
         public string Description => "Want to modify the scatter points interactively? " +
             "A ScatterPlotDraggable lets you move the points around with the mouse. " +
@@ -257,7 +257,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
     public class ScatterPlotDraggableVertical : IRecipe
     {
         public string Category => "Plottable: Scatter Plot";
-        public string ID => "scatter_draggable";
+        public string ID => "scatter_draggable_vertical";
         public string Title => "Draggable Scatter Plot Vertical";
         public string Description => "You can restrict dragging to just X or Y directions.";
 


### PR DESCRIPTION
- This currently does not work
- Unless I missed something, I do not understand why the points leave the plot area
- With respect to https://github.com/ScottPlot/ScottPlot/issues/1422#issuecomment-1015981553 this implementation should be able to handle the cases where `Xs` and `Ys` are totally random, at the cost of two initial sort.
