### PR TITLE
Axis Line: Label Positioning

### DIFF
--- a/src/ScottPlot4/ScottPlot.Sandbox/WinFormsApp/Form1.Designer.cs
+++ b/src/ScottPlot4/ScottPlot.Sandbox/WinFormsApp/Form1.Designer.cs
@@ -29,33 +29,50 @@
         private void InitializeComponent()
         {
             this.formsPlot1 = new ScottPlot.FormsPlot();
+            this.checkBox1 = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // formsPlot1
             // 
+            this.formsPlot1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.formsPlot1.BackColor = System.Drawing.Color.Transparent;
-            this.formsPlot1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.formsPlot1.Location = new System.Drawing.Point(0, 0);
+            this.formsPlot1.Location = new System.Drawing.Point(12, 37);
             this.formsPlot1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.formsPlot1.Name = "formsPlot1";
-            this.formsPlot1.Size = new System.Drawing.Size(808, 417);
+            this.formsPlot1.Size = new System.Drawing.Size(783, 368);
             this.formsPlot1.TabIndex = 0;
+            // 
+            // checkBox1
+            // 
+            this.checkBox1.AutoSize = true;
+            this.checkBox1.Location = new System.Drawing.Point(12, 12);
+            this.checkBox1.Name = "checkBox1";
+            this.checkBox1.Size = new System.Drawing.Size(151, 19);
+            this.checkBox1.TabIndex = 1;
+            this.checkBox1.Text = "Opposite Label Position";
+            this.checkBox1.UseVisualStyleBackColor = true;
+            this.checkBox1.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
             // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(808, 417);
+            this.Controls.Add(this.checkBox1);
             this.Controls.Add(this.formsPlot1);
             this.Name = "Form1";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "FormsPlot Sandbox";
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
         #endregion
 
         private ScottPlot.FormsPlot formsPlot1;
+        private System.Windows.Forms.CheckBox checkBox1;
     }
 }

--- a/src/ScottPlot4/ScottPlot.Sandbox/WinFormsApp/Form1.cs
+++ b/src/ScottPlot4/ScottPlot.Sandbox/WinFormsApp/Form1.cs
@@ -1,72 +1,86 @@
 ﻿using ScottPlot;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace WinFormsApp
 {
     public partial class Form1 : Form
     {
-        Random Rand = new(0);
-        double[] Xs;
-        double[] Ys;
-        ScottPlot.Plottable.MarkerPlot Marker;
-        double SnapDistancePx = 50;
+        ScottPlot.Plottable.VLine VLine1;
+        ScottPlot.Plottable.VLine VLine2;
+        ScottPlot.Plottable.HLine HLine1;
+        ScottPlot.Plottable.HLine HLine2;
 
         public Form1()
         {
             InitializeComponent();
-            (Xs, Ys) = DataGen.RandomWalk2D(Rand, 50);
-            formsPlot1.Plot.AddScatter(Xs, Ys);
-            Marker = formsPlot1.Plot.AddMarker(0, 0, MarkerShape.openCircle, 20, Color.Red);
-            formsPlot1.LeftClicked += FormsPlot1_LeftClicked;
-            formsPlot1.Plot.Title("Waiting for click...");
+
+            formsPlot1.Plot.AddSignal(DataGen.Sin(51), 1, Color.Black);
+            formsPlot1.Plot.AddSignal(DataGen.Cos(51), 1, Color.Gray);
+
+            VLine1 = formsPlot1.Plot.AddVerticalLine(23, Color.Blue);
+            VLine1.LineWidth = 2;
+            VLine1.PositionLabel = true;
+            VLine1.DragEnabled = true;
+            VLine1.PositionLabelBackground = VLine1.Color;
+            VLine1.PositionLabelFont.Size = 16;
+
+            VLine2 = formsPlot1.Plot.AddVerticalLine(24, Color.Red);
+            VLine2.LineWidth = 2;
+            VLine2.PositionLabel = true;
+            VLine2.DragEnabled = true;
+            VLine2.PositionLabelBackground = VLine2.Color;
+            VLine2.PositionLabelFont.Size = 16;
+
+            HLine1 = formsPlot1.Plot.AddHorizontalLine(.2, Color.Green);
+            HLine1.DragEnabled = true;
+            HLine1.PositionLabel = true;
+            HLine1.PositionLabelBackground = HLine1.Color;
+
+            HLine2 = formsPlot1.Plot.AddHorizontalLine(.4, Color.Orange);
+            HLine2.DragEnabled = true;
+            HLine2.PositionLabel = true;
+            HLine2.PositionLabelBackground = HLine2.Color;
+
+            formsPlot1.PlottableDragged += FormsPlot1_PlottableDragged;
+
+            formsPlot1.Plot.Layout(right: 40);
+            FormsPlot1_PlottableDragged(null, null);
             formsPlot1.Refresh();
         }
 
-        private void FormsPlot1_LeftClicked(object sender, EventArgs e)
+        private void FormsPlot1_PlottableDragged(object sender, EventArgs e)
         {
-            (double mousePixelX, double mousePixelY) = formsPlot1.GetMousePixel();
-            (double mouseX, double mouseY) = formsPlot1.GetMouseCoordinates();
-
-            // determine the point in the scatter plot closest to the mouse
-            double closestDistance = double.PositiveInfinity;
-            int closestIndex = 0;
-            for (int i = 0; i < Xs.Length; i++)
+            if (VLine1.X > VLine2.X)
             {
-                (double x, double y) = formsPlot1.Plot.GetPixel(Xs[i], Ys[i]);
-                double dX = mousePixelX - x;
-                double dY = mousePixelY - y;
-                double distance = Math.Sqrt(dX * dX + dY * dY);
-                if (distance < closestDistance)
-                {
-                    closestDistance = distance;
-                    closestIndex = i;
-                }
-            }
-
-            // take action based on whether the click engaged a point
-            if (closestDistance < SnapDistancePx)
-            {
-                double x = Xs[closestIndex];
-                double y = Ys[closestIndex];
-                formsPlot1.Plot.Title($"Clicked point [{closestIndex}] (X={x:0.00}, Y={y:0.00})");
-                Marker.IsVisible = true;
-                Marker.X = x;
-                Marker.Y = y;
+                VLine1.PositionLabelAlignmentX = ScottPlot.HorizontalAlignment.Left;
+                VLine2.PositionLabelAlignmentX = ScottPlot.HorizontalAlignment.Right;
             }
             else
             {
-                formsPlot1.Plot.Title($"Clicked empty space (X={mouseX:0.00}, Y={mouseY:0.00})");
-                Marker.IsVisible = false;
+                VLine1.PositionLabelAlignmentX = ScottPlot.HorizontalAlignment.Right;
+                VLine2.PositionLabelAlignmentX = ScottPlot.HorizontalAlignment.Left;
             }
 
+            if (HLine1.Y > HLine2.Y)
+            {
+                HLine1.PositionLabelAlignmentY = ScottPlot.VerticalAlignment.Lower;
+                HLine2.PositionLabelAlignmentY = ScottPlot.VerticalAlignment.Upper;
+            }
+            else
+            {
+                HLine1.PositionLabelAlignmentY = ScottPlot.VerticalAlignment.Upper;
+                HLine2.PositionLabelAlignmentY = ScottPlot.VerticalAlignment.Lower;
+            }
+        }
+
+        private void checkBox1_CheckedChanged(object sender, EventArgs e)
+        {
+            VLine1.PositionLabelOppositeAxis = checkBox1.Checked;
+            VLine2.PositionLabelOppositeAxis = checkBox1.Checked;
+            HLine1.PositionLabelOppositeAxis = checkBox1.Checked;
+            HLine2.PositionLabelOppositeAxis = checkBox1.Checked;
             formsPlot1.Refresh();
         }
     }

--- a/src/ScottPlot4/ScottPlot.Tests/Misc/Drawing.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/Misc/Drawing.cs
@@ -219,5 +219,24 @@ namespace ScottPlotTests.Misc
             sigxy.StepDisplayRight = false;
             TestTools.SaveFig(plt, "step2");
         }
+
+        [Test]
+        public void Test_DrawString_Aligned()
+        {
+            using System.Drawing.Bitmap bmp = new(400, 300);
+            using Graphics gfx = Graphics.FromImage(bmp);
+            gfx.Clear(Color.Navy);
+
+            gfx.DrawLine(Pens.Gray, 150, 0, 150, 300);
+            gfx.DrawLine(Pens.Gray, 0, 150, 400, 150);
+            gfx.DrawEllipse(Pens.White, 145, 145, 10, 10);
+
+            GDI.DrawLabel(
+                gfx, "testing", 150, 150, InstalledFont.Sans(), 16, true,
+                HorizontalAlignment.Left, VerticalAlignment.Upper,
+                Color.Yellow, Color.Magenta);
+
+            TestTools.SaveBitmap(bmp);
+        }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Drawing/GDI.cs
+++ b/src/ScottPlot4/ScottPlot/Drawing/GDI.cs
@@ -361,5 +361,42 @@ namespace ScottPlot.Drawing
             System.Drawing.Color color = ColorTranslator.FromHtml(htmlColor);
             return (alpha == 1) ? color : System.Drawing.Color.FromArgb((int)(color.A * alpha), color);
         }
+
+        /// <summary>
+        /// Draw a string at a point on the graphics.
+        /// Alignment describes where the point is relative to the text.
+        /// </summary>
+        public static void DrawLabel(Graphics gfx, string text, float x, float y,
+            string fontName, float fontSize, bool bold, HorizontalAlignment h, VerticalAlignment v,
+            Color fontColor, Color fillColor)
+        {
+            SizeF size = MeasureString(gfx, text, fontName, fontSize, bold);
+
+            float xOffset = h switch
+            {
+                HorizontalAlignment.Left => size.Width / 2,
+                HorizontalAlignment.Center => 0,
+                HorizontalAlignment.Right => -size.Width / 2,
+                _ => throw new NotImplementedException(h.ToString()),
+            };
+
+            float yOffset = v switch
+            {
+                VerticalAlignment.Upper => size.Height / 2,
+                VerticalAlignment.Middle => 0,
+                VerticalAlignment.Lower => -size.Height / 2,
+                _ => throw new NotImplementedException(h.ToString()),
+            };
+
+            using var font = GDI.Font(fontName, fontSize, bold);
+            using var fillBrush = GDI.Brush(fillColor);
+            using var fontBrush = GDI.Brush(fontColor);
+            using var sf = GDI.StringFormat(HorizontalAlignment.Center, VerticalAlignment.Middle);
+
+            gfx.TranslateTransform(x + xOffset, y + yOffset);
+            gfx.FillRectangle(fillBrush, -size.Width / 2, -size.Height / 2, size.Width, size.Height);
+            gfx.DrawString(text, font, fontBrush, 0, 0, sf);
+            gfx.ResetTransform();
+        }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Plottable/AxisLine.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/AxisLine.cs
@@ -27,6 +27,10 @@ namespace ScottPlot.Plottable
         /// </summary>
         public Color PositionLabelBackground { get; set; } = Color.Black;
 
+        public HorizontalAlignment PositionLabelAlignmentX { get; set; } = HorizontalAlignment.Center;
+
+        public VerticalAlignment PositionLabelAlignmentY { get; set; } = VerticalAlignment.Middle;
+
         /// <summary>
         /// If true the position label will be drawn on the right or top of the data area.
         /// </summary>
@@ -191,34 +195,53 @@ namespace ScottPlot.Plottable
                 if (Position > dims.YMax || Position < dims.YMin)
                     return;
 
-                float pixelY = dims.GetPixelY(Position);
-                string yLabel = PositionFormatter(Position);
-                SizeF yLabelSize = GDI.MeasureString(gfx, yLabel, PositionLabelFont);
-                float xPos = PositionLabelOppositeAxis
-                    ? dims.DataOffsetX + dims.DataWidth + axisOffset
-                    : dims.DataOffsetX - yLabelSize.Width - axisOffset;
-                float yPos = pixelY - yLabelSize.Height / 2;
-                RectangleF xLabelRect = new(xPos, yPos, yLabelSize.Width, yLabelSize.Height);
-                gfx.FillRectangle(fillBrush, xLabelRect);
-                var sf = GDI.StringFormat(HorizontalAlignment.Left, VerticalAlignment.Middle);
-                gfx.DrawString(yLabel, fnt, fontBrush, xPos, pixelY, sf);
+                if (PositionLabelOppositeAxis)
+                {
+                    GDI.DrawLabel(gfx,
+                        text: PositionFormatter(Position),
+                        x: dims.DataOffsetX + dims.DataWidth + axisOffset,
+                        y: dims.GetPixelY(Position),
+                        PositionLabelFont.Name, PositionLabelFont.Size, PositionLabelFont.Bold,
+                        HorizontalAlignment.Left, PositionLabelAlignmentY,
+                        PositionLabelFont.Color, PositionLabelBackground);
+                }
+                else
+                {
+                    GDI.DrawLabel(gfx,
+                        text: PositionFormatter(Position),
+                        x: dims.DataOffsetX - axisOffset,
+                        y: dims.GetPixelY(Position),
+                        PositionLabelFont.Name, PositionLabelFont.Size, PositionLabelFont.Bold,
+                        HorizontalAlignment.Right, PositionLabelAlignmentY,
+                        PositionLabelFont.Color, PositionLabelBackground);
+                }
+
             }
             else
             {
                 if (Position > dims.XMax || Position < dims.XMin)
                     return;
 
-                float pixelX = dims.GetPixelX(Position);
-                string xLabel = PositionFormatter(Position);
-                SizeF xLabelSize = GDI.MeasureString(gfx, xLabel, PositionLabelFont);
-                float xPos = pixelX - xLabelSize.Width / 2;
-                float yPos = PositionLabelOppositeAxis
-                    ? dims.DataOffsetY - xLabelSize.Height - axisOffset
-                    : dims.DataOffsetY + dims.DataHeight + axisOffset;
-                RectangleF xLabelRect = new(xPos, yPos, xLabelSize.Width, xLabelSize.Height);
-                gfx.FillRectangle(fillBrush, xLabelRect);
-                var sf = GDI.StringFormat(HorizontalAlignment.Center, VerticalAlignment.Upper);
-                gfx.DrawString(xLabel, fnt, fontBrush, pixelX, yPos, sf);
+                if (PositionLabelOppositeAxis)
+                {
+                    GDI.DrawLabel(gfx,
+                        text: PositionFormatter(Position),
+                        x: dims.GetPixelX(Position),
+                        y: dims.DataOffsetY - axisOffset,
+                        PositionLabelFont.Name, PositionLabelFont.Size, PositionLabelFont.Bold,
+                        PositionLabelAlignmentX, VerticalAlignment.Lower,
+                        PositionLabelFont.Color, PositionLabelBackground);
+                }
+                else
+                {
+                    GDI.DrawLabel(gfx,
+                        text: PositionFormatter(Position),
+                        x: dims.GetPixelX(Position),
+                        y: dims.DataOffsetY + dims.DataHeight + axisOffset,
+                        PositionLabelFont.Name, PositionLabelFont.Size, PositionLabelFont.Bold,
+                        PositionLabelAlignmentX, VerticalAlignment.Upper,
+                        PositionLabelFont.Color, PositionLabelBackground);
+                }
             }
         }
 

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -8,6 +8,7 @@ _not yet published on NuGet..._
 * Signal Plot: Improve support for plots with a single point (#1951, #1949) _Thanks @bclehmann and @Fruchtzwerg94_
 * Draggable Marker Plots: Improved drag behavior when drag limits are in use (#1970) _Thanks @xmln17_
 * Signal Plot: Added support for plotting `byte` arrays (#1945)
+* Axis Line: Added properties to customize alignment of position labels (#1972) _Thanks @hamhub7_
 
 ## ScottPlot 4.1.52
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-07-09_


### PR DESCRIPTION
Adds properties to axis lines for customizing label positions. This allows labels to be moved out of the way to prevent overlapping. See code in #1972 for details.

![overlap3](https://user-images.githubusercontent.com/4165489/182987831-8a70749b-2944-4b6b-952c-9278713815e1.gif)

Resolves #1972