### PR TITLE
`GetPixel` : Support of arbitrary `AxisIndex`

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -8,6 +8,7 @@ _In development / not yet on NuGet_
 * Plot: Exposed `GetDraggable()` to allow users to retrieve the plotted objects at specific pixel positions (#1578) _Thanks @BambOoxX_
 * Axis Limits: Improved handling of axis limits for plots containing no data (#1581) _Thanks @EFeru_
 * Repeating Axis Line: Improved display of text labels (#1586, #1557) _Thanks @BambOoxX_
+* Axis: Improved multi-axis support for `GetPixel()` methods (#1584, #1587) _Thanks @ChrisCC6 and @BambOoxX_
 
 ## ScottPlot 4.1.31
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-01-17_

--- a/src/ScottPlot/Plot/Plot.Axis.cs
+++ b/src/ScottPlot/Plot/Plot.Axis.cs
@@ -324,23 +324,32 @@ namespace ScottPlot
         /// </summary>
         /// <param name="x">horizontal coordinate</param>
         /// <param name="y">vertical coordinate</param>
+        /// <param name="xAxisIndex">index of the horizontal axis to use</param>
+        /// <param name="yAxisIndex">index of the vertical axis to use</param>
         /// <returns>pixel location</returns>
-        public (float xPixel, float yPixel) GetPixel(double x, double y) =>
-            (settings.XAxis.Dims.GetPixel(x), settings.YAxis.Dims.GetPixel(y));
+        public (float xPixel, float yPixel) GetPixel(double x, double y, int xAxisIndex = 0, int yAxisIndex = 0)
+        {
+            float xPixel = settings.GetXAxis(xAxisIndex).Dims.GetPixel(x);
+            float yPixel = settings.GetYAxis(yAxisIndex).Dims.GetPixel(y);
+            return (xPixel, yPixel);
+
+        }
 
         /// <summary>
         /// Return the horizontal pixel location given position in coordinate space
         /// </summary>
         /// <param name="x">horizontal coordinate</param>
+        /// <param name="xAxisIndex">index of the horizontal axis to use</param>
         /// <returns>horizontal pixel position</returns>
-        public float GetPixelX(double x) => settings.XAxis.Dims.GetPixel(x);
+        public float GetPixelX(double x, int xAxisIndex = 0) => settings.GetXAxis(xAxisIndex).Dims.GetPixel(x);
 
         /// <summary>
         /// Return the vertical pixel location given position in coordinate space
         /// </summary>
         /// <param name="y">vertical coordinate</param>
+        /// <param name="yAxisIndex">index of the vertical axis to use</param>
         /// <returns>vertical pixel position</returns>
-        public float GetPixelY(double y) => settings.YAxis.Dims.GetPixel(y);
+        public float GetPixelY(double y, int yAxisIndex = 0) => settings.GetYAxis(yAxisIndex).Dims.GetPixel(y);
 
         #endregion
 


### PR DESCRIPTION
This aims at solving #1584.

Implementation is based on https://github.com/ScottPlot/ScottPlot/issues/1584#issue-1110565204 and previous work in #1556 