### PR TITLE
BubblePlot: Add methods to get the bubble nearest the mouse

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -2,6 +2,7 @@
 
 ## ScottPlot 4.1.34
 _In development / not yet on NuGet ..._
+* Bubble plot: Added methods to get the point nearest the cursor (#1657, #1652) _Thanks @BambOoxX and @adgriff2_
 
 ## ScottPlot 4.1.33
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-02-04_

--- a/src/ScottPlot/Plottable/BubblePlot.cs
+++ b/src/ScottPlot/Plottable/BubblePlot.cs
@@ -136,5 +136,83 @@ namespace ScottPlot.Plottable
                 gfx.DrawEllipse(pen, rect);
             }
         }
+
+        /// <summary>
+        /// Return the X/Y coordinates of the point nearest the X position
+        /// </summary>
+        /// <param name="x">X position in plot space</param>
+        /// <returns></returns>
+        public (double x, double y, int index) GetPointNearestX(double x)
+        {
+            double minDistance = Double.PositiveInfinity;
+            int minIndex = 0;
+            Bubble currBubble = Bubbles.ElementAt(0);
+            for (int i = 0; i <= Bubbles.Count; i++)
+            {
+                currBubble = Bubbles.ElementAt(i);
+                double currDistance = Math.Abs(currBubble.X - x);
+                if (currDistance < minDistance)
+                {
+                    minIndex = i;
+                    minDistance = currDistance;
+                }
+            }
+
+            return (currBubble.X, currBubble.Y, minIndex);
+        }
+
+        /// <summary>
+        /// Return the X/Y coordinates of the point nearest the Y position
+        /// </summary>
+        /// <param name="y">Y position in plot space</param>
+        /// <returns></returns>
+        public (double x, double y, int index) GetPointNearestY(double y)
+        {
+            double minDistance = Double.PositiveInfinity;
+            int minIndex = 0;
+            Bubble currBubble = Bubbles.ElementAt(0);
+            for (int i = 0; i <= Bubbles.Count; i++)
+            {
+                currBubble = Bubbles.ElementAt(i);
+                double currDistance = Math.Abs(currBubble.Y - y);
+                if (currDistance < minDistance)
+                {
+                    minIndex = i;
+                    minDistance = currDistance;
+                }
+            }
+
+            return (currBubble.X, currBubble.Y, minIndex);
+        }
+
+        /// <summary>
+        /// Return the position and index of the data point nearest the given coordinate
+        /// </summary>
+        /// <param name="x">location in coordinate space</param>
+        /// <param name="y">location in coordinate space</param>
+        /// <param name="xyRatio">Ratio of pixels per unit (X/Y) when rendered</param>
+        public (double x, double y, int index) GetPointNearest(double x, double y, double xyRatio = 1)
+        {
+
+            double xyRatioSquared = xyRatio * xyRatio;
+            double pointDistanceSquared(double x1, double y1) =>
+                (x1 - x) * (x1 - x) * xyRatioSquared + (y1 - y) * (y1 - y);
+
+            double minDistance = Double.PositiveInfinity;
+            int minIndex = 0;
+            Bubble currBubble = Bubbles.ElementAt(0);
+            for (int i = 0; i <= Bubbles.Count; i++)
+            {
+                currBubble = Bubbles.ElementAt(i);
+                double currDistance = pointDistanceSquared(currBubble.X, currBubble.Y);
+                if (currDistance < minDistance)
+                {
+                    minIndex = i;
+                    minDistance = currDistance;
+                }
+            }
+
+            return (currBubble.X, currBubble.Y, minIndex);
+        }
     }
 }


### PR DESCRIPTION
- Added `GetPointNearest`, `GetPointNearestX` and `GetPointNearestY` to `BubblePlot`
- I believe the code should be working, and it seems a good adaptation from `ScatterPlot`s but I had noting to test it.

Resolves #1652