### PR TITLE
Frameless: remove 3px border

### DIFF
--- a/src/ScottPlot/Renderable/Axis.cs
+++ b/src/ScottPlot/Renderable/Axis.cs
@@ -108,7 +108,13 @@ namespace ScottPlot.Renderable
         /// <summary>
         /// Returns the number of pixels occupied by this axis
         /// </summary>
-        public float GetSize() => IsVisible ? PixelSize + PixelSizePadding : 0;
+        public float GetSize()
+        {
+            if (IsVisible == false || Collapsed)
+                return 0;
+            else
+                return PixelSize + PixelSizePadding;
+        }
 
         public override string ToString() => $"{Edge} axis from {Dims.Min} to {Dims.Max}";
 

--- a/src/tests/Plot/Frameless.cs
+++ b/src/tests/Plot/Frameless.cs
@@ -26,5 +26,24 @@ namespace ScottPlotTests.Plot
             plt.Frameless(false);
             TestTools.SaveFig(plt, "2");
         }
+
+        [Test]
+        public void Test_Frameless_HasNoFrame()
+        {
+            var plt = new ScottPlot.Plot(600, 400);
+            plt.Style(figureBackground: System.Drawing.Color.Magenta);
+            plt.Grid(false);
+            plt.Frameless();
+
+            plt.AddSignal(ScottPlot.DataGen.Sin(51), color: System.Drawing.Color.Gray);
+            plt.Margins(0, 0);
+
+            var bmp = TestTools.GetLowQualityBitmap(plt);
+            TestTools.SaveFig(bmp);
+            var after = new MeanPixel(bmp);
+
+            Assert.That(after.IsGray());
+
+        }
     }
 }


### PR DESCRIPTION
resolves #1605

... although _technically_ there is a 1-pixel area on the upper and left edge which does not render plot graphics. This is due to clipping. It probably does not need to be fixed, but if so I think the fix is to adjust the `GDI.Graphics()` call and have it clip 1 pixel upward and to the left