### PR TITLE
Fix inverted sign handling for additional axis ticks

### DIFF
--- a/src/ScottPlot4/ScottPlot/Ticks/TickCollection.cs
+++ b/src/ScottPlot4/ScottPlot/Ticks/TickCollection.cs
@@ -563,10 +563,12 @@ namespace ScottPlot.Ticks
 
             if (additionalTickPositions is not null)
             {
+                double sign = LabelUsingInvertedSign ? -1 : 1;
+
                 for (int i = 0; i < additionalTickPositions.Length; i++)
                 {
                     var tick = new Tick(
-                        position: additionalTickPositions[i],
+                        position: additionalTickPositions[i] * sign,
                         label: additionalTickLabels[i],
                         isMajor: true,
                         isDateTime: LabelFormat == TickLabelFormat.DateTime);

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.43
 _not yet published on NuGet..._
 * Draggable Scatter Plot: Fixed a bug where horizontal drag limits were applied to the vertical axis (#1795) _Thanks @m4se_
+* Plot: Improved support for user-defined ticks when inverted axis mode is enabled (#1826, #1814) _Thanks @Xerxes004_
 
 ## ScottPlot 4.1.42
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-05-01_


### PR DESCRIPTION
**Purpose:**
* Fixes a bug where manual tick labels were not reversed with the other labels

**Example:**
```c#
double[] positions = { Math.PI, 2 * Math.PI };
string[] labels = { "π", "2π" };
plt.XAxis.AutomaticTickPositions(positions, labels);
plt.XAxis.TickDensity(0.5);
plt.XAxis.TickLabelNotation(invertSign: true);
```

**Before:**
![before](https://user-images.githubusercontent.com/9276814/166337996-69b309f5-2f45-4eb1-aeee-49b80ecdc01b.png)

**After:**
![after](https://user-images.githubusercontent.com/9276814/166338004-add68563-4379-435c-a8a0-e409e8549a0b.png)
