### PR TITLE
ScottPlot5: Drastic AvaPlot performance improvements

### DIFF
--- a/src/ScottPlot5/Controls/ScottPlot.Avalonia/AvaPlot.axaml
+++ b/src/ScottPlot5/Controls/ScottPlot.Avalonia/AvaPlot.axaml
@@ -7,7 +7,6 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
 			 Focusable="true"
-			 PropertyChanged="OnPropertyChanged"
              PointerPressed="OnMouseDown"
 			 PointerReleased="OnMouseUp"
 			 PointerMoved="OnMouseMove"
@@ -15,12 +14,5 @@
 			 KeyDown="OnKeyDown"
 			 KeyUp="OnKeyUp"
 		>
-	<Grid RowDefinitions="*" ColumnDefinitions="*">
-        <Image 
-			Name="image" 
-			Grid.Row="0"
-			Grid.Column="0"
-		/>
-	</Grid>
 </UserControl>
  

--- a/src/ScottPlot5/Controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
+++ b/src/ScottPlot5/Controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
@@ -42,7 +42,7 @@ namespace ScottPlot.Avalonia
         {
             AvaloniaXamlLoader.Load(this);
         }
-        
+
         public override void Render(DrawingContext context)
         {
             SKImageInfo imageInfo = new((int)Bounds.Width, (int)Bounds.Height);


### PR DESCRIPTION
**Purpose:**
This does two things:

- Overrides `Render` directly, rather than using an `Image` control. I'm unsure of the performance improvement here, it's likely small to negligible. However, it simplifies the control quite a bit
    - This doesn't depend on a Skia drawing context like a similar idea I discussed
- No longer saves the `WriteableBitmap` to a stream in order to then construct an Avalonia `Bitmap`
    - The only reason we couldn't draw a `WritableBitmap` directly is because we didn't release the lock, causing a deadlock. This is what I get for writing PRs late at night
    - The performance impact of skipping these two copies is monstrous.
