### PR TITLE
FormsPlot: Fix exception when right mouse clicking on a plot with Crosshair.

### DIFF
--- a/src/ScottPlot4/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot4/ScottPlot.WinForms/FormsPlot.cs
@@ -209,6 +209,7 @@ namespace ScottPlot
         public void DefaultRightClickEvent(object sender, EventArgs e)
         {
             bool legendHasItems = Plot.GetPlottables()
+                .Where(x => x.GetLegendItems() != null)
                 .SelectMany(x => x.GetLegendItems())
                 .Where(x => !string.IsNullOrEmpty(x.label))
                 .Any();

--- a/src/ScottPlot4/ScottPlot/Plottable/Annotation.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Annotation.cs
@@ -41,7 +41,7 @@ namespace ScottPlot.Plottable
         public int YAxisIndex { get; set; } = 0;
 
         public override string ToString() => $"PlottableAnnotation at ({X} px, {Y} px)";
-        public LegendItem[] GetLegendItems() => null;
+        public LegendItem[] GetLegendItems() => Array.Empty<LegendItem>();
         public AxisLimits GetAxisLimits() => new AxisLimits(double.NaN, double.NaN, double.NaN, double.NaN);
 
         public void ValidateData(bool deep = false)

--- a/src/ScottPlot4/ScottPlot/Plottable/BubblePlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/BubblePlot.cs
@@ -83,7 +83,7 @@ namespace ScottPlot.Plottable
             }
         }
 
-        public LegendItem[] GetLegendItems() => null; // does not appear in legend
+        public LegendItem[] GetLegendItems() => Array.Empty<LegendItem>();
 
         public AxisLimits GetAxisLimits()
         {

--- a/src/ScottPlot4/ScottPlot/Plottable/Colorbar.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Colorbar.cs
@@ -177,7 +177,7 @@ namespace ScottPlot.Plottable
             SetTicks(fracs, labels);
         }
 
-        public LegendItem[] GetLegendItems() => null;
+        public LegendItem[] GetLegendItems() => Array.Empty<LegendItem>();
 
         public AxisLimits GetAxisLimits() => new(double.NaN, double.NaN, double.NaN, double.NaN);
 

--- a/src/ScottPlot4/ScottPlot/Plottable/CoxcombPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/CoxcombPlot.cs
@@ -150,7 +150,7 @@ namespace ScottPlot.Plottable
         public LegendItem[] GetLegendItems()
         {
             if (SliceLabels is null)
-                return null;
+                return Array.Empty<LegendItem>();
 
             return Enumerable
                 .Range(0, Values.Length)

--- a/src/ScottPlot4/ScottPlot/Plottable/Crosshair.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Crosshair.cs
@@ -132,7 +132,7 @@ namespace ScottPlot.Plottable
 
         public AxisLimits GetAxisLimits() => new(double.NaN, double.NaN, double.NaN, double.NaN);
 
-        public LegendItem[] GetLegendItems() => null;
+        public LegendItem[] GetLegendItems() => Array.Empty<LegendItem>();
 
         public void ValidateData(bool deep = false) { }
 

--- a/src/ScottPlot4/ScottPlot/Plottable/ErrorBar.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/ErrorBar.cs
@@ -58,10 +58,7 @@ namespace ScottPlot.Plottable
             return new AxisLimits(xMin, xMax, yMin, yMax);
         }
 
-        public LegendItem[] GetLegendItems()
-        {
-            return new LegendItem[0];
-        }
+        public LegendItem[] GetLegendItems() => Array.Empty<LegendItem>();
 
         public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
         {

--- a/src/ScottPlot4/ScottPlot/Plottable/FinancePlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/FinancePlot.cs
@@ -46,7 +46,7 @@ namespace ScottPlot.Plottable
 
         public bool IsVisible { get; set; } = true;
         public override string ToString() => $"FinancePlot with {OHLCs.Count} OHLC indicators";
-        public LegendItem[] GetLegendItems() => null;
+        public LegendItem[] GetLegendItems() => Array.Empty<LegendItem>();
         public int XAxisIndex { get; set; } = 0;
         public int YAxisIndex { get; set; } = 0;
 

--- a/src/ScottPlot4/ScottPlot/Plottable/IPlottable.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/IPlottable.cs
@@ -10,7 +10,7 @@
 
         /// <summary>
         /// Returns items to show in the legend. Most plottables return a single item. in this array will appear in the legend.
-        /// Plottables which never appear in the legend can return null.
+        /// Plottables which never appear in the legend should return an empty array (not null).
         /// </summary>
         LegendItem[] GetLegendItems();
 

--- a/src/ScottPlot4/ScottPlot/Plottable/Image.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Image.cs
@@ -53,7 +53,7 @@ namespace ScottPlot.Plottable
 
         public override string ToString() => $"PlottableImage Size(\"{Bitmap.Size}\") at ({X}, {Y})";
         public AxisLimits GetAxisLimits() => new AxisLimits(X, X, Y, Y);
-        public LegendItem[] GetLegendItems() => null;
+        public LegendItem[] GetLegendItems() => Array.Empty<LegendItem>();
 
         public void ValidateData(bool deep = false)
         {

--- a/src/ScottPlot4/ScottPlot/Plottable/PiePlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/PiePlot.cs
@@ -60,7 +60,7 @@ namespace ScottPlot.Plottable
         public LegendItem[] GetLegendItems()
         {
             if (SliceLabels is null)
-                return null;
+                return Array.Empty<LegendItem>();
 
             return Enumerable
                 .Range(0, Values.Length)

--- a/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
@@ -217,7 +217,7 @@ namespace ScottPlot.Plottable
         public LegendItem[] GetLegendItems()
         {
             if (GroupLabels is null)
-                return null;
+                return Array.Empty<LegendItem>();
 
             List<LegendItem> legendItems = new List<LegendItem>();
             for (int i = 0; i < GroupLabels.Length; i++)

--- a/src/ScottPlot4/ScottPlot/Plottable/RadialGaugePlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/RadialGaugePlot.cs
@@ -225,7 +225,7 @@ namespace ScottPlot.Plottable
         public LegendItem[] GetLegendItems()
         {
             if (Labels is null)
-                return null;
+                return Array.Empty<LegendItem>();
 
             List<LegendItem> legendItems = new();
             for (int i = 0; i < Labels.Length; i++)

--- a/src/ScottPlot4/ScottPlot/Plottable/ScaleBar.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/ScaleBar.cs
@@ -41,7 +41,7 @@ namespace ScottPlot.Plottable
 
         public override string ToString() => $"PlottableScaleBar ({HorizontalLabel}={Width}, {VerticalLabel}={Height})";
         public AxisLimits GetAxisLimits() => new AxisLimits(double.NaN, double.NaN, double.NaN, double.NaN);
-        public LegendItem[] GetLegendItems() => null;
+        public LegendItem[] GetLegendItems() => Array.Empty<LegendItem>();
 
         public void SetStyle(Color? tickMarkColor, Color? tickFontColor)
         {

--- a/src/ScottPlot4/ScottPlot/Plottable/Text.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Text.cs
@@ -39,7 +39,7 @@ namespace ScottPlot.Plottable
 
         public override string ToString() => $"PlottableText \"{Label}\" at ({X}, {Y})";
         public AxisLimits GetAxisLimits() => new AxisLimits(X, X, Y, Y);
-        public LegendItem[] GetLegendItems() => null;
+        public LegendItem[] GetLegendItems() => Array.Empty<LegendItem>();
 
         public void ValidateData(bool deep = false)
         {

--- a/src/ScottPlot4/ScottPlot/Plottable/Tooltip.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Tooltip.cs
@@ -34,7 +34,7 @@ namespace ScottPlot.Plottable
         /// </summary>
         public double Y;
 
-        public LegendItem[] GetLegendItems() => null;
+        public LegendItem[] GetLegendItems() => Array.Empty<LegendItem>();
 
         public AxisLimits GetAxisLimits() => new AxisLimits(double.NaN, double.NaN, double.NaN, double.NaN);
 

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -5,6 +5,7 @@ _not yet published on NuGet..._
 * SignalXY: Fixed bug causing plots to disappear when displaying partial data containing duplicated X values. (#1803, #1806) _Thanks @StendProg and @bernhardbreuss_
 * SignalXY: X data is no longer required to be ascending when it is first assigned, improving support for plots utilizing min/max render indexing (#1771, #1777) _Thanks @bernhardbreuss_
 * Grid: Calling `Plot.Grid(onTop: true)` will cause grid lines to be drawn on top of plottables (#1780, #1779, #1773) _Thanks @bclehmann and @KATAMANENI_
+* FormsPlot: Fixed a bug that caused the default right-click menu to throw an exception when certain types of plottables were present (#1791, #1794) _Thanks @ShenxuanLi, @MareMare, and @StendProg_
 
 ## ScottPlot 4.1.41
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-04-09_


### PR DESCRIPTION
**Purpose:**
I tried solve #1791.

Fixed a `NullReferenceException` exception raised by right mouse click on a WinForms Plot with Crosshair. 
