### PR TITLE
Heatmaps with custom X and Y sizing or positioning no longer call `AxisScaleLock()` automatically

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -4,6 +4,7 @@
 _In development / not yet on NuGet_
 * Spline Interpolation: Added new methods for data smoothing including Bézier interpolation (#1593, #1606)
 * Detachable Legend: Added an option to detach the legend to the right-click menu in the Windows Forms control. Clicking items in the detached legend toggles their visibility on the plot (#1589, #1573, #1326) _Thanks @BambOoxX_
+* Heatmap: Heatmaps with custom X and Y sizing or positioning no longer call `AxisScaleLock()` automatically (#1145) _Thanks @bclehmann_
 
 ## ScottPlot 4.1.32
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-01-23_

--- a/src/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot/Plot/Plot.Add.cs
@@ -383,13 +383,16 @@ namespace ScottPlot
         /// Returns the heatmap that was added to the plot.
         /// Act on its public fields and methods to customize it or update its data.
         /// </returns>
-        public Heatmap AddHeatmap(double?[,] intensities, Drawing.Colormap colormap = null, bool lockScales = true)
+        public Heatmap AddHeatmap(double?[,] intensities, Drawing.Colormap colormap = null, bool? lockScales = true)
         {
             var plottable = new Heatmap();
             plottable.Update(intensities, colormap);
             Add(plottable);
 
-            if (lockScales)
+            if (lockScales.HasValue && lockScales.Value == true)
+                AxisScaleLock(true);
+
+            if (lockScales is null && plottable.IsDefaultSizeAndLocation)
                 AxisScaleLock(true);
 
             return plottable;
@@ -406,13 +409,16 @@ namespace ScottPlot
         /// Returns the heatmap that was added to the plot.
         /// Act on its public fields and methods to customize it or update its data.
         /// </returns>
-        public Heatmap AddHeatmap(double[,] intensities, Drawing.Colormap colormap = null, bool lockScales = true)
+        public Heatmap AddHeatmap(double[,] intensities, Drawing.Colormap colormap = null, bool? lockScales = null)
         {
             var plottable = new Heatmap();
             plottable.Update(intensities, colormap);
             Add(plottable);
 
-            if (lockScales)
+            if (lockScales.HasValue && lockScales.Value == true)
+                AxisScaleLock(true);
+
+            if (lockScales is null && plottable.IsDefaultSizeAndLocation)
                 AxisScaleLock(true);
 
             return plottable;

--- a/src/ScottPlot/Plottable/Heatmap.cs
+++ b/src/ScottPlot/Plottable/Heatmap.cs
@@ -90,6 +90,11 @@ namespace ScottPlot.Plottable
         }
 
         /// <summary>
+        /// Indicates whether the heatmap's size or location has been modified by the user
+        /// </summary>
+        public bool IsDefaultSizeAndLocation => OffsetX == 0 && OffsetY == 0 && CellHeight == 1 && CellWidth == 1;
+
+        /// <summary>
         /// Text to appear in the legend
         /// </summary>
         public string Label { get; set; }


### PR DESCRIPTION
resolves #1445