### PR TITLE
Signal and Scatter: GetYDataRange()

### DIFF
--- a/src/ScottPlot4/ScottPlot.Tests/GetYDataRange.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/GetYDataRange.cs
@@ -1,0 +1,56 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlotTests
+{
+    internal class GetYDataRange
+    {
+        [TestCase(new double[] { 1, 2, 3, 4, 5 }, new double[] { 10, 12, 14, 8, 10 }, 1, 5, 8, 14)]
+        [TestCase(new double[] { 1, 2, 3, 4, 5 }, new double[] { 10, 12, 14, 8, 10 }, 1, 3, 10, 14)]
+        [TestCase(new double[] { 1, 2, 3, 4, 5 }, new double[] { 10, 12, 14, 8, 10 }, 3, 3, 14, 14)]
+        [TestCase(new double[] { 1, 2, 3, 4, 5 }, new double[] { 10, 12, 14, 8, 10 }, 2.1, 3.9, 14, 14)]
+        public void Scatter(double[] xs, double[] ys, double xStart, double xEnd, double expectedMin, double expectedMax)
+        {
+            var plt = new ScottPlot.Plot();
+            var scat = plt.AddScatter(xs, ys);
+            (double yMin, double yMax) = scat.GetYDataRange(xStart, xEnd);
+
+            Assert.AreEqual(expectedMin, yMin);
+            Assert.AreEqual(expectedMax, yMax);
+        }
+
+        [TestCase(new double[] { 10, 12, 14, 8, 10 }, 0, 4, 8, 14)]
+        [TestCase(new double[] { 10, 12, 14, 8, 10 }, 0, 2, 10, 14)]
+        [TestCase(new double[] { 10, 12, 14, 8, 10 }, 2, 2, 14, 14)]
+        public void Signal(double[] ys, double xStart, double xEnd, double expectedMin, double expectedMax)
+        {
+            var plt = new ScottPlot.Plot();
+            var sig = plt.AddSignal(ys);
+            (double yMin, double yMax) = sig.GetYDataRange(xStart, xEnd);
+
+            Assert.AreEqual(expectedMin, yMin);
+            Assert.AreEqual(expectedMax, yMax);
+        }
+
+        [TestCase(new double[] { 10, 12, 14, 8, 10 }, 0, 4, 8, 14)]
+        [TestCase(new double[] { 10, 12, 14, 8, 10 }, 0, 2, 10, 14)]
+        [TestCase(new double[] { 10, 12, 14, 8, 10 }, 2, 2, 14, 14)]
+        public void SignalWithXOffsetAndSampleRate(double[] ys, double xStart, double xEnd, double expectedMin, double expectedMax)
+        {
+            const double sampleRate = 25;
+            const double xOffset = -100;
+
+            var plt = new ScottPlot.Plot();
+            var sig = plt.AddSignal(ys, sampleRate: sampleRate);
+            sig.OffsetX = xOffset;
+            (double yMin, double yMax) = sig.GetYDataRange(xStart * sampleRate + xOffset, xEnd * sampleRate + xOffset);
+
+            Assert.AreEqual(expectedMin, yMin);
+            Assert.AreEqual(expectedMax, yMax);
+        }
+    }
+}

--- a/src/ScottPlot4/ScottPlot/Plottable/IHasPoints.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/IHasPoints.cs
@@ -15,7 +15,7 @@
     public interface IHasPointsGenericX<TX, TY>
     {
         (TX x, TY y, int index) GetPointNearestX(TX x);
-        (TY yMin, TY yMax) GetYDataRange(TX xStart, TX xEnd);
+        (TY yMin, TY yMax) GetYDataRange(TX xMin, TX xMax);
     }
 
     /// <summary>

--- a/src/ScottPlot4/ScottPlot/Plottable/IHasPoints.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/IHasPoints.cs
@@ -15,6 +15,7 @@
     public interface IHasPointsGenericX<TX, TY>
     {
         (TX x, TY y, int index) GetPointNearestX(TX x);
+        (TY yMin, TY yMax) GetYDataRange(TX xStart, TX xEnd);
     }
 
     /// <summary>

--- a/src/ScottPlot4/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/ScatterPlot.cs
@@ -449,9 +449,12 @@ namespace ScottPlot.Plottable
             return (Xs[minIndex], Ys[minIndex], minIndex);
         }
 
-        public (double yMin, double yMax) GetYDataRange(double xStart, double xEnd)
+        /// <summary>
+        /// Return the vertical limits of the data between horizontal positions (inclusive)
+        /// </summary>
+        public (double yMin, double yMax) GetYDataRange(double xMin, double xMax)
         {
-            var includedYs = Ys.Where((y, i) => Xs[i] >= xStart && Xs[i] <= xEnd);
+            var includedYs = Ys.Where((y, i) => Xs[i] >= xMin && Xs[i] <= xMax);
             return (includedYs.Min(), includedYs.Max());
         }
     }

--- a/src/ScottPlot4/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/ScatterPlot.cs
@@ -448,5 +448,11 @@ namespace ScottPlot.Plottable
 
             return (Xs[minIndex], Ys[minIndex], minIndex);
         }
+
+        public (double yMin, double yMax) GetYDataRange(double xStart, double xEnd)
+        {
+            var includedYs = Ys.Where((y, i) => Xs[i] >= xStart && Xs[i] <= xEnd);
+            return (includedYs.Min(), includedYs.Max());
+        }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotBase.cs
@@ -823,15 +823,20 @@ namespace ScottPlot.Plottable
                 throw new InvalidOperationException($"A Color must be assigned to FillColor2 to use fill type '{_FillType}'");
         }
 
+        /// <summary>
+        /// Return the index for the data point corresponding to the given X coordinate
+        /// </summary>
         private int GetIndexForX(double x)
         {
             int index = (int)((x - OffsetX) / SampleRate);
             index = Math.Max(index, MinRenderIndex);
             index = Math.Min(index, MaxRenderIndex);
-
             return index;
         }
 
+        /// <summary>
+        /// Return the X coordinate of the data point at the given index
+        /// </summary>
         private double IndexToX(int index)
         {
             return index * SampleRate + OffsetX;
@@ -926,12 +931,15 @@ namespace ScottPlot.Plottable
             _GradientFillColor2 = GDI.Semitransparent(below1, alpha);
         }
 
-        public (T yMin, T yMax) GetYDataRange(double xStart, double xEnd)
+        /// <summary>
+        /// Return the vertical limits of the data between horizontal positions (inclusive)
+        /// </summary>
+        public (T yMin, T yMax) GetYDataRange(double xMin, double xMax)
         {
-            int startIndex = GetIndexForX(xStart);
-            int endIndex = GetIndexForX(xEnd);
+            int startIndex = GetIndexForX(xMin);
+            int endIndex = GetIndexForX(xMax);
 
-            if (IndexToX(endIndex) < xEnd)
+            if (IndexToX(endIndex) < xMax)
             {
                 endIndex = Math.Min(endIndex + 1, MaxRenderIndex);
             }

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -341,9 +341,14 @@ namespace ScottPlot.Plottable
                 return GetPointByIndex(index);
         }
 
-        public (TY yMin, TY yMax) GetYDataRange(TX xStart, TX xEnd)
+        /// <summary>
+        /// Return the vertical range of values between the given horizontal positions
+        /// </summary>
+        public (TY yMin, TY yMax) GetYDataRange(TX xMin, TX xMax)
         {
-            return base.GetYDataRange(NumericConversion.GenericToDouble(ref xStart), NumericConversion.GenericToDouble(ref xEnd));
+            return base.GetYDataRange(
+                xMin: NumericConversion.GenericToDouble(ref xMin),
+                xMax: NumericConversion.GenericToDouble(ref xMax));
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -340,5 +340,10 @@ namespace ScottPlot.Plottable
             else // x closer to XS[index]
                 return GetPointByIndex(index);
         }
+
+        public (TY yMin, TY yMax) GetYDataRange(TX xStart, TX xEnd)
+        {
+            return base.GetYDataRange(NumericConversion.GenericToDouble(ref xStart), NumericConversion.GenericToDouble(ref xEnd));
+        }
     }
 }

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -2,6 +2,7 @@
 
 ## ScottPlot 4.1.54
 _not yet published on NuGet..._
+* Scatter and Signal Plot: `GetYDataRange()` now returns the range of Y values between a range of X positions, useful for setting automatic axis limits when plots are zoomed-in (#1946, #1942, #1929) _Thanks @bclehmann_
 
 ## ScottPlot 4.1.53
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-07-10_


### PR DESCRIPTION
**Purpose:**
Adds `GetYDataRange` to `IHasPointsGenericX`. This interface is implemented by ScatterPlots and SignalPlots (and their derivatives). #1942, #1929

```cs
(double yMin, double yMax) = scat.GetYDataRange(xStart, xEnd);
```

I wrote some tests, though they might be a little sparse. I'm not sure how this should be put in the cookbook? I suppose we could just draw a line at the bounds like we did for nth-order statistics and quantiles: https://scottplot.net/cookbook/4.1/category/statistics/#quantiles