### PR TITLE
GDI: do not crop when frameless

### DIFF
--- a/src/ScottPlot4/ScottPlot.Tests/PlottableRenderTests/AxisSpan.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlottableRenderTests/AxisSpan.cs
@@ -113,9 +113,15 @@ namespace ScottPlotTests.PlottableRenderTests
             plt.Style(figureBackground: System.Drawing.Color.Green);
             plt.AddHorizontalSpan(10, 20, System.Drawing.Color.Magenta);
 
-            TestTools.SaveFig(plt, "default");
+            plt.XAxis.Ticks(false);
+            plt.YAxis.Ticks(false);
+
+            plt.XAxis.Line(false);
             plt.XAxis2.Line(false);
+            plt.YAxis.Line(false);
+            plt.YAxis2.Line(false);
             TestTools.SaveFig(plt, "noline");
+
             plt.Frameless();
             TestTools.SaveFig(plt, "frameless");
         }

--- a/src/ScottPlot4/ScottPlot.Tests/PlottableRenderTests/AxisSpan.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlottableRenderTests/AxisSpan.cs
@@ -104,5 +104,20 @@ namespace ScottPlotTests.PlottableRenderTests
             // Y Ticks has more affect on mean pixel
             Assert.AreEqual(smallZoom.RGB, extremeZoom.RGB, 20);
         }
+
+        [Test]
+        public void AxisHSpan_Frameless()
+        {
+            var plt = new ScottPlot.Plot(200, 100);
+            plt.Style(dataBackground: System.Drawing.Color.Blue);
+            plt.Style(figureBackground: System.Drawing.Color.Green);
+            plt.AddHorizontalSpan(10, 20, System.Drawing.Color.Magenta);
+
+            TestTools.SaveFig(plt, "default");
+            plt.XAxis2.Line(false);
+            TestTools.SaveFig(plt, "noline");
+            plt.Frameless();
+            TestTools.SaveFig(plt, "frameless");
+        }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Drawing/GDI.cs
+++ b/src/ScottPlot4/ScottPlot/Drawing/GDI.cs
@@ -159,9 +159,9 @@ namespace ScottPlot.Drawing
         {
             Graphics gfx = Graphics(bmp, lowQuality, dims.ScaleFactor);
 
-            bool dataIsSmallerThanFigure = dims.DataWidth < dims.Width && dims.DataHeight < dims.Height;
+            bool isFrameless = (dims.DataWidth == dims.Width) && (dims.DataHeight == dims.Height);
 
-            if (dataIsSmallerThanFigure && clipToDataArea)
+            if (clipToDataArea && !isFrameless)
             {
                 /* These dimensions are withdrawn by 1 pixel to leave room for a 1px wide data frame.
                  * Rounding is intended to exactly match rounding used when frame placement is determined.

--- a/src/ScottPlot4/ScottPlot/Drawing/GDI.cs
+++ b/src/ScottPlot4/ScottPlot/Drawing/GDI.cs
@@ -159,7 +159,9 @@ namespace ScottPlot.Drawing
         {
             Graphics gfx = Graphics(bmp, lowQuality, dims.ScaleFactor);
 
-            if (clipToDataArea)
+            bool dataIsSmallerThanFigure = dims.DataWidth < dims.Width && dims.DataHeight < dims.Height;
+
+            if (dataIsSmallerThanFigure && clipToDataArea)
             {
                 /* These dimensions are withdrawn by 1 pixel to leave room for a 1px wide data frame.
                  * Rounding is intended to exactly match rounding used when frame placement is determined.

--- a/src/ScottPlot4/ScottPlot/Plottable/AxisSpan.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/AxisSpan.cs
@@ -220,7 +220,7 @@ namespace ScottPlot.Plottable
             using var gfx = GDI.Graphics(bmp, dims, lowQuality);
             using var brush = GDI.Brush(Color, HatchColor, HatchStyle);
             using var pen = GDI.Pen(BorderColor, BorderLineWidth, BorderLineStyle);
-            RectangleF rect = GetClippedRectangle(dims);           
+            RectangleF rect = GetClippedRectangle(dims);
             gfx.FillRectangle(brush, rect);
             if (BorderLineWidth > 0 && BorderColor != Color.Transparent && BorderLineStyle != LineStyle.None)
                 gfx.DrawRectangle(pen, rect.X, rect.Y, rect.Width, rect.Height);

--- a/src/ScottPlot4/ScottPlot/Plottable/AxisSpan.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/AxisSpan.cs
@@ -200,20 +200,30 @@ namespace ScottPlot.Plottable
             float width = right - left + 1;
             float height = bottom - top + 1;
 
+            // expand slightly so anti-aliasing transparency is not observed at the edges of frameless plots
+            if (IsHorizontal)
+            {
+                top -= 1;
+                height += 2;
+            }
+            else
+            {
+                left -= 1;
+                width += 2;
+            }
+
             return new RectangleF(left, top, width, height);
         }
 
         public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
         {
-            using (var gfx = GDI.Graphics(bmp, dims, lowQuality))
-            using (var brush = GDI.Brush(Color, HatchColor, HatchStyle))
-            using (var pen = GDI.Pen(BorderColor, BorderLineWidth, BorderLineStyle))
-            {
-                RectangleF rect = GetClippedRectangle(dims);
-                gfx.FillRectangle(brush, rect);
-                if (BorderLineWidth > 0 && BorderColor != Color.Transparent && BorderLineStyle != LineStyle.None)
-                    gfx.DrawRectangle(pen, rect.X, rect.Y, rect.Width, rect.Height);
-            }
+            using var gfx = GDI.Graphics(bmp, dims, lowQuality);
+            using var brush = GDI.Brush(Color, HatchColor, HatchStyle);
+            using var pen = GDI.Pen(BorderColor, BorderLineWidth, BorderLineStyle);
+            RectangleF rect = GetClippedRectangle(dims);           
+            gfx.FillRectangle(brush, rect);
+            if (BorderLineWidth > 0 && BorderColor != Color.Transparent && BorderLineStyle != LineStyle.None)
+                gfx.DrawRectangle(pen, rect.X, rect.Y, rect.Width, rect.Height);
         }
     }
 }

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -5,6 +5,7 @@ _not yet published on NuGet..._
 * Scatter: Improved `GetPointNearest()` when `OnNaN` is `Gap` or `Ignore` (#2048) _Thanks @thopri_
 * Heatmap and Image: Added `Coordinate[] ClippingPoints` to give users the ability to clip to an arbitrary polygon (#2049, #2052) _Thanks @xichaoqiang_
 * Image: Improved automatic axis limits measurement when `HeightInAxisUnits` is defined
+* Plot: Reduced anti-aliasing artifacts at the edge of frameless plots (#2051)
 
 ## ScottPlot 4.1.56
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-08-16_


### PR DESCRIPTION
Cropping results in anti-aliasing artifacts near the edges of the bitmap

resolves #2051