### PR TITLE
EtoPlot: Usse Drawable.OnPaint directly rather than setting ImageView.Image

### DIFF
--- a/src/ScottPlot5/Controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
+++ b/src/ScottPlot5/Controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
@@ -43,6 +43,8 @@ namespace ScottPlot.Avalonia
 
         public override void Render(DrawingContext context)
         {
+            base.Render(context);
+
             SKImageInfo imageInfo = new((int)Bounds.Width, (int)Bounds.Height);
 
             using var surface = SKSurface.Create(imageInfo);

--- a/src/ScottPlot5/ScottPlot.Eto/EtoPlot.cs
+++ b/src/ScottPlot5/ScottPlot.Eto/EtoPlot.cs
@@ -41,6 +41,8 @@ namespace ScottPlot.Eto
 
         protected override void OnPaint(PaintEventArgs args)
         {
+            base.OnPaint(args);
+
             SKImageInfo imageInfo = new((int)Bounds.Width, (int)Bounds.Height);
 
             using var surface = SKSurface.Create(imageInfo);

--- a/src/ScottPlot5/ScottPlot.Eto/EtoPlot.cs
+++ b/src/ScottPlot5/ScottPlot.Eto/EtoPlot.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 
 namespace ScottPlot.Eto
 {
-    public class EtoPlot : ImageView, IPlotControl
+    public class EtoPlot : Drawable, IPlotControl
     {
         public Plot Plot { get; } = new();
 
@@ -36,6 +36,11 @@ namespace ScottPlot.Eto
 
         public void Refresh()
         {
+            Invalidate();
+        }
+
+        protected override void OnPaint(PaintEventArgs args)
+        {
             SKImageInfo imageInfo = new((int)Bounds.Width, (int)Bounds.Height);
 
             using var surface = SKSurface.Create(imageInfo);
@@ -55,7 +60,7 @@ namespace ScottPlot.Eto
                 Marshal.Copy(bytes, 0, data.Data, bytes.Length);
             }
 
-            this.Image = bmp;
+            args.Graphics.DrawImage(bmp, 0, 0);
         }
 
         private void OnMouseDown(object sender, MouseEventArgs e)


### PR DESCRIPTION
**Purpose:**
Eto allows us to render directly to the control, rather than setting an image that gets rendered. This is simpler and yields massive performance boosts. It also seems to be more consistent between WPF and WinForms
