### PR TITLE
Marker markerlinewidth

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -13,6 +13,7 @@ _In development / not yet on NuGet ..._
 * SignalXY: Fix bug affecting the edge of the plot when step mode is active (#1703, #1699) _Thanks @PeppermintKing_
 * SignalXY: Improve appearance of filled regions when step mode is active (#1703, #1697) _Thanks @PeppermintKing_
 * Axis Span: Added options to customize fill pattern and border (#1692) _Thanks @BambOoxX_
+* Markers: Additional customization options such as `MarkerLineWidth` (#1690) _Thanks @BambOoxX_
 
 ## ScottPlot 4.1.33
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-02-04_

--- a/src/ScottPlot/Marker/MarkerTools.cs
+++ b/src/ScottPlot/Marker/MarkerTools.cs
@@ -26,21 +26,21 @@ namespace ScottPlot
             marker.Draw(gfx, pixelLocation, radius, brush, pen);
         }
 
-        public static void DrawMarker(Graphics gfx, PointF pixelLocation, MarkerShape shape, float size, Color color)
+        public static void DrawMarker(Graphics gfx, PointF pixelLocation, MarkerShape shape, float size, Color color, float linewidth = 1)
         {
             using Brush brush = new SolidBrush(color);
-            using Pen pen = new(color);
+            using Pen pen = new(color, linewidth);
             DrawMarker(gfx, pixelLocation, shape, size, brush, pen);
         }
 
-        public static void DrawMarkers(Graphics gfx, ICollection<PointF> pixelLocations, MarkerShape shape, float size, Color color)
+        public static void DrawMarkers(Graphics gfx, ICollection<PointF> pixelLocations, MarkerShape shape, float size, Color color, float linewidth = 1)
         {
             using SolidBrush brush = new(color);
-            using Pen pen = new(color);
+            using Pen pen = new(color, linewidth);
 
             foreach (PointF pt in pixelLocations)
             {
-                DrawMarker(gfx, pt, shape, size, color);
+                DrawMarker(gfx, pt, shape, size, color, linewidth);
             }
         }
 

--- a/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
+++ b/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Drawing;
 using System.Diagnostics;
@@ -81,7 +81,7 @@ namespace ScottPlot.Plottable
     /// This plot type displays a marker at a point that can be dragged with the mouse,
     /// but when dragged it "snapps" to specific X/Y coordinates defined by two arrays of values.
     /// </summary>
-    public class DraggableMarkerPlotInVector : IDraggable, IPlottable
+    public class DraggableMarkerPlotInVector : IDraggable, IPlottable, IHasMarker
     {
         public bool IsVisible { get; set; } = true;
         public int XAxisIndex { get; set; } = 0;
@@ -108,12 +108,17 @@ namespace ScottPlot.Plottable
         /// <summary>
         /// Size of the marker in pixel units
         /// </summary>
-        public double MarkerSize { get; set; } = 10;
+        public float MarkerSize { get; set; } = 10;
 
         /// <summary>
         /// Color of the marker to display at this point
         /// </summary>
-        public Color Color { get; set; } = Color.Black;
+        public Color MarkerColor { get; set; } = Color.Black;
+
+        /// <summary>
+        /// Width of the marker lines in pixel units
+        /// </summary>
+        public float MarkerLineWidth { get; set; } = 1;
 
         /// <summary>
         /// Text to appear in the legend (if populated)
@@ -233,7 +238,7 @@ namespace ScottPlot.Plottable
                 label = Label,
                 markerShape = MarkerShape,
                 markerSize = MarkerSize,
-                color = Color
+                color = MarkerColor,
             };
             return new LegendItem[] { singleItem };
         }

--- a/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
+++ b/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
@@ -190,7 +190,7 @@ namespace ScottPlot.Plottable
             {
                 PointF point = new PointF(dims.GetPixelX(Xs[CurrentIndex]), dims.GetPixelY(Ys[CurrentIndex]));
 
-                MarkerTools.DrawMarker(gfx, point, MarkerShape, (float)MarkerSize, MarkerColor, MarkerLineWidth);
+                MarkerTools.DrawMarker(gfx, point, MarkerShape, (float)MarkerSize, Color, MarkerLineWidth);
             }
         }
 

--- a/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
+++ b/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
@@ -243,7 +243,7 @@ namespace ScottPlot.Plottable
                 label = Label,
                 markerShape = MarkerShape,
                 markerSize = MarkerSize,
-                color = MarkerColor,
+                color = Color,
             };
             return new LegendItem[] { singleItem };
         }

--- a/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
+++ b/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Drawing;
 using System.Diagnostics;
@@ -185,7 +185,7 @@ namespace ScottPlot.Plottable
             {
                 PointF point = new PointF(dims.GetPixelX(Xs[CurrentIndex]), dims.GetPixelY(Ys[CurrentIndex]));
 
-                MarkerTools.DrawMarker(gfx, point, MarkerShape, (float)MarkerSize, Color);
+                MarkerTools.DrawMarker(gfx, point, MarkerShape, (float)MarkerSize, MarkerColor, MarkerLineWidth);
             }
         }
 

--- a/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
+++ b/src/ScottPlot/Plottable/DraggableMarkerPlot.cs
@@ -113,7 +113,12 @@ namespace ScottPlot.Plottable
         /// <summary>
         /// Color of the marker to display at this point
         /// </summary>
-        public Color MarkerColor { get; set; } = Color.Black;
+        public Color Color { get; set; } = Color.Black;
+
+        /// <summary>
+        /// Color of the marker to display at this point
+        /// </summary>
+        public Color MarkerColor { get => Color; set { Color = value; } }
 
         /// <summary>
         /// Width of the marker lines in pixel units

--- a/src/ScottPlot/Plottable/ErrorBar.cs
+++ b/src/ScottPlot/Plottable/ErrorBar.cs
@@ -26,6 +26,7 @@ namespace ScottPlot.Plottable
         public Color LineColor { get => Color; set { Color = value; } }
         public LineStyle LineStyle { get; set; } = LineStyle.Solid;
         public MarkerShape MarkerShape { get; set; } = MarkerShape.filledCircle;
+        public float MarkerLineWidth { get; set; } = 1;
         public float MarkerSize { get; set; } = 0;
         public Color MarkerColor { get => Color; set { Color = value; } }
 

--- a/src/ScottPlot/Plottable/ErrorBar.cs
+++ b/src/ScottPlot/Plottable/ErrorBar.cs
@@ -113,13 +113,15 @@ namespace ScottPlot.Plottable
 
         private void DrawMarkers(PlotDimensions dims, Graphics gfx)
         {
+            PointF[] pixels = new PointF[Xs.Length];
             for (int i = 0; i < Xs.Length; i++)
             {
                 float xPixel = dims.GetPixelX(Xs[i]);
                 float yPixel = dims.GetPixelY(Ys[i]);
-                PointF pixel = new(xPixel, yPixel);
-                MarkerTools.DrawMarker(gfx, pixel, MarkerShape, MarkerSize, Color);
+                pixels[i] = new(xPixel, yPixel);
+                ;
             }
+            MarkerTools.DrawMarkers(gfx, pixels, MarkerShape, MarkerSize, Color, MarkerLineWidth);
         }
 
         public void ValidateData(bool deep = false)

--- a/src/ScottPlot/Plottable/ErrorBar.cs
+++ b/src/ScottPlot/Plottable/ErrorBar.cs
@@ -119,7 +119,6 @@ namespace ScottPlot.Plottable
                 float xPixel = dims.GetPixelX(Xs[i]);
                 float yPixel = dims.GetPixelY(Ys[i]);
                 pixels[i] = new(xPixel, yPixel);
-                ;
             }
             MarkerTools.DrawMarkers(gfx, pixels, MarkerShape, MarkerSize, Color, MarkerLineWidth);
         }

--- a/src/ScottPlot/Plottable/IHasMarker.cs
+++ b/src/ScottPlot/Plottable/IHasMarker.cs
@@ -5,6 +5,7 @@ namespace ScottPlot.Plottable
     public interface IHasMarker
     {
         float MarkerSize { get; set; }
+        float MarkerLineWidth { get; set; }
         MarkerShape MarkerShape { get; set; }
         Color MarkerColor { get; set; }
     }

--- a/src/ScottPlot/Plottable/LegendItem.cs
+++ b/src/ScottPlot/Plottable/LegendItem.cs
@@ -17,36 +17,21 @@ namespace ScottPlot.Plottable
         public LineStyle borderLineStyle;
 
         public LineStyle lineStyle;
+
+        private double _lineWidth = 0;
         public double lineWidth
         {
-            get
-            {
-                if (Parent is not IHasLine)
-                    return 0;
-                double lineWidth = ((IHasLine)Parent).LineWidth;
-                return Math.Min(lineWidth, 10);
-            }
-            set
-            {
-                // TODO: !!!!!
-            }
+            get => (Parent is IHasLine parent) ? Math.Min(parent.LineWidth, 10) : _lineWidth;
+            set { _lineWidth = value; }
         }
         public Color LineColor => Parent is IHasLine p ? p.LineColor : color;
 
         public MarkerShape markerShape;
+        private float _markerSize = 0;
         public float markerSize
         {
-            get
-            {
-                if (Parent is not IHasMarker)
-                    return 0;
-                float markerSize = ((IHasMarker)Parent).MarkerSize;
-                return Math.Min(markerSize, 10);
-            }
-            set
-            {
-                // TODO: !!!!!
-            }
+            get => (Parent is IHasMarker parent) ? parent.MarkerSize : _markerSize;
+            set { _markerSize = value; }
         }
 
         public float markerLineWidth =>

--- a/src/ScottPlot/Plottable/LegendItem.cs
+++ b/src/ScottPlot/Plottable/LegendItem.cs
@@ -1,4 +1,6 @@
 ﻿using ScottPlot.Drawing;
+using System;
+using System.Drawing;
 
 namespace ScottPlot.Plottable
 {
@@ -8,28 +10,50 @@ namespace ScottPlot.Plottable
     public class LegendItem
     {
         public string label;
-        public System.Drawing.Color color;
-        public System.Drawing.Color hatchColor;
-        public System.Drawing.Color borderColor;
+        public Color color;
+        public Color hatchColor;
+        public Color borderColor;
         public float borderWith;
         public LineStyle borderLineStyle;
 
         public LineStyle lineStyle;
         public double lineWidth
         {
-            get { return Parent is IHasLine p ? System.Math.Min(p.LineWidth, 10) : 0; }
-            set { }
+            get
+            {
+                if (Parent is not IHasLine)
+                    return 0;
+                double lineWidth = ((IHasLine)Parent).LineWidth;
+                return Math.Min(lineWidth, 10);
+            }
+            set
+            {
+                // TODO: !!!!!
+            }
         }
-        public System.Drawing.Color LineColor => Parent is IHasLine p ? p.LineColor : color;
+        public Color LineColor => Parent is IHasLine p ? p.LineColor : color;
 
         public MarkerShape markerShape;
         public float markerSize
         {
-            get { return Parent is IHasMarker p ? System.Math.Min(p.MarkerSize, 10) : 0; }
-            set { }
+            get
+            {
+                if (Parent is not IHasMarker)
+                    return 0;
+                float markerSize = ((IHasMarker)Parent).MarkerSize;
+                return Math.Min(markerSize, 10);
+            }
+            set
+            {
+                // TODO: !!!!!
+            }
         }
-        public float markerLineWidth => Parent is IHasMarker p ? System.Math.Min(p.MarkerLineWidth, 3) : (float)lineWidth;
-        public System.Drawing.Color MarkerColor => Parent is IHasMarker p ? p.MarkerColor : color;
+
+        public float markerLineWidth =>
+            Parent is IHasMarker parent ? Math.Min(parent.MarkerLineWidth, 3) : (float)lineWidth;
+
+        public Color MarkerColor =>
+            Parent is IHasMarker parent ? parent.MarkerColor : color;
 
         public HatchStyle hatchStyle;
         public bool ShowAsRectangleInLegend
@@ -40,7 +64,6 @@ namespace ScottPlot.Plottable
                 bool hasArea = (Parent is not null) && (Parent is IHasArea);
                 return hasVeryLargeLineWidth || hasArea;
             }
-            set { lineWidth = 10; }
         }
 
         public readonly IPlottable Parent;

--- a/src/ScottPlot/Plottable/LegendItem.cs
+++ b/src/ScottPlot/Plottable/LegendItem.cs
@@ -1,4 +1,4 @@
-﻿using ScottPlot.Drawing;
+using ScottPlot.Drawing;
 
 namespace ScottPlot.Plottable
 {
@@ -19,6 +19,8 @@ namespace ScottPlot.Plottable
 
         public MarkerShape markerShape;
         public double markerSize;
+
+        public float markerLineWidth => Parent is IHasMarker p ? System.Math.Min(p.MarkerLineWidth, 3) : (float)lineWidth;
         public System.Drawing.Color MarkerColor => Parent is IHasMarker p ? p.MarkerColor : color;
 
         public HatchStyle hatchStyle;

--- a/src/ScottPlot/Plottable/LegendItem.cs
+++ b/src/ScottPlot/Plottable/LegendItem.cs
@@ -1,4 +1,4 @@
-using ScottPlot.Drawing;
+﻿using ScottPlot.Drawing;
 
 namespace ScottPlot.Plottable
 {
@@ -14,19 +14,26 @@ namespace ScottPlot.Plottable
         public float borderWith;
 
         public LineStyle lineStyle;
-        public double lineWidth;
+        public double lineWidth
+        {
+            get { return Parent is IHasLine p ? System.Math.Min(p.LineWidth, 10) : 0; }
+            set { }
+        }
         public System.Drawing.Color LineColor => Parent is IHasLine p ? p.LineColor : color;
 
         public MarkerShape markerShape;
-        public double markerSize;
-
+        public float markerSize
+        {
+            get { return Parent is IHasMarker p ? System.Math.Min(p.MarkerSize, 10) : 0; }
+            set { }
+        }
         public float markerLineWidth => Parent is IHasMarker p ? System.Math.Min(p.MarkerLineWidth, 3) : (float)lineWidth;
         public System.Drawing.Color MarkerColor => Parent is IHasMarker p ? p.MarkerColor : color;
 
         public HatchStyle hatchStyle;
         public bool IsRectangle
         {
-            get { return lineWidth >= 10; }
+            get { return lineWidth >= 10 && markerShape == MarkerShape.none; }
             set { lineWidth = 10; }
         }
 

--- a/src/ScottPlot/Plottable/MarkerPlot.cs
+++ b/src/ScottPlot/Plottable/MarkerPlot.cs
@@ -29,6 +29,11 @@ namespace ScottPlot.Plottable
         public float MarkerSize { get; set; } = 10;
 
         /// <summary>
+        /// Thickness of the marker lines in pixel units
+        /// </summary>
+        public float MarkerLineWidth { get; set; } = 1;
+
+        /// <summary>
         /// Color of the marker to display at this point
         /// </summary>
         public Color Color { get; set; }

--- a/src/ScottPlot/Plottable/MarkerPlot.cs
+++ b/src/ScottPlot/Plottable/MarkerPlot.cs
@@ -84,7 +84,7 @@ namespace ScottPlot.Plottable
             PointF point = new(dims.GetPixelX(X), dims.GetPixelY(Y));
 
             using Graphics gfx = Drawing.GDI.Graphics(bmp, dims, lowQuality);
-            MarkerTools.DrawMarker(gfx, point, MarkerShape, (float)MarkerSize, Color);
+            MarkerTools.DrawMarker(gfx, point, MarkerShape, (float)MarkerSize, Color, MarkerLineWidth);
 
             if (!string.IsNullOrEmpty(Text))
             {

--- a/src/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot/Plottable/ScatterPlot.cs
@@ -313,7 +313,7 @@ namespace ScottPlot.Plottable
                 // draw a marker at each point
                 if ((MarkerSize > 0) && (MarkerShape != MarkerShape.none))
                 {
-                    MarkerTools.DrawMarkers(gfx, points, MarkerShape, MarkerSize, MarkerColor);
+                    MarkerTools.DrawMarkers(gfx, points, MarkerShape, MarkerSize, MarkerColor, MarkerLineWidth);
                 }
             }
         }

--- a/src/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot/Plottable/ScatterPlot.cs
@@ -1,4 +1,4 @@
-using ScottPlot.Drawing;
+﻿using ScottPlot.Drawing;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -46,7 +46,7 @@ namespace ScottPlot.Plottable
         public double LineWidth
         {
             get => IsHighlighted ? _lineWidth * HighlightCoefficient : _lineWidth;
-            set { _lineWidth = value; }
+            set { _lineWidth = value; _markerLineWidth = (float)value / 2; _markerSize = (float)value * 2; }
         }
 
         private double _errorLineWidth = 1;

--- a/src/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot/Plottable/ScatterPlot.cs
@@ -1,4 +1,4 @@
-﻿using ScottPlot.Drawing;
+using ScottPlot.Drawing;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -63,6 +63,12 @@ namespace ScottPlot.Plottable
         {
             get => IsHighlighted ? _markerSize * HighlightCoefficient : _markerSize;
             set { _markerSize = value; }
+        }
+        private float _markerLineWidth = 1;
+        public float MarkerLineWidth
+        {
+            get => IsHighlighted ? (float)_lineWidth * HighlightCoefficient : _markerLineWidth;
+            set { _markerLineWidth = value; }
         }
 
         public bool StepDisplay = false;

--- a/src/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot/Plottable/ScatterPlot.cs
@@ -46,7 +46,7 @@ namespace ScottPlot.Plottable
         public double LineWidth
         {
             get => IsHighlighted ? _lineWidth * HighlightCoefficient : _lineWidth;
-            set { _lineWidth = value; _markerLineWidth = (float)value / 2; _markerSize = (float)value * 2; }
+            set { _lineWidth = value; }
         }
 
         private double _errorLineWidth = 1;

--- a/src/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot/Plottable/SignalPlotBase.cs
@@ -1,4 +1,4 @@
-﻿using ScottPlot.Drawing;
+using ScottPlot.Drawing;
 using ScottPlot.MinMaxSearchStrategies;
 using System;
 using System.Collections.Generic;
@@ -37,6 +37,13 @@ namespace ScottPlot.Plottable
         {
             get => IsHighlighted ? _lineWidth * HighlightCoefficient : _lineWidth;
             set { _lineWidth = value; }
+        }
+
+        private float _markerLineWidth;
+        public float MarkerLineWidth
+        {
+            get => IsHighlighted ? (float)_markerLineWidth * HighlightCoefficient : _markerLineWidth;
+            set { _markerLineWidth = value; }
         }
 
         public string Label { get; set; } = null;

--- a/src/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot/Plottable/SignalPlotBase.cs
@@ -1,4 +1,4 @@
-using ScottPlot.Drawing;
+﻿using ScottPlot.Drawing;
 using ScottPlot.MinMaxSearchStrategies;
 using System;
 using System.Collections.Generic;
@@ -36,7 +36,7 @@ namespace ScottPlot.Plottable
         public double LineWidth
         {
             get => IsHighlighted ? _lineWidth * HighlightCoefficient : _lineWidth;
-            set { _lineWidth = value; }
+            set { _lineWidth = value; _markerLineWidth = (float)value / 2; _markerSize = (float)value * 2; }
         }
 
         private float _markerLineWidth;
@@ -383,7 +383,7 @@ namespace ScottPlot.Plottable
 
                         foreach (PointF point in linePoints)
                         {
-                            MarkerTools.DrawMarker(gfx, point, MarkerShape, markerPxDiameter, Color);
+                            MarkerTools.DrawMarker(gfx, point, MarkerShape, markerPxDiameter, Color, MarkerLineWidth);
                         }
                     }
                     else

--- a/src/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot/Plottable/SignalPlotBase.cs
@@ -36,7 +36,7 @@ namespace ScottPlot.Plottable
         public double LineWidth
         {
             get => IsHighlighted ? _lineWidth * HighlightCoefficient : _lineWidth;
-            set { _lineWidth = value; _markerLineWidth = (float)value / 2; _markerSize = (float)value * 2; }
+            set { _lineWidth = value; }
         }
 
         private float _markerLineWidth;

--- a/src/ScottPlot/Renderable/Legend.cs
+++ b/src/ScottPlot/Renderable/Legend.cs
@@ -173,7 +173,7 @@ namespace ScottPlot.Renderable
                         // and perhaps a marker in the middle of the line
                         float lineXcenter = (lineX1 + lineX2) / 2;
                         PointF markerPoint = new PointF(lineXcenter, lineY);
-                        if ((item.markerShape != MarkerShape.none) && (item.markerSize > 0) && (item.markerLineWidth > 0))
+                        if ((item.markerShape != MarkerShape.none) && (item.markerSize > 0))
                             MarkerTools.DrawMarker(gfx, markerPoint, item.markerShape, item.markerSize, item.MarkerColor, item.markerLineWidth);
                     }
 

--- a/src/ScottPlot/Renderable/Legend.cs
+++ b/src/ScottPlot/Renderable/Legend.cs
@@ -173,8 +173,8 @@ namespace ScottPlot.Renderable
                         // and perhaps a marker in the middle of the line
                         float lineXcenter = (lineX1 + lineX2) / 2;
                         PointF markerPoint = new PointF(lineXcenter, lineY);
-                        if ((item.markerShape != MarkerShape.none) && (item.markerSize > 0))
-                            MarkerTools.DrawMarker(gfx, markerPoint, item.markerShape, MarkerWidth, item.MarkerColor);
+                        if ((item.markerShape != MarkerShape.none) && (item.markerSize > 0) && (item.markerLineWidth > 0))
+                            MarkerTools.DrawMarker(gfx, markerPoint, item.markerShape, item.markerSize, item.MarkerColor, item.markerLineWidth);
                     }
 
                     // Typically invisible legend items don't make it in the list.

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Marker.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Marker.cs
@@ -80,7 +80,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                 IsVisible = true,
                 MarkerSize = 15,
                 MarkerShape = MarkerShape.filledDiamond,
-                Color = Color.Magenta,
+                MarkerColor = Color.Magenta,
                 Label = "marker",
             };
             plt.Add(dmpv);

--- a/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Marker.cs
+++ b/src/cookbook/ScottPlot.Cookbook/Recipes/Plottable/Marker.cs
@@ -107,4 +107,40 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             marker.TextFont.Size = 28;
         }
     }
+
+    public class MarkerLineWidth : IRecipe
+    {
+        public string Category => "Plottable: Marker";
+        public string ID => "marker_linewidth";
+        public string Title => "Marker Line Width";
+        public string Description =>
+            "Markers have options that can be customized, such as line width.";
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[] ys1 = DataGen.Sin(30);
+            var cmap1 = ScottPlot.Drawing.Colormap.Viridis;
+
+            double[] ys2 = DataGen.Cos(30);
+            var cmap2 = ScottPlot.Drawing.Colormap.Turbo;
+
+            for (int i = 0; i < ys1.Length; i++)
+            {
+                double frac = i / (ys1.Length - 1f);
+
+                var circle = plt.AddMarker(i, ys1[i]);
+                circle.MarkerShape = MarkerShape.openCircle;
+                circle.MarkerSize = i + 5;
+                circle.MarkerLineWidth = 1 + i / 2;
+                circle.MarkerColor = cmap1.GetColor(1 - frac, .8);
+
+                var triangle = plt.AddMarker(i, ys2[i]);
+                triangle.MarkerShape = MarkerShape.openTriangleUp;
+                triangle.MarkerSize = i + 5;
+                triangle.MarkerLineWidth = 1 + i / 4;
+                triangle.MarkerColor = cmap2.GetColor(frac, .8);
+            }
+
+            plt.Margins(.2, .2);
+        }
+    }
 }


### PR DESCRIPTION
This PR implements a `MarkerLineWidth` property and subsequent modifications to allow to change the stroke width of a marker. 

This is still a WIP.

Commit cea499473b3e44cc15f3f7fd0bf5df7294654f61 breaks the legend for pie chart and maybe other plot types. 
This **might** be the occasion to create a `IHasArea` interface handling all plots that are related (visually at least) to an area / surface with respect to `IHasLine`. This would avoid to use the `isRectangle` property in `Legend`.

Here is how looks the "All Markers" example with the new capabilities and `sp.LineWidth = 2 --> sp.LineWidth = i;`

![image](https://user-images.githubusercontent.com/42067365/154820168-1abba06f-2037-450b-9baf-4a7fdf75dd64.png)
