### PR TITLE
Plot: Allows drawing gridlines above the plottables

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Axis.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Axis.cs
@@ -72,6 +72,29 @@ namespace ScottPlot.Cookbook.Recipes.Ticks
         }
     }
 
+    class GridAbove : IRecipe
+    {
+        public string Category => "Axis and Ticks";
+        public string ID => "axis_gridAbove";
+        public string Title => "Draw Grid Above Plottables";
+        public string Description =>
+            "Sometimes it's useful to draw the grid lines above the plottables rather than below.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[] xs = DataGen.Consecutive(51);
+            double[] sines = DataGen.Sin(51);
+            double[] cosines = DataGen.Cos(51);
+
+            plt.AddScatter(xs, sines);
+            plt.AddScatter(xs, cosines);
+            plt.AddFill(xs, sines);
+            plt.AddFill(xs, cosines);
+
+            plt.DrawGridAbovePlottables = true;
+        }
+    }
+
     class GridConfigure : IRecipe
     {
         public string Category => "Axis and Ticks";

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Axis.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Axis.cs
@@ -91,7 +91,7 @@ namespace ScottPlot.Cookbook.Recipes.Ticks
             plt.AddFill(xs, sines);
             plt.AddFill(xs, cosines);
 
-            plt.DrawGridAbovePlottables = true;
+            plt.Grid(onTop: true);
         }
     }
 

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Axis.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Axis.cs
@@ -112,7 +112,8 @@ namespace ScottPlot
         /// <param name="enable">sets visibility of X and Y grid lines</param>
         /// <param name="color">sets color of of X and Y grid lines</param>
         /// <param name="lineStyle">defines the style for X and Y grid lines</param>
-        public void Grid(bool? enable = null, Color? color = null, LineStyle? lineStyle = null)
+        /// <param name="onTop">defines whether the grid is drawn on top of plottables</param>
+        public void Grid(bool? enable = null, Color? color = null, LineStyle? lineStyle = null, bool? onTop = null)
         {
             if (enable.HasValue)
             {
@@ -122,6 +123,9 @@ namespace ScottPlot
 
             XAxis.MajorGrid(color: color, lineStyle: lineStyle);
             YAxis.MajorGrid(color: color, lineStyle: lineStyle);
+
+            if (onTop.HasValue)
+                settings.DrawGridAbovePlottables = onTop.Value;
         }
 
         /// <summary>

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Render.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Render.cs
@@ -57,20 +57,9 @@ namespace ScottPlot
         {
             settings.DataBackground.Render(dims, bmp, lowQuality);
 
-            foreach (var axis in settings.Axes)
+            if (!DrawGridAbovePlottables)
             {
-                PlotDimensions dims2 = axis.IsHorizontal ?
-                    settings.GetPlotDimensions(axis.AxisIndex, 0, dims.ScaleFactor) :
-                    settings.GetPlotDimensions(0, axis.AxisIndex, dims.ScaleFactor);
-
-                try
-                {
-                    axis.Render(dims2, bmp, lowQuality);
-                }
-                catch (OverflowException)
-                {
-                    throw new InvalidOperationException("data cannot contain Infinity");
-                }
+                RenderAxes(bmp, lowQuality, dims);
             }
         }
 
@@ -100,6 +89,11 @@ namespace ScottPlot
 
         private void RenderAfterPlottables(Bitmap bmp, bool lowQuality, PlotDimensions dims)
         {
+            if (DrawGridAbovePlottables)
+            {
+                RenderAxes(bmp, lowQuality, dims);
+            }
+
             settings.CornerLegend.UpdateLegendItems(this);
 
             if (settings.CornerLegend.IsVisible)
@@ -112,6 +106,25 @@ namespace ScottPlot
             settings.ZoomRectangle.Render(dims, bmp, lowQuality);
             settings.BenchmarkMessage.Render(dims, bmp, lowQuality);
             settings.ErrorMessage.Render(dims, bmp, lowQuality);
+        }
+
+        private void RenderAxes(Bitmap bmp, bool lowQuality, PlotDimensions dims)
+        {
+            foreach (var axis in settings.Axes)
+            {
+                PlotDimensions dims2 = axis.IsHorizontal ?
+                    settings.GetPlotDimensions(axis.AxisIndex, 0, dims.ScaleFactor) :
+                    settings.GetPlotDimensions(0, axis.AxisIndex, dims.ScaleFactor);
+
+                try
+                {
+                    axis.Render(dims2, bmp, lowQuality);
+                }
+                catch (OverflowException)
+                {
+                    throw new InvalidOperationException("data cannot contain Infinity");
+                }
+            }
         }
 
         #endregion

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Render.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Render.cs
@@ -57,7 +57,7 @@ namespace ScottPlot
         {
             settings.DataBackground.Render(dims, bmp, lowQuality);
 
-            if (!DrawGridAbovePlottables)
+            if (!settings.DrawGridAbovePlottables)
             {
                 RenderAxes(bmp, lowQuality, dims);
             }
@@ -97,7 +97,7 @@ namespace ScottPlot
 
         private void RenderAfterPlottables(Bitmap bmp, bool lowQuality, PlotDimensions dims)
         {
-            if (DrawGridAbovePlottables)
+            if (settings.DrawGridAbovePlottables)
             {
                 RenderAxes(bmp, lowQuality, dims);
             }

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.cs
@@ -24,11 +24,6 @@ namespace ScottPlot
         public float Height { get => settings.Height; set => Resize(settings.Width, value); }
 
         /// <summary>
-        /// Determines whether the grid lines should be drawn above the plottables.
-        /// </summary>
-        public bool DrawGridAbovePlottables { get; set; } = false;
-
-        /// <summary>
         /// A ScottPlot stores data in plottable objects and draws it on a bitmap when Render() is called
         /// </summary>
         /// <param name="width">default width (pixels) to use when rendering</param>

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.cs
@@ -24,6 +24,11 @@ namespace ScottPlot
         public float Height { get => settings.Height; set => Resize(settings.Width, value); }
 
         /// <summary>
+        /// Determines whether the grid lines should be drawn above the plottables.
+        /// </summary>
+        public bool DrawGridAbovePlottables { get; set; } = false;
+
+        /// <summary>
         /// A ScottPlot stores data in plottable objects and draws it on a bitmap when Render() is called
         /// </summary>
         /// <param name="width">default width (pixels) to use when rendering</param>

--- a/src/ScottPlot4/ScottPlot/Settings.cs
+++ b/src/ScottPlot4/ScottPlot/Settings.cs
@@ -142,6 +142,11 @@ namespace ScottPlot
         /// </summary>
         public bool IgnoreOverflowExceptionsDuringRender = true;
 
+        /// <summary>
+        /// Determines whether the grid lines should be drawn above the plottables.
+        /// </summary>
+        public bool DrawGridAbovePlottables { get; set; } = false;
+
         public Settings()
         {
             Plottables.CollectionChanged += (object sender, NotifyCollectionChangedEventArgs e) => PlottablesIdentifier++;

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.42
 _not yet published on NuGet..._
 * SignalXY: Fixed bug causing plots to disappear when displaying partial data containing duplicated X values. (#1803, #1806) _Thanks @StendProg and @bernhardbreuss_
+* Grid: Calling `Plot.Grid(onTop: true)` will cause grid lines to be drawn on top of plottables (#1780, #1779, #1773) _Thanks @bclehmann and @KATAMANENI_
 
 ## ScottPlot 4.1.41
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-04-09_


### PR DESCRIPTION
**Purpose:**
#1779 
<img width="323" alt="image" src="https://user-images.githubusercontent.com/8635304/162870849-92530905-e55c-4445-9ea4-ef8d94728c73.png">

```cs
// You can insert code examples like this
plt.DrawGridAbovePlottables = true;
```

I have one small note about these changes, it doesn't technically draw just the grid lines after the plottables, it draws the entire axes after. This should be the same thing as I don't believe any other part of the axis can be drawn in the data area (or any plottables can be drawn outside the data area). Just a note in case that isn't a safe assumption.