### PR TITLE
Reduce resources used to draw multiple markers

### DIFF
--- a/src/ScottPlot4/ScottPlot/Marker/MarkerTools.cs
+++ b/src/ScottPlot4/ScottPlot/Marker/MarkerTools.cs
@@ -12,6 +12,15 @@ namespace ScottPlot
             if (size == 0 || shape == MarkerShape.none)
                 return;
 
+            IMarker marker = Marker.Create(shape);
+            DrawMarker(gfx, pixelLocation, marker, size, brush, pen);
+        }
+
+        public static void DrawMarker(Graphics gfx, PointF pixelLocation, IMarker marker, float size, Brush brush, Pen pen)
+        {
+            if (size == 0)
+                return;
+
             float diameter = size;
             float radius = diameter / 2;
 
@@ -22,7 +31,6 @@ namespace ScottPlot
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 pixelLocation = new PointF(pixelLocation.X + .5f, pixelLocation.Y);
 
-            IMarker marker = Marker.Create(shape);
             marker.Draw(gfx, pixelLocation, radius, brush, pen);
         }
 
@@ -37,11 +45,10 @@ namespace ScottPlot
         {
             using SolidBrush brush = new(color);
             using Pen pen = new(color, linewidth);
+            IMarker marker = Marker.Create(shape);
 
             foreach (PointF pt in pixelLocations)
-            {
-                DrawMarker(gfx, pt, shape, size, color, linewidth);
-            }
+                DrawMarker(gfx, pt, marker, size, brush, pen);
         }
 
         internal static PointF[] DiamondPoints(PointF center, float radius)

--- a/src/ScottPlot4/ScottPlot/Plottable/ScatterPlotList.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/ScatterPlotList.cs
@@ -111,10 +111,7 @@ namespace ScottPlot.Plottable
             }
 
             if (MarkerShape != MarkerShape.none && MarkerSize > 0 && Count > 0)
-            {
-                foreach (PointF point in points)
-                    MarkerTools.DrawMarker(gfx, point, MarkerShape, MarkerSize, Color);
-            }
+                MarkerTools.DrawMarkers(gfx, points, MarkerShape, MarkerSize, Color);
         }
 
         public LegendItem[] GetLegendItems()

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotBase.cs
@@ -386,11 +386,7 @@ namespace ScottPlot.Plottable
                     if (markerPxRadius > .25)
                     {
                         ShowMarkersInLegend = true;
-
-                        foreach (PointF point in linePoints)
-                        {
-                            MarkerTools.DrawMarker(gfx, point, MarkerShape, markerPxDiameter, Color, MarkerLineWidth);
-                        }
+                        MarkerTools.DrawMarkers(gfx, linePoints, MarkerShape, markerPxDiameter, Color, MarkerLineWidth);
                     }
                     else
                     {

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.50
 _not yet published on NuGet..._
 * BarSeries: Lists passed into new BarSeries are preserved and can be modified after instantiation. Added a `Count` property. Added a `AddBarSeries()` overload that permits creating an empty BarSeries. (#1902)
+* Markers: Improved performance for plot types that render multiple markers (#1910) _Thanks @AbeniMatteo_
 
 ## ScottPlot 4.1.49
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-06-21_


### PR DESCRIPTION
`.DrawMarkers()` was allocating a `SolidBrush` and a `Pen` without using them, this bug is fixed and now the `IMarker` is also reused.

Plots affected:
- Scatter
- Signal
- Error bar

Repro:
```cs
var rnd = new Random(Seed: 123);
var ys = Enumerable.Range(0, 500).Select(_ => rnd.NextDouble()).ToArray();
var xs = Enumerable.Range(0, 500).Select(_ => rnd.NextDouble()).ToArray();

var ctrl = new ScottPlot.FormsPlot { Dock = DockStyle.Fill };
var sPlot = ctrl.Plot.AddScatter(xs, ys);

for (int i = 0; i < 1; i++)
    ctrl.Refresh();
```

|Points|Iters|Type|Alloc. before|Alloc. after|
|-|-|-|-|-|
|500|1|ScottPlot.MarkerShapes.FilledCircle|500|1|
|500|1|System.Drawing.Pen|525|25|
|500|1|System.Drawing.SolidBrush|509|9|
|500|100|ScottPlot.MarkerShapes.FilledCircle|51.500|103|
|500|100|System.Drawing.Pen|52.953|1.453|
|500|100|System.Drawing.SolidBrush|52.019|519|
