### PR TITLE
SignalXY: Fix bug where extrapolated pixel location could be infinity and crash GDI

### DIFF
--- a/src/ScottPlot4/ScottPlot.Tests/PlotTypes/SignalXY.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlotTypes/SignalXY.cs
@@ -1,9 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
-using System.Text;
 
 namespace ScottPlotTests.PlotTypes
 {
@@ -81,6 +78,32 @@ namespace ScottPlotTests.PlotTypes
                 plt.AxisZoom(.1, .1);
                 plt.Render();
             }
+        }
+
+        /// <summary>
+        /// This test for debug purpose only, it always pass
+        /// reproduce #1803 bug
+        /// this test trew OverflowException, but ScottPlot handle it in Plot.Render.RenderPlottables()
+        /// But it possible to catch in debugger
+        /// </summary>
+        [Test]
+        public void Test_SignalXY1803Bug_Throws()
+        {
+            var plt = new ScottPlot.Plot(1200, 800);
+            double[] ys = new double[10000];
+            double[] xs = ys.Select(x => double.PositiveInfinity).ToArray();
+            double r = 0.0;
+            for (int i = 0; i < ys.Length; i++)
+            {
+                r += 0.005;
+                xs[i] = r;
+                ys[i] = Math.Sin(r);
+            }
+            var signalXY = plt.AddSignalXY(xs, ys);
+            plt.AxisAutoY();
+            plt.XAxis.Dims.SetAxis(min: r - 10.0, r);
+            plt.Validate(deep: true);
+            plt.Render();
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Render.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Render.cs
@@ -91,9 +91,17 @@ namespace ScottPlot
                 {
                     plottable.Render(dims, bmp, lowQuality);
                 }
-                catch (OverflowException)
+                catch (OverflowException ex)
                 {
-                    Debug.WriteLine($"OverflowException plotting: {plottable}");
+                    // This exception is commonly thrown by System.Drawing when drawing to extremely large pixel locations.
+                    if (settings.IgnoreOverflowExceptionsDuringRender)
+                    {
+                        Debug.WriteLine($"OverflowException plotting: {plottable}");
+                    }
+                    else
+                    {
+                        throw new OverflowException("overflow during render", ex);
+                    }
                 }
             }
         }

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -1,11 +1,9 @@
 ﻿using ScottPlot.Drawing;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Runtime.InteropServices;
 
 namespace ScottPlot.Plottable
 {
@@ -183,8 +181,11 @@ namespace ScottPlot.Plottable
                 if (PointBefore.Length > 0 && PointsToDraw.Length >= 2 && !StepDisplay)
                 {
                     float x0 = -1 + dims.DataOffsetX;
-                    float y0 = PointsToDraw[1].Y + (PointsToDraw[0].Y - PointsToDraw[1].Y) * (x0 - PointsToDraw[1].X) / (PointsToDraw[0].X - PointsToDraw[1].X);
-                    PointsToDraw[0] = new PointF(x0, y0);
+                    if (PointsToDraw[0].X != PointsToDraw[1].X)
+                    {
+                        float y0 = PointsToDraw[1].Y + (PointsToDraw[0].Y - PointsToDraw[1].Y) * (x0 - PointsToDraw[1].X) / (PointsToDraw[0].X - PointsToDraw[1].X);
+                        PointsToDraw[0] = new PointF(x0, y0);
+                    }
                 }
 
                 // Interpolate after displayed point to make it x = datasize.Width(close to visible area)
@@ -193,10 +194,12 @@ namespace ScottPlot.Plottable
                 {
                     PointF lastPoint = PointsToDraw[PointsToDraw.Length - 2];
                     PointF afterPoint = PointsToDraw[PointsToDraw.Length - 1];
-
-                    float x1 = dims.DataWidth + dims.DataOffsetX;
-                    float y1 = lastPoint.Y + (afterPoint.Y - lastPoint.Y) * (x1 - lastPoint.X) / (afterPoint.X - lastPoint.X);
-                    PointsToDraw[PointsToDraw.Length - 1] = new PointF(x1, y1);
+                    if (afterPoint.X != lastPoint.X)
+                    {
+                        float x1 = dims.DataWidth + dims.DataOffsetX;
+                        float y1 = lastPoint.Y + (afterPoint.Y - lastPoint.Y) * (x1 - lastPoint.X) / (afterPoint.X - lastPoint.X);
+                        PointsToDraw[PointsToDraw.Length - 1] = new PointF(x1, y1);
+                    }
                 }
 
                 // Simulate a step display by adding extra points at the corners.

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -180,9 +180,9 @@ namespace ScottPlot.Plottable
                 // this fix extreme zoom in bug
                 if (PointBefore.Length > 0 && PointsToDraw.Length >= 2 && !StepDisplay)
                 {
-                    float x0 = -1 + dims.DataOffsetX;
                     if (PointsToDraw[0].X != PointsToDraw[1].X)
                     {
+                        float x0 = -1 + dims.DataOffsetX;
                         float y0 = PointsToDraw[1].Y + (PointsToDraw[0].Y - PointsToDraw[1].Y) * (x0 - PointsToDraw[1].X) / (PointsToDraw[0].X - PointsToDraw[1].X);
                         PointsToDraw[0] = new PointF(x0, y0);
                     }

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -180,6 +180,7 @@ namespace ScottPlot.Plottable
                 // this fix extreme zoom in bug
                 if (PointBefore.Length > 0 && PointsToDraw.Length >= 2 && !StepDisplay)
                 {
+                    // only extrapolate if points are different (otherwise extrapolated point may be infinity)
                     if (PointsToDraw[0].X != PointsToDraw[1].X)
                     {
                         float x0 = -1 + dims.DataOffsetX;
@@ -194,6 +195,8 @@ namespace ScottPlot.Plottable
                 {
                     PointF lastPoint = PointsToDraw[PointsToDraw.Length - 2];
                     PointF afterPoint = PointsToDraw[PointsToDraw.Length - 1];
+
+                    // only extrapolate if points are different (otherwise extrapolated point may be infinity)
                     if (afterPoint.X != lastPoint.X)
                     {
                         float x1 = dims.DataWidth + dims.DataOffsetX;

--- a/src/ScottPlot4/ScottPlot/Settings.cs
+++ b/src/ScottPlot4/ScottPlot/Settings.cs
@@ -136,6 +136,12 @@ namespace ScottPlot
         /// </summary>
         public double MarginsY = .1;
 
+        /// <summary>
+        /// Controls whether OferflowException is ignored in the Render() method.
+        /// This exception is commonly thrown by System.Drawing when drawing to extremely large pixel locations.
+        /// </summary>
+        public bool IgnoreOverflowExceptionsDuringRender = true;
+
         public Settings()
         {
             Plottables.CollectionChanged += (object sender, NotifyCollectionChangedEventArgs e) => PlottablesIdentifier++;

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -1,5 +1,9 @@
 # ScottPlot Changelog
 
+## ScottPlot 4.1.42
+_not yet published on NuGet..._
+* SignalXY: Fixed bug causing plots to disappear when displaying partial data containing duplicated X values. (#1803, #1806) _Thanks @StendProg and @bernhardbreuss_
+
 ## ScottPlot 4.1.41
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-04-09_
 * Plot: Added `Plot.GetImageHTML()` to make it easy to display ScottPlot images in .NET Interactive / Jupyter notebooks (#1772) _Thanks @StendProg and @Regenhardt_


### PR DESCRIPTION
**Purpose:**
Fix for #1803 

SignalXY in some cases, due to rounding errors when converting to `PointF`, the `PointBefore` has the same x coordinate as the first drawn point. As a result, interpolation between these points results in an `Overflow Exception`. Although ScottPlot catches this exception and continues to work, it becomes impossible to display SignalXY.

Since interpolation between these points was introduced for only one reason - GDI does not correctly draw points with strongly negative coordinates. In our case, the error occurs when both points have a coordinate close to 0. Therefore, this fix simply skips interpolation if the x coordinates are equal, because it is definitely not needed in this case.

I decided to keep the test that I used to reproduce the error, but it can be safely removed, because it can only be useful for manual debugging.