### PR TITLE
Scatter: improve GetPointNearest() NaN support

### DIFF
--- a/src/ScottPlot4/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/ScatterPlot.cs
@@ -529,7 +529,7 @@ namespace ScottPlot.Plottable
         {
             int from = MinRenderIndex ?? 0;
             int to = MaxRenderIndex ?? (Xs.Length - 1);
-            double minDistance = Math.Abs(Xs[from] - x);
+            double minDistance = double.PositiveInfinity;
             int minIndex = 0;
             for (int i = from; i <= to; i++)
             {
@@ -553,7 +553,7 @@ namespace ScottPlot.Plottable
         {
             int from = MinRenderIndex ?? 0;
             int to = MaxRenderIndex ?? (Ys.Length - 1);
-            double minDistance = Math.Abs(Ys[from] - y);
+            double minDistance = double.PositiveInfinity;
             int minIndex = 0;
             for (int i = from; i <= to; i++)
             {
@@ -587,7 +587,7 @@ namespace ScottPlot.Plottable
 
             double minDistance = double.PositiveInfinity;
             int minIndex = 0;
-            for (int i = 1; i < points.Count; i++)
+            for (int i = 0; i < points.Count; i++)
             {
                 if (double.IsNaN(points[i].x) || double.IsNaN(points[i].y))
                     continue;

--- a/src/ScottPlot4/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/ScatterPlot.cs
@@ -585,10 +585,13 @@ namespace ScottPlot.Plottable
             double pointDistanceSquared(double x1, double y1) =>
                 (x1 - x) * (x1 - x) * xyRatioSquared + (y1 - y) * (y1 - y);
 
-            double minDistance = pointDistanceSquared(points[0].x, points[0].y);
+            double minDistance = double.PositiveInfinity;
             int minIndex = 0;
             for (int i = 1; i < points.Count; i++)
             {
+                if (double.IsNaN(points[i].x) || double.IsNaN(points[i].y))
+                    continue;
+
                 double currDistance = pointDistanceSquared(points[i].x, points[i].y);
                 if (currDistance < minDistance)
                 {

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -1,7 +1,11 @@
 # ScottPlot Changelog
 
-## ScottPlot 4.1.56
+## ScottPlot 4.1.57
 _not yet published on NuGet..._
+* Scatter: Improved `GetPointNearest()` when `OnNaN` is `Gap` or `Ignore` (#2048) _Thanks @thopri_
+
+## ScottPlot 4.1.56
+_Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-08-16_
 * Signal: Improved accuracy of `GetIndexForX()` (#2044) _Thanks @CharlesMauldin_
 * Palette: Added help messages for users attempting to create custom palettes (#1966) _Thanks @EFeru_
 


### PR DESCRIPTION
previously NaN was always returned for any plot containing NaN

* resolves #2048