### PR TITLE
Improve support for notebooks

### DIFF
--- a/src/ScottPlot4/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj
+++ b/src/ScottPlot4/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj
@@ -15,9 +15,9 @@
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/ScottPlot/ScottPlot</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.1.40</Version>
-    <AssemblyVersion>4.1.40.0</AssemblyVersion>
-    <FileVersion>4.1.40.0</FileVersion>
+    <Version>4.1.41</Version>
+    <AssemblyVersion>4.1.41.0</AssemblyVersion>
+    <FileVersion>4.1.41.0</FileVersion>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/src/ScottPlot4/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj
+++ b/src/ScottPlot4/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj
@@ -14,9 +14,9 @@
     <PackageTags>plot graph data chart signal line bar heatmap scatter control interactive winforms windows forms</PackageTags>
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/ScottPlot/ScottPlot</RepositoryUrl>
-    <Version>4.1.40</Version>
-    <AssemblyVersion>4.1.40.0</AssemblyVersion>
-    <FileVersion>4.1.40.0</FileVersion>
+    <Version>4.1.41</Version>
+    <AssemblyVersion>4.1.41.0</AssemblyVersion>
+    <FileVersion>4.1.41.0</FileVersion>
     <SignAssembly>false</SignAssembly>
     <Authors>Scott Harden</Authors>
     <Company>Harden Technologies, LLC</Company>

--- a/src/ScottPlot4/ScottPlot.Sandbox/Notebook/ScottPlotQuickstart.ipynb
+++ b/src/ScottPlot4/ScottPlot.Sandbox/Notebook/ScottPlotQuickstart.ipynb
@@ -1,0 +1,97 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "source": [
+    "# ScottPlot Notebook Quickstart\n",
+    "\n",
+    "_How to use ScottPlot to plot data in a Jupyter / .NET Interactive notebook_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "// Install the ScottPlot NuGet package\n",
+    "#r \"nuget:ScottPlot\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "// Plot some data\n",
+    "double[] dataX = new double[] { 1, 2, 3, 4, 5 };\n",
+    "double[] dataY = new double[] { 1, 4, 9, 16, 25 };\n",
+    "var plt = new ScottPlot.Plot(400, 300);\n",
+    "plt.AddScatter(dataX, dataY);\n",
+    "\n",
+    "// Render the plot as a Bitmap and display its data\n",
+    "var bmp = plt.GetBitmap();\n",
+    "var memStream = new System.IO.MemoryStream();\n",
+    "bmp.Save(memStream, System.Drawing.Imaging.ImageFormat.Png);\n",
+    "string base64str = Convert.ToBase64String(memStream.ToArray());\n",
+    "var html = Microsoft.DotNet.Interactive.Formatting.PocketViewTags.img[src: \"data:image/png;base64,\" + base64str];\n",
+    "//Console.WriteLine(html);\n",
+    "display(html);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "vscode": {
+     "languageId": "dotnet-interactive.csharp"
+    }
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "9.0"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/ScottPlot4/ScottPlot.Tests/Plot/Render.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/Plot/Render.cs
@@ -30,7 +30,7 @@ namespace ScottPlotTests.Plot
             plt.AddSignal(ScottPlot.DataGen.Cos(51));
 
             string b64 = plt.GetImageBase64();
-            Assert.AreEqual(16984, b64.Length);
+            Assert.Greater(1000, b64.Length);
 
             string img = plt.GetImageHTML();
             Assert.Greater(img.Length, b64.Length);

--- a/src/ScottPlot4/ScottPlot.Tests/Plot/Render.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/Plot/Render.cs
@@ -30,7 +30,7 @@ namespace ScottPlotTests.Plot
             plt.AddSignal(ScottPlot.DataGen.Cos(51));
 
             string b64 = plt.GetImageBase64();
-            Assert.Greater(1000, b64.Length);
+            Assert.Greater(b64.Length, 1000);
 
             string img = plt.GetImageHTML();
             Assert.Greater(img.Length, b64.Length);

--- a/src/ScottPlot4/ScottPlot.Tests/Plot/Render.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/Plot/Render.cs
@@ -21,5 +21,21 @@ namespace ScottPlotTests.Plot
             plt.Render(bmp, scale: 1.5);
             TestTools.SaveBitmap(bmp);
         }
+
+        [Test]
+        public void Test_Render_Html()
+        {
+            var plt = new ScottPlot.Plot(400, 300);
+            plt.AddSignal(ScottPlot.DataGen.Sin(51));
+            plt.AddSignal(ScottPlot.DataGen.Cos(51));
+
+            string b64 = plt.GetImageBase64();
+            Assert.AreEqual(16984, b64.Length);
+
+            string img = plt.GetImageHTML();
+            Assert.Greater(img.Length, b64.Length);
+
+            TestTools.SaveHtml(img);
+        }
     }
 }

--- a/src/ScottPlot4/ScottPlot.Tests/TestTools.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/TestTools.cs
@@ -52,6 +52,29 @@ namespace ScottPlotTests
             Console.WriteLine();
         }
 
+        public static void SaveText(string txt, string subName = "")
+        {
+            var stackTrace = new System.Diagnostics.StackTrace();
+            string callingMethod = stackTrace.GetFrame(1).GetMethod().Name;
+            string fileName = callingMethod + subName + ".txt";
+            string filePath = System.IO.Path.GetFullPath(fileName);
+            System.IO.File.WriteAllText(filePath, txt);
+            Console.WriteLine($"Saved: {filePath}");
+            Console.WriteLine();
+        }
+
+        public static void SaveHtml(string body, string subName = "")
+        {
+            var stackTrace = new System.Diagnostics.StackTrace();
+            string callingMethod = stackTrace.GetFrame(1).GetMethod().Name;
+            string fileName = callingMethod + subName + ".html";
+            string filePath = System.IO.Path.GetFullPath(fileName);
+            string html = $"<html><head></head><body>{body}</body></html>";
+            System.IO.File.WriteAllText(filePath, html);
+            Console.WriteLine($"Saved: {filePath}");
+            Console.WriteLine();
+        }
+
         private static void SaveArtifact(ScottPlot.Plot plt, string name)
         {
             string osNameShort = ScottPlot.Tools.GetOsName(details: false);

--- a/src/ScottPlot4/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj
+++ b/src/ScottPlot4/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj
@@ -16,9 +16,9 @@
     <PackageTags>plot graph data chart signal line bar heatmap scatter control interactive WPF</PackageTags>
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/ScottPlot/ScottPlot</RepositoryUrl>
-    <Version>4.1.40</Version>
-    <AssemblyVersion>4.1.40.0</AssemblyVersion>
-    <FileVersion>4.1.40.0</FileVersion>
+    <Version>4.1.41</Version>
+    <AssemblyVersion>4.1.41.0</AssemblyVersion>
+    <FileVersion>4.1.41.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/src/ScottPlot4/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj
+++ b/src/ScottPlot4/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj
@@ -15,9 +15,9 @@
     <PackageTags>plot graph data chart signal line bar heatmap scatter control interactive winforms windows forms</PackageTags>
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/ScottPlot/ScottPlot</RepositoryUrl>
-    <Version>4.1.40</Version>
-    <AssemblyVersion>4.1.40.0</AssemblyVersion>
-    <FileVersion>4.1.40.0</FileVersion>
+    <Version>4.1.41</Version>
+    <AssemblyVersion>4.1.41.0</AssemblyVersion>
+    <FileVersion>4.1.41.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Render.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Render.cs
@@ -190,6 +190,23 @@ namespace ScottPlot
         }
 
         /// <summary>
+        /// Render the plot and return the image as a Bas64-encoded PNG
+        /// </summary>
+        public string GetImageBase64(bool lowQuality = false, double scale = 1.0)
+        {
+            return Convert.ToBase64String(GetImageBytes(lowQuality, scale));
+        }
+
+        /// <summary>
+        /// Render the plot and return an HTML img element containing a Base64-encoded PNG
+        /// </summary>
+        public string GetImageHTML(bool lowQuality = false, double scale = 1.0)
+        {
+            string b64 = GetImageBase64(lowQuality, scale);
+            return $"<img src=\"data:image/png;base64,{b64}\"></img>";
+        }
+
+        /// <summary>
         /// Return a new Bitmap containing only the legend
         /// </summary>
         /// <returns>new bitmap containing the legend</returns>

--- a/src/ScottPlot4/ScottPlot/ScottPlot.csproj
+++ b/src/ScottPlot4/ScottPlot/ScottPlot.csproj
@@ -12,9 +12,9 @@
     <PackageProjectUrl>https://ScottPlot.NET</PackageProjectUrl>
     <PackageTags>plot graph data chart signal line bar heatmap scatter</PackageTags>
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
-    <Version>4.1.40</Version>
-    <AssemblyVersion>4.1.40.0</AssemblyVersion>
-    <FileVersion>4.1.40.0</FileVersion>
+    <Version>4.1.41</Version>
+    <AssemblyVersion>4.1.41.0</AssemblyVersion>
+    <FileVersion>4.1.41.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -1,5 +1,9 @@
 # ScottPlot Changelog
 
+## ScottPlot 4.1.41
+_Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-04-09_
+* Plot: Added `Plot.GetImageHTML()` to make it easy to display ScottPlot images in .NET Interactive / Jupyter notebooks (#1772) _Thanks @StendProg and @Regenhardt_
+
 ## ScottPlot 4.1.40
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-04-07_
 * SignalPlotXY: Improved support for custom markers (#1763, #1764) _Thanks @bclehmann and @ChrisCC6_


### PR DESCRIPTION
Adds `Plot.GetImageHTML()` to simplify inclusion of plots in .NET Interactive notebooks

resolves #1772