### PR TITLE
SignalPlotXY: defer ascending X check to ValidateData and only validate between min/max render index

### DIFF
--- a/src/ScottPlot4/ScottPlot.Tests/PlotTypes/SignalXY.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlotTypes/SignalXY.cs
@@ -41,8 +41,8 @@ namespace ScottPlotTests.PlotTypes
             }
 
             var plt = new ScottPlot.Plot(500, 350);
-            var signalXY = plt.AddSignalXY(xs, ys);
-            Assert.Throws<InvalidOperationException>(() => { signalXY.ValidateData(deep: true); });
+            plt.AddSignalXY(xs, ys);
+            Assert.Throws<InvalidOperationException>(() => { plt.Render(); });
         }
 
         [Test]
@@ -68,7 +68,7 @@ namespace ScottPlotTests.PlotTypes
             var signalXY = plt.AddSignalXY(xs, ys);
             signalXY.MinRenderIndex = minRenderIndex;
             signalXY.MaxRenderIndex = maxRenderIndex;
-            Assert.DoesNotThrow(() => { signalXY.ValidateData(deep: true); });
+            Assert.DoesNotThrow(() => { plt.Render(); });
         }
 
         [Test]

--- a/src/ScottPlot4/ScottPlot.Tests/PlotTypes/SignalXY.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlotTypes/SignalXY.cs
@@ -27,7 +27,7 @@ namespace ScottPlotTests.PlotTypes
         }
 
         [Test]
-        public void Test_NotAllXsAscend_ValidateDataThrowsException()
+        public void Test_NotAllXsAscend_ThrowsException()
         {
             // generate random, NOT-ALL-ascending, unevenly-spaced data
             Random rand = new Random(0);

--- a/src/ScottPlot4/ScottPlot.Tests/PlotTypes/SignalXY.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlotTypes/SignalXY.cs
@@ -30,7 +30,7 @@ namespace ScottPlotTests.PlotTypes
         }
 
         [Test]
-        public void Test_NotAllXsAscend_ThrowsException()
+        public void Test_NotAllXsAscend_ValidateDataThrowsException()
         {
             // generate random, NOT-ALL-ascending, unevenly-spaced data
             Random rand = new Random(0);
@@ -44,7 +44,34 @@ namespace ScottPlotTests.PlotTypes
             }
 
             var plt = new ScottPlot.Plot(500, 350);
-            Assert.Throws<ArgumentException>(() => { plt.AddSignalXY(xs, ys); });
+            var signalXY = plt.AddSignalXY(xs, ys);
+            Assert.Throws<InvalidOperationException>(() => { signalXY.ValidateData(deep: true); });
+        }
+
+        [Test]
+        public void Test_OutsideOfRenderLimitsNotAllXsAscend_ValidateDataDoesNotThrowException()
+        {
+            int pointCount = 1000;
+            int minRenderIndex = 100;
+            int maxRenderIndex = 200;
+            double[] ys = new double[pointCount];
+            double[] xs = new double[pointCount];
+            for (int i = 0; i < minRenderIndex; i++)
+            {
+                ys[i] = double.MaxValue;
+                xs[i] = double.MaxValue;
+            }
+            for (int i = minRenderIndex; i <= maxRenderIndex; i++)
+            {
+                ys[i] = i;
+                xs[i] = i;
+            }
+
+            var plt = new ScottPlot.Plot(500, 350);
+            var signalXY = plt.AddSignalXY(xs, ys);
+            signalXY.MinRenderIndex = minRenderIndex;
+            signalXY.MaxRenderIndex = maxRenderIndex;
+            Assert.DoesNotThrow(() => { signalXY.ValidateData(deep: true); });
         }
 
         [Test]

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotBase.cs
@@ -806,7 +806,7 @@ namespace ScottPlot.Plottable
                     throw new InvalidOperationException("Data must not contain NaN");
         }
 
-        public void ValidateData(bool deep = false)
+        public virtual void ValidateData(bool deep = false)
         {
             // check Y values
             if (Ys is null)

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -14,6 +14,12 @@ namespace ScottPlot.Plottable
     /// <typeparam name="TY"></typeparam>
     public class SignalPlotXYGeneric<TX, TY> : SignalPlotBase<TY>, IHasPointsGenericX<TX, TY> where TX : struct, IComparable where TY : struct, IComparable
     {
+        /// <summary>
+        /// Indicates whether Xs have been validated to ensure all values are ascending.
+        /// Validation occurs before the first render (not at assignment) to allow the user time to set min/max render indexes.
+        /// </summary>
+        private bool XsHaveBeenValidated = false;
+
         private TX[] _Xs;
         public TX[] Xs
         {
@@ -26,6 +32,7 @@ namespace ScottPlot.Plottable
                     throw new ArgumentException("XS must have at least one element");
 
                 _Xs = value;
+                XsHaveBeenValidated = false;
             }
         }
 
@@ -99,6 +106,12 @@ namespace ScottPlot.Plottable
 
         public override void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
         {
+            if (!XsHaveBeenValidated)
+            {
+                ValidateData(deep: true);
+                XsHaveBeenValidated = true;
+            }
+
             using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
             using (var brush = new SolidBrush(Color))
             using (var penHD = GDI.Pen(Color, (float)LineWidth, LineStyle, true))

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -108,7 +108,7 @@ namespace ScottPlot.Plottable
         {
             if (!XsHaveBeenValidated)
             {
-                ValidateData(deep: true);
+                Validate.AssertAscending("xs", Xs, MinRenderIndex, MaxRenderIndex);
                 XsHaveBeenValidated = true;
             }
 

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -27,10 +27,6 @@ namespace ScottPlot.Plottable
                 if (value.Length == 0)
                     throw new ArgumentException("XS must have at least one element");
 
-                for (int i = 1; i < value.Length; i++)
-                    if (value[i].CompareTo(value[i - 1]) < 0)
-                        throw new ArgumentException("Xs must only contain ascending values");
-
                 _Xs = value;
             }
         }
@@ -250,12 +246,14 @@ namespace ScottPlot.Plottable
             }
         }
 
-        public new void ValidateData(bool deep = false)
+        public override void ValidateData(bool deep = false)
         {
             base.ValidateData(deep);
             Validate.AssertEqualLength("xs and ys", Xs, Ys);
             Validate.AssertHasElements("xs", Xs);
-            Validate.AssertAscending("xs", Xs);
+
+            if (deep)
+                Validate.AssertAscending("xs", Xs, MinRenderIndex, MaxRenderIndex);
         }
 
         public override string ToString()

--- a/src/ScottPlot4/ScottPlot/Validate.cs
+++ b/src/ScottPlot4/ScottPlot/Validate.cs
@@ -68,14 +68,14 @@ namespace ScottPlot
         /// <summary>
         /// Throw an exception if one elemnt is equal to or less than the previous element
         /// </summary>
-        public static void AssertAscending<T>(string label, T[] values)
+        public static void AssertAscending<T>(string label, T[] values, int minIndex, int maxIndex)
         {
             label = ValidLabel(label);
 
             if (values is null)
                 throw new InvalidOperationException($"{label} must not be null");
 
-            for (int i = 0; i < values.Length - 1; i++)
+            for (int i = minIndex; i < maxIndex; i++)
                 if (Convert.ToDouble(values[i]) >= Convert.ToDouble(values[i + 1]))
                     throw new InvalidOperationException($"{label} must be ascending values (index {i} >= {i + 1}");
         }

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.42
 _not yet published on NuGet..._
 * SignalXY: Fixed bug causing plots to disappear when displaying partial data containing duplicated X values. (#1803, #1806) _Thanks @StendProg and @bernhardbreuss_
+* SignalXY: X data is no longer required to be ascending when it is first assigned, improving support for plots utilizing min/max render indexing (#1771, #1777) _Thanks @bernhardbreuss_
 
 ## ScottPlot 4.1.41
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-04-09_


### PR DESCRIPTION
Hi @swharden,

I have tried to solve #1771 by validating X only between min/max render index.
Doing the check only between min/max render index in the setter didn't worked out very well:
- min/max render index must be set before
- before setting max render index Ys must be set
- min/max render index would have been added to `AddSignalXY` which then already started to look like the obsolete `PlotSignalXY`

Therefore I decided to only use the already present check in `ValidateData`.