### PR TITLE
Heatmap: Adds FlipVertically to allow bottom-to-top drawing

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
@@ -19,6 +19,25 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             plt.AddHeatmap(data2D);
         }
     }
+
+    public class HeatmapFlip : IRecipe
+    {
+        public ICategory Category => new Categories.PlotTypes.Heatmap();
+        public string ID => "heatmap_flip";
+        public string Title => "Flipped Heatmap";
+        public string Description =>
+            "Sometimes it's more intuitive to draw heatmaps from the bottom-left corner.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[,] data2D = { { 1, 2, 3 },
+                                 { 4, 5, 6 } };
+
+            var hm = plt.AddHeatmap(data2D);
+            hm.FlipVertically = true;
+        }
+    }
+
     public class HeatmapMargins : IRecipe
     {
         public ICategory Category => new Categories.PlotTypes.Heatmap();

--- a/src/ScottPlot4/ScottPlot/Plottable/Heatmap.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Heatmap.cs
@@ -168,6 +168,11 @@ namespace ScottPlot.Plottable
         public InterpolationMode Interpolation { get; set; } = InterpolationMode.NearestNeighbor;
 
         /// <summary>
+        /// If true the Heatmap will be drawn from the bottom left corner of the plot. Otherwise it will be drawn from the top left corner. Defaults to false.
+        /// </summary>
+        public bool FlipVertically { get; set; } = false;
+
+        /// <summary>
         /// This method analyzes the intensities and colormap to create a bitmap
         /// with a single pixel for every intensity value. The bitmap is stored
         /// and displayed (without anti-alias interpolation) when Render() is called.
@@ -363,10 +368,18 @@ namespace ScottPlot.Plottable
             int width = (int)Math.Round(dims.GetPixelX(OffsetX + DataWidth * CellWidth) - fromX);
             int height = (int)Math.Round(dims.GetPixelY(OffsetY) - fromY);
 
-            Rectangle destRect = new(fromX, fromY, width, height);
 
             ImageAttributes attr = new();
             attr.SetWrapMode(WrapMode.TileFlipXY);
+
+            gfx.TranslateTransform(fromX, fromY);
+
+            if (FlipVertically)
+            {
+                gfx.ScaleTransform(1, -1);
+            }
+
+            Rectangle destRect = FlipVertically ? new(0, -height, width, height) : new(0, 0, width, height);
 
             gfx.DrawImage(
                     image: BmpHeatmap,

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -2,7 +2,7 @@
 
 ## ScottPlot 4.1.46
 _not yet published on NuGet..._
-* Heatmap: Added `FlipVertically` property to invert orientation of original data (#1866, #1864) _Thanks @bclehmann_
+* Heatmap: Added `FlipVertically` property to invert orientation of original data (#1866, #1864) _Thanks @bclehmann and @vtozarks_
 * Axis: Improved placement of horizontal axis tick labels when multiple axes are in use (#1861, #1848) _Thanks @bclehmann and @Shengcancheng_
 * Crosshair: Now included in automatic axis limit detection. Use its `IgnoreAxisAuto` property to disable this functionality. (#1855, #1857) _Thanks @CarloToso and @bclehmann_
 * BarPlot: Improved automatic axis detection for bar plots containing negative values (#1855, #1857) _Thanks @CarloToso and @bclehmann_

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -2,6 +2,7 @@
 
 ## ScottPlot 4.1.46
 _not yet published on NuGet..._
+* Heatmap: Added `FlipVertically` property to invert orientation of original data (#1866, #1864) _Thanks @bclehmann_
 * Axis: Improved placement of horizontal axis tick labels when multiple axes are in use (#1861, #1848) _Thanks @bclehmann and @Shengcancheng_
 * Crosshair: Now included in automatic axis limit detection. Use its `IgnoreAxisAuto` property to disable this functionality. (#1855, #1857) _Thanks @CarloToso and @bclehmann_
 * BarPlot: Improved automatic axis detection for bar plots containing negative values (#1855, #1857) _Thanks @CarloToso and @bclehmann_


### PR DESCRIPTION
**Purpose:**
#1864

```cs
double[,] data2D = { { 1, 2, 3 },
                     { 4, 5, 6 } };

var hm = plt.AddHeatmap(data2D);
hm.FlipVertically = true;
```

<img width="316" alt="image" src="https://user-images.githubusercontent.com/8635304/171302013-c8da3b38-f898-452a-bac9-88da419b93cd.png">