### PR TITLE
Signal: optimization to draw fewer overlapping vertical lines

### DIFF
--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -97,12 +97,19 @@ namespace ScottPlot.Plottable
 
             var pointsCount = endIndex - startIndex;
 
-            yield return new PointF(x + dims.DataOffsetX, dims.GetPixelY(Strategy.SourceElement(startIndex) + Convert.ToDouble(OffsetY)));
+            var startValue = Strategy.SourceElement(startIndex);
+            yield return new PointF(x + dims.DataOffsetX, dims.GetPixelY(startValue + Convert.ToDouble(OffsetY)));
             if (pointsCount > 1)
             {
-                yield return new PointF(x + dims.DataOffsetX, dims.GetPixelY(min + Convert.ToDouble(OffsetY)));
-                yield return new PointF(x + dims.DataOffsetX, dims.GetPixelY(max + Convert.ToDouble(OffsetY)));
-                yield return new PointF(x + dims.DataOffsetX, dims.GetPixelY(Strategy.SourceElement(endIndex - 1) + Convert.ToDouble(OffsetY)));
+                var endValue = Strategy.SourceElement(endIndex - 1);
+
+                if (min != startValue && min != endValue)
+                    yield return new PointF(x + dims.DataOffsetX, dims.GetPixelY(min + Convert.ToDouble(OffsetY)));
+
+                if (max != startValue && max != endValue)
+                    yield return new PointF(x + dims.DataOffsetX, dims.GetPixelY(max + Convert.ToDouble(OffsetY)));
+
+                yield return new PointF(x + dims.DataOffsetX, dims.GetPixelY(endValue + Convert.ToDouble(OffsetY)));
             }
         }
 


### PR DESCRIPTION
While we finalize the other PR, we can start the conversation for this one.

**Purpose:**
Signals render 3 lines where only 2 or 1 are needed, this PR reduces the points\lines used to draw an interval.
For simplicity, i'm not doing anything fancy with the first and the last point.

This image shows an exploded view of what is happening on the same X pixel (and the end result on the right).

![image](https://user-images.githubusercontent.com/634710/177033712-36a5cab0-1540-4338-82e1-0987473d18f6.png)
