### PR TITLE
Add double-click event handling to Avalonia control

### DIFF
--- a/src/ScottPlot4/ScottPlot.Avalonia/AvaPlot.axaml.cs
+++ b/src/ScottPlot4/ScottPlot.Avalonia/AvaPlot.axaml.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -139,7 +140,7 @@ namespace ScottPlot.Avalonia
         private void OnScaleChanged(object sender, EventArgs e) { System.Diagnostics.Debug.WriteLine("SCALECHANGED"); OnSizeChanged(null, null); }
         private void OnMouseDown(object sender, PointerEventArgs e) { CaptureMouse(e.Pointer); Backend.MouseDown(GetInputState(e)); }
         private void OnMouseUp(object sender, PointerEventArgs e) { Backend.MouseUp(GetInputState(e)); UncaptureMouse(e.Pointer); }
-        private void OnDoubleClick(object sender, PointerEventArgs e) => Backend.DoubleClick();
+        private void OnDoubleClick(object sender, RoutedEventArgs e) => Backend.DoubleClick();
         private void OnMouseWheel(object sender, PointerWheelEventArgs e) => Backend.MouseWheel(GetInputState(e, e.Delta.Y));
         private void OnMouseMove(object sender, PointerEventArgs e) { Backend.MouseMove(GetInputState(e)); base.OnPointerMoved(e); }
         private void OnMouseEnter(object sender, PointerEventArgs e) => base.OnPointerEnter(e);
@@ -173,7 +174,7 @@ namespace ScottPlot.Avalonia
             PointerWheelChanged += OnMouseWheel;
             PointerEnter += OnMouseEnter;
             PointerLeave += OnMouseLeave;
-
+            DoubleTapped += OnDoubleClick;
             PropertyChanged += AvaPlot_PropertyChanged;
         }
 

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.41
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-04-09_
 * Plot: Added `Plot.GetImageHTML()` to make it easy to display ScottPlot images in .NET Interactive / Jupyter notebooks (#1772) _Thanks @StendProg and @Regenhardt_
+* Avalonia: Added double-click support which displays benchmark information by default (#1810) _Thanks @kivarsen_
 
 ## ScottPlot 4.1.40
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-04-07_

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -8,11 +8,11 @@ _not yet published on NuGet..._
 * FormsPlot: Fixed a bug that caused the default right-click menu to throw an exception when certain types of plottables were present (#1791, #1794) _Thanks @ShenxuanLi, @MareMare, and @StendProg_
 * Avalonia: Improved middle-click-drag zoom-rectangle behavior (#1807) _Thanks @kivarsen_
 * Avalonia: Improved position of right-click menu (#1809) _Thanks @kivarsen_
+* Avalonia: Added double-click support which displays benchmark information by default (#1810) _Thanks @kivarsen_
 
 ## ScottPlot 4.1.41
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-04-09_
 * Plot: Added `Plot.GetImageHTML()` to make it easy to display ScottPlot images in .NET Interactive / Jupyter notebooks (#1772) _Thanks @StendProg and @Regenhardt_
-* Avalonia: Added double-click support which displays benchmark information by default (#1810) _Thanks @kivarsen_
 
 ## ScottPlot 4.1.40
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-04-07_


### PR DESCRIPTION
**Purpose:**
After adding this, double-clicking to toggle the benchmark display works correctly:
![ScottPlott double click](https://user-images.githubusercontent.com/10566929/165686723-78249374-ff35-40e7-b98e-6ca85e320bc6.gif)

