### PR TITLE
Text: implement IDraggable

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -7,6 +7,7 @@ _In development / not yet on NuGet_
 * Marker: Added an optional `Text` (and `TextFont`) for displaying a message that moves with a marker (#1599)
 * Heatmap: Heatmaps with custom X and Y sizing or positioning no longer call `AxisScaleLock()` automatically (#1145) _Thanks @bclehmann_
 * Axis: GetCoordinateY() now returns more accurate coordinate (#1625, #1616) _Thanks @BambOoxX_
+* Text: Now has `IsDraggable` field and improved mouseover detection that supports rotation (#1616) _Thanks @BambOoxX_
 
 ## ScottPlot 4.1.32
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-01-23_

--- a/src/ScottPlot/PlotDimensions.cs
+++ b/src/ScottPlot/PlotDimensions.cs
@@ -40,7 +40,7 @@ namespace ScottPlot
 
         public Coordinate GetCoordinate(Pixel pixel) => new Coordinate(GetCoordinateX(pixel.X), GetCoordinateY(pixel.Y));
         public double GetCoordinateX(float pixel) => (pixel - DataOffsetX) / PxPerUnitX + XMin;
-        public double GetCoordinateY(float pixel) => DataHeight - ((pixel - YMin) * PxPerUnitY);
+        public double GetCoordinateY(float pixel) => YMax - (pixel - DataOffsetY) / PxPerUnitY;
 
         public PlotDimensions(SizeF figureSize, SizeF dataSize, PointF dataOffset,
             (double xMin, double xMax, double yMin, double yMax) axisLimits,

--- a/src/ScottPlot/Plottable/Text.cs
+++ b/src/ScottPlot/Plottable/Text.cs
@@ -96,13 +96,11 @@ namespace ScottPlot.Plottable
                 PointF pointA = new(xA, yA);
                 PointF pointC = new(xC, yC);
 
-                gfx.DrawEllipse(redPen, xA, yA, 2, 2);
-                gfx.DrawEllipse(redPen, xC, yC, 2, 2);
-
-                gfx.DrawString("A", font, fontBrush, pointA);
-                gfx.DrawString("C", font, fontBrush, pointC);
-
-                RectangleUnits = RectangleF.FromLTRB((float)dims.GetCoordinateX(xA), (float)dims.GetCoordinateY(yA), (float)dims.GetCoordinateX(xC), (float)dims.GetCoordinateY(yC));
+                RectangleUnits = RectangleF.FromLTRB(
+                    left: (float)dims.GetCoordinateX(pointA.X),
+                    top: (float)dims.GetCoordinateY(pointC.Y),
+                    right: (float)dims.GetCoordinateX(pointC.X),
+                    bottom: (float)dims.GetCoordinateY(pointA.Y));
             }
         }
 

--- a/src/ScottPlot/Plottable/Text.cs
+++ b/src/ScottPlot/Plottable/Text.cs
@@ -109,7 +109,7 @@ namespace ScottPlot.Plottable
         /// <summary>
         /// Indicates whether this marker is draggable in user controls.
         /// </summary>
-        public bool DragEnabled { get; set; } = true;
+        public bool DragEnabled { get; set; } = false;
 
         /// <summary>
         /// Cursor to display while hovering over this marker if dragging is enabled.

--- a/src/ScottPlot/Plottable/Text.cs
+++ b/src/ScottPlot/Plottable/Text.cs
@@ -33,7 +33,7 @@ namespace ScottPlot.Plottable
         public Color BorderColor { get; set; } = Color.Black;
         public float PixelOffsetX { get; set; } = 0;
         public float PixelOffsetY { get; set; } = 0;
-        RectangleF RectangleUnits;
+        RectangleF LastRenderRectangleCoordinates;
         private double DeltaCX = 0;
         private double DeltaCY = 0;
 
@@ -96,7 +96,7 @@ namespace ScottPlot.Plottable
                 PointF pointA = new(xA, yA);
                 PointF pointC = new(xC, yC);
 
-                RectangleUnits = RectangleF.FromLTRB(
+                LastRenderRectangleCoordinates = RectangleF.FromLTRB(
                     left: (float)dims.GetCoordinateX(pointA.X),
                     top: (float)dims.GetCoordinateY(pointC.Y),
                     right: (float)dims.GetCoordinateX(pointC.X),
@@ -169,8 +169,9 @@ namespace ScottPlot.Plottable
         /// <returns></returns>
         public bool IsUnderMouse(double coordinateX, double coordinateY, double snapX, double snapY)
         {
-            bool test = RectangleUnits.Contains((float)coordinateX, (float)coordinateY);
-            if (test)
+            PointF pt = new((float)coordinateX, (float)coordinateY);
+
+            if (IsPointInsideRectangle(pt, LastRenderRectangleCoordinates))
             {
                 DeltaCX = X - coordinateX;
                 DeltaCY = Y - coordinateY;
@@ -180,6 +181,44 @@ namespace ScottPlot.Plottable
             {
                 return false;
             }
+        }
+
+        private static bool IsPointInsideRectangle(PointF pt, RectangleF rect)
+        {
+            // https://swharden.com/blog/2022-02-01-point-in-rectangle/
+
+            double x1 = rect.Left;
+            double x2 = rect.Right;
+            double x3 = rect.Right;
+            double x4 = rect.Left;
+
+            double y1 = rect.Top;
+            double y2 = rect.Top;
+            double y3 = rect.Bottom;
+            double y4 = rect.Bottom;
+
+            double a1 = Math.Sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
+            double a2 = Math.Sqrt((x2 - x3) * (x2 - x3) + (y2 - y3) * (y2 - y3));
+            double a3 = Math.Sqrt((x3 - x4) * (x3 - x4) + (y3 - y4) * (y3 - y4));
+            double a4 = Math.Sqrt((x4 - x1) * (x4 - x1) + (y4 - y1) * (y4 - y1));
+
+            double b1 = Math.Sqrt((x1 - pt.X) * (x1 - pt.X) + (y1 - pt.Y) * (y1 - pt.Y));
+            double b2 = Math.Sqrt((x2 - pt.X) * (x2 - pt.X) + (y2 - pt.Y) * (y2 - pt.Y));
+            double b3 = Math.Sqrt((x3 - pt.X) * (x3 - pt.X) + (y3 - pt.Y) * (y3 - pt.Y));
+            double b4 = Math.Sqrt((x4 - pt.X) * (x4 - pt.X) + (y4 - pt.Y) * (y4 - pt.Y));
+
+            double u1 = (a1 + b1 + b2) / 2;
+            double u2 = (a2 + b2 + b3) / 2;
+            double u3 = (a3 + b3 + b4) / 2;
+            double u4 = (a4 + b4 + b1) / 2;
+
+            double A1 = Math.Sqrt(u1 * (u1 - a1) * (u1 - b1) * (u1 - b2));
+            double A2 = Math.Sqrt(u2 * (u2 - a2) * (u2 - b2) * (u2 - b3));
+            double A3 = Math.Sqrt(u3 * (u3 - a3) * (u3 - b3) * (u3 - b4));
+            double A4 = Math.Sqrt(u4 * (u4 - a4) * (u4 - b4) * (u4 - b1));
+
+            double difference = A1 + A2 + A3 + A4 - a1 * a2;
+            return difference < .001 * (rect.Height + rect.Width);
         }
     }
 }

--- a/src/ScottPlot/Plottable/Text.cs
+++ b/src/ScottPlot/Plottable/Text.cs
@@ -9,7 +9,7 @@ namespace ScottPlot.Plottable
     /// <summary>
     /// Display a text label at an X/Y position in coordinate space
     /// </summary>
-    public class Text : IPlottable, IHasPixelOffset
+    public class Text : IPlottable, IHasPixelOffset, IDraggable
     {
         // data
         public double X;
@@ -33,6 +33,9 @@ namespace ScottPlot.Plottable
         public Color BorderColor { get; set; } = Color.Black;
         public float PixelOffsetX { get; set; } = 0;
         public float PixelOffsetY { get; set; } = 0;
+        RectangleF RectangleUnits;
+        private double DeltaCX = 0;
+        private double DeltaCY = 0;
 
         public override string ToString() => $"PlottableText \"{Label}\" at ({X}, {Y})";
         public AxisLimits GetAxisLimits() => new AxisLimits(X, X, Y, Y);
@@ -60,6 +63,7 @@ namespace ScottPlot.Plottable
             using (var fontBrush = new SolidBrush(Font.Color))
             using (var frameBrush = new SolidBrush(BackgroundColor))
             using (var outlinePen = new Pen(BorderColor, BorderSize))
+            using (var redPen = new Pen(Color.Red, BorderSize))
             {
                 float pixelX = dims.GetPixelX(X) + PixelOffsetX;
                 float pixelY = dims.GetPixelY(Y) - PixelOffsetY;
@@ -82,6 +86,101 @@ namespace ScottPlot.Plottable
                 gfx.DrawString(Label, font, fontBrush, new PointF(0, 0));
 
                 GDI.ResetTransformPreservingScale(gfx, dims);
+
+                double degangle = Font.Rotation * Math.PI / 180;
+                float xA = pixelX - dX;
+                float yA = pixelY - dY;
+                float xC = xA + stringSize.Width * (float)Math.Cos(degangle) - stringSize.Height * (float)Math.Sin(degangle);
+                float yC = yA + stringSize.Height * (float)Math.Cos(degangle) + stringSize.Width * (float)Math.Sin(degangle);
+
+                PointF pointA = new(xA, yA);
+                PointF pointC = new(xC, yC);
+
+                gfx.DrawEllipse(redPen, xA, yA, 2, 2);
+                gfx.DrawEllipse(redPen, xC, yC, 2, 2);
+
+                gfx.DrawString("A", font, fontBrush, pointA);
+                gfx.DrawString("C", font, fontBrush, pointC);
+
+                RectangleUnits = RectangleF.FromLTRB((float)dims.GetCoordinateX(xA), (float)dims.GetCoordinateY(yA), (float)dims.GetCoordinateX(xC), (float)dims.GetCoordinateY(yC));
+            }
+        }
+
+        /// <summary>
+        /// Indicates whether this marker is draggable in user controls.
+        /// </summary>
+        public bool DragEnabled { get; set; } = true;
+
+        /// <summary>
+        /// Cursor to display while hovering over this marker if dragging is enabled.
+        /// </summary>
+        public Cursor DragCursor { get; set; } = Cursor.Hand;
+
+        /// <summary>
+        /// If dragging is enabled the marker cannot be dragged more negative than this position
+        /// </summary>
+        public double DragXLimitMin = double.NegativeInfinity;
+
+        /// <summary>
+        /// If dragging is enabled the marker cannot be dragged more positive than this position
+        /// </summary>
+        public double DragXLimitMax = double.PositiveInfinity;
+
+        /// <summary>
+        /// If dragging is enabled the marker cannot be dragged more negative than this position
+        /// </summary>
+        public double DragYLimitMin = double.NegativeInfinity;
+
+        /// <summary>
+        /// If dragging is enabled the marker cannot be dragged more positive than this position
+        /// </summary>
+        public double DragYLimitMax = double.PositiveInfinity;
+
+        /// <summary>
+        /// This event is invoked after the marker is dragged
+        /// </summary>
+        public event EventHandler Dragged = delegate { };
+
+        /// <summary>
+        /// Move the marker to a new coordinate in plot space.
+        /// </summary>
+        /// <param name="coordinateX">new X position</param>
+        /// <param name="coordinateY">new Y position</param>
+        /// <param name="fixedSize">This argument is ignored</param>
+        public void DragTo(double coordinateX, double coordinateY, bool fixedSize)
+        {
+            if (!DragEnabled)
+                return;
+
+            if (coordinateX < DragXLimitMin) coordinateX = DragXLimitMin;
+            if (coordinateX > DragXLimitMax) coordinateX = DragXLimitMax;
+            if (coordinateX < DragYLimitMin) coordinateY = DragYLimitMin;
+            if (coordinateX > DragYLimitMax) coordinateY = DragYLimitMax;
+            X = coordinateX + DeltaCX;
+            Y = coordinateY + DeltaCY;
+            Dragged(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Return True if the marker is within a certain number of pixels (snap) to the mouse
+        /// </summary>
+        /// <param name="coordinateX">mouse position (coordinate space)</param>
+        /// <param name="coordinateY">mouse position (coordinate space)</param>
+        /// <param name="snapX">snap distance (pixels)</param>
+        /// <param name="snapY">snap distance (pixels)</param>
+        /// <returns></returns>
+        public bool IsUnderMouse(double coordinateX, double coordinateY, double snapX, double snapY)
+        {
+            bool test = RectangleUnits.Contains((float)coordinateX, (float)coordinateY);
+            if (test)
+            {
+                DeltaCX = X - coordinateX;
+                DeltaCY = Y - coordinateY;
+                return true;
+            }
+            else
+            {
+                return false;
             }
         }
     }

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Text.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Text.cs
@@ -54,6 +54,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                 txt.Rotation = 5;
                 txt.BorderSize = 2;
                 txt.BorderColor = Color.Navy;
+                txt.DragEnabled = true;
 
                 plt.AddPoint(x, y, Color.Red, 10);
             }


### PR DESCRIPTION
This PR implements drag functionality for `Text` plottables. 

The current `isUnderMouse` test fails, but that seems internal to GDI. 

Another implementation, not pushed though, works fine using this test 
https://math.stackexchange.com/questions/190111/how-to-check-if-a-point-is-inside-a-rectangle
![image](https://user-images.githubusercontent.com/4165489/151895759-ca3a763d-64c3-4a9e-9892-83a73d48b1b6.png)

~This PR also contains a patch for `GetCoordinateY` in 650f60e29f3d405331d84a1ac344791ca68fbab7~ _EDIT: moved to #1625/#1626_