### PR TITLE
Style: add support for background image

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Style.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Style.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Text;
 
 namespace ScottPlot.Cookbook.Recipes
@@ -153,6 +154,52 @@ namespace ScottPlot.Cookbook.Recipes
             plt.Title("Style.Seaborn");
             plt.XLabel("Horizontal Axis");
             plt.YLabel("Vertical Axis");
+        }
+    }
+
+    class DataBackgroundImage : IRecipe
+    {
+        public ICategory Category => new Categories.Style();
+        public string ID => "misc_background_image_data";
+        public string Title => "Data Background Image";
+        public string Description =>
+            "A backgorund image can be drawn behind the data area. " +
+            "Users to do this may want to make grid lines semitransparent.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            plt.AddSignal(DataGen.Sin(51), 1, Color.Yellow);
+            plt.AddSignal(DataGen.Cos(51), 1, Color.Magenta);
+
+            Bitmap monaLisaBmp = ScottPlot.DataGen.SampleImage();
+
+            plt.Style(
+                grid: Color.FromArgb(50, Color.White),
+                dataBackgroundImage: monaLisaBmp);
+        }
+    }
+
+    class FigureBackgroundImage : IRecipe
+    {
+        public ICategory Category => new Categories.Style();
+        public string ID => "misc_background_image_figure";
+        public string Title => "Figure Background Image";
+        public string Description =>
+            "A backgorund image can be drawn behind the entire figure. " +
+            "If you do this you likely want to make your data background transparent.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            plt.AddSignal(DataGen.Sin(51), 1, Color.Yellow);
+            plt.AddSignal(DataGen.Cos(51), 1, Color.Magenta);
+
+            Bitmap monaLisaBmp = ScottPlot.DataGen.SampleImage();
+
+            plt.Style(
+                grid: Color.FromArgb(50, Color.White),
+                tick: Color.White,
+                dataBackground: Color.FromArgb(50, Color.White),
+                figureBackgroundImage: monaLisaBmp);
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.cs
@@ -3,6 +3,7 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
+using System.Runtime;
 
 namespace ScottPlot
 {
@@ -293,16 +294,23 @@ namespace ScottPlot
         /// <param name="tick">Color for axis tick marks and frame lines</param>
         /// <param name="axisLabel">Color for axis labels and tick labels</param>
         /// <param name="titleLabel">Color for the top axis label (XAxis2's title)</param>
+        /// <param name="dataBackgroundImage">Bitmap to display behind the data area</param>
+        /// <param name="figureBackgroundImage">Bitmap to display behind the entire figure</param>
         public void Style(
             Color? figureBackground = null,
             Color? dataBackground = null,
             Color? grid = null,
             Color? tick = null,
             Color? axisLabel = null,
-            Color? titleLabel = null)
+            Color? titleLabel = null,
+            Bitmap dataBackgroundImage = null,
+            Bitmap figureBackgroundImage = null)
         {
             settings.FigureBackground.Color = figureBackground ?? settings.FigureBackground.Color;
             settings.DataBackground.Color = dataBackground ?? settings.DataBackground.Color;
+
+            settings.FigureBackground.Bitmap ??= figureBackgroundImage;
+            settings.DataBackground.Bitmap ??= dataBackgroundImage;
 
             foreach (var axis in settings.Axes)
             {

--- a/src/ScottPlot4/ScottPlot/Renderable/DataBackground.cs
+++ b/src/ScottPlot4/ScottPlot/Renderable/DataBackground.cs
@@ -1,4 +1,5 @@
 ﻿using ScottPlot.Drawing;
+using ScottPlot.Drawing.Colormaps;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -10,15 +11,50 @@ namespace ScottPlot.Renderable
     {
         public Color Color { get; set; } = Color.White;
         public bool IsVisible { get; set; } = true;
+        public Bitmap Bitmap { get; set; } = null;
 
         public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
         {
-            using (var gfx = GDI.Graphics(bmp, dims, lowQuality: true, false))
-            using (var brush = GDI.Brush(Color))
+            if (Bitmap is null)
             {
-                var dataRect = new RectangleF(x: dims.DataOffsetX, y: dims.DataOffsetY, width: dims.DataWidth, height: dims.DataHeight);
-                gfx.FillRectangle(brush, dataRect);
+                RenderSolidColorBackground(dims, bmp);
             }
+            else
+            {
+                RenderImageBackground(dims, bmp);
+            }
+        }
+
+        private void RenderSolidColorBackground(PlotDimensions dims, Bitmap bmp)
+        {
+            using var gfx = GDI.Graphics(bmp, dims, lowQuality: true, clipToDataArea: false);
+            using var brush = GDI.Brush(Color);
+
+            var dataRect = new RectangleF(
+                x: dims.DataOffsetX,
+                y: dims.DataOffsetY,
+                width: dims.DataWidth,
+                height: dims.DataHeight);
+
+            gfx.FillRectangle(brush, dataRect);
+        }
+
+        private void RenderImageBackground(PlotDimensions dims, Bitmap bmp)
+        {
+            using var gfx = GDI.Graphics(bmp, dims, lowQuality: false, clipToDataArea: true);
+
+            float x = dims.DataOffsetX;
+            float y = dims.DataOffsetY;
+            float width = dims.DataWidth;
+            float height = dims.DataHeight;
+
+            // NOTE: increase size by 1 source pixel to prevent anti-aliasing transparency at edges
+            x -= width / Bitmap.Width;
+            y -= height / Bitmap.Height;
+            width += 2 * width / Bitmap.Width;
+            height += 2 * height / Bitmap.Height;
+
+            gfx.DrawImage(Bitmap, x, y, width, height);
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Renderable/FigureBackground.cs
+++ b/src/ScottPlot4/ScottPlot/Renderable/FigureBackground.cs
@@ -7,13 +7,42 @@ namespace ScottPlot.Renderable
     {
         public Color Color { get; set; } = Color.White;
         public bool IsVisible { get; set; } = true;
+        public Bitmap Bitmap { get; set; } = null;
 
         public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
         {
-            using (var gfx = GDI.Graphics(bmp, dims, lowQuality: true, false))
+            if (Bitmap is null)
             {
-                gfx.Clear(Color);
+                RenderSolidColorBackground(dims, bmp);
             }
+            else
+            {
+                RenderImageBackground(dims, bmp);
+            }
+        }
+
+        private void RenderSolidColorBackground(PlotDimensions dims, Bitmap bmp)
+        {
+            using var gfx = GDI.Graphics(bmp, dims, lowQuality: true, clipToDataArea: false);
+            gfx.Clear(Color);
+        }
+
+        private void RenderImageBackground(PlotDimensions dims, Bitmap bmp)
+        {
+            using var gfx = GDI.Graphics(bmp, dims, lowQuality: false, clipToDataArea: false);
+
+            float x = 0;
+            float y = 0;
+            float width = dims.Width;
+            float height = dims.Height;
+
+            // NOTE: increase size by 1 source pixel to prevent anti-aliasing transparency at edges
+            x -= width / Bitmap.Width;
+            y -= height / Bitmap.Height;
+            width += 2 * width / Bitmap.Width;
+            height += 2 * height / Bitmap.Height;
+
+            gfx.DrawImage(Bitmap, x, y, width, height);
         }
     }
 }

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -8,6 +8,7 @@ _not yet published on NuGet..._
 * HLine and VLine: Line (but not position label) is hidden if `LineWidth` is `0` (#2085) _Thanks @A1145681_
 * Controls: The cursor now reverts to `Configuration.DefaultCursor` after moving off draggable objects (#2091) _Thanks @kurupt44_
 * Snapping: SnapNearest classes now expose `SnapIndex()` (#2099) _Thanks @BambOoxX_
+* Background: Added optional arguments to `Style()` lets users place a custom background image behind their plot (#2016) _Thanks @apaaris_
 
 ## ScottPlot 4.1.57
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-08-18_


### PR DESCRIPTION
This PR allows background images to be placed behind the figure or data area.

```cs
plt.AddSignal(DataGen.Sin(51), 1, Color.Yellow);
plt.AddSignal(DataGen.Cos(51), 1, Color.Magenta);

Bitmap monaLisaBmp = ScottPlot.DataGen.SampleImage();

plt.Style(
    grid: Color.FromArgb(50, Color.White),
    dataBackgroundImage: monaLisaBmp);
```

![image](https://user-images.githubusercontent.com/4165489/188756422-fb2f4c68-35c2-48cd-90cf-128cc1a86001.png)

```cs
plt.AddSignal(DataGen.Sin(51), 1, Color.Yellow);
plt.AddSignal(DataGen.Cos(51), 1, Color.Magenta);

Bitmap monaLisaBmp = ScottPlot.DataGen.SampleImage();

plt.Style(
    grid: Color.FromArgb(50, Color.White),
    tick: Color.White,
    dataBackground: Color.FromArgb(50, Color.White),
    figureBackgroundImage: monaLisaBmp);
```

![image](https://user-images.githubusercontent.com/4165489/188756451-1b4824ce-c61b-4eb2-bec7-b73b91ca1b50.png)
