### PR TITLE
Scatter.OnNaN: customizes NaN behavior

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Scatter.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Scatter.cs
@@ -344,4 +344,78 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             plt.Legend();
         }
     }
+
+    public class ScatterNaNIgnore : IRecipe
+    {
+        public ICategory Category => new Categories.PlotTypes.Scatter();
+        public string ID => "scatter_nan_ignore";
+        public string Title => "NaN Values Ignored";
+        public string Description =>
+            "When the OnNaN field is set to Ignore, points containing NaN X or Y values are skipped, " +
+            "and the scatter plot is drawn as one continuous line.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            // create data that does NOT contain NaN
+            double[] xs = ScottPlot.DataGen.Consecutive(51);
+            double[] ys = ScottPlot.DataGen.Sin(51);
+
+            // plot it the traditional way
+            plt.AddScatter(xs, ys, Color.FromArgb(50, Color.Black));
+
+            // create new data that contains NaN
+            double[] ysWithNan = ScottPlot.DataGen.Sin(51);
+            static void FillWithNan(double[] values, int start, int count)
+            {
+                for (int i = 0; i < count; i++)
+                    values[start + i] = double.NaN;
+            }
+            FillWithNan(ysWithNan, 5, 15);
+            FillWithNan(ysWithNan, 25, 1);
+            FillWithNan(ysWithNan, 30, 15);
+            ysWithNan[10] = ys[10];
+
+            // add a scatter plot and customize NaN behavior
+            var sp2 = plt.AddScatter(xs, ysWithNan, Color.Black);
+            sp2.OnNaN = ScottPlot.Plottable.ResponseToNaN.Ignore;
+            plt.Title($"OnNaN = {sp2.OnNaN}");
+        }
+    }
+
+    public class ScatterNaNGap : IRecipe
+    {
+        public ICategory Category => new Categories.PlotTypes.Scatter();
+        public string ID => "scatter_nan_gap";
+        public string Title => "NaN Values Break the Line";
+        public string Description =>
+            "When the OnNaN field is set to Gap, points containing NaN X or Y values break the line. " +
+            "This results in a scatter plot appearing as multiple lines, with gaps representing missing data.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            // create data that does NOT contain NaN
+            double[] xs = ScottPlot.DataGen.Consecutive(51);
+            double[] ys = ScottPlot.DataGen.Sin(51);
+
+            // plot it the traditional way
+            plt.AddScatter(xs, ys, Color.FromArgb(50, Color.Black));
+
+            // create new data that contains NaN
+            double[] ysWithNan = ScottPlot.DataGen.Sin(51);
+            static void FillWithNan(double[] values, int start, int count)
+            {
+                for (int i = 0; i < count; i++)
+                    values[start + i] = double.NaN;
+            }
+            FillWithNan(ysWithNan, 5, 15);
+            FillWithNan(ysWithNan, 25, 1);
+            FillWithNan(ysWithNan, 30, 15);
+            ysWithNan[10] = ys[10];
+
+            // add a scatter plot and customize NaN behavior
+            var sp2 = plt.AddScatter(xs, ysWithNan, Color.Black);
+            sp2.OnNaN = ScottPlot.Plottable.ResponseToNaN.Gap;
+            plt.Title($"OnNaN = {sp2.OnNaN}");
+        }
+    }
 }

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Scatter.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Scatter.cs
@@ -377,7 +377,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
 
             // add a scatter plot and customize NaN behavior
             var sp2 = plt.AddScatter(xs, ysWithNan, Color.Black);
-            sp2.OnNaN = ScottPlot.Plottable.ResponseToNaN.Ignore;
+            sp2.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Ignore;
             plt.Title($"OnNaN = {sp2.OnNaN}");
         }
     }
@@ -414,7 +414,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
 
             // add a scatter plot and customize NaN behavior
             var sp2 = plt.AddScatter(xs, ysWithNan, Color.Black);
-            sp2.OnNaN = ScottPlot.Plottable.ResponseToNaN.Gap;
+            sp2.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Gap;
             plt.Title($"OnNaN = {sp2.OnNaN}");
         }
     }

--- a/src/ScottPlot4/ScottPlot.Tests/PlotTypes/Scatter.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlotTypes/Scatter.cs
@@ -121,5 +121,67 @@ namespace ScottPlotTests.PlotTypes
 
             TestTools.SaveFig(plt);
         }
+
+
+        [Test]
+        public void Test_Scatter_AllNan()
+        {
+            double[] xs = ScottPlot.DataGen.Full(51, double.NaN);
+            double[] ys = ScottPlot.DataGen.Full(51, double.NaN);
+
+            ScottPlot.Plot plt = new();
+            var sp = plt.AddScatter(xs, ys);
+
+            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Throw;
+            Assert.Throws<InvalidOperationException>(() => { plt.Render(); });
+
+            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Ignore;
+            Assert.DoesNotThrow(() => { plt.Render(); });
+
+            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Gap;
+            Assert.DoesNotThrow(() => { plt.Render(); });
+        }
+
+
+        [Test]
+        public void Test_Scatter_AllYsNan()
+        {
+            double[] xs = ScottPlot.DataGen.Consecutive(51);
+            double[] ys = ScottPlot.DataGen.Full(51, double.NaN);
+
+            ScottPlot.Plot plt = new();
+            var sp = plt.AddScatter(xs, ys);
+
+            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Throw;
+            Assert.Throws<InvalidOperationException>(() => { plt.Render(); });
+
+            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Ignore;
+            Assert.DoesNotThrow(() => { plt.Render(); });
+
+            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Gap;
+            Assert.DoesNotThrow(() => { plt.Render(); });
+        }
+
+
+        [Test]
+        public void Test_Scatter_AllNanButOne()
+        {
+            double[] xs = ScottPlot.DataGen.Full(51, double.NaN);
+            double[] ys = ScottPlot.DataGen.Full(51, double.NaN);
+            xs[42] = 420;
+            ys[42] = 69;
+
+            ScottPlot.Plot plt = new();
+            var sp = plt.AddScatter(xs, ys);
+
+            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Throw;
+            Assert.Throws<InvalidOperationException>(() => { plt.Render(); });
+
+            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Ignore;
+            Assert.DoesNotThrow(() => { plt.Render(); });
+
+            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Gap;
+            Assert.DoesNotThrow(() => { plt.Render(); });
+        }
     }
 }

--- a/src/ScottPlot4/ScottPlot.Tests/PlotTypes/Scatter.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlotTypes/Scatter.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using ScottPlot;
+using System.Drawing;
 
 namespace ScottPlotTests.PlotTypes
 {
@@ -66,6 +67,58 @@ namespace ScottPlotTests.PlotTypes
 
             plt.Legend();
             plt.SetAxisLimits(0, 30, 1.42, 1.62);
+            TestTools.SaveFig(plt);
+        }
+
+        [Test]
+        public void Test_Scatter_IgnoreNaN()
+        {
+            double[] xs = ScottPlot.DataGen.Consecutive(51);
+            double[] ys = ScottPlot.DataGen.Sin(51);
+
+            Random rand = new(0);
+            double[] ys2 = ScottPlot.DataGen.InsertNanRanges(ys, rand, 5);
+            Console.WriteLine(string.Join(", ", ys2.Select(x => x.ToString())));
+
+            ScottPlot.Plot plt = new(600, 400);
+            var sp1 = plt.AddScatter(xs, ys, color: Color.FromArgb(50, Color.Black), label: "original data");
+            var sp2 = plt.AddScatter(xs, ys2, color: Color.Black, label: "data with gaps");
+            plt.Legend(location: Alignment.LowerLeft);
+
+            // default behavior throws with a NaN error
+            Assert.Throws<InvalidOperationException>(() => { plt.Render(); });
+
+            // ignoring NaN points prevents the error
+            sp2.OnNaN = ScottPlot.Plottable.ResponseToNaN.Ignore;
+            plt.Title($"OnNaN = {sp2.OnNaN}");
+            Assert.DoesNotThrow(() => plt.Render());
+
+            TestTools.SaveFig(plt);
+        }
+
+        [Test]
+        public void Test_Scatter_GapNaN()
+        {
+            double[] xs = ScottPlot.DataGen.Consecutive(51);
+            double[] ys = ScottPlot.DataGen.Sin(51);
+
+            Random rand = new(0);
+            double[] ys2 = ScottPlot.DataGen.InsertNanRanges(ys, rand, 5);
+            Console.WriteLine(string.Join(", ", ys2.Select(x => x.ToString())));
+
+            ScottPlot.Plot plt = new(600, 400);
+            var sp1 = plt.AddScatter(xs, ys, color: Color.FromArgb(50, Color.Black), label: "original data");
+            var sp2 = plt.AddScatter(xs, ys2, color: Color.Black, label: "data with gaps");
+            plt.Legend(location: Alignment.LowerLeft);
+
+            // default behavior throws with a NaN error
+            Assert.Throws<InvalidOperationException>(() => { plt.Render(); });
+
+            // gapping NaN points prevents the error
+            sp2.OnNaN = ScottPlot.Plottable.ResponseToNaN.Gap;
+            plt.Title($"OnNaN = {sp2.OnNaN}");
+            Assert.DoesNotThrow(() => plt.Render());
+
             TestTools.SaveFig(plt);
         }
     }

--- a/src/ScottPlot4/ScottPlot.Tests/PlotTypes/Scatter.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlotTypes/Scatter.cs
@@ -89,7 +89,7 @@ namespace ScottPlotTests.PlotTypes
             Assert.Throws<InvalidOperationException>(() => { plt.Render(); });
 
             // ignoring NaN points prevents the error
-            sp2.OnNaN = ScottPlot.Plottable.ResponseToNaN.Ignore;
+            sp2.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Ignore;
             plt.Title($"OnNaN = {sp2.OnNaN}");
             Assert.DoesNotThrow(() => plt.Render());
 
@@ -115,7 +115,7 @@ namespace ScottPlotTests.PlotTypes
             Assert.Throws<InvalidOperationException>(() => { plt.Render(); });
 
             // gapping NaN points prevents the error
-            sp2.OnNaN = ScottPlot.Plottable.ResponseToNaN.Gap;
+            sp2.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Gap;
             plt.Title($"OnNaN = {sp2.OnNaN}");
             Assert.DoesNotThrow(() => plt.Render());
 
@@ -132,13 +132,13 @@ namespace ScottPlotTests.PlotTypes
             ScottPlot.Plot plt = new();
             var sp = plt.AddScatter(xs, ys);
 
-            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Throw;
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Throw;
             Assert.Throws<InvalidOperationException>(() => { plt.Render(); });
 
-            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Ignore;
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Ignore;
             Assert.DoesNotThrow(() => { plt.Render(); });
 
-            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Gap;
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Gap;
             Assert.DoesNotThrow(() => { plt.Render(); });
         }
 
@@ -152,13 +152,13 @@ namespace ScottPlotTests.PlotTypes
             ScottPlot.Plot plt = new();
             var sp = plt.AddScatter(xs, ys);
 
-            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Throw;
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Throw;
             Assert.Throws<InvalidOperationException>(() => { plt.Render(); });
 
-            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Ignore;
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Ignore;
             Assert.DoesNotThrow(() => { plt.Render(); });
 
-            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Gap;
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Gap;
             Assert.DoesNotThrow(() => { plt.Render(); });
         }
 
@@ -174,13 +174,13 @@ namespace ScottPlotTests.PlotTypes
             ScottPlot.Plot plt = new();
             var sp = plt.AddScatter(xs, ys);
 
-            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Throw;
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Throw;
             Assert.Throws<InvalidOperationException>(() => { plt.Render(); });
 
-            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Ignore;
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Ignore;
             Assert.DoesNotThrow(() => { plt.Render(); });
 
-            sp.OnNaN = ScottPlot.Plottable.ResponseToNaN.Gap;
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Gap;
             Assert.DoesNotThrow(() => { plt.Render(); });
         }
     }

--- a/src/ScottPlot4/ScottPlot.Tests/PlotTypes/Scatter.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlotTypes/Scatter.cs
@@ -78,7 +78,6 @@ namespace ScottPlotTests.PlotTypes
 
             Random rand = new(0);
             double[] ys2 = ScottPlot.DataGen.InsertNanRanges(ys, rand, 5);
-            Console.WriteLine(string.Join(", ", ys2.Select(x => x.ToString())));
 
             ScottPlot.Plot plt = new(600, 400);
             var sp1 = plt.AddScatter(xs, ys, color: Color.FromArgb(50, Color.Black), label: "original data");
@@ -104,7 +103,6 @@ namespace ScottPlotTests.PlotTypes
 
             Random rand = new(0);
             double[] ys2 = ScottPlot.DataGen.InsertNanRanges(ys, rand, 5);
-            Console.WriteLine(string.Join(", ", ys2.Select(x => x.ToString())));
 
             ScottPlot.Plot plt = new(600, 400);
             var sp1 = plt.AddScatter(xs, ys, color: Color.FromArgb(50, Color.Black), label: "original data");

--- a/src/ScottPlot4/ScottPlot.Tests/PlotTypes/ScatterPlotList.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlotTypes/ScatterPlotList.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -27,6 +28,125 @@ namespace ScottPlotTests.PlotTypes
 
             plt.SetAxisLimits(0, 30, 1.42, 1.62); // mimic excel
             TestTools.SaveFig(plt);
+        }
+
+        [Test]
+        public void Test_Scatter_IgnoreNaN()
+        {
+            double[] xs = ScottPlot.DataGen.Consecutive(51);
+            double[] ys = ScottPlot.DataGen.Sin(51);
+
+            Random rand = new(0);
+            double[] ys2 = ScottPlot.DataGen.InsertNanRanges(ys, rand, 5);
+
+            ScottPlot.Plot plt = new(600, 400);
+            var sp1 = plt.AddScatterList(color: Color.FromArgb(50, Color.Black), label: "original data");
+            sp1.AddRange(xs, ys);
+            var sp2 = plt.AddScatterList(color: Color.Black, label: "data with gaps");
+            sp2.AddRange(xs, ys2);
+            plt.Legend(location: ScottPlot.Alignment.LowerLeft);
+
+            // default behavior throws with a NaN error
+            Assert.Throws<InvalidOperationException>(() => { plt.Render(); });
+
+            // ignoring NaN points prevents the error
+            sp2.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Ignore;
+            plt.Title($"OnNaN = {sp2.OnNaN}");
+            Assert.DoesNotThrow(() => plt.Render());
+
+            TestTools.SaveFig(plt);
+        }
+
+        [Test]
+        public void Test_Scatter_GapNaN()
+        {
+            double[] xs = ScottPlot.DataGen.Consecutive(51);
+            double[] ys = ScottPlot.DataGen.Sin(51);
+
+            Random rand = new(0);
+            double[] ys2 = ScottPlot.DataGen.InsertNanRanges(ys, rand, 5);
+
+            ScottPlot.Plot plt = new(600, 400);
+            var sp1 = plt.AddScatterList(color: Color.FromArgb(50, Color.Black), label: "original data");
+            sp1.AddRange(xs, ys);
+            var sp2 = plt.AddScatterList(color: Color.Black, label: "data with gaps");
+            sp2.AddRange(xs, ys2);
+            plt.Legend(location: ScottPlot.Alignment.LowerLeft);
+
+            // default behavior throws with a NaN error
+            Assert.Throws<InvalidOperationException>(() => { plt.Render(); });
+
+            // gapping NaN points prevents the error
+            sp2.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Gap;
+            plt.Title($"OnNaN = {sp2.OnNaN}");
+            Assert.DoesNotThrow(() => plt.Render());
+
+            TestTools.SaveFig(plt);
+        }
+
+
+        [Test]
+        public void Test_Scatter_AllNan()
+        {
+            double[] xs = ScottPlot.DataGen.Full(51, double.NaN);
+            double[] ys = ScottPlot.DataGen.Full(51, double.NaN);
+
+            ScottPlot.Plot plt = new();
+            var sp = plt.AddScatterList();
+            sp.AddRange(xs, ys);
+
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Throw;
+            Assert.Throws<InvalidOperationException>(() => { plt.Render(); });
+
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Ignore;
+            Assert.DoesNotThrow(() => { plt.Render(); });
+
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Gap;
+            Assert.DoesNotThrow(() => { plt.Render(); });
+        }
+
+
+        [Test]
+        public void Test_Scatter_AllYsNan()
+        {
+            double[] xs = ScottPlot.DataGen.Consecutive(51);
+            double[] ys = ScottPlot.DataGen.Full(51, double.NaN);
+
+            ScottPlot.Plot plt = new();
+            var sp = plt.AddScatterList();
+            sp.AddRange(xs, ys);
+
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Throw;
+            Assert.Throws<InvalidOperationException>(() => { plt.Render(); });
+
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Ignore;
+            Assert.DoesNotThrow(() => { plt.Render(); });
+
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Gap;
+            Assert.DoesNotThrow(() => { plt.Render(); });
+        }
+
+
+        [Test]
+        public void Test_Scatter_AllNanButOne()
+        {
+            double[] xs = ScottPlot.DataGen.Full(51, double.NaN);
+            double[] ys = ScottPlot.DataGen.Full(51, double.NaN);
+            xs[42] = 420;
+            ys[42] = 69;
+
+            ScottPlot.Plot plt = new();
+            var sp = plt.AddScatterList();
+            sp.AddRange(xs, ys);
+
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Throw;
+            Assert.Throws<InvalidOperationException>(() => { plt.Render(); });
+
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Ignore;
+            Assert.DoesNotThrow(() => { plt.Render(); });
+
+            sp.OnNaN = ScottPlot.Plottable.ScatterPlot.NanBehavior.Gap;
+            Assert.DoesNotThrow(() => { plt.Render(); });
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot.Tests/ScottPlot.Tests.csproj
+++ b/src/ScottPlot4/ScottPlot.Tests/ScottPlot.Tests.csproj
@@ -27,9 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/ScottPlot4/ScottPlot/DataGen.cs
+++ b/src/ScottPlot4/ScottPlot/DataGen.cs
@@ -1025,5 +1025,28 @@ namespace ScottPlot
 
             return values2;
         }
+
+        /// <summary>
+        /// Return a new array of given length, filled with <paramref name="fillValue"/>.
+        /// </summary>
+        public static double[] Full(int length, double fillValue)
+        {
+            return FullGeneric(length, fillValue);
+        }
+
+        /// <summary>
+        /// Return a new array of given length, filled with <paramref name="fillValue"/>.
+        /// </summary>
+        public static T[] FullGeneric<T>(int length, T fillValue)
+        {
+            T[] data = new T[length];
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                data[i] = fillValue;
+            }
+
+            return data;
+        }
     }
 }

--- a/src/ScottPlot4/ScottPlot/DataGen.cs
+++ b/src/ScottPlot4/ScottPlot/DataGen.cs
@@ -1004,5 +1004,26 @@ namespace ScottPlot
 
             return ys;
         }
+
+
+        /// <summary>
+        /// Return a copy of the input array with large spans of NaN.
+        /// The higher the stability, the larger the spans are.
+        /// </summary>
+        public static double[] InsertNanRanges(double[] values, Random rand, int stability = 10)
+        {
+            double[] values2 = new double[values.Length];
+
+            bool isNan = rand.NextDouble() > .5;
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                values2[i] = isNan ? double.NaN : values[i];
+                if (rand.Next(stability) == 0)
+                    isNan = !isNan;
+            }
+
+            return values2;
+        }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/ScatterPlot.cs
@@ -238,32 +238,44 @@ namespace ScottPlot.Plottable
             int to = MaxRenderIndex ?? (Xs.Length - 1);
 
             // TODO: don't use an array for this
-            double[] limits = new double[4];
+            double[] limits = { double.NaN, double.NaN, double.NaN, double.NaN };
 
             if (XError == null)
             {
                 var XsRange = Xs.Skip(from).Take(to - from + 1).Where(x => !double.IsNaN(x));
-                limits[0] = XsRange.Min();
-                limits[1] = XsRange.Max();
+                if (XsRange.Any())
+                {
+                    limits[0] = XsRange.Min();
+                    limits[1] = XsRange.Max();
+                }
             }
             else
             {
                 var XsAndError = Xs.Zip(XError, (x, e) => (x, e)).Skip(from).Take(to - from + 1).Where(p => !double.IsNaN(p.x + p.e));
-                limits[0] = XsAndError.Min(p => p.x - p.e);
-                limits[1] = XsAndError.Max(p => p.x + p.e);
+                if (XsAndError.Any())
+                {
+                    limits[0] = XsAndError.Min(p => p.x - p.e);
+                    limits[1] = XsAndError.Max(p => p.x + p.e);
+                }
             }
 
             if (YError == null)
             {
                 var YsRange = Ys.Skip(from).Take(to - from + 1).Where(x => !double.IsNaN(x));
-                limits[2] = YsRange.Min();
-                limits[3] = YsRange.Max();
+                if (YsRange.Any())
+                {
+                    limits[2] = YsRange.Min();
+                    limits[3] = YsRange.Max();
+                }
             }
             else
             {
                 var YsAndError = Ys.Zip(YError, (y, e) => (y, e)).Skip(from).Take(to - from + 1).Where(p => !double.IsNaN(p.y + p.e));
-                limits[2] = YsAndError.Min(p => p.y - p.e);
-                limits[3] = YsAndError.Max(p => p.y + p.e);
+                if (YsAndError.Any())
+                {
+                    limits[2] = YsAndError.Min(p => p.y - p.e);
+                    limits[3] = YsAndError.Max(p => p.y + p.e);
+                }
             }
 
             if (double.IsInfinity(limits[0]) || double.IsInfinity(limits[1]))

--- a/src/ScottPlot4/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/ScatterPlot.cs
@@ -6,13 +6,6 @@ using System.Linq;
 
 namespace ScottPlot.Plottable
 {
-    public enum ResponseToNaN
-    {
-        Throw,
-        Ignore,
-        Gap
-    }
-
     /// <summary>
     /// The scatter plot renders X/Y pairs as points and/or connected lines.
     /// Scatter plots can be extremely slow for large datasets, so use Signal plots in these situations.
@@ -24,6 +17,25 @@ namespace ScottPlot.Plottable
         public double[] Ys { get; private set; }
         public double[] XError { get; set; }
         public double[] YError { get; set; }
+
+        public enum NanBehavior
+        {
+            /// <summary>
+            /// Throw a <see cref="NotImplementedException"/> if <see cref="Xs"/> or <see cref="Ys"/> contains <see cref="double.NaN"/>
+            /// </summary>
+            Throw,
+
+            /// <summary>
+            /// Ignore points where X or Y is <see cref="double.NaN"/>, drawing a line between adjacent non-NaN points.
+            /// </summary>
+            Ignore,
+
+            /// <summary>
+            /// Treat points where X or Y is <see cref="double.NaN"/> as missing data and render the scatter plot as a 
+            /// broken line with gaps indicating NaN points.
+            /// </summary>
+            Gap
+        }
 
         /// <summary>
         /// Add this value to each X value before plotting (axis units)
@@ -99,7 +111,7 @@ namespace ScottPlot.Plottable
         /// </summary>
         public double SmoothTension = 0.5;
 
-        public ResponseToNaN OnNaN = ResponseToNaN.Throw;
+        public NanBehavior OnNaN = NanBehavior.Throw;
 
         public bool IsHighlighted { get; set; } = false;
         public float HighlightCoefficient { get; set; } = 2;
@@ -224,9 +236,9 @@ namespace ScottPlot.Plottable
         {
             return OnNaN switch
             {
-                ResponseToNaN.Throw => GetAxisLimitsThrowOnNaN(),
-                ResponseToNaN.Ignore => GetAxisLimitsIgnoreNaN(),
-                ResponseToNaN.Gap => GetAxisLimitsIgnoreNaN(),
+                NanBehavior.Throw => GetAxisLimitsThrowOnNaN(),
+                NanBehavior.Ignore => GetAxisLimitsIgnoreNaN(),
+                NanBehavior.Gap => GetAxisLimitsIgnoreNaN(),
                 _ => throw new NotImplementedException($"{nameof(OnNaN)} behavior not yet supported: {OnNaN}"),
             };
         }
@@ -388,7 +400,7 @@ namespace ScottPlot.Plottable
                     }
                 }
 
-                if (OnNaN == ResponseToNaN.Throw)
+                if (OnNaN == NanBehavior.Throw)
                 {
                     foreach (PointF point in points)
                     {
@@ -398,11 +410,11 @@ namespace ScottPlot.Plottable
 
                     DrawLines(points, gfx, penLine);
                 }
-                else if (OnNaN == ResponseToNaN.Ignore)
+                else if (OnNaN == NanBehavior.Ignore)
                 {
                     DrawLinesIngoringNaN(points, gfx, penLine);
                 }
-                else if (OnNaN == ResponseToNaN.Gap)
+                else if (OnNaN == NanBehavior.Gap)
                 {
                     DrawLinesWithGaps(points, gfx, penLine);
                 }

--- a/src/ScottPlot4/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/ScatterPlot.cs
@@ -111,6 +111,9 @@ namespace ScottPlot.Plottable
         /// </summary>
         public double SmoothTension = 0.5;
 
+        /// <summary>
+        /// Defines behavior when <see cref="Xs"/> or <see cref="Ys"/> contains <see cref="double.NaN"/>
+        /// </summary>
         public NanBehavior OnNaN = NanBehavior.Throw;
 
         public bool IsHighlighted { get; set; } = false;

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -2,7 +2,7 @@
 
 ## ScottPlot 4.1.54
 _not yet published on NuGet..._
-* Scatter: Data may now contain NaN if the `OnNaN` field is customized. `Ignore` skips over NaN values. `Gap` draws a scatter plot as multiple lines with breaks where NaNs are. (#203, #396, #546, #618, #976, #1161)
+* Scatter: Data may now contain NaN if the `OnNaN` field is customized. `Throw` throws an exception of NaN is detected (default behavior), `Ignore` skips over NaN values (connecting adjacent points with a line), and `Gap` breaks the line so NaN values appear as gaps. (#2040, #2041)
 
 ## ScottPlot 4.1.53
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-08-11_

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -2,6 +2,7 @@
 
 ## ScottPlot 4.1.54
 _not yet published on NuGet..._
+* Scatter: Data may now contain NaN if the `OnNaN` field is customized. `Ignore` skips over NaN values. `Gap` draws a scatter plot as multiple lines with breaks where NaNs are. (#203, #396, #546, #618, #976, #1161)
 
 ## ScottPlot 4.1.53
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-08-11_


### PR DESCRIPTION
This PR adds an `OnNaN` field to `ScatterPlot` which customizes this behavior. 

The default action is `Throw`, but `Ignore` skips NaN points and `Gap` renders the line as multiple lines with gaps where data is NaN.

Related: 
* #203
* #396
* #546 
* #618
* #976
* #1161

Resolves:
* #2040

![image](https://user-images.githubusercontent.com/4165489/184508071-a5042bf9-6f5a-43a4-ab2b-20d30dfe8f92.png)

![image](https://user-images.githubusercontent.com/4165489/184508104-ee824839-0cbc-430f-b71a-d60a46be7faf.png)