### PR TITLE
BarPlot: clip fills to data area

### DIFF
--- a/src/ScottPlot4/ScottPlot.Tests/PlotTypes/Bar.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlotTypes/Bar.cs
@@ -238,5 +238,24 @@ namespace ScottPlotTests.PlotTypes
             Assert.GreaterOrEqual(limits.YMax, 2);
             Assert.LessOrEqual(limits.YMin, -1);
         }
+
+        [Test]
+        public void Test_Bar_ZoomFarIn()
+        {
+            var plt = new ScottPlot.Plot(400, 300);
+
+            double[] values = { 1e6, 2e6, 3e6 };
+            var bar = plt.AddBar(values);
+
+            plt.SetAxisLimits(-1, 3, 1000, 1000 + .001);
+            MeanPixel bmpVisible = new(plt);
+            //TestTools.SaveFig(plt, "visible");
+
+            bar.IsVisible = false;
+            MeanPixel bmpHidden = new(plt);
+            //TestTools.SaveFig(plt, "hidden");
+
+            Assert.That(bmpVisible.IsDifferentThan(bmpHidden));
+        }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Plottable/BarPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/BarPlot.cs
@@ -70,7 +70,7 @@ namespace ScottPlot.Plottable
             float errorPx2 = dims.GetPixelY(error2);
             float errorPx1 = dims.GetPixelY(error1);
 
-            RenderBarFromRect(rect, value < 0, gfx);
+            RenderBarFromRect(ClipRectToDataArea(rect, dims), value < 0, gfx);
 
             if (ErrorLineWidth > 0 && valueError > 0)
             {
@@ -101,7 +101,7 @@ namespace ScottPlot.Plottable
                 height: (float)(BarWidth * dims.PxPerUnitY),
                 width: (float)(valueSpan * dims.PxPerUnitX));
 
-            RenderBarFromRect(rect, value < 0, gfx);
+            RenderBarFromRect(ClipRectToDataArea(rect, dims), value < 0, gfx);
 
             // errorbar
             double error1 = value > 0 ? value2 - Math.Abs(valueError) : value1 - Math.Abs(valueError);
@@ -164,6 +164,16 @@ namespace ScottPlot.Plottable
         public void ValidateData(bool deep = false)
         {
             // TODO: refactor entire data validation system for all plot types (triaged March 2021)
+        }
+
+        private static RectangleF ClipRectToDataArea(RectangleF rect, PlotDimensions dims)
+        {
+            float left = Math.Max(rect.Left, dims.DataOffsetX - 1);
+            float right = Math.Min(rect.Right, dims.DataOffsetX + dims.DataWidth + 1);
+            float top = Math.Max(rect.Top, dims.DataOffsetY - 1);
+            float bottom = Math.Min(rect.Bottom, dims.DataOffsetY + dims.DataHeight + 1);
+
+            return new RectangleF(left, top, right - left, bottom - top);
         }
     }
 }

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.46
 _not yet published on NuGet..._
 * FormsPlot: Set `Configuration.EnablePlotObjectEditor` to `true` to allow users to launch a plot object property editor from the right-click menu (#1842, #1831) _Thanks @bradmartin333 and @BambOoxX_
+* BarPlot: Fixed bug where zooming extremely far in would cause large fills to disappear (#1849, #1850) _Thanks @ChrisAtVault_
 
 ## ScottPlot 4.1.45
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-05-05_


### PR DESCRIPTION
This PR clips rendering of large rectangles to the size of the data area to overcome limitations related to extremely large rectangles. Resolves #1849