### PR TITLE
Ticks: improve manual tick checking

### DIFF
--- a/src/ScottPlot4/ScottPlot.Tests/Ticks/TickGeneration.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/Ticks/TickGeneration.cs
@@ -130,5 +130,23 @@ namespace ScottPlotTests.Ticks
             plt.XAxis.AutomaticTickPositions();
             Assert.AreEqual(originalTicks, TestTools.GetXTickString(plt));
         }
+
+        [Test]
+        public void Test_ManualTicks_DifferentLengths()
+        {
+            ScottPlot.Plot plt = new();
+
+            plt.AddSignal(DataGen.Sin(51));
+            plt.AddSignal(DataGen.Cos(51));
+
+            double[] positions = { 10, 20, 30 };
+            string[] badLabels = { "ten", "twenty" };
+            string[] goodLabels = { "ten", "twenty", "thirty" };
+
+            Assert.Throws<ArgumentException>(() => plt.XAxis.ManualTickPositions(positions, badLabels));
+
+            Assert.DoesNotThrow(() => plt.XAxis.ManualTickPositions(positions, goodLabels));
+
+        }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Renderable/Axis.cs
+++ b/src/ScottPlot4/ScottPlot/Renderable/Axis.cs
@@ -283,6 +283,9 @@ namespace ScottPlot.Renderable
         /// </summary>
         public void ManualTickPositions(double[] positions, string[] labels)
         {
+            if (positions.Length != labels.Length)
+                throw new ArgumentException($"{nameof(positions)} must have the same length as {nameof(labels)}");
+
             AxisTicks.TickCollection.manualTickPositions = positions;
             AxisTicks.TickCollection.manualTickLabels = labels;
         }

--- a/src/ScottPlot4/ScottPlot/Ticks/TickCollection.cs
+++ b/src/ScottPlot4/ScottPlot/Ticks/TickCollection.cs
@@ -140,6 +140,9 @@ namespace ScottPlot.Ticks
             }
             else
             {
+                if (manualTickPositions.Length != manualTickLabels.Length)
+                    throw new InvalidOperationException($"{nameof(manualTickPositions)} must have the same length as {nameof(manualTickLabels)}");
+
                 double min = Orientation == AxisOrientation.Vertical ? dims.YMin : dims.XMin;
                 double max = Orientation == AxisOrientation.Vertical ? dims.YMax : dims.XMax;
 

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.58
 _not yet published on NuGet..._
 * Radar: New `Smooth` field allows radar areas to be drawn with smooth lines (#2067, #2065) _Thanks @theelderwand_
+* Ticks: Setting manual ticks will now throw an immediate `ArgumentException` if positions and labels have different lengths (#2063) _Thanks @sergaent_
 
 ## ScottPlot 4.1.57
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-08-18_


### PR DESCRIPTION
now throws immediately if manual ticks are supplied with mismatching position/label lengths

resolves #2063