### PR TITLE
SignalXY: only draw markers at original data points when step mode is enabled

### DIFF
--- a/src/ScottPlot4/ScottPlot.Tests/PlotTypes/SignalXY.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlotTypes/SignalXY.cs
@@ -7,7 +7,7 @@ namespace ScottPlotTests.PlotTypes
     class SignalXY
     {
         [Test]
-        public void Test_AscendingUnevenlySpacedXs_ShouldRenderWell()
+        public void Test_Ascending_UnevenlySpacedXs()
         {
             // generate random, ascending, unevenly-spaced data
             Random rand = new Random(0);
@@ -23,6 +23,27 @@ namespace ScottPlotTests.PlotTypes
             var plt = new ScottPlot.Plot(500, 350);
             plt.AddSignalXY(xs, ys);
             plt.SetAxisLimits(20530, 20560, -61, -57);
+            TestTools.SaveFig(plt);
+        }
+
+        [Test]
+        public void Test_Ascending_UnevenlySpacedXs_Step()
+        {
+            // generate random, ascending, unevenly-spaced data
+            Random rand = new Random(0);
+            int pointCount = 100_000;
+            double[] ys = new double[pointCount];
+            double[] xs = new double[pointCount];
+            for (int i = 1; i < ys.Length; i++)
+            {
+                ys[i] = ys[i - 1] + rand.NextDouble() - .5;
+                xs[i] = xs[i - 1] + rand.NextDouble();
+            }
+
+            var plt = new ScottPlot.Plot(500, 350);
+            var sig = plt.AddSignalXY(xs, ys);
+            sig.StepDisplay = true;
+            plt.SetAxisLimits(20550, 20560, -61, -57);
             TestTools.SaveFig(plt);
         }
 

--- a/src/ScottPlot4/ScottPlot.Tests/TestTools.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/TestTools.cs
@@ -21,20 +21,22 @@ namespace ScottPlotTests
         {
             var stackTrace = new System.Diagnostics.StackTrace();
             string callingMethod = stackTrace.GetFrame(1).GetMethod().Name;
+            string callingClass = stackTrace.GetFrame(1).GetMethod().DeclaringType.ToString();
+            string prefix = callingClass + "." + callingMethod;
 
             if (subName != "")
                 subName = "_" + subName;
 
-            string fileName = callingMethod + subName + ".png";
+            string fileName = prefix + subName + ".png";
             string filePath = System.IO.Path.GetFullPath(fileName);
             plt.SaveFig(filePath);
 
-            DisplayRenderInfo(callingMethod, subName, plt.GetSettings(false).BenchmarkMessage.MSec);
+            DisplayRenderInfo(prefix, subName, plt.GetSettings(false).BenchmarkMessage.MSec);
             Console.WriteLine($"Saved: {filePath}");
             Console.WriteLine();
 
             if (artifact)
-                SaveArtifact(plt, callingMethod + subName);
+                SaveArtifact(plt, prefix + subName);
 
             return filePath;
         }

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -216,6 +216,8 @@ namespace ScottPlot.Plottable
                     }
                 }
 
+                PointF[] markersToDraw = PointsToDraw;
+
                 // Simulate a step display by adding extra points at the corners.
                 if (StepDisplay)
                     PointsToDraw = GetStepPoints(PointsToDraw);
@@ -246,19 +248,19 @@ namespace ScottPlot.Plottable
                 }
 
                 // draw markers
-                if (PointsToDraw.Length > 1)
+                if (markersToDraw.Length > 1)
                 {
-                    float dataSpanXPx = PointsToDraw[PointsToDraw.Length - 1].X - PointsToDraw[0].X;
-                    float markerPxRadius = .3f * dataSpanXPx / PointsToDraw.Length;
+                    float dataSpanXPx = markersToDraw[markersToDraw.Length - 1].X - markersToDraw[0].X;
+                    float markerPxRadius = .3f * dataSpanXPx / markersToDraw.Length;
                     markerPxRadius = Math.Min(markerPxRadius, MarkerSize / 2);
                     float scaledMarkerSize = markerPxRadius * 2;
 
                     if (markerPxRadius > .3)
                     {
                         // skip not visible before and after points
-                        var PointsWithMarkers = PointsToDraw
+                        var PointsWithMarkers = markersToDraw
                                                 .Skip(PointBefore.Length)
-                                                .Take(PointsToDraw.Length - PointBefore.Length - PointAfter.Length)
+                                                .Take(markersToDraw.Length - PointBefore.Length - PointAfter.Length)
                                                 .ToArray();
 
                         MarkerTools.DrawMarkers(gfx, PointsWithMarkers, MarkerShape, scaledMarkerSize, MarkerColor, MarkerLineWidth);

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.49
 _not yet published on NuGet..._
 * BarSeries: A new type of bar plot which allows each bar to be individually customized and offers mouse collision detection (#1891, #1749) _Thanks @jhm-ciberman_
+* SignalXY: When step mode is activated markers are now only drawn at original data points (#1896) _Thanks @grabul_
 
 ## ScottPlot 4.1.48
 * Plottable: Collapsed `IHasAxisLimits`, `IHasDataValidation`, and `IHasLegendItems` back into `IPlottable`, reverting a change introduced by the previous version. The intent of the original change was to promote interface segregation (e.g., colorbar has no axis limits). However, the purpose of this reversion is to maintain consistent behavior for users who implemented their own plottables implementing `IPlottable` and may not be aware of these new interfaces. (#1868, #1881)


### PR DESCRIPTION
before | after
---|---
![image](https://user-images.githubusercontent.com/4165489/174910470-43a7e3f1-04e5-40d1-b683-bad22685749d.png)|![image](https://user-images.githubusercontent.com/4165489/174910455-06310e50-0fa4-4396-bf86-95b3d42d03ba.png)

resolves #1896