### PR TITLE
ScottPlot 5 Avalonia: Fixes Shift+MWheel yielding a deltaY of 0.

### DIFF
--- a/src/ScottPlot5/Controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
+++ b/src/ScottPlot5/Controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
@@ -103,7 +103,13 @@ namespace ScottPlot.Avalonia
 
         private void OnMouseWheel(object sender, PointerWheelEventArgs e)
         {
-            Backend.MouseWheelVertical(e.ToPixel(this), (float)e.Delta.Y);
+            // Avalonia flips the delta vector when shift is held. This is seemingly intentional: https://github.com/AvaloniaUI/Avalonia/pull/7520
+            float delta = (float)(e.KeyModifiers.HasFlag(KeyModifiers.Shift) ? e.Delta.X : e.Delta.Y);
+
+            if (delta != 0)
+            {
+                Backend.MouseWheelVertical(e.ToPixel(this), delta);
+            }
         }
 
         private void OnKeyDown(object sender, KeyEventArgs e)

--- a/src/ScottPlot5/ScottPlot/Control/PlotActionCommander.cs
+++ b/src/ScottPlot5/ScottPlot/Control/PlotActionCommander.cs
@@ -91,6 +91,11 @@ public class PlotActionCommander
 
     public void MouseWheelVertical(Pixel pixel, float delta)
     {
+        if (delta == 0)
+        {
+            return;
+        }
+
         MouseWheelDirection direction = delta > 0 ? MouseWheelDirection.Up : MouseWheelDirection.Down;
 
         if (Bindings.ZoomInWheelDirection.HasValue && Bindings.ZoomInWheelDirection == direction)


### PR DESCRIPTION
**Purpose:**
On Avalonia holding [shift flips the scroll vector](https://github.com/AvaloniaUI/Avalonia/pull/7520), mapping horizontal scrolls to vertical and vice versa. This results in `e.Delta.Y` being 0 (which used to be interpreted as scrolling down, but we now return early for it).
