### PR TITLE
Fix the Avalonia control to display the context menu next to the mouse...

### DIFF
--- a/src/ScottPlot4/ScottPlot.Avalonia/AvaPlot.axaml.cs
+++ b/src/ScottPlot4/ScottPlot.Avalonia/AvaPlot.axaml.cs
@@ -6,6 +6,7 @@ using Avalonia.Threading;
 using Avalonia.VisualTree;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using Ava = Avalonia;
 
@@ -32,7 +33,6 @@ namespace ScottPlot.Avalonia
 
         /// <summary>
         /// This event is invoked any time the plot is right-clicked.
-        /// By default it contains DefaultRightClickEvent(), but you can remove this and add your own method.
         /// </summary>
         public event EventHandler RightClicked;
 
@@ -89,7 +89,8 @@ namespace ScottPlot.Avalonia
             Backend.Configuration.ScaleChanged += new EventHandler(OnScaleChanged);
             Configuration = Backend.Configuration;
 
-            RightClicked += DefaultRightClickEvent;
+            ContextMenuProperty.Changed.Subscribe(ContextMenuChanged);
+            ContextMenu = GetDefaultContextMenu();
 
             InitializeLayout();
             Backend.StartProcessingEvents();
@@ -169,7 +170,7 @@ namespace ScottPlot.Avalonia
 
             PointerPressed += OnMouseDown;
             PointerMoved += OnMouseMove;
-            PointerReleased += OnMouseUp;
+            // Note: PointerReleased is handled in OnPointerReleased override instead
             PointerWheelChanged += OnMouseWheel;
             PointerEnter += OnMouseEnter;
             PointerLeave += OnMouseLeave;
@@ -250,7 +251,47 @@ namespace ScottPlot.Avalonia
             return cm;
         }
 
-        public void DefaultRightClickEvent(object sender, EventArgs e) => GetDefaultContextMenu().Open(this);
+        private void ContextMenuChanged(AvaloniaPropertyChangedEventArgs e)
+        {
+            // Make sure that any context menus that get assigned do not 
+            // display when the right mouse button is released if the mouse
+            // was dragged while the button was down
+
+            if (e.OldValue is ContextMenu oldMenu)
+            {
+                oldMenu.ContextMenuOpening -= InhibitContextMenuIfMouseDragged;
+            }
+            if (e.NewValue is ContextMenu newMenu)
+            {
+                newMenu.ContextMenuOpening += InhibitContextMenuIfMouseDragged;
+            }
+        }
+
+        private void InhibitContextMenuIfMouseDragged(object sender, CancelEventArgs e)
+        {
+            e.Cancel = Backend.MouseDownDragged;
+        }
+
+        protected override void OnPointerReleased(PointerReleasedEventArgs e)
+        {
+            // First, make sure backend sees that we are no longer pressing mouse button.
+            // Otherwise, after selecting an item from the context menu, the control
+            // will still think we are right-click-dragging even though the button
+            // is no longer down.
+            OnMouseUp(this, e);
+
+            // Then allow Avalonia's own click handling to allow the context menu
+            // to be displayed if needed.
+            base.OnPointerReleased(e);
+        }
+
+        /// <summary>
+        /// This default handler is no longer used to display a context menu, but is kept 
+        /// around for backwards compatibility with existing code that expects to remove 
+        /// this handler before adding custom right-click handling.
+        /// </summary>
+        [Obsolete("use 'ContextMenu' property instead to assign custom context menus")]
+        public void DefaultRightClickEvent(object sender, EventArgs e) { }
         private void RightClickMenu_Copy_Click(object sender, EventArgs e) => throw new NotImplementedException();
         private void RightClickMenu_Help_Click(object sender, EventArgs e) => new HelpWindow().Show();
         private void RightClickMenu_AutoAxis_Click(object sender, EventArgs e) { Plot.AxisAuto(); Refresh(); }

--- a/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/RightClickMenu.axaml.cs
+++ b/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.Avalonia/AvaloniaDemos/RightClickMenu.axaml.cs
@@ -8,12 +8,6 @@ using System.Collections.Generic;
 
 namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
 {
-    public struct ContextMenuItem
-    {
-        public string itemName;
-        public Action onClick;
-    }
-
     public class RightClickMenu : Window
     {
         private readonly AvaPlot avaPlot1;
@@ -30,27 +24,27 @@ namespace ScottPlot.Demo.Avalonia.AvaloniaDemos
             avaPlot1.Plot.AddSignal(DataGen.Cos(51));
             avaPlot1.Refresh();
 
-            List<ContextMenuItem> contextMenu = new List<ContextMenuItem>
+            ContextMenu contextMenu = new ContextMenu
             {
-                new ContextMenuItem()
-                {
-                    itemName = "Add Sine Wave",
-                    onClick = AddSine
-                },
-
-                new ContextMenuItem()
-                {
-                    itemName = "Clear Plot",
-                    onClick = ClearPlot
+                Items = new[] {
+                    MakeMenuItem("Add Sine Wave", AddSine),
+                    MakeMenuItem("Clear Plot", ClearPlot)
                 }
             };
 
-            //avaPlot1.SetContextMenu(contextMenu);
+            avaPlot1.ContextMenu = contextMenu;
         }
 
         public void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
+        }
+
+        private MenuItem MakeMenuItem(string label, Action onClick)
+        {
+            MenuItem menuItem = new MenuItem() { Header = label };
+            menuItem.Click += (sender, e) => onClick();
+            return menuItem;
         }
 
         private void AddSine()

--- a/src/ScottPlot4/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot4/ScottPlot/Control/Backend.cs
@@ -219,7 +219,7 @@ namespace ScottPlot.Control
         /// <summary>
         /// True if the mouse was dragged (with a button down) long enough to quality as a drag instead of a click
         /// </summary>
-        private bool MouseDownDragged => MouseDownTravelDistance > Configuration.IgnoreMouseDragDistance;
+        public bool MouseDownDragged => MouseDownTravelDistance > Configuration.IgnoreMouseDragDistance;
 
 
         /// <summary>

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -7,6 +7,7 @@ _not yet published on NuGet..._
 * Grid: Calling `Plot.Grid(onTop: true)` will cause grid lines to be drawn on top of plottables (#1780, #1779, #1773) _Thanks @bclehmann and @KATAMANENI_
 * FormsPlot: Fixed a bug that caused the default right-click menu to throw an exception when certain types of plottables were present (#1791, #1794) _Thanks @ShenxuanLi, @MareMare, and @StendProg_
 * Avalonia: Improved middle-click-drag zoom-rectangle behavior (#1807) _Thanks @kivarsen_
+* Avalonia: Improved position of right-click menu (#1809) _Thanks @kivarsen_
 
 ## ScottPlot 4.1.41
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-04-09_


### PR DESCRIPTION
…pointer rather than along the top/bottom edge of the control.

Supports use of Avalonia's ContextMenu property, and will not show the menu if the mouse had been dragged while the right mouse button was pressed.

Also completes the implementation of the "Custom Right-Click Menu" control demo.

**Purpose:**
Here is the original behavior:
![ScottPlot Avalonia context menu](https://user-images.githubusercontent.com/10566929/165682423-54f85349-504a-43bb-8eea-91d73e26139f.gif)

And the new behavior:
![ScottPlot context menu fix](https://user-images.githubusercontent.com/10566929/165683658-3c0ce886-8b63-4815-b641-2c5f82e1a97a.gif)

**Implementation**
The public ContextMenu.Open(Control) method in Avalonia does not take pointer position into account, so the context menu gets shown with Bottom alignment by default (switching to Top if there is not enough space).

There is a 3-argument override to Open() that includes an isRequestedByPointer argument. If true, it displays the menu at the pointer position. Unfortunately, this override is private. (I have a branch that calls this method using reflection. It works well but feels messy.)

Instead, this commit handles the context menu using Avalonia's built-in ContextMenu property and display handling. The biggest downside of the default handling is that the menu will display after a right-click-drag zoom sequence. To account for this, I made Backend.MouseDownDragged public, and automatically add an event handler to any ContextMenu assigned to AvaPlot that will inhibit display of the context menu if the mouse has been dragged.

The other problem with this scheme is that OnPointerReleased will get handled by a superclass of UserControl and AvaPlot won't get a chance to detect that the right mouse button has been released. This will cause the control to continue to be in a right-drag-zoom state after selecting an item from the context menu. To prevent this, the implementation overrides OnPointerReleased so that we can handle the pointer release first and then pass on to base classes for context menu display handling.

