### PR TITLE
SignalXY respect marker settings

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/SignalXY.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/SignalXY.cs
@@ -19,7 +19,10 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         {
             (double[] xs, double[] ys) = DataGen.RandomWalk2D(new Random(0), 5_000);
 
-            plt.AddSignalXY(xs, ys);
+            var sig = plt.AddSignalXY(xs, ys);
+            sig.MarkerColor = System.Drawing.Color.Cyan;
+            sig.MarkerShape = MarkerShape.eks;
+            sig.LineWidth = 0;
         }
     }
 

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/SignalXY.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/SignalXY.cs
@@ -19,10 +19,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         {
             (double[] xs, double[] ys) = DataGen.RandomWalk2D(new Random(0), 5_000);
 
-            var sig = plt.AddSignalXY(xs, ys);
-            sig.MarkerColor = System.Drawing.Color.Cyan;
-            sig.MarkerShape = MarkerShape.eks;
-            sig.LineWidth = 0;
+            plt.AddSignalXY(xs, ys);
         }
     }
 

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/SignalXY.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/SignalXY.cs
@@ -131,4 +131,25 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             plt.Margins(x: 0);
         }
     }
+
+    public class SignalCustomMarkers : IRecipe
+    {
+        public string Category => "Plottable: SignalXY";
+        public string ID => "signalxy_markers";
+        public string Title => "Customize Markers";
+        public string Description => "SignalXY plots have markers which only appear when they are zoomed in.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            var rand = new Random(0);
+            double[] ys = DataGen.RandomWalk(rand, 200);
+            double[] xs = DataGen.Consecutive(200);
+
+            var sig = plt.AddSignalXY(xs, ys);
+            sig.MarkerShape = MarkerShape.filledTriangleUp;
+            sig.MarkerSize = 10;
+
+            plt.SetAxisLimits(100, 120, 10, 15);
+        }
+    }
 }

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -222,7 +222,7 @@ namespace ScottPlot.Plottable
                 }
 
                 // Draw lines
-                if (PointsToDraw.Length > 1)
+                if (PointsToDraw.Length > 1 && LineStyle != LineStyle.None && LineWidth > 0)
                 {
                     ValidatePoints(PointsToDraw);
                     gfx.DrawLines(penHD, PointsToDraw);

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -241,7 +241,7 @@ namespace ScottPlot.Plottable
                                                 .Skip(PointBefore.Length)
                                                 .Take(PointsToDraw.Length - PointBefore.Length - PointAfter.Length)
                                                 .ToArray();
-                        
+
                         MarkerTools.DrawMarkers(gfx, PointsWithMarkers, MarkerShape, MarkerSize, MarkerColor, MarkerLineWidth);
                     }
                 }

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -234,6 +234,8 @@ namespace ScottPlot.Plottable
                     float dataSpanXPx = PointsToDraw[PointsToDraw.Length - 1].X - PointsToDraw[0].X;
                     float markerPxRadius = .3f * dataSpanXPx / PointsToDraw.Length;
                     markerPxRadius = Math.Min(markerPxRadius, MarkerSize / 2);
+                    float scaledMarkerSize = markerPxRadius * 2;
+
                     if (markerPxRadius > .3)
                     {
                         // skip not visible before and after points
@@ -242,7 +244,7 @@ namespace ScottPlot.Plottable
                                                 .Take(PointsToDraw.Length - PointBefore.Length - PointAfter.Length)
                                                 .ToArray();
 
-                        MarkerTools.DrawMarkers(gfx, PointsWithMarkers, MarkerShape, MarkerSize, MarkerColor, MarkerLineWidth);
+                        MarkerTools.DrawMarkers(gfx, PointsWithMarkers, MarkerShape, scaledMarkerSize, MarkerColor, MarkerLineWidth);
                     }
                 }
             }

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -239,18 +239,10 @@ namespace ScottPlot.Plottable
                         // skip not visible before and after points
                         var PointsWithMarkers = PointsToDraw
                                                 .Skip(PointBefore.Length)
-                                                .Take(PointsToDraw.Length - PointBefore.Length - PointAfter.Length);
-                        foreach (PointF pt in PointsWithMarkers)
-                        {
-                            // adjust marker offset to improve rendering on Linux and MacOS
-                            float markerOffsetX = (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? 0 : 1;
-
-                            gfx.FillEllipse(brush,
-                                  x: pt.X - markerPxRadius + markerOffsetX,
-                                  y: pt.Y - markerPxRadius,
-                                  width: markerPxRadius * 2,
-                                  height: markerPxRadius * 2);
-                        }
+                                                .Take(PointsToDraw.Length - PointBefore.Length - PointAfter.Length)
+                                                .ToArray();
+                        
+                        MarkerTools.DrawMarkers(gfx, PointsWithMarkers, MarkerShape, MarkerSize, MarkerColor, MarkerLineWidth);
                     }
                 }
             }

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -1,5 +1,9 @@
 # ScottPlot Changelog
 
+## ScottPlot 4.1.39
+_In development / not yet on NuGet..._
+* SignalPlotXY: Improved support for custom markers (#1763, #1764) _Thanks @bclehmann and @ChrisCC6_
+
 ## ScottPlot 4.1.38
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-04-01_
 * SignalPlotXY: Fixed bug where `GetPointNearestX()` did not check proximity to the final point (#1757) _Thanks @MareMare_


### PR DESCRIPTION
**Purpose:**
#1763

This also fixes a similar issue where `LineWidth` of zero was ignored, as well as `LineStyle.None`.