### PR TITLE
Plot: only hit test visible draggables

### DIFF
--- a/src/ScottPlot4/ScottPlot/Plot/Plot.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.cs
@@ -159,6 +159,7 @@ namespace ScottPlot
                            .Where(x => x is IDraggable)
                            .Select(x => (IDraggable)x)
                            .Where(x => x.DragEnabled)
+                           .Where(x => x is IPlottable p && p.IsVisible)
                            .ToArray();
 
             foreach (IDraggable draggable in enabledDraggables)

--- a/src/ScottPlot4/ScottPlot/Plottable/AxisLine.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/AxisLine.cs
@@ -294,9 +294,6 @@ namespace ScottPlot.Plottable
         /// <returns></returns>
         public bool IsUnderMouse(double coordinateX, double coordinateY, double snapX, double snapY)
         {
-            if (!IsVisible)
-                return false;
-
             return IsHorizontal
                 ? Math.Abs(Position - coordinateY) <= snapY
                 : Math.Abs(Position - coordinateX) <= snapX;

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -10,7 +10,7 @@ _not yet published on NuGet..._
 * Snapping: SnapNearest classes now expose `SnapIndex()` (#2099) _Thanks @BambOoxX_
 * Background: Added optional arguments to `Style()` lets users place a custom background image behind their plot (#2016) _Thanks @apaaris_
 * Axis Line: Remove the ability to drag invisible lines (#2110) _Thanks @A1145681_
-* Controls: Draggable objects can now only be dragged with the left mouse button (#2111) _Thanks @A1145681_
+* Controls: Draggable objects can now only be dragged with the left mouse button (#2111, #2120) _Thanks @A1145681_
 
 ## ScottPlot 4.1.57
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-08-18_


### PR DESCRIPTION
Moves visibility check out of individual plottables and puts it inside the render loop so it applies to all plottables

resolves #2120
resolves #2110