### PR TITLE
Bracket: Use pixels for calculating normal vector

### DIFF
--- a/src/ScottPlot4/ScottPlot/Plottable/Bracket.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Bracket.cs
@@ -96,7 +96,7 @@ namespace ScottPlot.Plottable
             using var font = GDI.Font(Font);
 
             var v = new Vector2((float)(X2 - X1), (float)(Y2 - Y1));
-            var vPixel = new Vector2((float)(v.X * dims.PxPerUnitX),(float)(v.Y * dims.PxPerUnitY));
+            var vPixel = new Vector2((float)(v.X * dims.PxPerUnitX), (float)(v.Y * dims.PxPerUnitY));
             var vDirectionVector = Vector2.Normalize(vPixel);
 
             if (v.X < 0 || (v.X == 0 && v.Y < 0)) // To prevent switching the order of the points from changing label position

--- a/src/ScottPlot4/ScottPlot/Plottable/Bracket.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Bracket.cs
@@ -96,14 +96,15 @@ namespace ScottPlot.Plottable
             using var font = GDI.Font(Font);
 
             var v = new Vector2((float)(X2 - X1), (float)(Y2 - Y1));
-            var vDirectionVector = Vector2.Normalize(v);
+            var vPixel = new Vector2((float)(v.X * dims.PxPerUnitX),(float)(v.Y * dims.PxPerUnitY));
+            var vDirectionVector = Vector2.Normalize(vPixel);
 
             if (v.X < 0 || (v.X == 0 && v.Y < 0)) // To prevent switching the order of the points from changing label position
             {
                 vDirectionVector = Vector2.Negate(vDirectionVector);
             }
 
-            Vector2 normal = Vector2.Normalize(new(v.Y, v.X));
+            Vector2 normal = Vector2.Normalize(new(vPixel.Y, vPixel.X));
             Vector2 antiNormal = Vector2.Negate(normal);
 
             var clockwiseNormalVector = AngleBetweenVectors(vDirectionVector, normal) > 0 ? normal : antiNormal;


### PR DESCRIPTION
**Purpose:**
#1869

The same snippet as in #1869:

![image](https://user-images.githubusercontent.com/8635304/171787373-87941315-3514-402a-9b8c-9aac1e4a8349.png)
