### PR TITLE
Plot.ManualDataArea for pixel-perfect layouts

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Layout.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Layout.cs
@@ -164,7 +164,7 @@ namespace ScottPlot.Cookbook.Recipes
                 bottom: 100,
                 top: 10);
 
-            plt.ManualDataPadding(padding);
+            plt.ManualDataArea(padding);
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Layout.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Layout.cs
@@ -139,4 +139,32 @@ namespace ScottPlot.Cookbook.Recipes
             plt.Margins(x: .25, y: .4);
         }
     }
+
+    class LayoutManualDataArea : IRecipe
+    {
+        public ICategory Category => new Categories.Layout();
+        public string ID => "layout_manual";
+        public string Title => "Manual Data Area";
+        public string Description =>
+            "The layout system automatically measures axis labels and ticks to provide " +
+            "a plot with the largest data area possible. However, this can be problematic " +
+            "for animated plots (with changing tick label sizes) or when users wish to achieve " +
+            "pixel-perfect similarity between two different plots. In these cases the user can " +
+            "manually override the layout system and define exactly how large the data area is.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            plt.Style(Style.Blue1);
+            plt.AddSignal(DataGen.Sin(51));
+            plt.AddSignal(DataGen.Cos(51));
+
+            var padding = new ScottPlot.PixelPadding(
+                left: 150,
+                right: 30,
+                bottom: 100,
+                top: 10);
+
+            plt.ManualDataPadding(padding);
+        }
+    }
 }

--- a/src/ScottPlot4/ScottPlot/PixelPadding.cs
+++ b/src/ScottPlot4/ScottPlot/PixelPadding.cs
@@ -1,0 +1,18 @@
+﻿namespace ScottPlot
+{
+    public struct PixelPadding
+    {
+        public float Left;
+        public float Right;
+        public float Bottom;
+        public float Top;
+
+        public PixelPadding(float left, float right, float bottom, float top)
+        {
+            Left = left;
+            Right = right;
+            Bottom = bottom;
+            Top = top;
+        }
+    }
+}

--- a/src/ScottPlot4/ScottPlot/PixelRect.cs
+++ b/src/ScottPlot4/ScottPlot/PixelRect.cs
@@ -1,0 +1,23 @@
+﻿namespace ScottPlot
+{
+    public class PixelRect
+    {
+        public float X;
+        public float Y;
+        public float Width;
+        public float Height;
+
+        public PixelRect(float x, float y, float width, float height)
+        {
+            X = x;
+            Y = y;
+            Width = width;
+            Height = height;
+        }
+
+        public Pixel TopLeft => new(X, Y);
+        public Pixel TopRight => new(X, Y + Width);
+        public Pixel BottomLeft => new(X, Y + Height);
+        public Pixel BottomRight => new(X + Width, Y + Height);
+    }
+}

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Axis.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Axis.cs
@@ -188,10 +188,11 @@ namespace ScottPlot
         }
 
         /// <summary>
-        /// Define the shape of the data area and it will not be adjusted as axis labels or ticks change.
-        /// Pass null to disable manual data area.
+        /// Define the shape of the data area as padding (in pixels) on all 4 sides.
+        /// Once defined, the layout will not be adjusted as axis labels or ticks change.
+        /// Pass null into this function to disable the manual data area.
         /// </summary>
-        public void ManualDataPadding(PixelPadding padding)
+        public void ManualDataArea(PixelPadding padding)
         {
             settings.ManualDataPadding = padding;
         }

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Axis.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Axis.cs
@@ -188,6 +188,15 @@ namespace ScottPlot
         }
 
         /// <summary>
+        /// Define the shape of the data area and it will not be adjusted as axis labels or ticks change.
+        /// Pass null to disable manual data area.
+        /// </summary>
+        public void ManualDataPadding(PixelPadding padding)
+        {
+            settings.ManualDataPadding = padding;
+        }
+
+        /// <summary>
         /// Manually define X axis tick labels using consecutive integer positions (0, 1, 2, etc.)
         /// </summary>
         /// <param name="labels">new tick labels for the X axis</param>

--- a/src/ScottPlot4/ScottPlot/Settings.cs
+++ b/src/ScottPlot4/ScottPlot/Settings.cs
@@ -147,6 +147,12 @@ namespace ScottPlot
         /// </summary>
         public bool DrawGridAbovePlottables { get; set; } = false;
 
+        /// <summary>
+        /// If defined, the data area will use this rectangle and not be adjusted
+        /// depending on axis labels or ticks.
+        /// </summary>
+        public PixelPadding? ManualDataPadding { get; set; } = null;
+
         public Settings()
         {
             Plottables.CollectionChanged += (object sender, NotifyCollectionChangedEventArgs e) => PlottablesIdentifier++;
@@ -164,6 +170,18 @@ namespace ScottPlot
             var figureSize = new SizeF(XAxis.Dims.FigureSizePx, YAxis.Dims.FigureSizePx);
             var dataSize = new SizeF(XAxis.Dims.DataSizePx, YAxis.Dims.DataSizePx);
             var dataOffset = new PointF(XAxis.Dims.DataOffsetPx, YAxis.Dims.DataOffsetPx);
+
+            // manual override if manual padding is enabled
+            if (ManualDataPadding is not null)
+            {
+                dataOffset = new PointF(
+                    x: ManualDataPadding.Value.Left,
+                    y: ManualDataPadding.Value.Top);
+
+                dataSize = new SizeF(
+                    width: figureSize.Width - ManualDataPadding.Value.Left - ManualDataPadding.Value.Right,
+                    height: figureSize.Height - ManualDataPadding.Value.Top - ManualDataPadding.Value.Bottom);
+            }
 
             // determine axis limits based on specific X and Y axes
             (double xMin, double xMax) = xAxis.Dims.RationalLimits();

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -4,6 +4,7 @@
 _not yet published on NuGet..._
 * BarSeries: Lists passed into new BarSeries are preserved and can be modified after instantiation. Added a `Count` property. Added a `AddBarSeries()` overload that permits creating an empty BarSeries. (#1902)
 * Markers: Improved performance for plot types that render multiple markers (#1910) _Thanks @AbeniMatteo_
+* Plot: New `ManualDataArea()` function allows users to define pixel-perfect layouts (#1907, #1901) _Thanks @dhgigisoave_
 
 ## ScottPlot 4.1.49
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-06-21_


### PR DESCRIPTION
`Plot.ManualDataArea()` function allows users to define pixel-perfect layouts

* Resolves #1907

* Resolves #1901