### PR TITLE
1557 plottable repeatingaxisline continued

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -6,6 +6,7 @@ _In development / not yet on NuGet_
 * Legend: `GetBitmap()` returns a transparent image instead of throwing an exception if there are no items in the legend (#1578) _Thanks @BambOoxX_
 * Legend: Added `Count`, `HasItems`, and `GetItems()` so users can inspect legend contents to if/how they want to display it (#1578) _Thanks @BambOoxX_
 * Plot: Exposed `GetDraggable()` to allow users to retrieve the plotted objects at specific pixel positions (#1578) _Thanks @BambOoxX_
+* Repeating Axis Line: Improved display of text labels (#1586, #1557) _Thanks @BambOoxX_
 
 ## ScottPlot 4.1.31
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-01-17_

--- a/src/ScottPlot/Plottable/RepeatingAxisLine.cs
+++ b/src/ScottPlot/Plottable/RepeatingAxisLine.cs
@@ -232,7 +232,7 @@ namespace ScottPlot.Plottable
                 {
                     double lineposition = ComputePosition(Position, Offset, Shift, i, RelativePosition);
                     if (lineposition > dims.YMax || lineposition < dims.YMin)
-                        return;
+                        continue;
 
                     float pixelY = dims.GetPixelY(lineposition);
                     string yLabel = PositionFormatter(lineposition);
@@ -251,7 +251,7 @@ namespace ScottPlot.Plottable
                 {
                     double lineposition = ComputePosition(Position, Offset, Shift, i, RelativePosition);
                     if (lineposition > dims.XMax || lineposition < dims.XMin)
-                        return;
+                        continue;
 
                     float pixelX = dims.GetPixelX(lineposition);
                     string xLabel = PositionFormatter(lineposition);

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/AxisLineAndSpan.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/AxisLineAndSpan.cs
@@ -271,4 +271,40 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             plt.SetAxisLimitsX(-100, 300);
         }
     }
+
+    public class AxisLineVector : IRecipe
+    {
+        public string Category => "Plottable: Axis Line and Span";
+        public string ID => "axisLine_Vector";
+        public string Title => "Axis Line Vector";
+        public string Description =>
+            "An AxisLineVector allows to setup a series of VLines or HLines, without hassle." +
+            "These lines can optionally be dragged as their counterparts";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            Random rand = new Random(0);
+            double[] xs = DataGen.Random(rand, 50);
+            double[] ys = DataGen.Random(rand, 50);
+
+            var scatter = plt.AddScatterPoints(xs, ys, Color.Blue, 10);
+
+            var vlines = new ScottPlot.Plottable.VLineVector();
+            vlines.Xs = new double[] { xs[1], xs[12], xs[35] };
+            vlines.Color = Color.Red;
+            vlines.PositionLabel = true;
+            vlines.PositionLabelBackground = vlines.Color;
+
+            var hlines = new ScottPlot.Plottable.HLineVector();
+            hlines.Ys = new double[] { ys[1], ys[12], ys[35] };
+            hlines.Color = Color.DarkCyan;
+            hlines.PositionLabel = true;
+            hlines.PositionLabelBackground = hlines.Color;
+            hlines.DragEnabled = true;
+
+            plt.Add(scatter);
+            plt.Add(vlines);
+            plt.Add(hlines);
+        }
+    }
 }


### PR DESCRIPTION
This PR implements some missing features from #1557 
- `AxisLineVector` now has an example in the cookbook and is draggable as a `ScatterPlotDraggable`
- The bug making `PositionLabel`s disappearing is fixed