### PR TITLE
Signal, SignalXY: Ensure markers are drawn for single-point arrays

### DIFF
--- a/src/ScottPlot4/ScottPlot.Tests/PlottableRenderTests/Signal.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlottableRenderTests/Signal.cs
@@ -1,0 +1,41 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlotTests.PlottableRenderTests
+{
+    internal class Signal
+    {
+        [Test]
+        public void Test_Signal_SinglePointShouldDrawMarker()
+        {
+            double[] dataY = { 69 };
+
+            var plt = new ScottPlot.Plot(400, 300);
+            plt.AddSignal(dataY);
+
+            var meanPixel = new MeanPixel(plt);
+            Assert.That(meanPixel.IsNotGray());
+
+            TestTools.SaveFig(plt);
+        }
+
+        [Test]
+        public void Test_SignalXY_SinglePointShouldDrawMarker()
+        {
+            double[] dataX = { 42 };
+            double[] dataY = { 69 };
+
+            var plt = new ScottPlot.Plot(400, 300);
+            plt.AddSignalXY(dataX, dataY);
+
+            var meanPixel = new MeanPixel(plt);
+            Assert.That(meanPixel.IsNotGray());
+
+            TestTools.SaveFig(plt);
+        }
+    }
+}

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotBase.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotBase.cs
@@ -384,23 +384,23 @@ namespace ScottPlot.Plottable
                     default:
                         throw new InvalidOperationException("unsupported fill type");
                 }
+            }
 
-                if ((MarkerSize > 0) && (MarkerShape != MarkerShape.none))
+            if ((MarkerSize > 0) && (MarkerShape != MarkerShape.none))
+            {
+                // make markers transition away smoothly by making them smaller as the user zooms out
+                float pixelsBetweenPoints = (float)((Ys.Length > 1 ? _SamplePeriod : 1) * dims.DataWidth / dims.XSpan);
+                float zoomTransitionScale = Math.Min(1, pixelsBetweenPoints / 10);
+                float markerPxDiameter = MarkerSize * zoomTransitionScale;
+                float markerPxRadius = markerPxDiameter / 2;
+                if (markerPxRadius > .25)
                 {
-                    // make markers transition away smoothly by making them smaller as the user zooms out
-                    float pixelsBetweenPoints = (float)(_SamplePeriod * dims.DataWidth / dims.XSpan);
-                    float zoomTransitionScale = Math.Min(1, pixelsBetweenPoints / 10);
-                    float markerPxDiameter = MarkerSize * zoomTransitionScale;
-                    float markerPxRadius = markerPxDiameter / 2;
-                    if (markerPxRadius > .25)
-                    {
-                        ShowMarkersInLegend = true;
-                        MarkerTools.DrawMarkers(gfx, linePoints, MarkerShape, markerPxDiameter, Color, MarkerLineWidth);
-                    }
-                    else
-                    {
-                        ShowMarkersInLegend = false;
-                    }
+                    ShowMarkersInLegend = true;
+                    MarkerTools.DrawMarkers(gfx, linePoints, MarkerShape, markerPxDiameter, Color, MarkerLineWidth);
+                }
+                else
+                {
+                    ShowMarkersInLegend = false;
                 }
             }
         }
@@ -774,11 +774,11 @@ namespace ScottPlot.Plottable
             double dataWidthPx = lastPointX - firstPointX;
             double columnsWithData = Math.Min(dataWidthPx, dataWidthPx2);
 
-            if (columnsWithData < 1)
+            if (columnsWithData < 1 && Ys.Length > 1)
             {
                 RenderSingleLine(dims, gfx, penHD);
             }
-            else if (pointsPerPixelColumn > 1)
+            else if (pointsPerPixelColumn > 1 && Ys.Length > 1)
             {
                 if (densityLevelsAvailable)
                     RenderHighDensityDistributionParallel(dims, gfx, offsetPoints, columnPointCount);

--- a/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/SignalPlotXYGeneric.cs
@@ -258,11 +258,11 @@ namespace ScottPlot.Plottable
                 }
 
                 // draw markers
-                if (markersToDraw.Length > 1)
+                if (markersToDraw.Length >= 1)
                 {
                     float dataSpanXPx = markersToDraw[markersToDraw.Length - 1].X - markersToDraw[0].X;
                     float markerPxRadius = .3f * dataSpanXPx / markersToDraw.Length;
-                    markerPxRadius = Math.Min(markerPxRadius, MarkerSize / 2);
+                    markerPxRadius = markersToDraw.Length > 1 ? Math.Min(markerPxRadius, MarkerSize / 2) : MarkerSize / 2;
                     float scaledMarkerSize = markerPxRadius * 2;
 
                     if (markerPxRadius > .3)

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -5,6 +5,7 @@ _not yet published on NuGet..._
 * Scatter and Signal Plot: `GetYDataRange()` now returns the range of Y values between a range of X positions, useful for setting automatic axis limits when plots are zoomed-in (#1946, #1942, #1929) _Thanks @bclehmann_
 * WPF Control: Right-click copy now renders high quality image to the clipboard (#1952) _Thanks @bclehmann_
 * Radar, Coxcomb, and Pie Chart: New options to customize hatch pattern and color. See cookbook for examples. (#1948, #1943) _Thanks @bclehmann_
+* Signal Plot: Improve support for plots with a single point (#1951, #1949) _Thanks @bclehmann and @Fruchtzwerg94_
 
 ## ScottPlot 4.1.53
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-07-10_


### PR DESCRIPTION
**Purpose:**
#1949

This also necessitated disabling the adaptive marker size for N=1, as it would ordinarily return a very small (not necessarily zero) number. I believe for SignalXY it would always return zero.