### PR TITLE
Additional X Axes: Tick labels respect PixelOffset

### DIFF
--- a/src/ScottPlot4/ScottPlot.Eto/PlotView.cs
+++ b/src/ScottPlot4/ScottPlot.Eto/PlotView.cs
@@ -33,12 +33,12 @@ namespace ScottPlot.Eto
         /// This event is invoked any time the plot is left-clicked.
         /// It is typically used to interact with custom plot types.
         /// </summary>
-        public event EventHandler LeftClicked;
+        public event EventHandler? LeftClicked;
 
         /// <summary>
         /// This event is invoked when a <seealso cref="Plottable.IHittable"/> plottable is left-clicked.
         /// </summary>
-        public event EventHandler LeftClickedPlottable;
+        public event EventHandler? LeftClickedPlottable;
 
         /// <summary>
         /// This event is invoked after the mouse moves while dragging a draggable plottable.

--- a/src/ScottPlot4/ScottPlot/Renderable/AxisTicksRender.cs
+++ b/src/ScottPlot4/ScottPlot/Renderable/AxisTicksRender.cs
@@ -92,7 +92,7 @@ namespace ScottPlot.Renderable
                     for (int i = 0; i < visibleMajorTicks.Length; i++)
                     {
                         float x = dims.GetPixelX(visibleMajorTicks[i].Position);
-                        float y = dims.DataOffsetY + dims.DataHeight + MajorTickLength;
+                        float y = dims.DataOffsetY + dims.DataHeight + MajorTickLength + PixelOffset;
 
                         gfx.TranslateTransform(x, y);
                         gfx.RotateTransform(-rotation);
@@ -108,7 +108,7 @@ namespace ScottPlot.Renderable
                     for (int i = 0; i < visibleMajorTicks.Length; i++)
                     {
                         float x = dims.GetPixelX(visibleMajorTicks[i].Position);
-                        float y = dims.DataOffsetY - MajorTickLength;
+                        float y = dims.DataOffsetY - MajorTickLength - PixelOffset;
 
                         gfx.TranslateTransform(x, y);
                         gfx.RotateTransform(-rotation);

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -2,6 +2,7 @@
 
 ## ScottPlot 4.1.46
 _not yet published on NuGet..._
+* Axis: Improved placement of horizontal axis tick labels when multiple axes are in use (#1861, #1848) _Thanks @bclehmann and @Shengcancheng_
 * Crosshair: Now included in automatic axis limit detection. Use its `IgnoreAxisAuto` property to disable this functionality. (#1855, #1857) _Thanks @CarloToso and @bclehmann_
 * BarPlot: Improved automatic axis detection for bar plots containing negative values (#1855, #1857) _Thanks @CarloToso and @bclehmann_
 * IHittable: new interface to facilitate mouse click and hover hit detection (#1845) _Thanks @StendProg and @bclehmann_


### PR DESCRIPTION
**Purpose:**
#1848 

Replication (note that this doesn't quite match the code in #1848, as I don't have access to their data. I also shoehorned it into WPF for debugging)
```cs
var plt = WpfPlot1.Plot;

double[] ROParray = new double[] { 1, 0, -1, -2, -3 };
double[] RPMarray = new double[] { 1000, 1200, 1400, 1600, 1800 };
double[] iarray = new double[] { 1, 2, 3, 4, 5 };

var x3 = plt.AddAxis(ScottPlot.Renderable.Edge.Top, axisIndex: 2);
x3.Label("RPM");
x3.Ticks(true);
x3.Grid(true);
x3.SetSizeLimit(0, 300);

plt.XAxis.Ticks(false);
plt.XAxis.Grid(false);
plt.XAxis2.Ticks(true);
plt.XAxis2.Grid(true);

plt.YAxis.SetSizeLimit(-2, 2);
WpfPlot1.Refresh();

plt.Clear();
plt.AddScatter(ROParray, iarray, lineWidth: 2f, markerShape: ScottPlot.MarkerShape.none).XAxisIndex = 1;
plt.AddScatter(RPMarray, iarray, lineWidth: 2f, markerShape: ScottPlot.MarkerShape.none).XAxisIndex = 2;
WpfPlot1.Refresh();
```

Before: (note the axis ticks overlap on the X axis)
<img width="583" alt="image" src="https://user-images.githubusercontent.com/8635304/170422781-361f8946-d44c-46b3-8a9a-f12737000480.png">

After: 
<img width="583" alt="image" src="https://user-images.githubusercontent.com/8635304/170422895-52a78db0-75da-43d0-9095-9ba4a7b36da7.png">

