### PR TITLE
Fix middle-click-drag zooming for Avalonia

### DIFF
--- a/src/ScottPlot4/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot4/ScottPlot/Control/Backend.cs
@@ -139,11 +139,6 @@ namespace ScottPlot.Control
         private bool IsZoomingRectangle;
 
         /// <summary>
-        /// True if a zoom rectangle is being actively drawn using ALT + left click
-        /// </summary>
-        private bool IsZoomingWithAlt;
-
-        /// <summary>
         /// The plot underlying this control.
         /// </summary>
         public Plot Plot { get; private set; }
@@ -531,15 +526,14 @@ namespace ScottPlot.Control
         /// </summary>
         public void MouseMove(InputState input)
         {
-            bool altWasLifted = IsZoomingWithAlt && !input.AltDown;
-            bool middleButtonLifted = IsZoomingRectangle && !input.MiddleWasJustPressed;
-            if (IsZoomingRectangle && (altWasLifted || middleButtonLifted))
-                Settings.ZoomRectangle.Clear();
+            bool isZoomingRectangleWithAltLeft = IsLeftDown && input.AltDown;
+            bool isZoomingRectangleWithMiddle = IsMiddleDown && Configuration.MiddleClickDragZoom;
 
-            IsZoomingWithAlt = IsLeftDown && input.AltDown;
-            bool isMiddleClickDragZooming = IsMiddleDown && !middleButtonLifted;
-            bool isZooming = IsZoomingWithAlt || isMiddleClickDragZooming;
-            IsZoomingRectangle = isZooming && Configuration.MiddleClickDragZoom && MouseDownDragged;
+            bool wasZoomingRectangle = IsZoomingRectangle;
+            IsZoomingRectangle = isZoomingRectangleWithAltLeft || isZoomingRectangleWithMiddle;
+
+            if (wasZoomingRectangle && !IsZoomingRectangle)
+                Settings.ZoomRectangle.Clear();
 
             MouseDownTravelDistance += Math.Abs(input.X - MouseLocationX);
             MouseDownTravelDistance += Math.Abs(input.Y - MouseLocationY);

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -6,6 +6,7 @@ _not yet published on NuGet..._
 * SignalXY: X data is no longer required to be ascending when it is first assigned, improving support for plots utilizing min/max render indexing (#1771, #1777) _Thanks @bernhardbreuss_
 * Grid: Calling `Plot.Grid(onTop: true)` will cause grid lines to be drawn on top of plottables (#1780, #1779, #1773) _Thanks @bclehmann and @KATAMANENI_
 * FormsPlot: Fixed a bug that caused the default right-click menu to throw an exception when certain types of plottables were present (#1791, #1794) _Thanks @ShenxuanLi, @MareMare, and @StendProg_
+* Avalonia: Improved middle-click-drag zoom-rectangle behavior (#1807) _Thanks @kivarsen_
 
 ## ScottPlot 4.1.41
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-04-09_


### PR DESCRIPTION
**Purpose**
Middle-click-drag zooming was not working consistently for the Avalonia control. It would only actually zoom in about half the time.

![ScottPlot Avalonia zoom bug](https://user-images.githubusercontent.com/10566929/165645595-bf4554c6-02b8-4e05-9ad0-f5259e997b37.gif)

**Details**
The difference in behavior between Avalonia and WinForms/WPF/Eto seems to be in the semantics of MiddleWasJustPressed. For the other platforms, MiddleWasJustPressed is essentially identical to IsMiddleDown when evaluated within Backend.MouseMove(). However, in the Avalonia implementation, MiddleWasJustPressed==true only within MouseDown. The result of MiddleWasJustPressed always being false in Backend.MouseMove() was that IsZoomingRectangle would toggle between true and false on each event when the middle button was down, causing the actual zoom to randomly fail 50% of the time when MouseUp() eventually fired.

I tried to streamline the logic a bit and only depend IsXDown within the MouseMove handler. 

**Testing**
I tested the new code in the Avalonia, Eto.Forms, WinForms, and WPF demo apps using both middle-click-drag and alt-left-drag methods of zooming, and everything seems consistent and reliable. I also tested various draggables and they seem to perform as expected.