### PR TITLE
Hatched fills for Pie, Coxcomb, and Radar

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Coxcomb.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Coxcomb.cs
@@ -36,11 +36,11 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             double[] values = { 11, 16, 7, 3, 14 };
             var coxcomb = plt.AddCoxcomb(values);
             coxcomb.HatchOptions = new HatchOptions[] {
-                new () { HatchStyle = HatchStyle.StripedUpwardDiagonal, HatchColor = Color.FromArgb(100, Color.Gray) },
-                new () { HatchStyle = HatchStyle.StripedDownwardDiagonal, HatchColor = Color.FromArgb(100, Color.Gray) },
-                new () { HatchStyle = HatchStyle.LargeCheckerBoard, HatchColor = Color.FromArgb(100, Color.Gray) },
-                new () { HatchStyle = HatchStyle.SmallCheckerBoard, HatchColor = Color.FromArgb(100, Color.Gray) },
-                new () { HatchStyle = HatchStyle.LargeGrid, HatchColor = Color.FromArgb(100, Color.Gray) },
+                new () { Pattern = HatchStyle.StripedUpwardDiagonal, Color = Color.FromArgb(100, Color.Gray) },
+                new () { Pattern = HatchStyle.StripedDownwardDiagonal, Color = Color.FromArgb(100, Color.Gray) },
+                new () { Pattern = HatchStyle.LargeCheckerBoard, Color = Color.FromArgb(100, Color.Gray) },
+                new () { Pattern = HatchStyle.SmallCheckerBoard, Color = Color.FromArgb(100, Color.Gray) },
+                new () { Pattern = HatchStyle.LargeGrid, Color = Color.FromArgb(100, Color.Gray) },
             };
             coxcomb.OutlineWidth = 1;
 

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Coxcomb.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Coxcomb.cs
@@ -36,11 +36,11 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             double[] values = { 11, 16, 7, 3, 14 };
             var coxcomb = plt.AddCoxcomb(values);
             coxcomb.HatchOptions = new HatchOptions[] {
-                new () { HatchStyle = HatchStyle.StripedUpwardDiagonal, HatchColor = Color.FromArgb(100, Color.White) },
-                new () { HatchStyle = HatchStyle.StripedDownwardDiagonal, HatchColor = Color.FromArgb(100, Color.White) },
-                new () { HatchStyle = HatchStyle.LargeCheckerBoard, HatchColor = Color.FromArgb(100, Color.White) },
-                new () { HatchStyle = HatchStyle.SmallCheckerBoard, HatchColor = Color.FromArgb(100, Color.White) },
-                new () { HatchStyle = HatchStyle.LargeGrid, HatchColor = Color.FromArgb(100, Color.White) },
+                new () { HatchStyle = HatchStyle.StripedUpwardDiagonal, HatchColor = Color.FromArgb(100, Color.Gray) },
+                new () { HatchStyle = HatchStyle.StripedDownwardDiagonal, HatchColor = Color.FromArgb(100, Color.Gray) },
+                new () { HatchStyle = HatchStyle.LargeCheckerBoard, HatchColor = Color.FromArgb(100, Color.Gray) },
+                new () { HatchStyle = HatchStyle.SmallCheckerBoard, HatchColor = Color.FromArgb(100, Color.Gray) },
+                new () { HatchStyle = HatchStyle.LargeGrid, HatchColor = Color.FromArgb(100, Color.Gray) },
             };
             coxcomb.OutlineWidth = 1;
 

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Coxcomb.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Coxcomb.cs
@@ -44,6 +44,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             };
             coxcomb.OutlineWidth = 1;
 
+            coxcomb.SliceLabels = new string[] { "bikes", "blimps", "subs", "saucers", "rockets" };
             plt.Legend();
         }
     }

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Coxcomb.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Coxcomb.cs
@@ -36,7 +36,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             double[] values = { 11, 16, 7, 3, 14 };
             var coxcomb = plt.AddCoxcomb(values);
             coxcomb.HatchOptions = new HatchOptions[] {
-                new () { HatchStyle = HatchStyle.StripedUpwardDiagonal, HatchColor = Color.White },
+                new () { HatchStyle = HatchStyle.StripedUpwardDiagonal, HatchColor = Color.FromArgb(100, Color.White) },
                 new () { HatchStyle = HatchStyle.StripedDownwardDiagonal, HatchColor = Color.FromArgb(100, Color.White) },
                 new () { HatchStyle = HatchStyle.LargeCheckerBoard, HatchColor = Color.FromArgb(100, Color.White) },
                 new () { HatchStyle = HatchStyle.SmallCheckerBoard, HatchColor = Color.FromArgb(100, Color.White) },

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Coxcomb.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Coxcomb.cs
@@ -23,7 +23,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             plt.Legend();
         }
     }
-    public class CoxcombHatch: IRecipe
+    public class CoxcombHatch : IRecipe
     {
         public ICategory Category => new Categories.PlotTypes.Coxcomb();
         public string ID => "coxcomb_hatch";

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Coxcomb.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Coxcomb.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using ScottPlot.Drawing;
+using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Text;
 
 namespace ScottPlot.Cookbook.Recipes.Plottable
@@ -21,6 +23,31 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             plt.Legend();
         }
     }
+    public class CoxcombHatch: IRecipe
+    {
+        public ICategory Category => new Categories.PlotTypes.Coxcomb();
+        public string ID => "coxcomb_hatch";
+        public string Title => "Custom Hatching (patterns)";
+        public string Description =>
+            "Coxcomb charts allow custom hatching of their slices.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[] values = { 11, 16, 7, 3, 14 };
+            var coxcomb = plt.AddCoxcomb(values);
+            coxcomb.HatchOptions = new HatchOptions[] {
+                new () { HatchStyle = HatchStyle.StripedUpwardDiagonal, HatchColor = Color.White },
+                new () { HatchStyle = HatchStyle.StripedDownwardDiagonal, HatchColor = Color.FromArgb(100, Color.White) },
+                new () { HatchStyle = HatchStyle.LargeCheckerBoard, HatchColor = Color.FromArgb(100, Color.White) },
+                new () { HatchStyle = HatchStyle.SmallCheckerBoard, HatchColor = Color.FromArgb(100, Color.White) },
+                new () { HatchStyle = HatchStyle.LargeGrid, HatchColor = Color.FromArgb(100, Color.White) },
+            };
+            coxcomb.OutlineWidth = 1;
+
+            plt.Legend();
+        }
+    }
+
     public class CoxcombWithIcons : IRecipe
     {
         public ICategory Category => new Categories.PlotTypes.Coxcomb();

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Function.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Function.cs
@@ -24,6 +24,9 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             plt.AddFunction(func1, lineWidth: 2);
             plt.AddFunction(func2, lineWidth: 2, lineStyle: LineStyle.Dot);
             plt.AddFunction(func3, lineWidth: 2, lineStyle: LineStyle.Dash);
+
+            // Manually set axis limits because functions do not have discrete data points
+            plt.SetAxisLimits(-10, 10, -1.5, 1.5);
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Pie.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Pie.cs
@@ -153,7 +153,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         }
     }
 
-    public class PieCustomHatch: IRecipe
+    public class PieCustomHatch : IRecipe
     {
         public ICategory Category => new Categories.PlotTypes.Pie();
         public string ID => "pie_customHatch";

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Pie.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Pie.cs
@@ -168,11 +168,11 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
 
             var pie = plt.AddPie(values);
             pie.HatchOptions = new HatchOptions[] {
-                new () { HatchStyle = HatchStyle.StripedUpwardDiagonal, HatchColor = Color.FromArgb(100, Color.Gray) },
-                new () { HatchStyle = HatchStyle.StripedDownwardDiagonal, HatchColor = Color.FromArgb(100, Color.Gray) },
-                new () { HatchStyle = HatchStyle.LargeCheckerBoard, HatchColor = Color.FromArgb(100, Color.Gray) },
-                new () { HatchStyle = HatchStyle.SmallCheckerBoard, HatchColor = Color.FromArgb(100, Color.Gray) },
-                new () { HatchStyle = HatchStyle.LargeGrid, HatchColor = Color.FromArgb(100, Color.Gray) },
+                new () { Pattern = HatchStyle.StripedUpwardDiagonal, Color = Color.FromArgb(100, Color.Gray) },
+                new () { Pattern = HatchStyle.StripedDownwardDiagonal, Color = Color.FromArgb(100, Color.Gray) },
+                new () { Pattern = HatchStyle.LargeCheckerBoard, Color = Color.FromArgb(100, Color.Gray) },
+                new () { Pattern = HatchStyle.SmallCheckerBoard, Color = Color.FromArgb(100, Color.Gray) },
+                new () { Pattern = HatchStyle.LargeGrid, Color = Color.FromArgb(100, Color.Gray) },
             };
             pie.OutlineSize = 1;
 

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Pie.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Pie.cs
@@ -168,11 +168,11 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
 
             var pie = plt.AddPie(values);
             pie.HatchOptions = new HatchOptions[] {
-                new () { HatchStyle = HatchStyle.StripedUpwardDiagonal, HatchColor = Color.FromArgb(100, Color.White) },
-                new () { HatchStyle = HatchStyle.StripedDownwardDiagonal, HatchColor = Color.FromArgb(100, Color.White) },
-                new () { HatchStyle = HatchStyle.LargeCheckerBoard, HatchColor = Color.FromArgb(100, Color.White) },
-                new () { HatchStyle = HatchStyle.SmallCheckerBoard, HatchColor = Color.FromArgb(100, Color.White) },
-                new () { HatchStyle = HatchStyle.LargeGrid, HatchColor = Color.FromArgb(100, Color.White) },
+                new () { HatchStyle = HatchStyle.StripedUpwardDiagonal, HatchColor = Color.FromArgb(100, Color.Gray) },
+                new () { HatchStyle = HatchStyle.StripedDownwardDiagonal, HatchColor = Color.FromArgb(100, Color.Gray) },
+                new () { HatchStyle = HatchStyle.LargeCheckerBoard, HatchColor = Color.FromArgb(100, Color.Gray) },
+                new () { HatchStyle = HatchStyle.SmallCheckerBoard, HatchColor = Color.FromArgb(100, Color.Gray) },
+                new () { HatchStyle = HatchStyle.LargeGrid, HatchColor = Color.FromArgb(100, Color.Gray) },
             };
             pie.OutlineSize = 1;
         }

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Pie.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Pie.cs
@@ -175,6 +175,9 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
                 new () { HatchStyle = HatchStyle.LargeGrid, HatchColor = Color.FromArgb(100, Color.Gray) },
             };
             pie.OutlineSize = 1;
+
+            pie.SliceLabels = labels;
+            plt.Legend();
         }
     }
 

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Pie.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Pie.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ScottPlot.Drawing;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -149,6 +150,31 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             pie.ShowLabels = true;
             pie.SliceFillColors = sliceColors;
             pie.SliceLabelColors = labelColors;
+        }
+    }
+
+    public class PieCustomHatch: IRecipe
+    {
+        public ICategory Category => new Categories.PlotTypes.Pie();
+        public string ID => "pie_customHatch";
+        public string Title => "Customize Pie Hatching";
+        public string Description =>
+            "Hatching (patterns) for pie slices and labels can be customized.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[] values = { 778, 43, 283, 76, 184 };
+            string[] labels = { "C#", "JAVA", "Python", "F#", "PHP" };
+
+            var pie = plt.AddPie(values);
+            pie.HatchOptions = new HatchOptions[] {
+                new () { HatchStyle = HatchStyle.StripedUpwardDiagonal, HatchColor = Color.FromArgb(100, Color.White) },
+                new () { HatchStyle = HatchStyle.StripedDownwardDiagonal, HatchColor = Color.FromArgb(100, Color.White) },
+                new () { HatchStyle = HatchStyle.LargeCheckerBoard, HatchColor = Color.FromArgb(100, Color.White) },
+                new () { HatchStyle = HatchStyle.SmallCheckerBoard, HatchColor = Color.FromArgb(100, Color.White) },
+                new () { HatchStyle = HatchStyle.LargeGrid, HatchColor = Color.FromArgb(100, Color.White) },
+            };
+            pie.OutlineSize = 1;
         }
     }
 

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Radar.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Radar.cs
@@ -176,8 +176,8 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             var radar = plt.AddRadar(values);
             radar.HatchOptions = new HatchOptions[]
             {
-                new() { HatchStyle = HatchStyle.StripedUpwardDiagonal, HatchColor = Color.FromArgb(100, Color.White) },
-                new() { HatchStyle = HatchStyle.StripedDownwardDiagonal, HatchColor = Color.FromArgb(100, Color.White) },
+                new() { HatchStyle = HatchStyle.StripedUpwardDiagonal, HatchColor = Color.FromArgb(100, Color.Gray) },
+                new() { HatchStyle = HatchStyle.StripedDownwardDiagonal, HatchColor = Color.FromArgb(100, Color.Gray) },
             };
 
             radar.GroupLabels = new string[] { "Sebastian Vettel", "Fernando Alonso" };

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Radar.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Radar.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using ScottPlot.Drawing;
+using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Text;
 
 namespace ScottPlot.Cookbook.Recipes.Plottable
@@ -145,6 +147,39 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
 
             var radar = plt.AddRadar(values);
             radar.OutlineWidth = 3;
+            radar.GroupLabels = new string[] { "Sebastian Vettel", "Fernando Alonso" };
+            plt.Title("2010 Formula One World Championship");
+            plt.Legend();
+
+            /* Data represents the 2010 Formula One World Championship
+             * https://en.wikipedia.org/wiki/2010_Formula_One_World_Championship
+             * Note: Alonso did not finish (DNF) in the Malaysian GP, but was included 
+             * here because he completed >90% of the race distance.
+             */
+        }
+    }
+
+    public class RadarHatch: IRecipe
+    {
+        public ICategory Category => new Categories.PlotTypes.Radar();
+        public string ID => "radar_hatch";
+        public string Title => "Customizable hatching (pattern)";
+        public string Description => "The hatch of each radar plot can be customized";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[,] values = {
+                { 5, 3, 10, 15, 3, 2 },
+                { 5, 2, 10, 10, 1, 4 },
+            };
+
+            var radar = plt.AddRadar(values);
+            radar.HatchOptions = new HatchOptions[]
+            {
+                new() { HatchStyle = HatchStyle.StripedUpwardDiagonal, HatchColor = Color.FromArgb(100, Color.White) },
+                new() { HatchStyle = HatchStyle.StripedDownwardDiagonal, HatchColor = Color.FromArgb(100, Color.White) },
+            };
+
             radar.GroupLabels = new string[] { "Sebastian Vettel", "Fernando Alonso" };
             plt.Title("2010 Formula One World Championship");
             plt.Legend();

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Radar.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Radar.cs
@@ -159,7 +159,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         }
     }
 
-    public class RadarHatch: IRecipe
+    public class RadarHatch : IRecipe
     {
         public ICategory Category => new Categories.PlotTypes.Radar();
         public string ID => "radar_hatch";

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Radar.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Radar.cs
@@ -176,8 +176,8 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             var radar = plt.AddRadar(values);
             radar.HatchOptions = new HatchOptions[]
             {
-                new() { HatchStyle = HatchStyle.StripedUpwardDiagonal, HatchColor = Color.FromArgb(100, Color.Gray) },
-                new() { HatchStyle = HatchStyle.StripedDownwardDiagonal, HatchColor = Color.FromArgb(100, Color.Gray) },
+                new() { Pattern = HatchStyle.StripedUpwardDiagonal, Color = Color.FromArgb(100, Color.Gray) },
+                new() { Pattern = HatchStyle.StripedDownwardDiagonal, Color = Color.FromArgb(100, Color.Gray) },
             };
 
             radar.GroupLabels = new string[] { "Sebastian Vettel", "Fernando Alonso" };

--- a/src/ScottPlot4/ScottPlot.WPF/WpfPlot.xaml.cs
+++ b/src/ScottPlot4/ScottPlot.WPF/WpfPlot.xaml.cs
@@ -313,7 +313,7 @@ namespace ScottPlot
             cm.IsOpen = true;
         }
 
-        private void RightClickMenu_Copy_Click(object sender, EventArgs e) => System.Windows.Clipboard.SetImage(BmpImageFromBmp(Backend.GetLatestBitmap()));
+        private void RightClickMenu_Copy_Click(object sender, EventArgs e) => System.Windows.Clipboard.SetImage(BmpImageFromBmp(Plot.Render()));
         private void RightClickMenu_Help_Click(object sender, EventArgs e) => new WPF.HelpWindow().Show();
         private void RightClickMenu_OpenInNewWindow_Click(object sender, EventArgs e) => new WpfPlotViewer(Plot).Show();
         private void RightClickMenu_AutoAxis_Click(object sender, EventArgs e) { Plot.AxisAuto(); Refresh(); }

--- a/src/ScottPlot4/ScottPlot/HatchOptions.cs
+++ b/src/ScottPlot4/ScottPlot/HatchOptions.cs
@@ -1,0 +1,16 @@
+﻿using ScottPlot.Drawing;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot
+{
+    public struct HatchOptions
+    {
+        public HatchStyle HatchStyle { get; set; }
+        public Color HatchColor { get; set; }
+    }
+}

--- a/src/ScottPlot4/ScottPlot/HatchOptions.cs
+++ b/src/ScottPlot4/ScottPlot/HatchOptions.cs
@@ -10,7 +10,7 @@ namespace ScottPlot
 {
     public struct HatchOptions
     {
-        public HatchStyle HatchStyle { get; set; }
-        public Color HatchColor { get; set; }
+        public HatchStyle Pattern { get; set; }
+        public Color Color { get; set; }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Plottable/CoxcombPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/CoxcombPlot.cs
@@ -187,7 +187,8 @@ namespace ScottPlot.Plottable
 
             return Enumerable
                 .Range(0, Values.Length)
-                .Select(i => new LegendItem(this) {
+                .Select(i => new LegendItem(this)
+                {
                     label = SliceLabels[i],
                     color = FillColors[i],
                     lineWidth = 10,

--- a/src/ScottPlot4/ScottPlot/Plottable/CoxcombPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/CoxcombPlot.cs
@@ -51,7 +51,7 @@ namespace ScottPlot.Plottable
         /// <summary>
         /// The color to draw the axis in
         /// </summary>
-        public Color WebColor { get; set; } = Color.Gray;
+        public Color WebColor { get; set; } = Color.Gray; // TODO: avoid this name in the future (see #1948)
 
         /// <summary>
         /// Controls rendering style of the concentric circles (ticks) of the web

--- a/src/ScottPlot4/ScottPlot/Plottable/CoxcombPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/CoxcombPlot.cs
@@ -33,6 +33,22 @@ namespace ScottPlot.Plottable
         public Color[] FillColors { get; set; }
 
         /// <summary>
+        /// Contains options for hatched (patterned) fills for each slice
+        /// </summary>
+        public HatchOptions[] HatchOptions { get; set; }
+
+        /// <summary>
+        /// The color of the slice outline.
+        /// </summary>
+        public Color Outline { get; set; } = Color.Black;
+
+        /// <summary>
+        /// The width of the slice outline.
+        /// </summary>
+        public float OutlineWidth { get; set; } = 0;
+
+
+        /// <summary>
         /// The color to draw the axis in
         /// </summary>
         public Color WebColor { get; set; } = Color.Gray;
@@ -85,24 +101,39 @@ namespace ScottPlot.Plottable
 
 
             using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
-            using SolidBrush sliceFillBrush = (SolidBrush)GDI.Brush(Color.Black);
+            using Pen outlinePen = GDI.Pen(Outline, OutlineWidth);
 
             RenderAxis(gfx, dims, bmp, lowQuality);
 
             double start = -90;
             for (int i = 0; i < numCategories; i++)
             {
+                using var sliceFillBrush = GDI.Brush(FillColors[i], HatchOptions?[i].HatchColor, HatchOptions?[i].HatchStyle ?? Drawing.HatchStyle.None);
+
                 double angle = (Math.PI / 180) * ((sweepAngle + 2 * start) / 2);
                 float diameter = (float)(maxDiameterPixels * Normalized[i]);
-                sliceFillBrush.Color = FillColors[i];
+
+                var pieX = (int)origin.X - diameter / 2;
+                var pieY = (int)origin.Y - diameter / 2;
 
                 gfx.FillPie(brush: sliceFillBrush,
-                    x: (int)origin.X - diameter / 2,
-                    y: (int)origin.Y - diameter / 2,
+                    x: pieX,
+                    y: pieY,
                     width: diameter,
                     height: diameter,
                     startAngle: (float)start,
                     sweepAngle: (float)sweepAngle);
+
+                if (OutlineWidth != 0)
+                {
+                    gfx.DrawPie(outlinePen,
+                        x: pieX,
+                        y: pieY,
+                        width: diameter,
+                        height: diameter,
+                        startAngle: (float)start,
+                        sweepAngle: (float)sweepAngle);
+                }
 
                 start += sweepAngle;
             }

--- a/src/ScottPlot4/ScottPlot/Plottable/CoxcombPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/CoxcombPlot.cs
@@ -187,7 +187,13 @@ namespace ScottPlot.Plottable
 
             return Enumerable
                 .Range(0, Values.Length)
-                .Select(i => new LegendItem(this) { label = SliceLabels[i], color = FillColors[i], lineWidth = 10 })
+                .Select(i => new LegendItem(this) {
+                    label = SliceLabels[i],
+                    color = FillColors[i],
+                    lineWidth = 10,
+                    hatchStyle = HatchOptions?[i].HatchStyle ?? Drawing.HatchStyle.None,
+                    hatchColor = HatchOptions?[i].HatchColor ?? Color.Black
+                })
                 .ToArray();
         }
 

--- a/src/ScottPlot4/ScottPlot/Plottable/CoxcombPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/CoxcombPlot.cs
@@ -108,7 +108,7 @@ namespace ScottPlot.Plottable
             double start = -90;
             for (int i = 0; i < numCategories; i++)
             {
-                using var sliceFillBrush = GDI.Brush(FillColors[i], HatchOptions?[i].HatchColor, HatchOptions?[i].HatchStyle ?? Drawing.HatchStyle.None);
+                using var sliceFillBrush = GDI.Brush(FillColors[i], HatchOptions?[i].Color, HatchOptions?[i].Pattern ?? Drawing.HatchStyle.None);
 
                 double angle = (Math.PI / 180) * ((sweepAngle + 2 * start) / 2);
                 float diameter = (float)(maxDiameterPixels * Normalized[i]);
@@ -192,8 +192,8 @@ namespace ScottPlot.Plottable
                     label = SliceLabels[i],
                     color = FillColors[i],
                     lineWidth = 10,
-                    hatchStyle = HatchOptions?[i].HatchStyle ?? Drawing.HatchStyle.None,
-                    hatchColor = HatchOptions?[i].HatchColor ?? Color.Black
+                    hatchStyle = HatchOptions?[i].Pattern ?? Drawing.HatchStyle.None,
+                    hatchColor = HatchOptions?[i].Color ?? Color.Black
                 })
                 .ToArray();
         }

--- a/src/ScottPlot4/ScottPlot/Plottable/PiePlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/PiePlot.cs
@@ -65,7 +65,14 @@ namespace ScottPlot.Plottable
 
             return Enumerable
                 .Range(0, Values.Length)
-                .Select(i => new LegendItem(this) { label = SliceLabels[i], color = SliceFillColors[i], lineWidth = 10 })
+                .Select(i => new LegendItem(this) { 
+                    label = SliceLabels[i],
+                    color = SliceFillColors[i],
+                    lineWidth = 10,
+                    hatchStyle = HatchOptions?[i].HatchStyle ?? Drawing.HatchStyle.None,
+                    hatchColor = HatchOptions?[i].HatchColor ?? Color.Black
+                    
+                })
                 .ToArray();
         }
 

--- a/src/ScottPlot4/ScottPlot/Plottable/PiePlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/PiePlot.cs
@@ -70,8 +70,8 @@ namespace ScottPlot.Plottable
                     label = SliceLabels[i],
                     color = SliceFillColors[i],
                     lineWidth = 10,
-                    hatchStyle = HatchOptions?[i].HatchStyle ?? Drawing.HatchStyle.None,
-                    hatchColor = HatchOptions?[i].HatchColor ?? Color.Black
+                    hatchStyle = HatchOptions?[i].Pattern ?? Drawing.HatchStyle.None,
+                    hatchColor = HatchOptions?[i].Color ?? Color.Black
 
                 })
                 .ToArray();
@@ -152,7 +152,7 @@ namespace ScottPlot.Plottable
                     string sliceLabelName = (ShowLabels && SliceLabels != null) ? SliceLabels[i] : "";
                     labelStrings[i] = $"{sliceLabelValue}\n{sliceLabelPercentage}\n{sliceLabelName}".Trim();
 
-                    using var sliceFillBrush = GDI.Brush(SliceFillColors[i], HatchOptions?[i].HatchColor, HatchOptions?[i].HatchStyle ?? Drawing.HatchStyle.None);
+                    using var sliceFillBrush = GDI.Brush(SliceFillColors[i], HatchOptions?[i].Color, HatchOptions?[i].Pattern ?? Drawing.HatchStyle.None);
                     gfx.FillPie(brush: sliceFillBrush,
                         x: (int)(boundingRectangle.X + xOffset),
                         y: (int)(boundingRectangle.Y + yOffset),

--- a/src/ScottPlot4/ScottPlot/Plottable/PiePlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/PiePlot.cs
@@ -19,6 +19,7 @@ namespace ScottPlot.Plottable
         public Color[] SliceFillColors { get; set; }
         public Color[] SliceLabelColors { get; set; }
         public Color BackgroundColor { get; set; }
+        public HatchOptions[] HatchOptions { get; set; }
 
         public bool Explode { get; set; }
         public bool ShowValues { get; set; }
@@ -87,7 +88,6 @@ namespace ScottPlot.Plottable
             using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
             using (Pen backgroundPen = GDI.Pen(BackgroundColor))
             using (Pen outlinePen = GDI.Pen(OutlineColor, OutlineSize))
-            using (Brush sliceFillBrush = GDI.Brush(Color.Black))
             using (var sliceFont = GDI.Font(SliceFont))
             using (SolidBrush sliceFontBrush = (SolidBrush)GDI.Brush(SliceFont.Color))
             using (var centerFont = GDI.Font(CenterFont))
@@ -144,7 +144,7 @@ namespace ScottPlot.Plottable
                     string sliceLabelName = (ShowLabels && SliceLabels != null) ? SliceLabels[i] : "";
                     labelStrings[i] = $"{sliceLabelValue}\n{sliceLabelPercentage}\n{sliceLabelName}".Trim();
 
-                    ((SolidBrush)sliceFillBrush).Color = SliceFillColors[i];
+                    using var sliceFillBrush = GDI.Brush(SliceFillColors[i], HatchOptions?[i].HatchColor, HatchOptions?[i].HatchStyle ?? Drawing.HatchStyle.None);
                     gfx.FillPie(brush: sliceFillBrush,
                         x: (int)(boundingRectangle.X + xOffset),
                         y: (int)(boundingRectangle.Y + yOffset),

--- a/src/ScottPlot4/ScottPlot/Plottable/PiePlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/PiePlot.cs
@@ -65,13 +65,14 @@ namespace ScottPlot.Plottable
 
             return Enumerable
                 .Range(0, Values.Length)
-                .Select(i => new LegendItem(this) { 
+                .Select(i => new LegendItem(this)
+                {
                     label = SliceLabels[i],
                     color = SliceFillColors[i],
                     lineWidth = 10,
                     hatchStyle = HatchOptions?[i].HatchStyle ?? Drawing.HatchStyle.None,
                     hatchColor = HatchOptions?[i].HatchColor ?? Color.Black
-                    
+
                 })
                 .ToArray();
         }

--- a/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
@@ -70,7 +70,7 @@ namespace ScottPlot.Plottable
         /// <summary>
         /// Color of the axis lines and concentric circles representing ticks
         /// </summary>
-        public Color WebColor { get; set; } = Color.Gray;
+        public Color WebColor { get; set; } = Color.Gray; // TODO: avoid this name in the future (see #1948)
 
         /// <summary>
         /// Contains options for hatched (patterned) fills for each slice

--- a/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
@@ -232,7 +232,9 @@ namespace ScottPlot.Plottable
                     label = GroupLabels[i],
                     color = FillColors[i],
                     lineWidth = 10,
-                    markerShape = MarkerShape.none
+                    markerShape = MarkerShape.none,
+                    hatchStyle = HatchOptions?[i].HatchStyle ?? Drawing.HatchStyle.None,
+                    hatchColor = HatchOptions?[i].HatchColor ?? Color.Black
                 };
                 legendItems.Add(item);
             }

--- a/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
@@ -73,6 +73,11 @@ namespace ScottPlot.Plottable
         public Color WebColor { get; set; } = Color.Gray;
 
         /// <summary>
+        /// Contains options for hatched (patterned) fills for each slice
+        /// </summary>
+        public HatchOptions[] HatchOptions { get; set; }
+
+        /// <summary>
         /// Controls if values along each category axis are scaled independently or uniformly across all axes.
         /// </summary>
         public bool IndependentAxes { get; set; }
@@ -254,7 +259,6 @@ namespace ScottPlot.Plottable
 
             using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
             using (Pen pen = GDI.Pen(WebColor, OutlineWidth))
-            using (Brush brush = GDI.Brush(Color.Black))
             using (StringFormat sf = new StringFormat() { LineAlignment = StringAlignment.Center })
             using (StringFormat sf2 = new StringFormat())
             using (System.Drawing.Font font = GDI.Font(Font))
@@ -270,7 +274,7 @@ namespace ScottPlot.Plottable
                             (float)(Norm[i, j] * Math.Cos(sweepAngle * j - Math.PI / 2) * minScale + origin.X),
                             (float)(Norm[i, j] * Math.Sin(sweepAngle * j - Math.PI / 2) * minScale + origin.Y));
 
-                    ((SolidBrush)brush).Color = FillColors[i];
+                    using var brush = GDI.Brush(FillColors[i], HatchOptions?[i].HatchColor, HatchOptions?[i].HatchStyle ?? Drawing.HatchStyle.None);
                     pen.Color = LineColors[i];
                     gfx.FillPolygon(brush, points);
                     gfx.DrawPolygon(pen, points);

--- a/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
@@ -233,8 +233,8 @@ namespace ScottPlot.Plottable
                     color = FillColors[i],
                     lineWidth = 10,
                     markerShape = MarkerShape.none,
-                    hatchStyle = HatchOptions?[i].HatchStyle ?? Drawing.HatchStyle.None,
-                    hatchColor = HatchOptions?[i].HatchColor ?? Color.Black
+                    hatchStyle = HatchOptions?[i].Pattern ?? Drawing.HatchStyle.None,
+                    hatchColor = HatchOptions?[i].Color ?? Color.Black
                 };
                 legendItems.Add(item);
             }
@@ -276,7 +276,7 @@ namespace ScottPlot.Plottable
                             (float)(Norm[i, j] * Math.Cos(sweepAngle * j - Math.PI / 2) * minScale + origin.X),
                             (float)(Norm[i, j] * Math.Sin(sweepAngle * j - Math.PI / 2) * minScale + origin.Y));
 
-                    using var brush = GDI.Brush(FillColors[i], HatchOptions?[i].HatchColor, HatchOptions?[i].HatchStyle ?? Drawing.HatchStyle.None);
+                    using var brush = GDI.Brush(FillColors[i], HatchOptions?[i].Color, HatchOptions?[i].Pattern ?? Drawing.HatchStyle.None);
                     pen.Color = LineColors[i];
                     gfx.FillPolygon(brush, points);
                     gfx.DrawPolygon(pen, points);

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -4,6 +4,7 @@
 _not yet published on NuGet..._
 * Scatter and Signal Plot: `GetYDataRange()` now returns the range of Y values between a range of X positions, useful for setting automatic axis limits when plots are zoomed-in (#1946, #1942, #1929) _Thanks @bclehmann_
 * WPF Control: Right-click copy now renders high quality image to the clipboard (#1952) _Thanks @bclehmann_
+* Radar, Coxcomb, and Pie Chart: New options to customize hatch pattern and color. See cookbook for examples. (#1948, #1943) _Thanks @bclehmann_
 
 ## ScottPlot 4.1.53
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-07-10_

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.54
 _not yet published on NuGet..._
 * Scatter and Signal Plot: `GetYDataRange()` now returns the range of Y values between a range of X positions, useful for setting automatic axis limits when plots are zoomed-in (#1946, #1942, #1929) _Thanks @bclehmann_
+* WPF Control: Right-click copy now renders high quality image to the clipboard (#1952) _Thanks @bclehmann_
 
 ## ScottPlot 4.1.53
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-07-10_


### PR DESCRIPTION
**Purpose:**
#1943 

```cs
pie.HatchOptions = new HatchOptions[] {
    new () { HatchStyle = HatchStyle.StripedUpwardDiagonal, HatchColor = Color.FromArgb(100, Color.Gray) },
    new () { HatchStyle = HatchStyle.StripedDownwardDiagonal, HatchColor = Color.FromArgb(100, Color.Gray) },
    new () { HatchStyle = HatchStyle.LargeCheckerBoard, HatchColor = Color.FromArgb(100, Color.Gray) },
    new () { HatchStyle = HatchStyle.SmallCheckerBoard, HatchColor = Color.FromArgb(100, Color.Gray) },
    new () { HatchStyle = HatchStyle.LargeGrid, HatchColor = Color.FromArgb(100, Color.Gray) },
};
```

Pie: 
![image](https://user-images.githubusercontent.com/8635304/178627587-b8500635-a112-4cf2-916f-dd35f95e4475.png)

Cocxomb:
![image](https://user-images.githubusercontent.com/8635304/178627604-bd14ddf3-2935-458c-ac9d-becf31d7be88.png)

Radar:
![image](https://user-images.githubusercontent.com/8635304/178627636-d02cc200-133e-4841-bf80-dc4a61dd5588.png)

I promise they look better than in the screenshots, I used right-click and copy to paste the images in, and that disables anti-aliasing, which might be worth looking into separately.