### PR TITLE
RadarPlot: Add `Smooth` parameter

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Radar.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Radar.cs
@@ -70,6 +70,26 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         }
     }
 
+    public class RadarSmooth : IRecipe
+    {
+        public ICategory Category => new Categories.PlotTypes.Radar();
+        public string ID => "radar_smooth";
+        public string Title => "Smooth Radar";
+        public string Description =>
+            "The Smooth field controls whether radar areas are drawn with smooth or straight lines.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            double[,] values = {
+                    { 78, 83, 84, 76, 43 },
+                    { 100, 50, 70, 60, 90 }
+                };
+
+            var radarPlot = plt.AddRadar(values);
+            radarPlot.Smooth = true;
+        }
+    }
+
     public class RadarUnlabeledAxes : IRecipe
     {
         public ICategory Category => new Categories.PlotTypes.Radar();

--- a/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
@@ -116,6 +116,11 @@ namespace ScottPlot.Plottable
         public int XAxisIndex { get; set; } = 0;
         public int YAxisIndex { get; set; } = 0;
 
+        /// <summary>
+        /// If enabled, the plot will fill using a curve instead of polygon.
+        /// </summary>
+        public bool Smooth = false;
+
         public RadarPlot(double[,] values, Color[] lineColors, Color[] fillColors, bool independentAxes, double[] maxValues = null)
         {
             LineColors = lineColors;
@@ -278,8 +283,17 @@ namespace ScottPlot.Plottable
 
                     using var brush = GDI.Brush(FillColors[i], HatchOptions?[i].Color, HatchOptions?[i].Pattern ?? Drawing.HatchStyle.None);
                     pen.Color = LineColors[i];
-                    gfx.FillPolygon(brush, points);
-                    gfx.DrawPolygon(pen, points);
+
+                    if (Smooth)
+                    {
+                        gfx.FillClosedCurve(brush, points);
+                        gfx.DrawClosedCurve(pen, points);
+                    }
+                    else
+                    {
+                        gfx.FillPolygon(brush, points);
+                        gfx.DrawPolygon(pen, points);
+                    }
                 }
             }
         }

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -2,6 +2,7 @@
 
 ## ScottPlot 4.1.58
 _not yet published on NuGet..._
+* Radar: New `Smooth` field allows radar areas to be drawn with smooth lines (#2067, #2065) _Thanks @theelderwand_
 
 ## ScottPlot 4.1.57
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-08-18_


### PR DESCRIPTION
**Purpose:**
This pull request adds a new property Smooth (default false) to RadarPlot. When enabled the radar plot will render as a closed curve instead of a polygon.

![image](https://user-images.githubusercontent.com/2137463/186723524-654b5036-c7e2-46c9-9ebf-eb5af4f0943b.png)


```cs
// You can insert code examples like this
var radar = plot.AddRadar(values);
radar.Smooth = true;
plot.Render();