### PR TITLE
2049

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Heatmap.cs
@@ -337,4 +337,29 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             hm.YMax = 10;
         }
     }
+
+    public class HeatmapClipping : IRecipe
+    {
+        public ICategory Category => new Categories.PlotTypes.Heatmap();
+        public string ID => "heatmap_clipping";
+        public string Title => "Heatmap Clipping";
+        public string Description =>
+            "Heatmaps can be clipped to an arbitrary polygon";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[,] imageData = DataGen.SampleImageData();
+            var hm = plt.AddHeatmap(imageData, lockScales: false);
+            hm.ClippingPoints = new Coordinate[]
+            {
+                new Coordinate(30, 15),
+                new Coordinate(55, 40),
+                new Coordinate(60, 45),
+                new Coordinate(80, 60),
+                new Coordinate(40, 95),
+                new Coordinate(15, 90),
+                new Coordinate(5, 50),
+            };
+        }
+    }
 }

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Image.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Image.cs
@@ -149,4 +149,31 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             plt.AddPoint(40, -.5, color: Color.Green, size: 20);
         }
     }
+
+    public class ImageClipping : IRecipe
+    {
+        public ICategory Category => new Categories.PlotTypes.Image();
+        public string ID => "image_clipping";
+        public string Title => "Image Clipping";
+        public string Description =>
+            "Images can be clipped to an arbitrary polygon";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            Bitmap bmp = DataGen.SampleImage();
+            var img = plt.AddImage(bmp, 0, bmp.Height);
+            img.HeightInAxisUnits = bmp.Height;
+            img.WidthInAxisUnits = bmp.Width;
+            img.ClippingPoints = new Coordinate[]
+            {
+                new Coordinate(30, 15),
+                new Coordinate(55, 40),
+                new Coordinate(60, 45),
+                new Coordinate(80, 60),
+                new Coordinate(40, 95),
+                new Coordinate(15, 90),
+                new Coordinate(5, 50),
+            };
+        }
+    }
 }

--- a/src/ScottPlot4/ScottPlot/Drawing/GDI.cs
+++ b/src/ScottPlot4/ScottPlot/Drawing/GDI.cs
@@ -398,5 +398,19 @@ namespace ScottPlot.Drawing
             gfx.DrawString(text, font, fontBrush, 0, 0, sf);
             gfx.ResetTransform();
         }
+
+        /// <summary>
+        /// Add extra clipping beyond the data area based on an array of user-defined coordinates
+        /// </summary>
+        public static void ClipIntersection(Graphics gfx, PlotDimensions dims, Coordinate[] coordinates)
+        {
+            if (coordinates is null || coordinates.Length < 2)
+                return;
+
+            PointF[] points = coordinates.Select(x => dims.GetPixel(x).ToPointF()).ToArray();
+            GraphicsPath path = new();
+            path.AddPolygon(points);
+            gfx.SetClip(path, CombineMode.Intersect);
+        }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Pixel.cs
+++ b/src/ScottPlot4/ScottPlot/Pixel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 
 namespace ScottPlot
 {
@@ -84,6 +85,27 @@ namespace ScottPlot
             int x = BitConverter.ToInt32(BitConverter.GetBytes(X), 0);
             int y = BitConverter.ToInt32(BitConverter.GetBytes(Y), 0);
             return x * 12345 + y;
+        }
+
+        public PointF ToPointF()
+        {
+            return new PointF(X, Y);
+        }
+
+        public static float Clamp(float value, float min, float max)
+        {
+            if (min > max)
+                throw new ArgumentException($"{nameof(min)} must be <= {nameof(max)}");
+            if (value < min) return min;
+            else if (value > max) return max;
+            else return value;
+        }
+
+        public Pixel Clamp(PixelRect rect)
+        {
+            float x = Clamp(X, rect.X, rect.X + rect.Width);
+            float y = Clamp(Y, rect.Y, rect.Y + rect.Height);
+            return new Pixel(x, y);
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Plottable/Heatmap.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Heatmap.cs
@@ -172,6 +172,8 @@ namespace ScottPlot.Plottable
         /// </summary>
         public bool FlipVertically { get; set; } = false;
 
+        public Coordinate[] ClippingPoints { get; set; } = Array.Empty<Coordinate>();
+
         public LegendItem[] GetLegendItems() => Array.Empty<LegendItem>();
 
         /// <summary>
@@ -349,6 +351,7 @@ namespace ScottPlot.Plottable
         protected virtual void RenderHeatmap(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
         {
             using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
+            GDI.ClipIntersection(gfx, dims, ClippingPoints);
 
             gfx.InterpolationMode = Interpolation;
             gfx.PixelOffsetMode = PixelOffsetMode.Half;
@@ -357,7 +360,6 @@ namespace ScottPlot.Plottable
             int fromY = (int)Math.Round(dims.GetPixelY(OffsetY + DataHeight * CellHeight));
             int width = (int)Math.Round(dims.GetPixelX(OffsetX + DataWidth * CellWidth) - fromX);
             int height = (int)Math.Round(dims.GetPixelY(OffsetY) - fromY);
-
 
             ImageAttributes attr = new();
             attr.SetWrapMode(WrapMode.TileFlipXY);

--- a/src/ScottPlot4/ScottPlot/Plottable/Image.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Image.cs
@@ -79,8 +79,8 @@ namespace ScottPlot.Plottable
             return new AxisLimits(
                 xMin: X,
                 xMax: X + WidthInAxisUnits ?? 0,
-                yMin: Y,
-                yMax: Y + HeightInAxisUnits ?? 0);
+                yMin: Y - HeightInAxisUnits ?? 0,
+                yMax: Y);
         }
 
         public LegendItem[] GetLegendItems() => Array.Empty<LegendItem>();

--- a/src/ScottPlot4/ScottPlot/Plottable/Image.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Image.cs
@@ -69,6 +69,8 @@ namespace ScottPlot.Plottable
 
         public int YAxisIndex { get; set; } = 0;
 
+        public Coordinate[] ClippingPoints { get; set; } = Array.Empty<Coordinate>();
+
         public AxisLimits GetAxisLimits()
         {
             if (Bitmap is null)
@@ -155,6 +157,8 @@ namespace ScottPlot.Plottable
             using (Graphics gfx = GDI.Graphics(bmp, dims, lowQuality))
             using (var framePen = new Pen(BorderColor, BorderSize * 2))
             {
+                GDI.ClipIntersection(gfx, dims, ClippingPoints);
+
                 gfx.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.Half;
                 gfx.TranslateTransform(defaultPoint.X, defaultPoint.Y);
                 gfx.RotateTransform((float)Rotation);

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -3,7 +3,7 @@
 ## ScottPlot 4.1.57
 _not yet published on NuGet..._
 * Scatter: Improved `GetPointNearest()` when `OnNaN` is `Gap` or `Ignore` (#2048) _Thanks @thopri_
-* Heatmap and Image: Added `Coordinate[] ClippingPoints` to give users the ability to clip to an arbitrary polygon (#2049) _Thanks @xichaoqiang_
+* Heatmap and Image: Added `Coordinate[] ClippingPoints` to give users the ability to clip to an arbitrary polygon (#2049, #2052) _Thanks @xichaoqiang_
 * Image: Improved automatic axis limits measurement when `HeightInAxisUnits` is defined
 
 ## ScottPlot 4.1.56

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -4,6 +4,7 @@
 _not yet published on NuGet..._
 * Scatter: Improved `GetPointNearest()` when `OnNaN` is `Gap` or `Ignore` (#2048) _Thanks @thopri_
 * Heatmap and Image: Added `Coordinate[] ClippingPoints` to give users the ability to clip to an arbitrary polygon (#2049) _Thanks @xichaoqiang_
+* Image: Improved automatic axis limits measurement when `HeightInAxisUnits` is defined
 
 ## ScottPlot 4.1.56
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-08-16_

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.57
 _not yet published on NuGet..._
 * Scatter: Improved `GetPointNearest()` when `OnNaN` is `Gap` or `Ignore` (#2048) _Thanks @thopri_
+* Heatmap and Image: Added `Coordinate[] ClippingPoints` to give users the ability to clip to an arbitrary polygon (#2049) _Thanks @xichaoqiang_
 
 ## ScottPlot 4.1.56
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-08-16_


### PR DESCRIPTION
* resolves #2049

```cs
Coordinate[] polygon =
{
    new Coordinate(30, 15),
    new Coordinate(55, 40),
    new Coordinate(60, 45),
    new Coordinate(80, 60),
    new Coordinate(40, 95),
    new Coordinate(15, 90),
    new Coordinate(5, 50),
};

double[,] data = ScottPlot.DataGen.SampleImageData();
var heatmap = formsPlot1.Plot.AddHeatmap(data);
heatmap.ClippingPoints = polygon;
```

original | clipping
---|---
![image](https://user-images.githubusercontent.com/4165489/185254232-158e0900-890e-41b9-aa6c-28c23eb9b583.png)|![image](https://user-images.githubusercontent.com/4165489/185254197-099d8255-6db9-428d-9356-4db193422ba7.png)
