### PR TITLE
Generic Signal plots: add support for byte arrays

### DIFF
--- a/src/ScottPlot4/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj
+++ b/src/ScottPlot4/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj
@@ -15,9 +15,9 @@
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/ScottPlot/ScottPlot</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.1.52</Version>
-    <AssemblyVersion>4.1.52.0</AssemblyVersion>
-    <FileVersion>4.1.52.0</FileVersion>
+    <Version>4.1.53</Version>
+    <AssemblyVersion>4.1.53.0</AssemblyVersion>
+    <FileVersion>4.1.53.0</FileVersion>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/src/ScottPlot4/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj
+++ b/src/ScottPlot4/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj
@@ -14,9 +14,9 @@
     <PackageTags>plot graph data chart signal line bar heatmap scatter control interactive winforms windows forms</PackageTags>
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/ScottPlot/ScottPlot</RepositoryUrl>
-    <Version>4.1.52</Version>
-    <AssemblyVersion>4.1.52.0</AssemblyVersion>
-    <FileVersion>4.1.52.0</FileVersion>
+    <Version>4.1.53</Version>
+    <AssemblyVersion>4.1.53.0</AssemblyVersion>
+    <FileVersion>4.1.53.0</FileVersion>
     <SignAssembly>false</SignAssembly>
     <Authors>Scott Harden</Authors>
     <Company>Harden Technologies, LLC</Company>

--- a/src/ScottPlot4/ScottPlot.Sandbox/WinFormsApp/Form1.Designer.cs
+++ b/src/ScottPlot4/ScottPlot.Sandbox/WinFormsApp/Form1.Designer.cs
@@ -29,62 +29,33 @@
         private void InitializeComponent()
         {
             this.formsPlot1 = new ScottPlot.FormsPlot();
-            this.progressBar1 = new System.Windows.Forms.ProgressBar();
-            this.label1 = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // formsPlot1
             // 
-            this.formsPlot1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.formsPlot1.BackColor = System.Drawing.Color.Transparent;
-            this.formsPlot1.Location = new System.Drawing.Point(0, 66);
+            this.formsPlot1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.formsPlot1.Location = new System.Drawing.Point(0, 0);
             this.formsPlot1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.formsPlot1.Name = "formsPlot1";
-            this.formsPlot1.Size = new System.Drawing.Size(808, 351);
+            this.formsPlot1.Size = new System.Drawing.Size(808, 417);
             this.formsPlot1.TabIndex = 0;
-            // 
-            // progressBar1
-            // 
-            this.progressBar1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.progressBar1.Location = new System.Drawing.Point(12, 12);
-            this.progressBar1.Maximum = 10000;
-            this.progressBar1.Name = "progressBar1";
-            this.progressBar1.Size = new System.Drawing.Size(784, 23);
-            this.progressBar1.TabIndex = 1;
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.label1.Location = new System.Drawing.Point(12, 38);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(120, 25);
-            this.label1.TabIndex = 2;
-            this.label1.Text = "Stack Depth: ";
             // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(808, 417);
-            this.Controls.Add(this.label1);
-            this.Controls.Add(this.progressBar1);
             this.Controls.Add(this.formsPlot1);
             this.Name = "Form1";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "FormsPlot Sandbox";
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
         #endregion
 
         private ScottPlot.FormsPlot formsPlot1;
-        private System.Windows.Forms.ProgressBar progressBar1;
-        private System.Windows.Forms.Label label1;
     }
 }

--- a/src/ScottPlot4/ScottPlot.Sandbox/WinFormsApp/Form1.cs
+++ b/src/ScottPlot4/ScottPlot.Sandbox/WinFormsApp/Form1.cs
@@ -13,26 +13,12 @@ namespace WinFormsApp
 {
     public partial class Form1 : Form
     {
-        readonly ScottPlot.Plottable.Crosshair MyCrosshair;
-
         public Form1()
         {
             InitializeComponent();
-            Width = 1200;
-            Height = 1000;
-            MyCrosshair = formsPlot1.Plot.AddCrosshair(0, 0);
+            byte[] ys = DataGen.Sin(100_000, 5_000, 100, 100).Select(x => (byte)x).ToArray();
+            formsPlot1.Plot.AddSignalConst(ys);
             formsPlot1.Refresh();
-            formsPlot1.MouseMove += FormsPlot1_MouseMove;
-        }
-
-        private void FormsPlot1_MouseMove(object sender, MouseEventArgs e)
-        {
-            (MyCrosshair.X, MyCrosshair.Y) = formsPlot1.GetMouseCoordinates();
-            formsPlot1.Refresh(skipIfCurrentlyRendering: true);
-
-            int depth = new System.Diagnostics.StackTrace().FrameCount;
-            label1.Text = $"Stack depth: {depth}";
-            progressBar1.Value = depth;
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot.Tests/NumericConversionTests.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/NumericConversionTests.cs
@@ -44,7 +44,8 @@ namespace ScottPlotTests
             Assert.DoesNotThrow(() => new ScottPlot.Plottable.SignalPlotXYGeneric<double, double>());
             Assert.DoesNotThrow(() => new ScottPlot.Plottable.SignalPlotXYGeneric<float, float>());
             Assert.DoesNotThrow(() => new ScottPlot.Plottable.SignalPlotXYGeneric<int, int>());
-            Assert.DoesNotThrow(() => new ScottPlot.Plottable.SignalPlotXYGeneric<byte, byte>());
+            Assert.DoesNotThrow(() => new ScottPlot.Plottable.SignalPlotXYGeneric<double, byte>());
+            Assert.Throws<InvalidOperationException>(() => new ScottPlot.Plottable.SignalPlotXYGeneric<byte, byte>());
         }
 
         [Test]
@@ -62,7 +63,7 @@ namespace ScottPlotTests
             ScottPlot.Plot plt = new();
             plt.AddSignalConst(doubles, label: "doubles");
             plt.AddSignalConst(bytes, label: "bytes");
-            plt.AddSignalXYConst(bytesX, bytesY, label: "bytes XY");
+            plt.AddSignalXYConst(doublesX, bytesY, label: "bytes XY");
             plt.AddSignalXYConst(doublesX, doublesY, label: "doubles XY");
             plt.Legend();
             TestTools.SaveFig(plt);

--- a/src/ScottPlot4/ScottPlot.Tests/NumericConversionTests.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/NumericConversionTests.cs
@@ -53,9 +53,13 @@ namespace ScottPlotTests
             double[] doubles = ScottPlot.DataGen.Sin(51, offset: 100, mult: 100);
             byte[] bytes = doubles.Select(x => (byte)(x + 5)).ToArray();
 
+            byte[] bytesX = ScottPlot.DataGen.Consecutive(51).Select(x => (byte)x).ToArray();
+            byte[] bytesY = doubles.Select(x => (byte)(x + 10)).ToArray();
+
             ScottPlot.Plot plt = new();
             plt.AddSignalConst(doubles, label: "doubles");
             plt.AddSignalConst(bytes, label: "bytes");
+            plt.AddSignalXYConst(bytesX, bytesY, label: "bytes XY");
             plt.Legend();
             TestTools.SaveFig(plt);
         }

--- a/src/ScottPlot4/ScottPlot.Tests/NumericConversionTests.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/NumericConversionTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
+using System.Linq;
 
 namespace ScottPlotTests
 {
@@ -38,12 +39,25 @@ namespace ScottPlotTests
             Assert.DoesNotThrow(() => new ScottPlot.Plottable.SignalPlotConst<double>());
             Assert.DoesNotThrow(() => new ScottPlot.Plottable.SignalPlotConst<float>());
             Assert.DoesNotThrow(() => new ScottPlot.Plottable.SignalPlotConst<int>());
-            Assert.Throws<InvalidOperationException>(() => new ScottPlot.Plottable.SignalPlotConst<byte>());
+            Assert.DoesNotThrow(() => new ScottPlot.Plottable.SignalPlotConst<byte>());
 
             Assert.DoesNotThrow(() => new ScottPlot.Plottable.SignalPlotXYGeneric<double, double>());
             Assert.DoesNotThrow(() => new ScottPlot.Plottable.SignalPlotXYGeneric<float, float>());
             Assert.DoesNotThrow(() => new ScottPlot.Plottable.SignalPlotXYGeneric<int, int>());
-            Assert.Throws<InvalidOperationException>(() => new ScottPlot.Plottable.SignalPlotXYGeneric<byte, byte>());
+            Assert.DoesNotThrow(() => new ScottPlot.Plottable.SignalPlotXYGeneric<byte, byte>());
+        }
+
+        [Test]
+        public void Test_GenericSignal_ByteArray()
+        {
+            double[] doubles = ScottPlot.DataGen.Sin(51, offset: 100, mult: 100);
+            byte[] bytes = doubles.Select(x => (byte)(x + 5)).ToArray();
+
+            ScottPlot.Plot plt = new();
+            plt.AddSignalConst(doubles, label: "doubles");
+            plt.AddSignalConst(bytes, label: "bytes");
+            plt.Legend();
+            TestTools.SaveFig(plt);
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot.Tests/NumericConversionTests.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/NumericConversionTests.cs
@@ -56,12 +56,54 @@ namespace ScottPlotTests
             byte[] bytesX = ScottPlot.DataGen.Consecutive(51).Select(x => (byte)x).ToArray();
             byte[] bytesY = doubles.Select(x => (byte)(x + 10)).ToArray();
 
+            double[] doublesX = ScottPlot.DataGen.Consecutive(51);
+            double[] doublesY = doubles.Select(x => x + 15).ToArray();
+
             ScottPlot.Plot plt = new();
             plt.AddSignalConst(doubles, label: "doubles");
             plt.AddSignalConst(bytes, label: "bytes");
             plt.AddSignalXYConst(bytesX, bytesY, label: "bytes XY");
+            plt.AddSignalXYConst(doublesX, doublesY, label: "doubles XY");
             plt.Legend();
             TestTools.SaveFig(plt);
+        }
+
+        [Test]
+        public void Test_TypeSpecificFunction_Add()
+        {
+            Assert.That(ScottPlot.NumericConversion.CreateAddFunction<double>().Invoke(42, 69), Is.EqualTo(111));
+            Assert.That(ScottPlot.NumericConversion.CreateAddFunction<float>().Invoke(42, 69), Is.EqualTo(111));
+            Assert.That(ScottPlot.NumericConversion.CreateAddFunction<int>().Invoke(42, 69), Is.EqualTo(111));
+            Assert.That(ScottPlot.NumericConversion.CreateAddFunction<byte>().Invoke(42, 69), Is.EqualTo(111));
+        }
+
+        [Test]
+        public void Test_TypeSpecificFunction_Subtract()
+        {
+            Assert.That(ScottPlot.NumericConversion.CreateSubtractFunction<double>().Invoke(111, 69), Is.EqualTo(42));
+            Assert.That(ScottPlot.NumericConversion.CreateSubtractFunction<float>().Invoke(111, 69), Is.EqualTo(42));
+            Assert.That(ScottPlot.NumericConversion.CreateSubtractFunction<int>().Invoke(111, 69), Is.EqualTo(42));
+            Assert.That(ScottPlot.NumericConversion.CreateSubtractFunction<byte>().Invoke(111, 69), Is.EqualTo(42));
+        }
+
+        [Test]
+        public void Test_TypeSpecificFunction_LessThanOrEqual()
+        {
+            Assert.That(ScottPlot.NumericConversion.CreateLessThanOrEqualFunction<double>().Invoke(111, 69), Is.False);
+            Assert.That(ScottPlot.NumericConversion.CreateLessThanOrEqualFunction<double>().Invoke(69, 69), Is.True);
+            Assert.That(ScottPlot.NumericConversion.CreateLessThanOrEqualFunction<double>().Invoke(42, 69), Is.True);
+
+            Assert.That(ScottPlot.NumericConversion.CreateLessThanOrEqualFunction<float>().Invoke(111, 69), Is.False);
+            Assert.That(ScottPlot.NumericConversion.CreateLessThanOrEqualFunction<float>().Invoke(69, 69), Is.True);
+            Assert.That(ScottPlot.NumericConversion.CreateLessThanOrEqualFunction<float>().Invoke(42, 69), Is.True);
+
+            Assert.That(ScottPlot.NumericConversion.CreateLessThanOrEqualFunction<int>().Invoke(111, 69), Is.False);
+            Assert.That(ScottPlot.NumericConversion.CreateLessThanOrEqualFunction<int>().Invoke(69, 69), Is.True);
+            Assert.That(ScottPlot.NumericConversion.CreateLessThanOrEqualFunction<int>().Invoke(42, 69), Is.True);
+
+            Assert.That(ScottPlot.NumericConversion.CreateLessThanOrEqualFunction<byte>().Invoke(111, 69), Is.False);
+            Assert.That(ScottPlot.NumericConversion.CreateLessThanOrEqualFunction<byte>().Invoke(69, 69), Is.True);
+            Assert.That(ScottPlot.NumericConversion.CreateLessThanOrEqualFunction<byte>().Invoke(42, 69), Is.True);
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj
+++ b/src/ScottPlot4/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj
@@ -16,9 +16,9 @@
     <PackageTags>plot graph data chart signal line bar heatmap scatter control interactive WPF</PackageTags>
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/ScottPlot/ScottPlot</RepositoryUrl>
-    <Version>4.1.52</Version>
-    <AssemblyVersion>4.1.52.0</AssemblyVersion>
-    <FileVersion>4.1.52.0</FileVersion>
+    <Version>4.1.53</Version>
+    <AssemblyVersion>4.1.53.0</AssemblyVersion>
+    <FileVersion>4.1.53.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/src/ScottPlot4/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj
+++ b/src/ScottPlot4/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj
@@ -15,9 +15,9 @@
     <PackageTags>plot graph data chart signal line bar heatmap scatter control interactive winforms windows forms</PackageTags>
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/ScottPlot/ScottPlot</RepositoryUrl>
-    <Version>4.1.52</Version>
-    <AssemblyVersion>4.1.52.0</AssemblyVersion>
-    <FileVersion>4.1.52.0</FileVersion>
+    <Version>4.1.53</Version>
+    <AssemblyVersion>4.1.53.0</AssemblyVersion>
+    <FileVersion>4.1.53.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>

--- a/src/ScottPlot4/ScottPlot/NumericConversion.cs
+++ b/src/ScottPlot4/ScottPlot/NumericConversion.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 
 namespace ScottPlot
@@ -98,6 +99,52 @@ namespace ScottPlot
             {
                 v = (T)Convert.ChangeType(value, typeof(T));
             }
+        }
+
+        public static byte AddBytes(byte a, byte b) => (byte)(a + b);
+        public static byte SubtractBytes(byte a, byte b) => (byte)(a - b);
+        public static bool LessThanOrEqualBytes(byte a, byte b) => a <= b;
+
+        public static Func<T, T, T> CreateAddFunction<T>()
+        {
+            ParameterExpression paramA = Expression.Parameter(typeof(T), "a");
+            ParameterExpression paramB = Expression.Parameter(typeof(T), "b");
+
+            BinaryExpression bodyAdd = Type.GetTypeCode(typeof(T)) switch
+            {
+                TypeCode.Byte => Expression.Add(paramA, paramB, typeof(NumericConversion).GetMethod(nameof(NumericConversion.AddBytes))),
+                _ => Expression.Add(paramA, paramB),
+            };
+
+            return Expression.Lambda<Func<T, T, T>>(bodyAdd, paramA, paramB).Compile();
+        }
+
+        public static Func<T, T, T> CreateSubtractFunction<T>()
+        {
+            ParameterExpression paramA = Expression.Parameter(typeof(T), "a");
+            ParameterExpression paramB = Expression.Parameter(typeof(T), "b");
+
+            BinaryExpression bodyAdd = Type.GetTypeCode(typeof(T)) switch
+            {
+                TypeCode.Byte => Expression.Add(paramA, paramB, typeof(NumericConversion).GetMethod(nameof(NumericConversion.SubtractBytes))),
+                _ => Expression.Subtract(paramA, paramB),
+            };
+
+            return Expression.Lambda<Func<T, T, T>>(bodyAdd, paramA, paramB).Compile();
+        }
+
+        public static Func<T, T, bool> CreateLessThanOrEqualFunction<T>()
+        {
+            ParameterExpression paramA = Expression.Parameter(typeof(T), "a");
+            ParameterExpression paramB = Expression.Parameter(typeof(T), "b");
+
+            BinaryExpression bodyAdd = Type.GetTypeCode(typeof(T)) switch
+            {
+                TypeCode.Byte => Expression.Add(paramA, paramB, typeof(NumericConversion).GetMethod(nameof(NumericConversion.LessThanOrEqualBytes))),
+                _ => Expression.LessThanOrEqual(paramA, paramB),
+            };
+
+            return Expression.Lambda<Func<T, T, bool>>(bodyAdd, paramA, paramB).Compile();
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot/NumericConversion.cs
+++ b/src/ScottPlot4/ScottPlot/NumericConversion.cs
@@ -110,13 +110,13 @@ namespace ScottPlot
             ParameterExpression paramA = Expression.Parameter(typeof(T), "a");
             ParameterExpression paramB = Expression.Parameter(typeof(T), "b");
 
-            BinaryExpression bodyAdd = Type.GetTypeCode(typeof(T)) switch
+            BinaryExpression body = Type.GetTypeCode(typeof(T)) switch
             {
                 TypeCode.Byte => Expression.Add(paramA, paramB, typeof(NumericConversion).GetMethod(nameof(NumericConversion.AddBytes))),
                 _ => Expression.Add(paramA, paramB),
             };
 
-            return Expression.Lambda<Func<T, T, T>>(bodyAdd, paramA, paramB).Compile();
+            return Expression.Lambda<Func<T, T, T>>(body, paramA, paramB).Compile();
         }
 
         public static Func<T, T, T> CreateSubtractFunction<T>()
@@ -124,13 +124,13 @@ namespace ScottPlot
             ParameterExpression paramA = Expression.Parameter(typeof(T), "a");
             ParameterExpression paramB = Expression.Parameter(typeof(T), "b");
 
-            BinaryExpression bodyAdd = Type.GetTypeCode(typeof(T)) switch
+            BinaryExpression body = Type.GetTypeCode(typeof(T)) switch
             {
-                TypeCode.Byte => Expression.Add(paramA, paramB, typeof(NumericConversion).GetMethod(nameof(NumericConversion.SubtractBytes))),
+                TypeCode.Byte => Expression.Subtract(paramA, paramB, typeof(NumericConversion).GetMethod(nameof(NumericConversion.SubtractBytes))),
                 _ => Expression.Subtract(paramA, paramB),
             };
 
-            return Expression.Lambda<Func<T, T, T>>(bodyAdd, paramA, paramB).Compile();
+            return Expression.Lambda<Func<T, T, T>>(body, paramA, paramB).Compile();
         }
 
         public static Func<T, T, bool> CreateLessThanOrEqualFunction<T>()
@@ -138,13 +138,13 @@ namespace ScottPlot
             ParameterExpression paramA = Expression.Parameter(typeof(T), "a");
             ParameterExpression paramB = Expression.Parameter(typeof(T), "b");
 
-            BinaryExpression bodyAdd = Type.GetTypeCode(typeof(T)) switch
+            BinaryExpression body = Type.GetTypeCode(typeof(T)) switch
             {
-                TypeCode.Byte => Expression.Add(paramA, paramB, typeof(NumericConversion).GetMethod(nameof(NumericConversion.LessThanOrEqualBytes))),
+                TypeCode.Byte => Expression.LessThanOrEqual(paramA, paramB, false, typeof(NumericConversion).GetMethod(nameof(NumericConversion.LessThanOrEqualBytes))),
                 _ => Expression.LessThanOrEqual(paramA, paramB),
             };
 
-            return Expression.Lambda<Func<T, T, bool>>(bodyAdd, paramA, paramB).Compile();
+            return Expression.Lambda<Func<T, T, bool>>(body, paramA, paramB).Compile();
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotBase.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace ScottPlot.Plottable
 {
@@ -247,7 +248,7 @@ namespace ScottPlot.Plottable
         /// <summary>
         /// This expression adds two parameters of the generic type used by this signal plot.
         /// </summary>
-        private readonly Func<T, T, T> AddYsGenericExpression;
+        private readonly Func<T, T, T> AddYsGenericExpression = NumericConversion.CreateAddFunction<T>();
 
         /// <summary>
         /// Add two Y values (of the generic type used by this signal plot) and return the result as a double
@@ -265,10 +266,6 @@ namespace ScottPlot.Plottable
 
         public SignalPlotBase()
         {
-            ParameterExpression paramA = Expression.Parameter(typeof(T), "a");
-            ParameterExpression paramB = Expression.Parameter(typeof(T), "b");
-            BinaryExpression bodyAdd = Expression.Add(paramA, paramB);
-            AddYsGenericExpression = Expression.Lambda<Func<T, T, T>>(bodyAdd, paramA, paramB).Compile();
         }
 
         /// <summary>

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -57,6 +57,10 @@ namespace ScottPlot.Plottable
 
         public SignalPlotXYGeneric() : base()
         {
+            if (Type.GetTypeCode(typeof(TX)) == TypeCode.Byte)
+            {
+                throw new InvalidOperationException("SignalXY plots cannot use a byte array for their horizontal axis positions");
+            }
         }
 
         public override AxisLimits GetAxisLimits()

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -51,9 +51,12 @@ namespace ScottPlot.Plottable
             }
         }
 
+        private static Func<TX, TX, TX> SubstractExp = NumericConversion.CreateSubtractFunction<TX>();
+
+        private static Func<TX, TX, bool> LessThanOrEqualExp = NumericConversion.CreateLessThanOrEqualFunction<TX>();
+
         public SignalPlotXYGeneric() : base()
         {
-            InitExp();
         }
 
         public override AxisLimits GetAxisLimits()
@@ -332,19 +335,6 @@ namespace ScottPlot.Plottable
                 return GetPointByIndex(index - 1);
             else // x closer to XS[index]
                 return GetPointByIndex(index);
-        }
-
-        private static Func<TX, TX, TX> SubstractExp;
-        private static Func<TX, TX, bool> LessThanOrEqualExp;
-
-        private void InitExp()
-        {
-            ParameterExpression paramA = Expression.Parameter(typeof(TX), "a");
-            ParameterExpression paramB = Expression.Parameter(typeof(TX), "b");
-            BinaryExpression bodySubstract = Expression.Subtract(paramA, paramB);
-            BinaryExpression bodyLessOrEqual = Expression.LessThanOrEqual(paramA, paramB);
-            SubstractExp = Expression.Lambda<Func<TX, TX, TX>>(bodySubstract, paramA, paramB).Compile();
-            LessThanOrEqualExp = Expression.Lambda<Func<TX, TX, bool>>(bodyLessOrEqual, paramA, paramB).Compile();
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot/ScottPlot.csproj
+++ b/src/ScottPlot4/ScottPlot/ScottPlot.csproj
@@ -12,9 +12,9 @@
     <PackageProjectUrl>https://ScottPlot.NET</PackageProjectUrl>
     <PackageTags>plot graph data chart signal line bar heatmap scatter</PackageTags>
     <PackageReleaseNotes>https://ScottPlot.NET/changelog</PackageReleaseNotes>
-    <Version>4.1.52</Version>
-    <AssemblyVersion>4.1.52.0</AssemblyVersion>
-    <FileVersion>4.1.52.0</FileVersion>
+    <Version>4.1.53</Version>
+    <AssemblyVersion>4.1.53.0</AssemblyVersion>
+    <FileVersion>4.1.53.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -1,7 +1,11 @@
 # ScottPlot Changelog
 
-## ScottPlot 4.1.53
+## ScottPlot 4.1.54
 _not yet published on NuGet..._
+
+## ScottPlot 4.1.53
+_Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-07-10_
+* Signal Plot: Added support for plotting `byte` arrays (#1945)
 
 ## ScottPlot 4.1.52
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-07-09_


### PR DESCRIPTION
The goal of this PR is to add support for `byte[]` back into generic signal (SignalConst and SignalXY) types

* extends #1927