### PR TITLE
VectorFieldList

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/VectorField.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/VectorField.cs
@@ -1,4 +1,5 @@
-﻿using ScottPlot.Statistics;
+﻿using ScottPlot.Drawing;
+using ScottPlot.Statistics;
 using System;
 using System.Collections.Generic;
 
@@ -155,23 +156,33 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
 
         public void ExecuteRecipe(Plot plt)
         {
-            Random rand = new(0);
-
             // Create a vector field list and add it to the plot
             var field = plt.AddVectorFieldList();
 
+            // Optionally color arrows using a colormap and custom scaling function
+            field.Colormap = Colormap.Turbo;
+            field.ColormapScaler = (magnitude) => magnitude * 5;
+
+            // Additional arrow styling options are here
+            field.ArrowStyle.ScaledArrowheads = true;
+            field.ArrowStyle.Anchor = ArrowAnchor.Base;
+            field.ArrowStyle.LineWidth = 3;
+            field.ArrowStyle.MarkerSize = 10;
+            field.ArrowStyle.MarkerShape = MarkerShape.filledDiamond;
+
             // Generate random vectors
-            for (int i = 0; i < 50; i++)
+            Random rand = new(0);
+            int pointCount = 20;
+            for (int i = 0; i < pointCount + 1; i++)
             {
-                Coordinate coordinate = new(
-                    x: 20 * rand.NextDouble() - 10,
-                    y: 20 * rand.NextDouble() - 10);
+                double x = i / (double)pointCount;
+                double y = Math.Sin(i * 2 * Math.PI / pointCount);
+                Coordinate coordinate = new(x, y);
 
-                CoordinateVector vector = new(
-                    x: 4 * rand.NextDouble() - 2,
-                    y: 4 * rand.NextDouble() - 2);
+                double dX = i / (double)pointCount * .15;
+                double dY = i / (double)pointCount * .15;
+                CoordinateVector vector = new(dX, dY);
 
-                // Create a tuple that pairs a location and vector and add it to the list
                 var rootedVector = (coordinate, vector);
                 field.RootedVectors.Add(rootedVector);
             }

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/VectorField.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/VectorField.cs
@@ -1,5 +1,6 @@
 ﻿using ScottPlot.Statistics;
 using System;
+using System.Collections.Generic;
 
 namespace ScottPlot.Cookbook.Recipes.Plottable
 {
@@ -141,6 +142,39 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             vf.ScaledArrowheads = true;
             vf.Anchor = ArrowAnchor.Base;
             vf.MarkerSize = 3;
+        }
+    }
+
+    public class VectorFieldArbitrary : IRecipe
+    {
+        public ICategory Category => new Categories.PlotTypes.VectorField();
+        public string ID => "vectorField_arbitrary";
+        public string Title => "Arbitrary Vectors";
+        public string Description => "Vectors can be placed arbitrarily in coordiante space " +
+            "(they are not required to be in a grid)";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            Random rand = new(0);
+
+            // Create a vector field list and add it to the plot
+            var field = plt.AddVectorFieldList();
+
+            // Generate random vectors
+            for (int i = 0; i < 50; i++)
+            {
+                Coordinate coordinate = new(
+                    x: 20 * rand.NextDouble() - 10,
+                    y: 20 * rand.NextDouble() - 10);
+
+                CoordinateVector vector = new(
+                    x: 4 * rand.NextDouble() - 2,
+                    y: 4 * rand.NextDouble() - 2);
+
+                // Create a tuple that pairs a location and vector and add it to the list
+                var rootedVector = (coordinate, vector);
+                field.RootedVectors.Add(rootedVector);
+            }
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot/CoordinateVector.cs
+++ b/src/ScottPlot4/ScottPlot/CoordinateVector.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace ScottPlot;
+
+/// <summary>
+/// Represents direction and magnitude in coordinate space
+/// </summary>
+public struct CoordinateVector
+{
+    public double X { get; set; }
+
+    public double Y { get; set; }
+
+    public double Magnitude => Math.Sqrt(X * X + Y * Y);
+
+    public CoordinateVector(double x, double y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    public static Coordinate operator +(Coordinate coordinate, CoordinateVector vector)
+    {
+        return new Coordinate(coordinate.X + vector.X, coordinate.Y + vector.Y);
+    }
+
+    public static Coordinate operator -(Coordinate coordinate, CoordinateVector vector)
+    {
+        return new Coordinate(coordinate.X - vector.X, coordinate.Y - vector.Y);
+    }
+}

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Add.cs
@@ -1289,6 +1289,16 @@ namespace ScottPlot
         }
 
         /// <summary>
+        /// Add a 2D vector field to the plot
+        /// </summary>
+        public VectorFieldList AddVectorFieldList()
+        {
+            var vectorFieldList = new VectorFieldList();
+            Add(vectorFieldList);
+            return vectorFieldList;
+        }
+
+        /// <summary>
         /// Add a vertical axis line at a specific Y position
         /// </summary>
         public VLine AddVerticalLine(double x, Color? color = null, float width = 1, LineStyle style = LineStyle.Solid, string label = null)

--- a/src/ScottPlot4/ScottPlot/Plottable/VectorFieldList.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/VectorFieldList.cs
@@ -1,0 +1,60 @@
+﻿using ScottPlot.Drawing;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+
+namespace ScottPlot.Plottable
+{
+    /// <summary>
+    /// The VectorField displays arrows representing a 2D array of 2D vectors
+    /// </summary>
+    public class VectorFieldList : IPlottable
+    {
+        public string Label { get; set; } = null;
+        public bool IsVisible { get; set; } = true;
+        public int XAxisIndex { get; set; } = 0;
+        public int YAxisIndex { get; set; } = 0;
+
+        public readonly List<(Coordinate coordinate, CoordinateVector vector)> RootedVectors = new();
+
+        public readonly Renderable.ArrowStyle ArrowStyle = new();
+
+        public VectorFieldList()
+        {
+
+        }
+
+        public override string ToString()
+        {
+            string label = string.IsNullOrWhiteSpace(Label) ? "" : $" ({Label})";
+            return $"PlottableVectorField{label} with {RootedVectors.Count} vectors";
+        }
+
+        public LegendItem[] GetLegendItems() => Array.Empty<LegendItem>();
+
+        public void ValidateData(bool deep = false) { }
+
+        public AxisLimits GetAxisLimits()
+        {
+            if (!RootedVectors.Any())
+                return AxisLimits.NoLimits;
+            else
+                return new AxisLimits(
+                    xMin: RootedVectors.Select(x => x.coordinate.X - x.vector.X).Min(),
+                    xMax: RootedVectors.Select(x => x.coordinate.X + x.vector.X).Max(),
+                    yMin: RootedVectors.Select(x => x.coordinate.Y - x.vector.Y).Min(),
+                    yMax: RootedVectors.Select(x => x.coordinate.Y + x.vector.Y).Max());
+        }
+
+        public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+        {
+            using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
+            foreach (var arrow in RootedVectors)
+            {
+                Color color = Color.Blue;
+                ArrowStyle.RenderArrow(dims, gfx, arrow.coordinate, arrow.vector, color);
+            }
+        }
+    }
+}

--- a/src/ScottPlot4/ScottPlot/Plottable/VectorFieldList.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/VectorFieldList.cs
@@ -16,8 +16,15 @@ namespace ScottPlot.Plottable
         public int XAxisIndex { get; set; } = 0;
         public int YAxisIndex { get; set; } = 0;
 
+        /// <summary>
+        /// Tuples define location and direction of vectors to display as arrows.
+        /// Users may manipulate this List to add/remove their own vectors.
+        /// </summary>
         public readonly List<(Coordinate coordinate, CoordinateVector vector)> RootedVectors = new();
 
+        /// <summary>
+        /// Advanced configuration options that control how vectors are drawn as arrows
+        /// </summary>
         public readonly Renderable.ArrowStyle ArrowStyle = new();
 
         /// <summary>

--- a/src/ScottPlot4/ScottPlot/Plottable/VectorFieldList.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/VectorFieldList.cs
@@ -20,6 +20,23 @@ namespace ScottPlot.Plottable
 
         public readonly Renderable.ArrowStyle ArrowStyle = new();
 
+        /// <summary>
+        /// Color to draw the arrows (if <see cref="Colormap"/> is null)
+        /// </summary>
+        public Color Color { get; set; } = Color.Blue;
+
+        /// <summary>
+        /// If defined, this colormap is used to color each arrow based on its magnitude
+        /// </summary>
+        public Colormap Colormap { get; set; } = null;
+
+        /// <summary>
+        /// If <see cref="Colormap"/> is defined, each arrow's magnitude 
+        /// is run through this function to get the fraction (from 0 to 1) 
+        /// along the colormap to sample from.
+        /// </summary>
+        public Func<double, double> ColormapScaler = (magnitude) => magnitude;
+
         public VectorFieldList()
         {
 
@@ -50,10 +67,13 @@ namespace ScottPlot.Plottable
         public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
         {
             using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
-            foreach (var arrow in RootedVectors)
+            foreach ((Coordinate coordinate, CoordinateVector vector) in RootedVectors)
             {
-                Color color = Color.Blue;
-                ArrowStyle.RenderArrow(dims, gfx, arrow.coordinate, arrow.vector, color);
+                Color color = Colormap is null
+                    ? Color
+                    : Colormap.GetColor(ColormapScaler.Invoke(vector.Magnitude));
+
+                ArrowStyle.RenderArrow(dims, gfx, coordinate, vector, color);
             }
         }
     }

--- a/src/ScottPlot4/ScottPlot/Plottable/VectorFieldList.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/VectorFieldList.cs
@@ -49,6 +49,11 @@ namespace ScottPlot.Plottable
 
         }
 
+        public VectorFieldList(List<(Coordinate coordinate, CoordinateVector vector)> rootedVectors)
+        {
+            RootedVectors = rootedVectors;
+        }
+
         public override string ToString()
         {
             string label = string.IsNullOrWhiteSpace(Label) ? "" : $" ({Label})";

--- a/src/ScottPlot4/ScottPlot/Renderable/ArrowStyle.cs
+++ b/src/ScottPlot4/ScottPlot/Renderable/ArrowStyle.cs
@@ -49,6 +49,11 @@ namespace ScottPlot.Renderable
         /// </summary>
         public float MarkerSize = 0;
 
+        /// <summary>
+        /// Thickness of the arrow lines
+        /// </summary>
+        public float LineWidth = 1; 
+
         public (float tipScale, float headAngle) GetTipDimensions()
         {
             float tipScale = (float)Math.Sqrt(ScaledArrowheadLength * ScaledArrowheadLength + ScaledArrowheadWidth * ScaledArrowheadWidth);
@@ -109,7 +114,7 @@ namespace ScottPlot.Renderable
                     throw new NotImplementedException("unsupported anchor type");
             }
 
-            using Pen pen = Drawing.GDI.Pen(color);
+            using Pen pen = Drawing.GDI.Pen(color, LineWidth, rounded: true);
 
             if (ScaledArrowheads)
             {

--- a/src/ScottPlot4/ScottPlot/Renderable/ArrowStyle.cs
+++ b/src/ScottPlot4/ScottPlot/Renderable/ArrowStyle.cs
@@ -61,60 +61,87 @@ namespace ScottPlot.Renderable
         /// </summary>
         public void Render(PlotDimensions dims, Graphics gfx, double[] xs, double[] ys, Statistics.Vector2[,] vectors, Color[] colors)
         {
-            (float tipScale, float headAngle) = GetTipDimensions(); // precalculate angles for fancy arrows
-
-            using Pen pen = Drawing.GDI.Pen(Color.Black);
-            if (!ScaledArrowheads)
-                pen.CustomEndCap = new System.Drawing.Drawing2D.AdjustableArrowCap(NonScaledArrowheadWidth, NonScaledArrowheadLength);
 
             for (int i = 0; i < xs.Length; i++)
             {
                 for (int j = 0; j < ys.Length; j++)
                 {
-                    Statistics.Vector2 v = vectors[i, j];
-                    float tailX, tailY, endX, endY;
-
-                    switch (Anchor)
-                    {
-                        case ArrowAnchor.Base:
-                            tailX = dims.GetPixelX(xs[i]);
-                            tailY = dims.GetPixelY(ys[j]);
-                            endX = dims.GetPixelX(xs[i] + v.X);
-                            endY = dims.GetPixelY(ys[j] + v.Y);
-                            break;
-                        case ArrowAnchor.Center:
-                            tailX = dims.GetPixelX(xs[i] - v.X / 2);
-                            tailY = dims.GetPixelY(ys[j] - v.Y / 2);
-                            endX = dims.GetPixelX(xs[i] + v.X / 2);
-                            endY = dims.GetPixelY(ys[j] + v.Y / 2);
-                            break;
-                        case ArrowAnchor.Tip:
-                            tailX = dims.GetPixelX(xs[i] - v.X);
-                            tailY = dims.GetPixelY(ys[j] - v.Y);
-                            endX = dims.GetPixelX(xs[i]);
-                            endY = dims.GetPixelY(ys[j]);
-                            break;
-                        default:
-                            throw new NotImplementedException("unsupported anchor type");
-                    }
-
-                    pen.Color = colors[i * ys.Length + j];
-                    if (ScaledArrowheads)
-                        DrawFancyArrow(gfx, pen, tailX, tailY, endX, endY, headAngle, tipScale);
-                    else
-                        gfx.DrawLine(pen, tailX, tailY, endX, endY);
-
-                    if (MarkerShape != MarkerShape.none && MarkerSize > 0)
-                    {
-                        PointF markerPoint = new PointF(dims.GetPixelX(xs[i]), dims.GetPixelY(ys[j]));
-                        MarkerTools.DrawMarker(gfx, markerPoint, MarkerShape, MarkerSize, pen.Color);
-                    }
+                    Coordinate coordinate = new(xs[i], ys[j]);
+                    CoordinateVector vector = new(vectors[i, j].X, vectors[i, j].Y);
+                    Color color = colors[i * ys.Length + j];
+                    RenderArrow(dims, gfx, coordinate, vector, color);
                 }
             }
         }
 
-        private void DrawFancyArrow(Graphics gfx, Pen pen, float x1, float y1, float x2, float y2, float headAngle, float tipScale)
+        /// <summary>
+        /// Render a single arrow placed anywhere in coordinace space
+        /// </summary>
+        public void RenderArrow(PlotDimensions dims, Graphics gfx, Coordinate pt, CoordinateVector vec, Color color)
         {
+            double x = pt.X;
+            double y = pt.Y;
+            double xVector = vec.X;
+            double yVector = vec.Y;
+
+            float tailX, tailY, endX, endY;
+            switch (Anchor)
+            {
+                case ArrowAnchor.Base:
+                    tailX = dims.GetPixelX(x);
+                    tailY = dims.GetPixelY(y);
+                    endX = dims.GetPixelX(x + xVector);
+                    endY = dims.GetPixelY(y + yVector);
+                    break;
+                case ArrowAnchor.Center:
+                    tailX = dims.GetPixelX(x - xVector / 2);
+                    tailY = dims.GetPixelY(y - yVector / 2);
+                    endX = dims.GetPixelX(x + xVector / 2);
+                    endY = dims.GetPixelY(y + yVector / 2);
+                    break;
+                case ArrowAnchor.Tip:
+                    tailX = dims.GetPixelX(x - xVector);
+                    tailY = dims.GetPixelY(y - yVector);
+                    endX = dims.GetPixelX(x);
+                    endY = dims.GetPixelY(y);
+                    break;
+                default:
+                    throw new NotImplementedException("unsupported anchor type");
+            }
+
+            using Pen pen = Drawing.GDI.Pen(color);
+
+            if (ScaledArrowheads)
+            {
+                DrawFancyArrow(gfx, pen, tailX, tailY, endX, endY);
+            }
+            else
+            {
+                DrawStandardArrow(gfx, pen, tailX, tailY, endX, endY);
+            }
+
+            DrawMarker(dims, gfx, pen, x, y);
+        }
+
+        private void DrawMarker(PlotDimensions dims, Graphics gfx, Pen pen, double x, double y)
+        {
+            if (MarkerShape != MarkerShape.none && MarkerSize > 0)
+            {
+                PointF markerPoint = new(dims.GetPixelX(x), dims.GetPixelY(y));
+                MarkerTools.DrawMarker(gfx, markerPoint, MarkerShape, MarkerSize, pen.Color);
+            }
+        }
+
+        private void DrawStandardArrow(Graphics gfx, Pen pen, float x1, float y1, float x2, float y2)
+        {
+            pen.CustomEndCap = new System.Drawing.Drawing2D.AdjustableArrowCap(NonScaledArrowheadWidth, NonScaledArrowheadLength);
+            gfx.DrawLine(pen, x1, y1, x2, y2);
+        }
+
+        private void DrawFancyArrow(Graphics gfx, Pen pen, float x1, float y1, float x2, float y2)
+        {
+            (float tipScale, float headAngle) = GetTipDimensions();
+
             var dx = x2 - x1;
             var dy = y2 - y1;
             var arrowAngle = (float)Math.Atan2(dy, dx);

--- a/src/ScottPlot4/ScottPlot/Renderable/ArrowStyle.cs
+++ b/src/ScottPlot4/ScottPlot/Renderable/ArrowStyle.cs
@@ -30,6 +30,16 @@ namespace ScottPlot.Renderable
         public double ScaledArrowheadLength = 0.5;
 
         /// <summary>
+        /// Length of the scaled arrowhead
+        /// </summary>
+        private double ScaledTipLength => Math.Sqrt(ScaledArrowheadLength * ScaledArrowheadLength + ScaledArrowheadWidth * ScaledArrowheadWidth);
+
+        /// <summary>
+        /// Width of the scaled arrowhead
+        /// </summary>
+        private double ScaledHeadAngle => Math.Atan2(ScaledArrowheadWidth, ScaledArrowheadLength);
+
+        /// <summary>
         /// Size of the arrowhead if custom/scaled arrowheads are not in use
         /// </summary>
         public float NonScaledArrowheadWidth = 2;
@@ -52,14 +62,7 @@ namespace ScottPlot.Renderable
         /// <summary>
         /// Thickness of the arrow lines
         /// </summary>
-        public float LineWidth = 1; 
-
-        public (float tipScale, float headAngle) GetTipDimensions()
-        {
-            float tipScale = (float)Math.Sqrt(ScaledArrowheadLength * ScaledArrowheadLength + ScaledArrowheadWidth * ScaledArrowheadWidth);
-            float headAngle = (float)Math.Atan2(ScaledArrowheadWidth, ScaledArrowheadLength);
-            return (tipScale, headAngle);
-        }
+        public float LineWidth = 1;
 
         /// <summary>
         /// Render an evenly-spaced 2D vector field.
@@ -145,17 +148,15 @@ namespace ScottPlot.Renderable
 
         private void DrawFancyArrow(Graphics gfx, Pen pen, float x1, float y1, float x2, float y2)
         {
-            (float tipScale, float headAngle) = GetTipDimensions();
-
             var dx = x2 - x1;
             var dy = y2 - y1;
             var arrowAngle = (float)Math.Atan2(dy, dx);
-            var sinA1 = (float)Math.Sin(headAngle - arrowAngle);
-            var cosA1 = (float)Math.Cos(headAngle - arrowAngle);
-            var sinA2 = (float)Math.Sin(headAngle + arrowAngle);
-            var cosA2 = (float)Math.Cos(headAngle + arrowAngle);
+            var sinA1 = (float)Math.Sin(ScaledHeadAngle - arrowAngle);
+            var cosA1 = (float)Math.Cos(ScaledHeadAngle - arrowAngle);
+            var sinA2 = (float)Math.Sin(ScaledHeadAngle + arrowAngle);
+            var cosA2 = (float)Math.Cos(ScaledHeadAngle + arrowAngle);
             var len = (float)Math.Sqrt(dx * dx + dy * dy);
-            var hypLen = len * tipScale;
+            var hypLen = len * ScaledTipLength;
 
             var corner1X = x2 - hypLen * cosA1;
             var corner1Y = y2 + hypLen * sinA1;
@@ -166,10 +167,11 @@ namespace ScottPlot.Renderable
             {
                 new PointF(x1, y1),
                 new PointF(x2, y2),
-                new PointF(corner1X, corner1Y),
+                new PointF((float)corner1X, (float)corner1Y),
                 new PointF(x2, y2),
-                new PointF(corner2X, corner2Y),
+                new PointF((float)corner2X, (float)corner2Y),
             };
+
             gfx.DrawLines(pen, arrowPoints);
         }
     }

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -4,6 +4,7 @@
 _not yet published on NuGet..._
 * Radar: New `Smooth` field allows radar areas to be drawn with smooth lines (#2067, #2065) _Thanks @theelderwand_
 * Ticks: Setting manual ticks will now throw an immediate `ArgumentException` if positions and labels have different lengths (#2063) _Thanks @sergaent_
+* VectorFieldList: New plot type for plotting arbitrary coordinate/vector pairs which are not confined to a grid (#2064, #2079) _Thanks @sjdemoor and @bclehmann_
 
 ## ScottPlot 4.1.57
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-08-18_


### PR DESCRIPTION
The goal of this PR is to create a new plot type which makes it simple to place vector arrows anywhere on the plot (not constrained to a grid like the current `VectorField`)

* Resolves #2064

![image](https://user-images.githubusercontent.com/4165489/187328695-cdc5dc6e-5ba8-4cd7-ab08-c8194641afd2.png)

```cs
ScottPlot.Plot plt = new();

// Create a vector field list and add it to the plot
var field = plt.AddVectorFieldList();

// Optionally color arrows using a colormap and custom scaling function
field.Colormap = Colormap.Turbo;
field.ColormapScaler = (magnitude) => magnitude * 5;

// Additional arrow styling options are here
field.ArrowStyle.ScaledArrowheads = true;
field.ArrowStyle.Anchor = ArrowAnchor.Base;
field.ArrowStyle.LineWidth = 3;
field.ArrowStyle.MarkerSize = 10;
field.ArrowStyle.MarkerShape = MarkerShape.filledDiamond;

// Generate random vectors
Random rand = new(0);
int pointCount = 20;
for (int i = 0; i < pointCount + 1; i++)
{
    double x = i / (double)pointCount;
    double y = Math.Sin(i * 2 * Math.PI / pointCount);
    Coordinate coordinate = new(x, y);

    double dX = i / (double)pointCount * .15;
    double dY = i / (double)pointCount * .15;
    CoordinateVector vector = new(dX, dY);

    var rootedVector = (coordinate, vector);
    field.RootedVectors.Add(rootedVector);
}

plt.SaveFig("vectors.png");
```