### PR TITLE
BarPlotBase: Fixes axis calculation.

### DIFF
--- a/src/ScottPlot4/ScottPlot/Plottable/BarPlotBase.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/BarPlotBase.cs
@@ -114,14 +114,11 @@ namespace ScottPlot.Plottable
 
             for (int i = 0; i < Positions.Length; i++)
             {
-                valueMin = Math.Min(valueMin, ValueOffsets[i] - ValueErrors[i]);
-                valueMax = Math.Max(valueMax, ValueOffsets[i] + ValueErrors[i] + Values[i]);
+                valueMin = Math.Min(Math.Min(valueMin, ValueOffsets[i] - ValueErrors[i] + Values[i]), ValueBase + ValueOffsets[i]);
+                valueMax = Math.Max(Math.Max(valueMax, ValueOffsets[i] + ValueErrors[i] + Values[i]), ValueBase + ValueOffsets[i]);
                 positionMin = Math.Min(positionMin, Positions[i]);
                 positionMax = Math.Max(positionMax, Positions[i]);
             }
-
-            valueMin = Math.Min(valueMin, ValueBase);
-            valueMax = Math.Max(valueMax, ValueBase);
 
             if (ShowValuesAboveBars)
                 valueMax += (valueMax - valueMin) * .1; // increase by 10% to accommodate label

--- a/src/ScottPlot4/ScottPlot/Plottable/Crosshair.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Crosshair.cs
@@ -88,6 +88,11 @@ namespace ScottPlot.Plottable
 
         public Color LineColor { get => Color; set { Color = value; } }
 
+        /// <summary>
+        /// If true, AxisAuto() will ignore the position of this line when determining axis limits
+        /// </summary>
+        public bool IgnoreAxisAuto { get; set; } = false;
+
         public Crosshair()
         {
             LineStyle = LineStyle.Dash;
@@ -97,7 +102,9 @@ namespace ScottPlot.Plottable
             VerticalLine.PositionLabel = true;
         }
 
-        public AxisLimits GetAxisLimits() => new(double.NaN, double.NaN, double.NaN, double.NaN);
+        public AxisLimits GetAxisLimits() => IgnoreAxisAuto
+                ? new(double.NaN, double.NaN, double.NaN, double.NaN)
+                : new(X, X, Y, Y);
 
         public LegendItem[] GetLegendItems() => Array.Empty<LegendItem>();
 

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -2,6 +2,7 @@
 
 ## ScottPlot 4.1.46
 _not yet published on NuGet..._
+* BarPlot: Improved automatic axis detection for bar plots containing negative values (#1855, #1857) _Thanks @CarloToso and @bclehmann_
 * IHittable: new interface to facilitate mouse click and hover hit detection (#1845) _Thanks @StendProg and @bclehmann_
 * Tooltip: Added logic to enable detection of mouse hover or click (#1843, #1844, #1845) _Thanks @kkaiser41, @bclehmann, and @StendProg_
 * Controls: All user controls now have a `LeftClickedPlottable` event that fires when a plottable implementing `IHittable` was left-clicked

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -2,6 +2,7 @@
 
 ## ScottPlot 4.1.46
 _not yet published on NuGet..._
+* Crosshair: Now included in automatic axis limit detection. Use its `IgnoreAxisAuto` property to disable this functionality. (#1855, #1857) _Thanks @CarloToso and @bclehmann_
 * BarPlot: Improved automatic axis detection for bar plots containing negative values (#1855, #1857) _Thanks @CarloToso and @bclehmann_
 * IHittable: new interface to facilitate mouse click and hover hit detection (#1845) _Thanks @StendProg and @bclehmann_
 * Tooltip: Added logic to enable detection of mouse hover or click (#1843, #1844, #1845) _Thanks @kkaiser41, @bclehmann, and @StendProg_


### PR DESCRIPTION
**Purpose:**
#1855

There were two issues:
  - `ValueOffsets` was not taken into account when calculating `ValueMin`
  - `ValueOffsets` was not taken into account when ensuring the base of the bar was between `ValueMin` and `ValueMax`

The second one is a little hard to explain without referencing the code, but there used to be these two lines:
```cs
valueMin = Math.Min(valueMin, ValueBase);
valueMax = Math.Max(valueMax, ValueBase);
```

This calculation is incorrect because the base of the bar is really `ValueBase + ValueOffsets[i]`, so for non-zero `ValueOffsets[i]` you get incorrect results, such as with the following code:
```cs
double[] values = { 23, 17, 19, 24, 22 };
double[] yOffsets = { -100, -100, -100, -100, -100 }; // This is in the cookbook, but I think the better way to do this is just set ValueBase = -100. Regardless, it illustrates the issue

var bar = plt.AddBar(values);
bar.ValueOffsets = yOffsets;
```

Before:
<img width="346" alt="image" src="https://user-images.githubusercontent.com/8635304/169713494-118a81e5-bb2f-4f87-af96-f4e6a7cf0a71.png">

Note that the axis goes from -100 to 0, as it's trying to keep `ValueBase = 0` in frame, but it should be keeping `ValueBase + ValueOffsets[i] = -100` in frame

After:
<img width="517" alt="image" src="https://user-images.githubusercontent.com/8635304/169713465-de440999-79f2-4a26-ad94-264a9236471f.png">