### PR TITLE
Use Monitor for RenderLock

### DIFF
--- a/src/ScottPlot4/ScottPlot.Tests/Concurrency/ConcurrencyTests.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/Concurrency/ConcurrencyTests.cs
@@ -27,11 +27,9 @@ namespace ScottPlotTests.Concurrency
                 plt.AddSignal(new double[] { 1, 2, 3 });
                 plt.RenderUnlock();
             }
-            Debug.WriteLine("Modification thread shutting down...");
-            Thread.Sleep(100);
         }
 
-        // This test takes 5 seconds to complete so it is not run routinely
+        // This test takes a long time to run so they are not performed routinely
         //[Test]
         public void Test_Concurrent_ModifyPlottablesWhileRendering()
         {
@@ -44,7 +42,8 @@ namespace ScottPlotTests.Concurrency
 
             // render repeatedly while the plottalbles are being modified
             var sw = Stopwatch.StartNew();
-            while (sw.ElapsedMilliseconds < 5000)
+            int runTimeSeconds = 30;
+            while (sw.ElapsedMilliseconds < runTimeSeconds * 1000)
             {
                 plt.Render(bmp);
             }

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Render.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Render.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
+using System.Threading;
 
 namespace ScottPlot
 {
@@ -20,32 +21,31 @@ namespace ScottPlot
         /// <returns>the same bitmap that was passed in (but was rendered onto)</returns>
         public Bitmap Render(Bitmap bmp, bool lowQuality = false, double scale = 1.0)
         {
-            while (IsRenderLocked) { }
-            IsRendering = true;
-
-            settings.BenchmarkMessage.Restart();
-            settings.Resize((int)(bmp.Width / scale), (int)(bmp.Height / scale));
-            settings.CopyPrimaryLayoutToAllAxes();
-            settings.AxisAutoUnsetAxes();
-            settings.EnforceEqualAxisScales();
-            settings.LayoutAuto();
-            if (settings.EqualScaleMode != EqualScaleMode.Disabled)
+            lock (_renderLocker)
             {
+                settings.BenchmarkMessage.Restart();
+                settings.Resize((int)(bmp.Width / scale), (int)(bmp.Height / scale));
+                settings.CopyPrimaryLayoutToAllAxes();
+                settings.AxisAutoUnsetAxes();
                 settings.EnforceEqualAxisScales();
                 settings.LayoutAuto();
-            }
+                if (settings.EqualScaleMode != EqualScaleMode.Disabled)
+                {
+                    settings.EnforceEqualAxisScales();
+                    settings.LayoutAuto();
+                }
 
-            PlotDimensions primaryDims = settings.GetPlotDimensions(0, 0, scale);
-            RenderClear(bmp, lowQuality, primaryDims);
-            if (primaryDims.DataWidth > 0 && primaryDims.DataHeight > 0)
-            {
-                RenderBeforePlottables(bmp, lowQuality, primaryDims);
-                RenderPlottables(bmp, lowQuality, scale);
-                RenderAfterPlottables(bmp, lowQuality, primaryDims);
-            }
+                PlotDimensions primaryDims = settings.GetPlotDimensions(0, 0, scale);
+                RenderClear(bmp, lowQuality, primaryDims);
+                if (primaryDims.DataWidth > 0 && primaryDims.DataHeight > 0)
+                {
+                    RenderBeforePlottables(bmp, lowQuality, primaryDims);
+                    RenderPlottables(bmp, lowQuality, scale);
+                    RenderAfterPlottables(bmp, lowQuality, primaryDims);
+                }
 
-            IsRendering = false;
-            return bmp;
+                return bmp;
+            }
         }
 
         private void RenderClear(Bitmap bmp, bool lowQuality, PlotDimensions primaryDims)
@@ -72,9 +72,7 @@ namespace ScottPlot
 
                 plottable.ValidateData(deep: false);
 
-                PlotDimensions dims = (plottable is Plottable.IPlottable p) ?
-                    settings.GetPlotDimensions(p.XAxisIndex, p.YAxisIndex, scaleFactor) :
-                    settings.GetPlotDimensions(0, 0, scaleFactor);
+                PlotDimensions dims = (plottable is Plottable.IPlottable p) ? settings.GetPlotDimensions(p.XAxisIndex, p.YAxisIndex, scaleFactor) : settings.GetPlotDimensions(0, 0, scaleFactor);
 
                 if (double.IsInfinity(dims.XSpan) || double.IsInfinity(dims.YSpan))
                     throw new InvalidOperationException($"Axis limits cannot be infinite: {dims}");
@@ -123,9 +121,7 @@ namespace ScottPlot
         {
             foreach (var axis in settings.Axes)
             {
-                PlotDimensions dims2 = axis.IsHorizontal ?
-                    settings.GetPlotDimensions(axis.AxisIndex, 0, dims.ScaleFactor) :
-                    settings.GetPlotDimensions(0, axis.AxisIndex, dims.ScaleFactor);
+                PlotDimensions dims2 = axis.IsHorizontal ? settings.GetPlotDimensions(axis.AxisIndex, 0, dims.ScaleFactor) : settings.GetPlotDimensions(0, axis.AxisIndex, dims.ScaleFactor);
 
                 try
                 {
@@ -142,8 +138,7 @@ namespace ScottPlot
 
         #region render lock
 
-        private bool IsRendering = false; // Becomes true only while the render loop is running and not locked
-        private bool IsRenderLocked = false; // RenderBitmap() will hang infinitely while this is true
+        private readonly object _renderLocker = new();
 
         /// <summary>
         /// Wait for the current render to finish, then prevent future renders until RenderUnlock() is called.
@@ -151,8 +146,7 @@ namespace ScottPlot
         /// </summary>
         public void RenderLock()
         {
-            IsRenderLocked = true; // prevent new renders from starting
-            while (IsRendering) { } // wait for the current render to finish
+            Monitor.Enter(_renderLocker);
         }
 
         /// <summary>
@@ -160,7 +154,7 @@ namespace ScottPlot
         /// </summary>
         public void RenderUnlock()
         {
-            IsRenderLocked = false; // allow new renders to occur
+            Monitor.Exit(_renderLocker);
         }
 
         #endregion
@@ -173,7 +167,7 @@ namespace ScottPlot
         /// <param name="lowQuality">if true, anti-aliasing will be disabled for this render</param>
         /// <returns>the Bitmap that was created</returns>
         public Bitmap Render(bool lowQuality = false) =>
-             Render(settings.Width, settings.Height, lowQuality);
+            Render(settings.Width, settings.Height, lowQuality);
 
         /// <summary>
         /// Render the plot onto a new Bitmap of the given dimensions

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Render.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Render.cs
@@ -72,7 +72,9 @@ namespace ScottPlot
 
                 plottable.ValidateData(deep: false);
 
-                PlotDimensions dims = (plottable is Plottable.IPlottable p) ? settings.GetPlotDimensions(p.XAxisIndex, p.YAxisIndex, scaleFactor) : settings.GetPlotDimensions(0, 0, scaleFactor);
+                PlotDimensions dims = (plottable is Plottable.IPlottable p)
+                    ? settings.GetPlotDimensions(p.XAxisIndex, p.YAxisIndex, scaleFactor)
+                    : settings.GetPlotDimensions(0, 0, scaleFactor);
 
                 if (double.IsInfinity(dims.XSpan) || double.IsInfinity(dims.YSpan))
                     throw new InvalidOperationException($"Axis limits cannot be infinite: {dims}");
@@ -121,7 +123,9 @@ namespace ScottPlot
         {
             foreach (var axis in settings.Axes)
             {
-                PlotDimensions dims2 = axis.IsHorizontal ? settings.GetPlotDimensions(axis.AxisIndex, 0, dims.ScaleFactor) : settings.GetPlotDimensions(0, axis.AxisIndex, dims.ScaleFactor);
+                PlotDimensions dims2 = axis.IsHorizontal
+                    ? settings.GetPlotDimensions(axis.AxisIndex, 0, dims.ScaleFactor)
+                    : settings.GetPlotDimensions(0, axis.AxisIndex, dims.ScaleFactor);
 
                 try
                 {
@@ -170,8 +174,10 @@ namespace ScottPlot
         /// </summary>
         /// <param name="lowQuality">if true, anti-aliasing will be disabled for this render</param>
         /// <returns>the Bitmap that was created</returns>
-        public Bitmap Render(bool lowQuality = false) =>
-            Render(settings.Width, settings.Height, lowQuality);
+        public Bitmap Render(bool lowQuality = false)
+        {
+            return Render(settings.Width, settings.Height, lowQuality);
+        }
 
         /// <summary>
         /// Render the plot onto a new Bitmap of the given dimensions

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Render.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Render.cs
@@ -21,7 +21,7 @@ namespace ScottPlot
         /// <returns>the same bitmap that was passed in (but was rendered onto)</returns>
         public Bitmap Render(Bitmap bmp, bool lowQuality = false, double scale = 1.0)
         {
-            lock (_renderLocker)
+            lock (RenderLocker)
             {
                 settings.BenchmarkMessage.Restart();
                 settings.Resize((int)(bmp.Width / scale), (int)(bmp.Height / scale));
@@ -138,7 +138,11 @@ namespace ScottPlot
 
         #region render lock
 
-        private readonly object _renderLocker = new();
+        /// <summary>
+        /// This object is locked by the render loop.
+        /// Locking this externally will prevent renders until it is released.
+        /// </summary>
+        private readonly object RenderLocker = new();
 
         /// <summary>
         /// Wait for the current render to finish, then prevent future renders until RenderUnlock() is called.
@@ -146,7 +150,7 @@ namespace ScottPlot
         /// </summary>
         public void RenderLock()
         {
-            Monitor.Enter(_renderLocker);
+            Monitor.Enter(RenderLocker);
         }
 
         /// <summary>
@@ -154,7 +158,7 @@ namespace ScottPlot
         /// </summary>
         public void RenderUnlock()
         {
-            Monitor.Exit(_renderLocker);
+            Monitor.Exit(RenderLocker);
         }
 
         #endregion

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -15,6 +15,7 @@ _not yet published on NuGet..._
 * Draggable: `IDraggable` now has functions to facilitate snapping (#2006, #2007, #2022) _Thanks @Agorath_
 * Palette: `ScottPlot.Palette` has been refactored to replace `ScottPlot.Drawing.Palette` and `ScottPlot.Drawing.Colorset` (#2024)
 * Palette: Palettes now implement `IEnumerable` and colors can be retrieved using `foreach` (#2028)
+* Render: Improved thread safety of the render lock system (#2030) _Thanks @anprevost_
 
 ## ScottPlot 4.1.52
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-07-09_


### PR DESCRIPTION
**Purpose:**
The current way of handling multithreading is not thread safe.
If one thread change the value of `IsRenderLocked` from `false` to `true`, there is a chance that another thread reading the same field will see `false`. Therefore, a Render might occur even if `RenderLock()` has been previously called.