### PR TITLE
Image: Add axis dependent sizing and bugfixes

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Image.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Image.cs
@@ -110,4 +110,32 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             });
         }
     }
+
+    public class ImageSize : IRecipe
+    {
+        public ICategory Category => new Categories.PlotTypes.Image();
+        public string ID => "image_size";
+        public string Title => "Image Size";
+        public string Description =>
+            "By default the image size is independent to the axis, but the size can be customized.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            // display some sample data
+            plt.AddSignal(DataGen.Sin(51));
+            plt.AddSignal(DataGen.Cos(51));
+
+            // place an image on the plot
+            plt.Add(new ScottPlot.Plottable.Image()
+            {
+                Bitmap = DataGen.SampleImage(),
+                X = 10,
+                Y = .5,
+                WidthInAxisUnits = 10,
+                HeightInAxisUnits = 1,
+                BorderColor = Color.Magenta,
+                BorderSize = 5,
+            });
+        }
+    }
 }

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Image.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Image.cs
@@ -11,23 +11,16 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string ID => "image_quickstart";
         public string Title => "Image Quickstart";
         public string Description =>
-            "The Image plottable places a Bitmap at a location in X/Y space." +
-            "The image's position will move in space as the axes move, but the " +
-            "size of the bitmap will always be the same (matched to the display resolution). ";
+            "The Image plottable places a Bitmap at coordinte in axis space.";
 
         public void ExecuteRecipe(Plot plt)
         {
-            // display some sample data
             plt.AddSignal(DataGen.Sin(51));
             plt.AddSignal(DataGen.Cos(51));
 
-            // create the bitmap we want to display
             Bitmap monaLisa = DataGen.SampleImage();
 
-            // create the image plottable and add it to the plot
-            var imagePlot = new ScottPlot.Plottable.Image() { Bitmap = monaLisa, X = 10, Y = .5 };
-
-            plt.Add(imagePlot);
+            plt.AddImage(monaLisa, 10, .5);
         }
     }
 
@@ -38,27 +31,23 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string Title => "Image Alignment";
         public string Description =>
             "By default the X/Y coordinates define the upper left position of the image, " +
-            "but alignment can be customized.";
+            "but alignment can be customized by defining the anchor.";
 
         public void ExecuteRecipe(Plot plt)
         {
-            // display some sample data
             plt.AddSignal(DataGen.Sin(51));
             plt.AddSignal(DataGen.Cos(51));
 
-            // display an image with 3 different alignments
             Bitmap monaLisa = DataGen.SampleImage();
-            var ip1 = new ScottPlot.Plottable.Image() { Bitmap = monaLisa, X = 10 };
-            var ip2 = new ScottPlot.Plottable.Image() { Bitmap = monaLisa, X = 25, Alignment = Alignment.MiddleCenter };
-            var ip3 = new ScottPlot.Plottable.Image() { Bitmap = monaLisa, X = 40, Alignment = Alignment.LowerRight };
 
-            plt.Add(ip1);
-            plt.Add(ip2);
-            plt.Add(ip3);
+            plt.AddImage(monaLisa, 10, 0);
+            plt.AddPoint(10, 0, Color.Magenta, size: 20);
 
-            plt.AddPoint(ip1.X, ip1.Y, Color.Magenta, size: 20);
-            plt.AddPoint(ip2.X, ip2.Y, Color.Magenta, size: 20);
-            plt.AddPoint(ip3.X, ip3.Y, Color.Magenta, size: 20);
+            plt.AddImage(monaLisa, 25, 0, anchor: Alignment.MiddleCenter);
+            plt.AddPoint(25, 0, Color.Magenta, size: 20);
+
+            plt.AddImage(monaLisa, 40, 0, anchor: Alignment.LowerRight);
+            plt.AddPoint(40, 0, Color.Magenta, size: 20);
         }
     }
 
@@ -68,19 +57,23 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string ID => "image_rotation";
         public string Title => "Image Rotation";
         public string Description =>
-            "Images can be rotated, but rotation is always relative to the upper left corner.";
+            "Images can be rotated around the position defined by their anchor.";
 
         public void ExecuteRecipe(Plot plt)
         {
-            // display some sample data
             plt.AddSignal(DataGen.Sin(51));
             plt.AddSignal(DataGen.Cos(51));
 
-            // place a rotated image on the plot
             Bitmap monaLisa = DataGen.SampleImage();
-            var ip1 = new ScottPlot.Plottable.Image() { Bitmap = monaLisa, X = 10, Y = .5, Rotation = 30 };
-            plt.Add(ip1);
-            plt.AddPoint(ip1.X, ip1.Y, color: Color.Magenta, size: 20);
+
+            plt.AddImage(monaLisa, 10, .5, rotation: 30);
+            plt.AddPoint(10, .5, color: Color.Magenta, size: 20);
+
+            plt.AddImage(monaLisa, 25, 0, rotation: -30);
+            plt.AddPoint(25, 0, color: Color.Magenta, size: 20);
+
+            plt.AddImage(monaLisa, 45, 0, rotation: 30, anchor: Alignment.MiddleCenter);
+            plt.AddPoint(45, 0, color: Color.Magenta, size: 20);
         }
     }
 
@@ -94,30 +87,48 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
 
         public void ExecuteRecipe(Plot plt)
         {
-            // display some sample data
             plt.AddSignal(DataGen.Sin(51));
             plt.AddSignal(DataGen.Cos(51));
 
-            // place an image on the plot
-            plt.Add(new ScottPlot.Plottable.Image()
-            {
-                Bitmap = DataGen.SampleImage(),
-                X = 10,
-                Y = .5,
-                Rotation = 30,
-                BorderColor = Color.Magenta,
-                BorderSize = 5,
-            });
+            Bitmap monaLisa = DataGen.SampleImage();
+
+            var img = plt.AddImage(monaLisa, 10, .5, rotation: 30);
+            img.BorderColor = Color.Magenta;
+            img.BorderSize = 5;
         }
     }
 
-    public class ImageSize : IRecipe
+    public class ImageScaling : IRecipe
     {
         public ICategory Category => new Categories.PlotTypes.Image();
-        public string ID => "image_size";
-        public string Title => "Image Size";
+        public string ID => "image_scaling";
+        public string Title => "Image Scaling";
         public string Description =>
-            "By default the image size is independent to the axis, but the size can be customized.";
+            "Size of the image (in relative pixel units) can be adjusted.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            plt.AddSignal(DataGen.Sin(51));
+            plt.AddSignal(DataGen.Cos(51));
+
+            Bitmap monaLisa = DataGen.SampleImage();
+
+            plt.AddImage(monaLisa, 5, .5);
+            plt.AddImage(monaLisa, 15, .5, scale: .5);
+            plt.AddImage(monaLisa, 30, .5, scale: 2);
+        }
+    }
+
+    public class ImageStretching : IRecipe
+    {
+        public ICategory Category => new Categories.PlotTypes.Image();
+        public string ID => "image_stretching";
+        public string Title => "Image Stretching";
+        public string Description =>
+            "By default image dimensions are in pixel units so they are not stretched " +
+            "as axes are manipulated. However, users have the option to define " +
+            "image dimensions in axis units. In this case, corners of images will remain " +
+            "fixed on the coordinate system and will get stretched as axes are stretched.";
 
         public void ExecuteRecipe(Plot plt)
         {
@@ -125,17 +136,17 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             plt.AddSignal(DataGen.Sin(51));
             plt.AddSignal(DataGen.Cos(51));
 
-            // place an image on the plot
-            plt.Add(new ScottPlot.Plottable.Image()
-            {
-                Bitmap = DataGen.SampleImage(),
-                X = 10,
-                Y = .5,
-                WidthInAxisUnits = 10,
-                HeightInAxisUnits = 1,
-                BorderColor = Color.Magenta,
-                BorderSize = 5,
-            });
+            Bitmap monaLisa = DataGen.SampleImage();
+
+            var img = plt.AddImage(monaLisa, 10, .5);
+            img.HeightInAxisUnits = 1;
+            img.WidthInAxisUnits = 30;
+
+            // 4 corners of the image remain fixed in coordinate space
+            plt.AddPoint(10, .5, color: Color.Magenta, size: 20);
+            plt.AddPoint(40, .5, color: Color.Green, size: 20);
+            plt.AddPoint(10, -.5, color: Color.Green, size: 20);
+            plt.AddPoint(40, -.5, color: Color.Green, size: 20);
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot.Tests/Plot/Image.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/Plot/Image.cs
@@ -26,7 +26,7 @@ namespace ScottPlotTests.Plot
                 img.BorderSize = 5;
                 plt.AddPoint(x, y, Color.Red, size: 5);
             }
-            plt.Title("TextAlignment.upperLeft");
+            plt.Title("ImageRotationAlignment.upperLeft");
             plt.AxisAuto(.5, .5);
             TestTools.SaveFig(plt);
         }
@@ -49,7 +49,7 @@ namespace ScottPlotTests.Plot
                 img.BorderSize = 5;
                 plt.AddPoint(x, y, Color.Red, size: 5);
             }
-            plt.Title("TextAlignment.upperCenter");
+            plt.Title("ImageRotationAlignment.upperCenter");
             plt.AxisAuto(.5, .5);
             TestTools.SaveFig(plt);
         }
@@ -72,7 +72,31 @@ namespace ScottPlotTests.Plot
                 img.BorderSize = 5;
                 plt.AddPoint(x, y, Color.Red, size: 5);
             }
-            plt.Title("TextAlignment.lowerRight");
+            plt.Title("ImageRotationAlignment.lowerRight");
+            plt.AxisAuto(.5, .5);
+            TestTools.SaveFig(plt);
+        }
+
+        [Test]
+        public void Test_ImageScale()
+        {
+            var plt = new ScottPlot.Plot(800, 600);
+            System.Drawing.Bitmap image = ScottPlot.DataGen.SampleImage();
+
+            float[] scales = { 0.2f, 0.5f, 1f, 1.5f };
+            for (int i = 0; i < scales.Length; i++)
+            {
+                double x = i / 2;
+                double y = i % 2;
+                var img = plt.AddImage(image, x, y);
+                img.Scale = scales[i];
+                img.Rotation = 30;
+                img.Alignment = ScottPlot.Alignment.LowerRight;
+                img.BorderColor = Color.LightGray;
+                img.BorderSize = 5;
+                plt.AddPoint(x, y, Color.Red, size: 5);
+            }
+            plt.Title("ImageScale");
             plt.AxisAuto(.5, .5);
             TestTools.SaveFig(plt);
         }

--- a/src/ScottPlot4/ScottPlot.Tests/PlottableRenderTests/Image.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlottableRenderTests/Image.cs
@@ -17,6 +17,8 @@ namespace ScottPlotTests.PlottableRenderTests
             var img = plt.AddImage(ScottPlot.DataGen.SampleImage(), 1, 9);
             img.X = 2;
             img.Y = 9;
+            img.WidthInAxisUnits = 1;
+            img.HeightInAxisUnits = 4;
             img.Rotation = 15;
 
             plt.SetAxisLimits(0, 10, 0, 10);
@@ -25,12 +27,18 @@ namespace ScottPlotTests.PlottableRenderTests
             img.Scale = 2;
             var bmp2 = TestTools.GetLowQualityBitmap(plt);
 
+            img.WidthInAxisUnits = 2;
+            var bmp3 = TestTools.GetLowQualityBitmap(plt);
+
             // measure what changed
             //TestTools.SaveFig(bmp1, "1");
             //TestTools.SaveFig(bmp2, "2");
+            //TestTools.SaveFig(bmp3, "3");
             var before = new MeanPixel(bmp1);
             var after = new MeanPixel(bmp2);
+            var afterafter = new MeanPixel(bmp3);
             Assert.That(after.IsDarkerThan(before));
+            Assert.That(afterafter.IsDarkerThan(after));
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Add.cs
@@ -630,17 +630,28 @@ namespace ScottPlot
             Add(plottable);
             return plottable;
         }
-
         /// <summary>
-        /// Display an image at a specific coordinate
+        /// Display an image at a specific coordinate.
+        /// The <paramref name="anchor"/> defines which part of the image is placed at that coordinate.
+        /// By default the image is shown at its original size (in pixel units), but this can be modified with <paramref name="scale"/>.
         /// </summary>
-        public Plottable.Image AddImage(Bitmap bitmap, double x, double y)
+        /// <param name="bitmap">Image to display</param>
+        /// <param name="x">horizontal position of the image anchor (axis units)</param>
+        /// <param name="y">vertical position of the image anchor (axis units)</param>
+        /// <param name="rotation">rotation in degrees</param>
+        /// <param name="scale">scale (1.0 = original scale, 2.0 = double size)</param>
+        /// <param name="anchor">definces which part of the image is placed at the given X and Y coordinates</param>
+        /// <returns></returns>
+        public Plottable.Image AddImage(Bitmap bitmap, double x, double y, double rotation = 0, double scale = 1, Alignment anchor = Alignment.UpperLeft)
         {
-            Plottable.Image plottable = new Plottable.Image()
+            Plottable.Image plottable = new()
             {
                 Bitmap = bitmap,
                 X = x,
                 Y = y,
+                Rotation = rotation,
+                Scale = scale,
+                Alignment = anchor,
             };
 
             settings.Plottables.Add(plottable);

--- a/src/ScottPlot4/ScottPlot/Plottable/Image.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Image.cs
@@ -14,18 +14,28 @@ namespace ScottPlot.Plottable
         public bool IsVisible { get; set; } = true;
 
         /// <summary>
-        /// Position of the primary corner (based on Alginment)
+        /// Position of the primary corner (based on Alignment)
         /// </summary>
         public double X { get; set; }
 
         /// <summary>
-        /// Position of the primary corner (based on Alginment)
+        /// Position of the primary corner (based on Alignment)
         /// </summary>
         public double Y { get; set; }
 
         /// <summary>
+        /// Width of the image, in axis units. If null, the image will use pixel units.
+        /// </summary>
+        public double? WidthInAxisUnits { get; set; } = null;
+
+        /// <summary>
+        /// Height of the image, in axis units. If null, the image will use pixel units.
+        /// </summary>
+        public double? HeightInAxisUnits { get; set; } = null;
+
+        /// <summary>
         /// Multiply the size of the image (in pixel units) by this scale factor.
-        /// The primary corner (based on Alginment) will remain anchored.
+        /// The primary corner (based on Alignment) will remain anchored.
         /// </summary>
         public float Scale = 1.0f;
 
@@ -51,9 +61,26 @@ namespace ScottPlot.Plottable
         public int XAxisIndex { get; set; } = 0;
         public int YAxisIndex { get; set; } = 0;
 
-        public override string ToString() => $"PlottableImage Size(\"{Bitmap.Size}\") at ({X}, {Y})";
-        public AxisLimits GetAxisLimits() => new(X, X, Y, Y);
+        public AxisLimits GetAxisLimits() => new(X, X + WidthInAxisUnits ?? 0, Y, Y + HeightInAxisUnits ?? 0);
         public LegendItem[] GetLegendItems() => Array.Empty<LegendItem>();
+
+        public override string ToString()
+        {
+            if (WidthInAxisUnits is double axisWidth)
+            {
+                if (HeightInAxisUnits is double axisHeight)
+                    return $"PlottableImage Axis Size({axisWidth}, {axisHeight}) at ({X}, {Y})";
+                else
+                    return $"PlottableImage Axis Width {axisWidth}, Pixel Height {Bitmap.Width} at ({X}, {Y})";
+            }
+            else
+            {
+                if (HeightInAxisUnits is double axisHeight)
+                    return $"PlottableImage Pixel Width {Bitmap.Width}, Axis Height {axisHeight} at ({X}, {Y})";
+                else
+                    return $"PlottableImage Size(\"{Bitmap.Size}\") at ({X}, {Y})";
+            }
+        }
 
         public void ValidateData(bool deep = false)
         {
@@ -63,6 +90,17 @@ namespace ScottPlot.Plottable
             if (double.IsNaN(Y) || double.IsInfinity(Y))
                 throw new InvalidOperationException("y must be a real value");
 
+            if (WidthInAxisUnits is double axisWidth)
+                if (double.IsNaN(axisWidth) || double.IsInfinity(axisWidth))
+                    throw new InvalidOperationException("width must be a real value");
+
+            if (HeightInAxisUnits is double axisHeight)
+                if (double.IsNaN(axisHeight) || double.IsInfinity(axisHeight))
+                    throw new InvalidOperationException("height must be a real value");
+
+            if (double.IsNaN(Scale) || double.IsInfinity(Scale))
+                throw new InvalidOperationException("scale must be a real value");
+
             if (double.IsNaN(Rotation) || double.IsInfinity(Rotation))
                 throw new InvalidOperationException("rotation must be a real value");
 
@@ -70,40 +108,52 @@ namespace ScottPlot.Plottable
                 throw new InvalidOperationException("image cannot be null");
         }
 
-        private PointF TextLocation(PointF input)
+        private PointF ImageLocationOffset(float width, float height)
         {
             return Alignment switch
             {
-                Alignment.LowerCenter => new PointF(input.X - Bitmap.Width / 2, input.Y - Bitmap.Height),
-                Alignment.LowerLeft => new PointF(input.X, input.Y - Bitmap.Height),
-                Alignment.LowerRight => new PointF(input.X - Bitmap.Width, input.Y - Bitmap.Height),
-                Alignment.MiddleLeft => new PointF(input.X, input.Y - Bitmap.Height / 2),
-                Alignment.MiddleRight => new PointF(input.X - Bitmap.Width, input.Y - Bitmap.Height / 2),
-                Alignment.UpperCenter => new PointF(input.X - Bitmap.Width / 2, input.Y),
-                Alignment.UpperLeft => new PointF(input.X, input.Y),
-                Alignment.UpperRight => new PointF(input.X - Bitmap.Width, input.Y),
-                Alignment.MiddleCenter => new PointF(input.X - Bitmap.Width / 2, input.Y - Bitmap.Height / 2),
+                Alignment.LowerCenter => new PointF(-width / 2, -height),
+                Alignment.LowerLeft => new PointF(0, -height),
+                Alignment.LowerRight => new PointF(-width, -height),
+                Alignment.MiddleLeft => new PointF(0, -height / 2),
+                Alignment.MiddleRight => new PointF(-width, -height / 2),
+                Alignment.UpperCenter => new PointF(-width / 2, 0),
+                Alignment.UpperLeft => new PointF(0, 0),
+                Alignment.UpperRight => new PointF(-width, 0),
+                Alignment.MiddleCenter => new PointF(-width / 2, -height / 2),
                 _ => throw new InvalidEnumArgumentException(),
             };
         }
 
         public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
         {
-            PointF defaultPoint = new PointF(dims.GetPixelX(X), dims.GetPixelY(Y));
-            PointF textLocationPoint = (Rotation == 0) ? TextLocation(defaultPoint) : defaultPoint;
+            PointF defaultPoint = new(dims.GetPixelX(X), dims.GetPixelY(Y));
+
+            float width, height;
+            if (WidthInAxisUnits is double axisWidth)
+                width = dims.GetPixelX(X + axisWidth) - defaultPoint.X;
+            else
+                width = Bitmap.Width;
+            if (HeightInAxisUnits is double axisHeight)
+                height = dims.GetPixelY(Y - axisHeight) - defaultPoint.Y;
+            else
+                height = Bitmap.Height;
+            width *= Scale;
+            height *= Scale;
 
             using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
             using (var framePen = new Pen(BorderColor, BorderSize * 2))
             {
-                gfx.TranslateTransform((int)textLocationPoint.X, (int)textLocationPoint.Y);
+                gfx.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.Half;
+                gfx.TranslateTransform(defaultPoint.X, defaultPoint.Y);
                 gfx.RotateTransform((float)Rotation);
 
-                if (BorderSize > 0)
-                    gfx.DrawRectangle(framePen, new Rectangle(0, 0, Bitmap.Width - 1, Bitmap.Height - 1));
+                RectangleF rect = new(ImageLocationOffset(width, height), new SizeF(width, height));
 
-                RectangleF rect = new(0, 0, Bitmap.Width * Scale, Bitmap.Height * Scale);
+                if (BorderSize > 0)
+                    gfx.DrawRectangle(framePen, Math.Min(rect.X, rect.Right), Math.Min(rect.Y, rect.Bottom), Math.Abs(rect.Width) - 1, Math.Abs(rect.Height) - 1);
+
                 gfx.DrawImage(Bitmap, rect);
-                GDI.ResetTransformPreservingScale(gfx, dims);
             }
         }
     }

--- a/src/ScottPlot4/ScottPlot/Plottable/Image.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Image.cs
@@ -2,7 +2,6 @@
 using System.Drawing;
 using ScottPlot.Drawing;
 using System;
-using System.Data;
 
 namespace ScottPlot.Plottable
 {

--- a/src/ScottPlot4/ScottPlot/Plottable/Image.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Image.cs
@@ -83,20 +83,9 @@ namespace ScottPlot.Plottable
 
         public override string ToString()
         {
-            if (WidthInAxisUnits is double axisWidth)
-            {
-                if (HeightInAxisUnits is double axisHeight)
-                    return $"PlottableImage Axis Size({axisWidth}, {axisHeight}) at ({X}, {Y})";
-                else
-                    return $"PlottableImage Axis Width {axisWidth}, Pixel Height {Bitmap.Width} at ({X}, {Y})";
-            }
-            else
-            {
-                if (HeightInAxisUnits is double axisHeight)
-                    return $"PlottableImage Pixel Width {Bitmap.Width}, Axis Height {axisHeight} at ({X}, {Y})";
-                else
-                    return $"PlottableImage Size(\"{Bitmap.Size}\") at ({X}, {Y})";
-            }
+            string w = (WidthInAxisUnits is null) ? $"{Bitmap.Width} pixels" : $"{WidthInAxisUnits} axis units";
+            string h = (HeightInAxisUnits is null) ? $"{Bitmap.Height} pixels" : $"{HeightInAxisUnits} axis units";
+            return $"Image at ({X}, {Y}), Width = {w}, Height = {h}";
         }
 
         public void ValidateData(bool deep = false)

--- a/src/ScottPlot4/ScottPlot/Plottable/Image.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Image.cs
@@ -24,12 +24,14 @@ namespace ScottPlot.Plottable
         public double Y { get; set; }
 
         /// <summary>
-        /// Width of the image, in axis units. If null, the image will use pixel units.
+        /// If defined, the image will be stretched to be this wide in axis units.
+        /// If null, the image will use screen/pixel units.
         /// </summary>
         public double? WidthInAxisUnits { get; set; } = null;
 
         /// <summary>
-        /// Height of the image, in axis units. If null, the image will use pixel units.
+        /// If defined, the image will be stretched to be this height in axis units.
+        /// If null, the image will use screen/pixel units.
         /// </summary>
         public double? HeightInAxisUnits { get; set; } = null;
 
@@ -37,7 +39,7 @@ namespace ScottPlot.Plottable
         /// Multiply the size of the image (in pixel units) by this scale factor.
         /// The primary corner (based on Alignment) will remain anchored.
         /// </summary>
-        public float Scale = 1.0f;
+        public double Scale = 1.0;
 
         /// <summary>
         /// Rotate the image clockwise around its primary corner (defined by Alignment) by this number of degrees
@@ -61,7 +63,15 @@ namespace ScottPlot.Plottable
         public int XAxisIndex { get; set; } = 0;
         public int YAxisIndex { get; set; } = 0;
 
-        public AxisLimits GetAxisLimits() => new(X, X + WidthInAxisUnits ?? 0, Y, Y + HeightInAxisUnits ?? 0);
+        public AxisLimits GetAxisLimits()
+        {
+            return new AxisLimits(
+                xMin: X,
+                xMax: X + WidthInAxisUnits ?? 0,
+                yMin: Y,
+                yMax: Y + HeightInAxisUnits ?? 0);
+        }
+
         public LegendItem[] GetLegendItems() => Array.Empty<LegendItem>();
 
         public override string ToString()
@@ -130,16 +140,19 @@ namespace ScottPlot.Plottable
             PointF defaultPoint = new(dims.GetPixelX(X), dims.GetPixelY(Y));
 
             float width, height;
+
             if (WidthInAxisUnits is double axisWidth)
                 width = dims.GetPixelX(X + axisWidth) - defaultPoint.X;
             else
                 width = Bitmap.Width;
+
             if (HeightInAxisUnits is double axisHeight)
                 height = dims.GetPixelY(Y - axisHeight) - defaultPoint.Y;
             else
                 height = Bitmap.Height;
-            width *= Scale;
-            height *= Scale;
+
+            width = (float)(width * Scale);
+            height = (float)(height * Scale);
 
             using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
             using (var framePen = new Pen(BorderColor, BorderSize * 2))

--- a/src/ScottPlot4/ScottPlot/Plottable/Image.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Image.cs
@@ -58,9 +58,16 @@ namespace ScottPlot.Plottable
         public Alignment Alignment { get; set; }
 
         public Color BorderColor { get; set; }
+
+        /// <summary>
+        /// Line width of the border (in pixels)
+        /// </summary>
         public float BorderSize { get; set; }
+
         public string Label { get; set; }
+
         public int XAxisIndex { get; set; } = 0;
+
         public int YAxisIndex { get; set; } = 0;
 
         public AxisLimits GetAxisLimits()

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -2,6 +2,7 @@
 
 ## ScottPlot 4.1.46
 _not yet published on NuGet..._
+* Image: `AddImage()` has optional arguments to define rotation, scale, and anchor alignment. The `Image` plot type has new public properties allowing images to be stretched so position and size can be defined using axis units (see Cookbook). `Rotation` now respects all anchor alignments. (#1847) _Thanks @wtywtykk and @bclehmann_
 * Bracket: New plot type to highlight a range of data between two points in coordinate space (#1863) _Thanks @bclehmann_
 * Heatmap: Added `FlipVertically` property to invert orientation of original data (#1866, #1864) _Thanks @bclehmann and @vtozarks_
 * Axis: Improved placement of horizontal axis tick labels when multiple axes are in use (#1861, #1848) _Thanks @bclehmann and @Shengcancheng_


### PR DESCRIPTION
**Purpose:**
* Add axis dependent sizing. This can be used to draw a background.
* The alignment was ignored with non-zero rotation. I'm not sure if that's on purpose, but seems strange. So I fixed it.
* The border was not scaled with the image. Fixed in this PR.
* Also added tests for scale and sizing.
* Fixed some typos.
![Drawing1](https://user-images.githubusercontent.com/13284789/168618666-1a8f3e49-75b9-4d5d-9f52-468fa745604b.png)
