### PR TITLE
Axis: improve support for switching between formatting strings and functions

### DIFF
--- a/src/ScottPlot4/ScottPlot.Tests/Axis/TickLabel.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/Axis/TickLabel.cs
@@ -73,5 +73,34 @@ namespace ScottPlotTests.Axis
 
             TestTools.SaveFig(plt);
         }
+
+        [Test]
+        public void Test_Format_CanBeReversed()
+        {
+            // Demonstrates bug described in https://github.com/ScottPlot/ScottPlot/pull/1813
+
+            var plt = new ScottPlot.Plot(800, 600);
+            var sig = plt.AddSignal(ScottPlot.DataGen.Sin(1000));
+
+            // repeat this multiple times to ensure changes can be undone/redone
+            for (int i = 0; i < 3; i++)
+            {
+                // custom NUMERIC format string
+                plt.XAxis.TickLabelFormat("F4", dateTimeFormat: false);
+                plt.Render();
+                Assert.AreEqual("0.0000", plt.XAxis.GetTicks().First().Label);
+
+                // custom DATETIME format string
+                plt.XAxis.TickLabelFormat("HH:mm:ss", dateTimeFormat: true);
+                plt.Render();
+                Assert.AreEqual("00:00:00", plt.XAxis.GetTicks().First().Label);
+
+                // custom format FUNCTION
+                static string customFormatter(double x) => "custom";
+                plt.XAxis.TickLabelFormat(customFormatter);
+                plt.Render();
+                Assert.AreEqual("custom", plt.XAxis.GetTicks().First().Label);
+            }
+        }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Renderable/Axis.cs
+++ b/src/ScottPlot4/ScottPlot/Renderable/Axis.cs
@@ -213,6 +213,7 @@ namespace ScottPlot.Renderable
         public void TickLabelFormat(Func<double, string> tickFormatter)
         {
             AxisTicks.TickCollection.ManualTickFormatter = tickFormatter;
+            TickLabelFormat(null, false);
         }
 
         /// <summary>

--- a/src/ScottPlot4/ScottPlot/Renderable/Axis.cs
+++ b/src/ScottPlot4/ScottPlot/Renderable/Axis.cs
@@ -213,7 +213,11 @@ namespace ScottPlot.Renderable
         public void TickLabelFormat(Func<double, string> tickFormatter)
         {
             AxisTicks.TickCollection.ManualTickFormatter = tickFormatter;
-            TickLabelFormat(null, false);
+
+            // delete existing custom tick format strings
+            AxisTicks.TickCollection.numericFormatString = null;
+            AxisTicks.TickCollection.dateTimeFormatString = null;
+            AxisTicks.TickCollection.LabelFormat = ScottPlot.Ticks.TickLabelFormat.Numeric;
         }
 
         /// <summary>
@@ -221,6 +225,9 @@ namespace ScottPlot.Renderable
         /// </summary>
         public void TickLabelFormat(string format, bool dateTimeFormat)
         {
+            // delete existing tick formatter function
+            AxisTicks.TickCollection.ManualTickFormatter = null;
+
             if (dateTimeFormat)
             {
                 AxisTicks.TickCollection.dateTimeFormatString = format;

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -9,6 +9,7 @@ _not yet published on NuGet..._
 * Avalonia: Improved middle-click-drag zoom-rectangle behavior (#1807) _Thanks @kivarsen_
 * Avalonia: Improved position of right-click menu (#1809) _Thanks @kivarsen_
 * Avalonia: Added double-click support which displays benchmark information by default (#1810) _Thanks @kivarsen_
+* Axis: Improved support for switching between custom tick label format strings and custom formatter functions (#1813) _Thanks @schifazl_
 
 ## ScottPlot 4.1.41
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-04-09_


### PR DESCRIPTION
### The problem
I don't know if this is a bug, a wanted behaviour or a corner case which wasn't considered before.

I have a plot which is used to display one or more ScatterPlot series coming from different measures. Each measure has a different duration (from 2 minutes to 45 minutes), so I've added a checkbox to my WPF form in order to switch the X axis from normal to logarithmic. In this way, multiple series are displayed more clearly.

This means that I have to switch from a DateTime format X axis:

`simPlot.Plot.XAxis.TickLabelFormat("HH:mm:ss", true);`

to a logarithmix X axis with custom format:

`static string logTickLabels(double x) => DateTime.FromOADate(Math.Pow(10, x)).ToString("HH:mm:ss");
simPlot.Plot.XAxis.TickLabelFormat(logTickLabels);`

But I noticed that when switching the axis from the DateTime to the logarithmic format, the logTickLabels function won't be called and the label will be wrong. Digging into the library I noticed that since the `TickLabelFormat` is set as `DateTime `, the `TickCollection.Recalculate` method calls the `RecalculatePositionsAutomaticDatetime` instead of the `RecalculatePositionsAutomaticNumeric` method.

### The solution
I fixed this by explicitly calling `TickLabelFormat(null, false)` when calling the `TickLabelFormat(Func<double, string> tickFormatter)` method.


### The workaround
If this behaviour is not a bug, but is wanted and should not be changed, the workaround is to manually call `scottPlot.Plot.XAxis.DateTimeFormat(false)` whenever going from the DateTime label format to the numeric one.