### PR TITLE
BubblePlot: fix GetPointNearest calculations

### DIFF
--- a/dev/changelog.md
+++ b/dev/changelog.md
@@ -2,7 +2,7 @@
 
 ## ScottPlot 4.1.34
 _In development / not yet on NuGet ..._
-* Bubble plot: Added methods to get the point nearest the cursor (#1657, #1652) _Thanks @BambOoxX and @adgriff2_
+* Bubble plot: Added methods to get the point nearest the cursor (#1657, #1652, #1705) _Thanks @BambOoxX, @Maoyao233, and @adgriff2_
 * Markers: Improved alignment of markers and lines on Linux and MacOS by half a pixel (#1660, #340)
 * Plottable: Added `IsHighlighted` properties to make some plot types bold (#1660) _Thanks @BambOoxX_
 * Plottable: Segregated existing functionality interfaces for `IHasLine`, `IHasMarker`, and `IHilightable` (#1660) _Thanks @BambOoxX_

--- a/src/ScottPlot/Plottable/BubblePlot.cs
+++ b/src/ScottPlot/Plottable/BubblePlot.cs
@@ -46,6 +46,7 @@ namespace ScottPlot.Plottable
         /// <param name="edgeColor"></param>
         public void Add(double x, double y, double radius, Color fillColor, double edgeWidth, Color edgeColor)
         {
+            // TODO: inconsistent argumen tnames in overloads (radius vs size)
             Bubbles.Add(new Bubble()
             {
                 X = x,
@@ -147,21 +148,19 @@ namespace ScottPlot.Plottable
             if (Bubbles.Count == 0)
                 throw new InvalidOperationException("BubblePlot is empty");
 
-            double minDistance = Double.PositiveInfinity;
-            int minIndex = 0;
-            Bubble currBubble = Bubbles.ElementAt(0);
+            double closestBubbleDistance = double.PositiveInfinity;
+            int closestBubbleIndex = 0;
             for (int i = 0; i < Bubbles.Count; i++)
             {
-                currBubble = Bubbles.ElementAt(i);
-                double currDistance = Math.Abs(currBubble.X - x);
-                if (currDistance < minDistance)
+                double currDistance = Math.Abs(Bubbles[i].X - x);
+                if (currDistance < closestBubbleDistance)
                 {
-                    minIndex = i;
-                    minDistance = currDistance;
+                    closestBubbleIndex = i;
+                    closestBubbleDistance = currDistance;
                 }
             }
 
-            return (currBubble.X, currBubble.Y, minIndex);
+            return (Bubbles[closestBubbleIndex].X, Bubbles[closestBubbleIndex].Y, closestBubbleIndex);
         }
 
         /// <summary>
@@ -174,21 +173,19 @@ namespace ScottPlot.Plottable
             if (Bubbles.Count == 0)
                 throw new InvalidOperationException("BubblePlot is empty");
 
-            double minDistance = Double.PositiveInfinity;
-            int minIndex = 0;
-            Bubble currBubble = Bubbles.ElementAt(0);
+            double closestBubbleDistance = double.PositiveInfinity;
+            int closestBubbleIndex = 0;
             for (int i = 0; i < Bubbles.Count; i++)
             {
-                currBubble = Bubbles.ElementAt(i);
-                double currDistance = Math.Abs(currBubble.Y - y);
-                if (currDistance < minDistance)
+                double currDistance = Math.Abs(Bubbles[i].Y - y);
+                if (currDistance < closestBubbleDistance)
                 {
-                    minIndex = i;
-                    minDistance = currDistance;
+                    closestBubbleIndex = i;
+                    closestBubbleDistance = currDistance;
                 }
             }
 
-            return (currBubble.X, currBubble.Y, minIndex);
+            return (Bubbles[closestBubbleIndex].X, Bubbles[closestBubbleIndex].Y, closestBubbleIndex);
         }
 
         /// <summary>
@@ -206,21 +203,19 @@ namespace ScottPlot.Plottable
             double pointDistanceSquared(double x1, double y1) =>
                 (x1 - x) * (x1 - x) * xyRatioSquared + (y1 - y) * (y1 - y);
 
-            double minDistance = Double.PositiveInfinity;
-            int minIndex = 0;
-            Bubble currBubble = Bubbles.ElementAt(0);
+            double closestBubbleDistance = double.PositiveInfinity;
+            int closestBubbleIndex = 0;
             for (int i = 0; i < Bubbles.Count; i++)
             {
-                currBubble = Bubbles.ElementAt(i);
-                double currDistance = pointDistanceSquared(currBubble.X, currBubble.Y);
-                if (currDistance < minDistance)
+                double currDistance = pointDistanceSquared(Bubbles[i].X, Bubbles[i].Y);
+                if (currDistance < closestBubbleDistance)
                 {
-                    minIndex = i;
-                    minDistance = currDistance;
+                    closestBubbleIndex = i;
+                    closestBubbleDistance = currDistance;
                 }
             }
 
-            return (currBubble.X, currBubble.Y, minIndex);
+            return (Bubbles[closestBubbleIndex].X, Bubbles[closestBubbleIndex].Y, closestBubbleIndex);
         }
     }
 }

--- a/src/ScottPlot/Plottable/BubblePlot.cs
+++ b/src/ScottPlot/Plottable/BubblePlot.cs
@@ -147,7 +147,7 @@ namespace ScottPlot.Plottable
             double minDistance = Double.PositiveInfinity;
             int minIndex = 0;
             Bubble currBubble = Bubbles.ElementAt(0);
-            for (int i = 0; i <= Bubbles.Count; i++)
+            for (int i = 0; i < Bubbles.Count; i++)
             {
                 currBubble = Bubbles.ElementAt(i);
                 double currDistance = Math.Abs(currBubble.X - x);
@@ -171,7 +171,7 @@ namespace ScottPlot.Plottable
             double minDistance = Double.PositiveInfinity;
             int minIndex = 0;
             Bubble currBubble = Bubbles.ElementAt(0);
-            for (int i = 0; i <= Bubbles.Count; i++)
+            for (int i = 0; i < Bubbles.Count; i++)
             {
                 currBubble = Bubbles.ElementAt(i);
                 double currDistance = Math.Abs(currBubble.Y - y);
@@ -201,7 +201,7 @@ namespace ScottPlot.Plottable
             double minDistance = Double.PositiveInfinity;
             int minIndex = 0;
             Bubble currBubble = Bubbles.ElementAt(0);
-            for (int i = 0; i <= Bubbles.Count; i++)
+            for (int i = 0; i < Bubbles.Count; i++)
             {
                 currBubble = Bubbles.ElementAt(i);
                 double currDistance = pointDistanceSquared(currBubble.X, currBubble.Y);

--- a/src/ScottPlot/Plottable/BubblePlot.cs
+++ b/src/ScottPlot/Plottable/BubblePlot.cs
@@ -144,6 +144,9 @@ namespace ScottPlot.Plottable
         /// <returns></returns>
         public (double x, double y, int index) GetPointNearestX(double x)
         {
+            if (Bubbles.Count == 0)
+                throw new InvalidOperationException("BubblePlot is empty");
+
             double minDistance = Double.PositiveInfinity;
             int minIndex = 0;
             Bubble currBubble = Bubbles.ElementAt(0);
@@ -168,6 +171,9 @@ namespace ScottPlot.Plottable
         /// <returns></returns>
         public (double x, double y, int index) GetPointNearestY(double y)
         {
+            if (Bubbles.Count == 0)
+                throw new InvalidOperationException("BubblePlot is empty");
+
             double minDistance = Double.PositiveInfinity;
             int minIndex = 0;
             Bubble currBubble = Bubbles.ElementAt(0);
@@ -193,6 +199,8 @@ namespace ScottPlot.Plottable
         /// <param name="xyRatio">Ratio of pixels per unit (X/Y) when rendered</param>
         public (double x, double y, int index) GetPointNearest(double x, double y, double xyRatio = 1)
         {
+            if (Bubbles.Count == 0)
+                throw new InvalidOperationException("BubblePlot is empty");
 
             double xyRatioSquared = xyRatio * xyRatio;
             double pointDistanceSquared(double x1, double y1) =>

--- a/src/tests/PlotTypes/BubblePlot.cs
+++ b/src/tests/PlotTypes/BubblePlot.cs
@@ -50,5 +50,61 @@ namespace ScottPlotTests.PlotTypes
             plt.AxisAuto(.2, .25);
             TestTools.SaveFig(plt);
         }
+
+        private ScottPlot.Plottable.BubblePlot CreateTestBubblePlot(bool plotToo = false)
+        {
+            int bubbleCount = 10;
+            double[] xs = ScottPlot.DataGen.Consecutive(bubbleCount);
+            double[] ys = ScottPlot.DataGen.Sin(bubbleCount);
+            System.Drawing.Color fillColor = System.Drawing.Color.Green;
+            System.Drawing.Color edgeColor = System.Drawing.Color.Magenta;
+            float edgeWidth = 2;
+            float radius = 5;
+
+            ScottPlot.Plottable.BubblePlot bp = new();
+            bp.Add(xs, ys, radius, fillColor, edgeWidth, edgeColor);
+
+            if (plotToo)
+            {
+                ScottPlot.Plot plt = new();
+                plt.Add(bp);
+                TestTools.SaveFig(plt);
+            }
+
+            return bp;
+        }
+
+        [Test]
+        public void Test_BubblePlot_GetPointNearestX()
+        {
+            ScottPlot.Plottable.BubblePlot bp = CreateTestBubblePlot();
+
+            (double x, double y, int index) = bp.GetPointNearestX(5.1);
+            Assert.AreEqual(5, x);
+            Assert.AreEqual(y, -.3, .1);
+            Assert.AreEqual(index, 5);
+        }
+
+        [Test]
+        public void Test_BubblePlot_GetPointNearestY()
+        {
+            ScottPlot.Plottable.BubblePlot bp = CreateTestBubblePlot();
+
+            (double x, double y, int index) = bp.GetPointNearestY(-0.25);
+            Assert.AreEqual(5, x);
+            Assert.AreEqual(y, -.3, .1);
+            Assert.AreEqual(index, 5);
+        }
+
+        [Test]
+        public void Test_BubblePlot_GetPointNearest()
+        {
+            ScottPlot.Plottable.BubblePlot bp = CreateTestBubblePlot();
+
+            (double x, double y, int index) = bp.GetPointNearest(5.1, -0.25);
+            Assert.AreEqual(5, x);
+            Assert.AreEqual(y, -.3, .1);
+            Assert.AreEqual(index, 5);
+        }
     }
 }


### PR DESCRIPTION
**Purpose:**
#1657 introduced an obvious out-of-range error. The index `i` reaches `Bubbles.Count`. 
