### PR TITLE
ScottPlot 4+5: Implemented a class derived from axis line that snaps to specified positions on its axis.

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/AxisLineAndSpan.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/AxisLineAndSpan.cs
@@ -107,6 +107,40 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         }
     }
 
+    public class DraggableAxisLineWithSnap : IRecipe
+    {
+        public ICategory Category => new Categories.PlotTypes.AxisLineAndSpan();
+        public string ID => "axisLineWithSnap";
+        public string Title => "Draggable Axis Lines With Snap";
+        public string Description =>
+            "In GUI environments, axis lines with snap can be draggable and moved with the mouse. " +
+            "Snap positions define the points on the axis the line will snap to. " +
+            "Drag limits define the boundaries the lines can be dragged.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            // plot sample data
+            plt.AddSignal(DataGen.Sin(51));
+            plt.AddSignal(DataGen.Cos(51));
+
+            // add axis lines and configure their drag settings
+            var yPositions = DataGen.Consecutive(11, 0.2D, -1D);
+            var hLine = plt.AddHorizontalLineWithSnap(0.8D, yPositions);
+            hLine.DragEnabled = true;
+            hLine.DragLimitMin = -1;
+            hLine.DragLimitMax = 1;
+
+            var xPositions = DataGen.Consecutive(11, 5D);
+            var vLine = plt.AddVerticalLineWithSnap(25, xPositions);
+            vLine.DragEnabled = true;
+            vLine.DragLimitMin = 0;
+            vLine.DragLimitMax = 50;
+
+            // you can access the position of an axis line at any time
+            string message = $"Vertical line is at X={vLine.X}";
+        }
+    }
+
     public class AxisLineWithPositionLabels : IRecipe
     {
         public ICategory Category => new Categories.PlotTypes.AxisLineAndSpan();

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/AxisLineAndSpan.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/AxisLineAndSpan.cs
@@ -125,19 +125,19 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
 
             // add axis lines and configure their drag settings
             var yPositions = DataGen.Consecutive(11, 0.2D, -1D);
-            var hLine = plt.AddHorizontalLineWithSnap(0.8D, yPositions);
-            hLine.DragEnabled = true;
-            hLine.DragLimitMin = -1;
-            hLine.DragLimitMax = 1;
+            var hLineWithSnap = plt.AddHorizontalLineWithSnap(0.8D, yPositions);
+            hLineWithSnap.DragEnabled = true;
+            hLineWithSnap.DragLimitMin = -1;
+            hLineWithSnap.DragLimitMax = 1;
 
             var xPositions = DataGen.Consecutive(11, 5D);
-            var vLine = plt.AddVerticalLineWithSnap(25, xPositions);
-            vLine.DragEnabled = true;
-            vLine.DragLimitMin = 0;
-            vLine.DragLimitMax = 50;
+            var vLineWithSnap = plt.AddVerticalLineWithSnap(25, xPositions);
+            vLineWithSnap.DragEnabled = true;
+            vLineWithSnap.DragLimitMin = 0;
+            vLineWithSnap.DragLimitMax = 50;
 
             // you can access the position of an axis line at any time
-            string message = $"Vertical line is at X={vLine.X}";
+            string message = $"Vertical line is at X={vLineWithSnap.X}";
         }
     }
 

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Add.cs
@@ -635,6 +635,26 @@ namespace ScottPlot
             return plottable;
         }
 
+        public HLineWithSnap AddHorizontalLineWithSnap(double y, double[] ys, Color? color = null, float width = 1,
+            LineStyle style = LineStyle.Solid, string label = null)
+        {
+            var position = y;
+            if (ys.Length != 0)
+                position = GetAxisLineWithSnapSnappedPosition(position, ys);
+
+            HLineWithSnap plottable = new HLineWithSnap()
+            {
+                Y = position,
+                Ys = ys,
+                Color = color ?? settings.GetNextColor(),
+                LineWidth = width,
+                LineStyle = style,
+                Label = label,
+            };
+            Add(plottable);
+            return plottable;
+        }
+
         /// <summary>
         /// Add a horizontal span (shades the region between two X positions)
         /// </summary>
@@ -1265,6 +1285,28 @@ namespace ScottPlot
         }
 
         /// <summary>
+        /// Add a vertical axis line with snap at a specific Y position
+        /// </summary>
+        public VLineWithSnap AddVerticalLineWithSnap(double x, double[] xs, Color? color = null, float width = 1, LineStyle style = LineStyle.Solid, string label = null)
+        {
+            var position = x;
+            if (xs.Length != 0)
+                position = GetAxisLineWithSnapSnappedPosition(position, xs);
+
+            VLineWithSnap plottable = new VLineWithSnap()
+            {
+                X = position,
+                Xs = xs,
+                Color = color ?? settings.GetNextColor(),
+                LineWidth = width,
+                LineStyle = style,
+                Label = label
+            };
+            Add(plottable);
+            return plottable;
+        }
+
+        /// <summary>
         /// Add a horizontal span (shades the region between two X positions)
         /// </summary>
         public VSpan AddVerticalSpan(double yMin, double yMax, Color? color = null, string label = null)
@@ -1279,5 +1321,25 @@ namespace ScottPlot
             Add(plottable);
             return plottable;
         }
+
+        #region Private Methods
+
+        private double GetAxisLineWithSnapSnappedPosition(double positionToSnapTo, double[] snapPositions)
+        {
+            var pointCount = snapPositions.Length;
+            var distancessq = new double[pointCount];
+            var currentIndex = 0;
+
+            for (var i = 0; i < pointCount; i++)
+                distancessq[i] = Math.Abs(snapPositions[i] - positionToSnapTo);
+
+            for (var i = 0; i < pointCount; i++)
+                if (distancessq[i] < distancessq[currentIndex])
+                    currentIndex = i;
+
+            return snapPositions[currentIndex];
+        }
+
+        #endregion
     }
 }

--- a/src/ScottPlot4/ScottPlot/Plottable/AxisLine.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/AxisLine.cs
@@ -59,7 +59,7 @@ namespace ScottPlot.Plottable
         /// <summary>
         /// Indicates whether the line is horizontal (position in Y units) or vertical (position in X units)
         /// </summary>
-        private readonly bool IsHorizontal;
+        protected readonly bool IsHorizontal;
 
         /// <summary>
         /// If true, AxisAuto() will ignore the position of this line when determining axis limits
@@ -103,6 +103,13 @@ namespace ScottPlot.Plottable
         /// This event is invoked after the line is dragged
         /// </summary>
         public event EventHandler Dragged = delegate { };
+
+        //The event-invoking method that derived classes can override.
+        protected void OnDragged()
+        {
+            // Safely raise the event for all subscribers
+            Dragged(this, EventArgs.Empty);
+        }
 
         /// <summary>
         /// The lower bound of the axis line.
@@ -251,7 +258,7 @@ namespace ScottPlot.Plottable
         /// <param name="coordinateX">new X position</param>
         /// <param name="coordinateY">new Y position</param>
         /// <param name="fixedSize">This argument is ignored</param>
-        public void DragTo(double coordinateX, double coordinateY, bool fixedSize)
+        public virtual void DragTo(double coordinateX, double coordinateY, bool fixedSize)
         {
             if (!DragEnabled)
                 return;

--- a/src/ScottPlot4/ScottPlot/Plottable/AxisLineWithSnap.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/AxisLineWithSnap.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace ScottPlot.Plottable
+{
+    public abstract class AxisLineWithSnap : AxisLine
+    {
+        /// <summary>
+        /// Location of the axis positions to snap to (Y position if horizontal line, X position if vertical line)
+        /// </summary>
+        protected double[] Positions;
+
+        public int PointCount => Positions.Length;
+
+        public int CurrentIndex { get; set; } = 0;
+
+        protected AxisLineWithSnap(bool isHorizontal) : base(isHorizontal) { }
+
+        public override void DragTo(double coordinateX, double coordinateY, bool fixedSize)
+        {
+            if (!DragEnabled)
+                return;
+
+            var distancessq = new double[PointCount];
+            if (IsHorizontal)
+            {
+                if (coordinateY < DragLimitMin) coordinateY = DragLimitMin;
+                if (coordinateY > DragLimitMax) coordinateY = DragLimitMax;
+
+                for (int i = 0; i < PointCount; i++)
+                    distancessq[i] = Math.Abs(Positions[i] - coordinateY);
+            }
+            else
+            {
+                if (coordinateX < DragLimitMin) coordinateX = DragLimitMin;
+                if (coordinateX > DragLimitMax) coordinateX = DragLimitMax;
+
+                for (int i = 0; i < PointCount; i++)
+                    distancessq[i] = Math.Abs(Positions[i] - coordinateX);
+            }
+
+            for (int i = 0; i < PointCount; i++)
+                if (distancessq[i] < distancessq[CurrentIndex])
+                    CurrentIndex = i;
+
+            Position = Positions[CurrentIndex];
+
+            OnDragged();
+        }
+    }
+}

--- a/src/ScottPlot4/ScottPlot/Plottable/HLineWithSnap.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/HLineWithSnap.cs
@@ -1,0 +1,16 @@
+﻿namespace ScottPlot.Plottable
+{
+    public class HLineWithSnap : AxisLineWithSnap
+    {
+        /// <summary>
+        /// Y position to render the line
+        /// </summary>
+        public double Y { get => Position; set => Position = value; }
+
+        public double[] Ys { get => Positions; set => Positions = value; }
+
+        public override string ToString() => $"Horizontal line with snap at Y={Y}";
+
+        public HLineWithSnap() : base(true) { }
+    }
+}

--- a/src/ScottPlot4/ScottPlot/Plottable/VLineWithSnap.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/VLineWithSnap.cs
@@ -1,0 +1,16 @@
+﻿namespace ScottPlot.Plottable
+{
+    public class VLineWithSnap : AxisLineWithSnap
+    {
+        /// <summary>
+        /// X position to render the line
+        /// </summary>
+        public double X { get => Position; set => Position = value; }
+
+        public double[] Xs { get => Positions; set => Positions = value; }
+
+        public override string ToString() => $"Vertical line with snap at X={X}";
+
+        public VLineWithSnap() : base(false) { }
+    }
+}


### PR DESCRIPTION
**Purpose:**
This pull request aims to provide an implementation of an axis line that snaps to a defined list of positions on either the horizontal or vertical axis.
The implementation tries to reuse as much code as possible while guaranteeing the proper function of the new snap mechanic for axis lines.

The general idea was to provide a feature for draggable axis lines similar to what the DraggableMarkerPlotInVector offers for draggable markers.

As this is my first pull request, I hope I correctly followed what is mentioned in CONTRIBUTING.md.
Minus the creation of an issue before starting the implementation... I started the implementation as a test balloon to get familiar with the code base and more or less because I just wanted to try it out. As it was very easy to implement, I was done faster than I first anticipated and then I got around to reading CONTRIBUTING.md but was already done...

I hope you like the new plottable. I'm looking forward to your feedback! :-)

https://user-images.githubusercontent.com/6412444/183265378-ed990412-8120-4363-a702-4b106dfb66db.mp4

```cs
var yPositions = DataGen.Consecutive(11, 0.2D, -1D);
var hLineWithSnap = plt.AddHorizontalLineWithSnap(0.8D, yPositions);
hLineWithSnap.DragEnabled = true;
hLineWithSnap.DragLimitMin = -1;
hLineWithSnap.DragLimitMax = 1;

var xPositions = DataGen.Consecutive(11, 5D);
var vLineWithSnap = plt.AddVerticalLineWithSnap(25, xPositions);
vLineWithSnap.DragEnabled = true;
vLineWithSnap.DragLimitMin = 0;
vLineWithSnap.DragLimitMax = 50;