### PR TITLE
ScottPlot 5 Legends

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Corner.cs
+++ b/src/ScottPlot5/ScottPlot5/Corner.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot
+{
+    public enum Corner
+    {
+        TopLeft,
+        TopRight,
+        BottomLeft,
+        BottomRight
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -13,8 +13,11 @@ public static class Drawing
      */
     public static PixelSize MeasureString(string text, SKPaint paint)
     {
-        float width = paint.MeasureText(text);
-        float height = paint.TextSize;
+        SKRect bounds = new();
+        paint.MeasureText(text, ref bounds);
+        
+        float width = bounds.Width;
+        float height = bounds.Height;
         return new PixelSize(width, height);
     }
 

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -15,7 +15,7 @@ public static class Drawing
     {
         SKRect bounds = new();
         paint.MeasureText(text, ref bounds);
-        
+
         float width = bounds.Width;
         float height = bounds.Height;
         return new PixelSize(width, height);

--- a/src/ScottPlot5/ScottPlot5/EnumerableHelpers.cs
+++ b/src/ScottPlot5/ScottPlot5/EnumerableHelpers.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot
+{
+    internal static class EnumerableHelpers
+    {
+        public static IEnumerable<T> One<T>(T item) { yield return item; }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/IPlottable.cs
+++ b/src/ScottPlot5/ScottPlot5/IPlottable.cs
@@ -31,5 +31,5 @@ public interface IPlottable
     /// By default the surface is already clipped to the data area, but this can be cleared inside the plottable.
     /// </summary>
     void Render(SKSurface surface);
-    IList<LegendItem> GetLegendItems();
+    IEnumerable<LegendItem> LegendItems { get; }
 }

--- a/src/ScottPlot5/ScottPlot5/IPlottable.cs
+++ b/src/ScottPlot5/ScottPlot5/IPlottable.cs
@@ -31,4 +31,5 @@ public interface IPlottable
     /// By default the surface is already clipped to the data area, but this can be cleared inside the plottable.
     /// </summary>
     void Render(SKSurface surface);
+    IList<LegendItem> GetLegendItems();
 }

--- a/src/ScottPlot5/ScottPlot5/IsExternalInit.cs
+++ b/src/ScottPlot5/ScottPlot5/IsExternalInit.cs
@@ -1,0 +1,8 @@
+﻿using System.ComponentModel;
+
+// This is required to allow init-only setters in .NET <5.0. See more here: https://stackoverflow.com/questions/64749385/predefined-type-system-runtime-compilerservices-isexternalinit-is-not-defined
+namespace System.Runtime.CompilerServices
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit { }
+}

--- a/src/ScottPlot5/ScottPlot5/LegendItem.cs
+++ b/src/ScottPlot5/ScottPlot5/LegendItem.cs
@@ -7,12 +7,12 @@ using System.Threading.Tasks;
 
 namespace ScottPlot
 {
-    public class LegendItem
+    public class LegendItem // TODO: Should this be a struct?
     {
         public string? Label { get; set; } // TODO: I waffled on whether to make these init-only setters. I think there's enough value to in letting them be mutable
         public Stroke? Line { get; set; }
         public Marker? Marker { get; set; }
         public Fill? Fill { get; set; }
-        public IList<LegendItem> Children { get; set; } = Array.Empty<LegendItem>();
+        public IEnumerable<LegendItem> Children { get; set; } = Array.Empty<LegendItem>();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/LegendItem.cs
+++ b/src/ScottPlot5/ScottPlot5/LegendItem.cs
@@ -1,0 +1,18 @@
+﻿using ScottPlot.Style;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot
+{
+    public class LegendItem
+    {
+        public string? Label { get; set; } // TODO: I waffled on whether to make these init-only setters. I think there's enough value to in letting them be mutable
+        public Stroke? Line { get; set; }
+        public Marker? Marker { get; set; }
+        public Fill? Fill { get; set; }
+        public IList<LegendItem> Children { get; set; } = Array.Empty<LegendItem>();
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/PixelSize.cs
+++ b/src/ScottPlot5/ScottPlot5/PixelSize.cs
@@ -2,9 +2,11 @@
 
 public struct PixelSize
 {
-    public float Width;
-    public float Height;
+    public readonly float Width;
+    public readonly float Height;
     public float Area => Width * Height;
+
+    public static readonly PixelSize Zero = new PixelSize(0, 0);
 
     public PixelSize(float width, float height)
     {

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -44,7 +44,7 @@ public class Plot
     /// The primary vertical axis (the first one in the list of <see cref="YAxes"/>)
     /// </summary>
     public IYAxis YAxis => YAxes.First();
-    
+
     public Plot()
     {
         var xAxis = new Axis.StandardAxes.BottomAxis();
@@ -262,10 +262,10 @@ public class Plot
     #region Legend
     public IEnumerable<LegendItem> LegendItems()
     {
-        foreach(var curr in Plottables)
+        foreach (var curr in Plottables)
             foreach (var item in curr.GetLegendItems())
                 yield return item;
     }
-    
+
     #endregion
 }

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -3,6 +3,7 @@ using ScottPlot.Axis;
 using ScottPlot.Rendering;
 using ScottPlot.LayoutSystem;
 using SkiaSharp;
+using ScottPlot.Plottables;
 
 namespace ScottPlot;
 
@@ -43,7 +44,7 @@ public class Plot
     /// The primary vertical axis (the first one in the list of <see cref="YAxes"/>)
     /// </summary>
     public IYAxis YAxis => YAxes.First();
-
+    
     public Plot()
     {
         var xAxis = new Axis.StandardAxes.BottomAxis();
@@ -256,5 +257,15 @@ public class Plot
         File.WriteAllBytes(path, bytes);
     }
 
+    #endregion
+
+    #region Legend
+    public IEnumerable<LegendItem> LegendItems()
+    {
+        foreach(var curr in Plottables)
+            foreach (var item in curr.GetLegendItems())
+                yield return item;
+    }
+    
     #endregion
 }

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -263,7 +263,7 @@ public class Plot
     public IEnumerable<LegendItem> LegendItems()
     {
         foreach (var curr in Plottables)
-            foreach (var item in curr.GetLegendItems())
+            foreach (var item in curr.LegendItems)
                 yield return item;
     }
 

--- a/src/ScottPlot5/ScottPlot5/PlottableFactory.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableFactory.cs
@@ -24,6 +24,13 @@ public class PlottableFactory
         return heatmap;
     }
 
+    public Legend Legend(IList<LegendItem>? legendItems = null)
+    {
+        Legend legend = new(legendItems ?? Plot.LegendItems());
+        Plot.Plottables.Add(legend);
+        return legend;
+    }
+
     public Pie Pie(IList<PieSlice> slices)
     {
         Pie pie = new(slices);

--- a/src/ScottPlot5/ScottPlot5/Plottables/DebugBenchmark.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/DebugBenchmark.cs
@@ -10,6 +10,7 @@ public class DebugBenchmark : IPlottable
     public bool IsVisible { get; set; } = false;
     public IAxes Axes { get; set; } = Axis.Axes.Default;
     public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
+    public IList<LegendItem> GetLegendItems() => Array.Empty<LegendItem>();
 
     public void Render(SKSurface surface)
     {

--- a/src/ScottPlot5/ScottPlot5/Plottables/DebugBenchmark.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/DebugBenchmark.cs
@@ -10,7 +10,7 @@ public class DebugBenchmark : IPlottable
     public bool IsVisible { get; set; } = false;
     public IAxes Axes { get; set; } = Axis.Axes.Default;
     public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
-    public IList<LegendItem> GetLegendItems() => Array.Empty<LegendItem>();
+    public IEnumerable<LegendItem> LegendItems => Enumerable.Empty<LegendItem>();
 
     public void Render(SKSurface surface)
     {

--- a/src/ScottPlot5/ScottPlot5/Plottables/DebugPoint.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/DebugPoint.cs
@@ -8,9 +8,16 @@ public class DebugPoint : IPlottable
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = Axis.Axes.Default;
     public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
-
+    public IList<LegendItem> GetLegendItems() => new LegendItem[]
+    {
+        new LegendItem {
+            Label = Label,
+            Marker = new(Style.MarkerShape.Circle, Color)
+        }
+    };
     public Coordinates Position { get; set; }
     public Color Color { get; set; } = new(255, 00, 255);
+    public string? Label { get; set; }
 
     public DebugPoint()
     {

--- a/src/ScottPlot5/ScottPlot5/Plottables/DebugPoint.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/DebugPoint.cs
@@ -8,13 +8,12 @@ public class DebugPoint : IPlottable
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = Axis.Axes.Default;
     public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
-    public IList<LegendItem> GetLegendItems() => new LegendItem[]
-    {
+    public IEnumerable<LegendItem> LegendItems => EnumerableHelpers.One(
         new LegendItem {
             Label = Label,
             Marker = new(Style.MarkerShape.Circle, Color)
-        }
-    };
+        });
+    
     public Coordinates Position { get; set; }
     public Color Color { get; set; } = new(255, 00, 255);
     public string? Label { get; set; }

--- a/src/ScottPlot5/ScottPlot5/Plottables/DebugPoint.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/DebugPoint.cs
@@ -9,11 +9,12 @@ public class DebugPoint : IPlottable
     public IAxes Axes { get; set; } = Axis.Axes.Default;
     public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
     public IEnumerable<LegendItem> LegendItems => EnumerableHelpers.One(
-        new LegendItem {
+        new LegendItem
+        {
             Label = Label,
             Marker = new(Style.MarkerShape.Circle, Color)
         });
-    
+
     public Coordinates Position { get; set; }
     public Color Color { get; set; } = new(255, 00, 255);
     public string? Label { get; set; }

--- a/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
@@ -156,6 +156,7 @@ namespace ScottPlot.Plottables
         {
             return new(AlignedExtent);
         }
+        public IList<LegendItem> GetLegendItems() => Array.Empty<LegendItem>();
 
         public void Render(SKSurface surface)
         {

--- a/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
@@ -156,7 +156,7 @@ namespace ScottPlot.Plottables
         {
             return new(AlignedExtent);
         }
-        public IList<LegendItem> GetLegendItems() => Array.Empty<LegendItem>();
+        public IEnumerable<LegendItem> LegendItems => Enumerable.Empty<LegendItem>();
 
         public void Render(SKSurface surface)
         {

--- a/src/ScottPlot5/ScottPlot5/Plottables/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Legend.cs
@@ -128,7 +128,7 @@ namespace ScottPlot.Plottables
             {
                 return PixelSize.Zero;
             }
-            
+
             using SKPaint paint = new(Font);
 
             PixelSize labelRect = Drawing.MeasureString(item.Label ?? "", paint);

--- a/src/ScottPlot5/ScottPlot5/Plottables/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Legend.cs
@@ -17,10 +17,10 @@ namespace ScottPlot.Plottables
         public bool IsVisible { get; set; } = true;
         public IAxes Axes { get; set; } = Axis.Axes.Default;
         public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
-        public IList<LegendItem> GetLegendItems() => Array.Empty<LegendItem>();
+        public IEnumerable<LegendItem> LegendItems => Enumerable.Empty<LegendItem>();
 
         public Corner Position { get; set; } = Corner.BottomRight; // TODO: Should we support positions that aren't corners?
-        public IEnumerable<LegendItem> LegendItems { get; set; }
+        public IEnumerable<LegendItem> Items { get; set; }
         public SKFont Font { get; set; } = new(); // TODO: Do we want our own abstraction for this? It wraps a native object and implements IDisposable
         public Stroke Border { get; set; } = new(Colors.DarkGray, 1);
         public Fill Background { get; set; } = new Fill(Colors.White);
@@ -28,7 +28,7 @@ namespace ScottPlot.Plottables
 
         public Legend(IEnumerable<LegendItem> legendItems)
         {
-            LegendItems = legendItems;
+            Items = legendItems;
         }
 
         public void Render(SKSurface surface)
@@ -52,7 +52,7 @@ namespace ScottPlot.Plottables
             surface.Canvas.Translate(Border.Width, Border.Width);
 
             float y = VerticalPadding;
-            foreach (var curr in LegendItems)
+            foreach (var curr in Items)
             {
                 RenderLegendItem(surface, curr, y);
                 y += Measure(curr).Height;
@@ -157,7 +157,7 @@ namespace ScottPlot.Plottables
 
         // I'm a Javascript developer, this was bound to happen someday
         public PixelSize Measure() =>
-            LegendItems
+            Items
                 .Select((LegendItem item) => Measure(item))
                 .Aggregate(
                     new PixelSize(Border.Width * 2, Border.Width * 2),

--- a/src/ScottPlot5/ScottPlot5/Plottables/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Legend.cs
@@ -1,0 +1,168 @@
+﻿using ScottPlot.Axis;
+using ScottPlot.Style;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Plottables
+{
+    public class Legend : IPlottable
+    {
+        private const int HorizontalPadding = 5;
+        private const int VerticalPadding = 5;
+        private const int SymbolWidth = 20;
+        public bool IsVisible { get; set; } = true;
+        public IAxes Axes { get; set; } = Axis.Axes.Default;
+        public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
+
+        public Corner Position { get; set; } = Corner.BottomRight; // TODO: Should we support positions that aren't corners?
+        public IList<LegendItem> LegendItems { get; set; }
+        public SKFont Font { get; set; } = new(); // TODO: Do we want our own abstraction for this? It wraps a native object and implements IDisposable
+        public Stroke Border { get; set; } = new(Colors.DarkGray, 1);
+        public Fill Background { get; set; } = new Fill(Colors.White);
+
+
+        public Legend(IList<LegendItem> legendItems)
+        {
+            LegendItems = legendItems;
+        }
+
+        public void Render(SKSurface surface)
+        {
+            PixelSize size = Measure();
+
+            Pixel topLeftCorner = GetTopLeftCorner(size);
+
+            surface.Canvas.Translate(topLeftCorner.X, topLeftCorner.Y);
+
+
+            using SKPaint paint = new();
+            paint.SetFill(Background);
+
+            SKRect border = new(0, 0, size.Width, size.Height);
+            surface.Canvas.DrawRect(border, paint);
+
+            paint.SetStroke(Border);
+            surface.Canvas.DrawRect(border, paint);
+
+            surface.Canvas.Translate(Border.Width, Border.Width);
+
+            float y = VerticalPadding;
+            foreach(var curr in LegendItems)
+            {
+                RenderLegendItem(surface, curr, y);
+                y += Measure(curr).Height;
+            }
+        }
+
+        private void RenderLegendItem(SKSurface surface, LegendItem item, float y)
+        {
+            using ScopedTransform transform = new(surface.Canvas);
+            using SKPaint paint = new(Font);
+            paint.SetFill(new(Colors.Black));
+
+            surface.Canvas.Translate(HorizontalPadding, 0);
+
+            float top = y;
+
+            RenderLegendSymbol(surface, item, new(0, top, SymbolWidth, top + paint.TextSize));
+            surface.Canvas.DrawText(item.Label, new(HorizontalPadding + SymbolWidth, top + paint.TextSize), paint);
+            
+            y += Measure(item, false).Height;
+            foreach(var curr in item.Children)
+            {
+                RenderLegendItem(surface, curr, y);
+                y += Measure(curr).Height;
+            }
+        }
+
+        private void RenderLegendSymbol(SKSurface surface, LegendItem item, SKRect rect)
+        {
+            using SKPaint paint = new();
+            if (item.Line.HasValue)
+            {
+                paint.SetStroke(item.Line.Value);
+
+                surface.Canvas.DrawLine(new(rect.Left, rect.MidY), new(rect.Right, rect.MidY), paint);
+            }
+
+            if (item.Marker.HasValue)
+            {
+                paint.Style = SKPaintStyle.Fill;
+                paint.Color = item.Marker.Value.Color.ToSKColor();
+
+                if (item.Marker.Value.Shape == MarkerShape.Circle)
+                {
+                    surface.Canvas.DrawCircle(new(rect.MidX, rect.MidY), item.Marker.Value.Size / 2, paint);
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            if (item.Fill.HasValue)
+            {
+                paint.SetFill(item.Fill.Value);
+
+                surface.Canvas.DrawRect(rect, paint);
+            }
+        } 
+ 
+        public PixelSize Measure(LegendItem item, bool includeChildren = true)
+        {
+            using SKPaint paint = new(Font);
+
+            PixelSize labelRect = Drawing.MeasureString(item.Label ?? "", paint);
+
+            float width = HorizontalPadding + SymbolWidth + HorizontalPadding + labelRect.Width + HorizontalPadding;
+            float height = 2 * VerticalPadding + labelRect.Height;
+
+            if (item.Children.Count > 0)
+            {
+                width += HorizontalPadding;
+            }
+
+            if (includeChildren)
+            {
+                for (int i = 0; i < item.Children.Count; i++)
+                {
+                    var childSize = Measure(item.Children[i]);
+                    width = Math.Max(width, childSize.Width);
+                    height += childSize.Height;
+                }
+            }
+
+            return new(width, height);
+        }
+
+        // I'm a Javascript developer, this was bound to happen someday
+        public PixelSize Measure() =>
+            LegendItems
+                .Select((LegendItem item) => Measure(item))
+                .Aggregate(
+                    new PixelSize(Border.Width * 2, Border.Width * 2),
+                    (a, b) => 
+                        new(
+                            Math.Max(a.Width, b.Width),
+                            a.Height + b.Height)
+                        );
+
+        private Pixel GetTopLeftCorner(PixelSize size)
+        {
+            const int margin = 5;
+
+            return Position switch
+            {
+                Corner.TopLeft => new Pixel(Axes.DataRect.Left, Axes.DataRect.Top) + new Pixel(margin, margin),
+                Corner.TopRight => new Pixel(Axes.DataRect.Right - size.Width, Axes.DataRect.Top) + new Pixel(-margin, margin),
+                Corner.BottomLeft => new Pixel(Axes.DataRect.Left, Axes.DataRect.Bottom - size.Height) + new Pixel(margin, -margin),
+                Corner.BottomRight => new Pixel(Axes.DataRect.Right - size.Width, Axes.DataRect.Bottom - size.Height) + new Pixel(-margin, -margin),
+                _ => throw new NotImplementedException(),
+            };
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Legend.cs
@@ -51,7 +51,7 @@ namespace ScottPlot.Plottables
             surface.Canvas.Translate(Border.Width, Border.Width);
 
             float y = VerticalPadding;
-            foreach(var curr in LegendItems)
+            foreach (var curr in LegendItems)
             {
                 RenderLegendItem(surface, curr, y);
                 y += Measure(curr).Height;
@@ -70,9 +70,9 @@ namespace ScottPlot.Plottables
 
             RenderLegendSymbol(surface, item, new(0, top, SymbolWidth, top + paint.TextSize));
             surface.Canvas.DrawText(item.Label, new(HorizontalPadding + SymbolWidth, top + paint.TextSize), paint);
-            
+
             y += Measure(item, false).Height;
-            foreach(var curr in item.Children)
+            foreach (var curr in item.Children)
             {
                 RenderLegendItem(surface, curr, y);
                 y += Measure(curr).Height;
@@ -110,8 +110,8 @@ namespace ScottPlot.Plottables
 
                 surface.Canvas.DrawRect(rect, paint);
             }
-        } 
- 
+        }
+
         public PixelSize Measure(LegendItem item, bool includeChildren = true)
         {
             using SKPaint paint = new(Font);
@@ -145,7 +145,7 @@ namespace ScottPlot.Plottables
                 .Select((LegendItem item) => Measure(item))
                 .Aggregate(
                     new PixelSize(Border.Width * 2, Border.Width * 2),
-                    (a, b) => 
+                    (a, b) =>
                         new(
                             Math.Max(a.Width, b.Width),
                             a.Height + b.Height)

--- a/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
@@ -6,7 +6,7 @@ namespace ScottPlot.Plottables
 {
     public class PieSlice
     {
-        public Label? Label { get; set; } = null; // TODO: render label
+        public string? Label { get; set; } // TODO: render label
         public double Value { get; set; }
         public Fill Fill { get; set; }
 
@@ -21,6 +21,7 @@ namespace ScottPlot.Plottables
 
     public class Pie : IPlottable
     {
+        public string? Label { get; set; }
         public IList<PieSlice> Slices { get; set; }
         public Stroke Stroke { get; set; } = new() { Width = 0 };
         public bool IsVisible { get; set; } = true;
@@ -42,6 +43,16 @@ namespace ScottPlot.Plottables
                 yMin: -1 - ExplodeFraction - padding,
                 yMax: 1 + ExplodeFraction + padding);
         }
+        public IList<LegendItem> GetLegendItems() => new LegendItem[] {
+            new LegendItem
+            {
+                Label = Label,
+                Children = Slices.Select(slice => new LegendItem { 
+                    Label = slice.Label,
+                    Fill = slice.Fill
+                }).ToArray()
+            }
+        };
 
         public void Render(SKSurface surface)
         {

--- a/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
@@ -47,7 +47,7 @@ namespace ScottPlot.Plottables
             new LegendItem
             {
                 Label = Label,
-                Children = Slices.Select(slice => new LegendItem { 
+                Children = Slices.Select(slice => new LegendItem {
                     Label = slice.Label,
                     Fill = slice.Fill
                 }).ToArray()

--- a/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
@@ -43,16 +43,15 @@ namespace ScottPlot.Plottables
                 yMin: -1 - ExplodeFraction - padding,
                 yMax: 1 + ExplodeFraction + padding);
         }
-        public IList<LegendItem> GetLegendItems() => new LegendItem[] {
+        public IEnumerable<LegendItem> LegendItems => EnumerableHelpers.One(
             new LegendItem
             {
                 Label = Label,
                 Children = Slices.Select(slice => new LegendItem {
                     Label = slice.Label,
                     Fill = slice.Fill
-                }).ToArray()
-            }
-        };
+                })
+            });
 
         public void Render(SKSurface surface)
         {

--- a/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
@@ -47,7 +47,8 @@ namespace ScottPlot.Plottables
             new LegendItem
             {
                 Label = Label,
-                Children = Slices.Select(slice => new LegendItem {
+                Children = Slices.Select(slice => new LegendItem
+                {
                     Label = slice.Label,
                     Fill = slice.Fill
                 })

--- a/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
@@ -16,15 +16,13 @@ public class Scatter : IPlottable
     public IAxes Axes { get; set; } = Axis.Axes.Default;
 
     public AxisLimits GetAxisLimits() => Data.GetLimits();
-    public IList<LegendItem> GetLegendItems() => new LegendItem[]
-    {
+    public IEnumerable<LegendItem> LegendItems => EnumerableHelpers.One<LegendItem>(
         new LegendItem
         {
             Label = Label,
             Marker = new(Style.MarkerShape.Circle, Color, MarkerSize),
             Line = new(Color, LineWidth),
-        }
-    };
+        });
 
     public readonly DataSource.IScatterSource Data;
     public Color Color = new(0, 0, 255);

--- a/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
@@ -11,10 +11,20 @@ namespace ScottPlot.Plottables;
 
 public class Scatter : IPlottable
 {
+    public string? Label { get; set; }
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = Axis.Axes.Default;
 
     public AxisLimits GetAxisLimits() => Data.GetLimits();
+    public IList<LegendItem> GetLegendItems() => new LegendItem[]
+    {
+        new LegendItem
+        {
+            Label = Label,
+            Marker = new(Style.MarkerShape.Circle, Color, MarkerSize),
+            Line = new(Color, LineWidth),
+        }
+    };
 
     public readonly DataSource.IScatterSource Data;
     public Color Color = new(0, 0, 255);

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -27,10 +27,11 @@ public class Signal : IPlottable
     }
 
     public AxisLimits GetAxisLimits() => Data.GetLimits();
-    public IEnumerable<LegendItem> LegendItems => EnumerableHelpers.One( 
-        new LegendItem { 
-            Label = Label, 
-            Marker = new(Style.MarkerShape.Circle, Color), 
+    public IEnumerable<LegendItem> LegendItems => EnumerableHelpers.One(
+        new LegendItem
+        {
+            Label = Label,
+            Marker = new(Style.MarkerShape.Circle, Color),
             Line = new(Color, LineWidth)
         });
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -27,14 +27,12 @@ public class Signal : IPlottable
     }
 
     public AxisLimits GetAxisLimits() => Data.GetLimits();
-    public IList<LegendItem> GetLegendItems() => new LegendItem[] {
-        new LegendItem
-        {
-            Label = Label,
-            Marker = new(Style.MarkerShape.Circle, Color),
+    public IEnumerable<LegendItem> LegendItems => EnumerableHelpers.One( 
+        new LegendItem { 
+            Label = Label, 
+            Marker = new(Style.MarkerShape.Circle, Color), 
             Line = new(Color, LineWidth)
-        }
-    };
+        });
 
     /// <summary>
     /// Return Y data limits for each pixel column in the data area

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -19,6 +19,7 @@ public class Signal : IPlottable
 
     public Color Color = new(0, 0, 255);
     public float LineWidth = 1;
+    public string? Label { get; set; }
 
     public Signal(DataSource.ISignalSource data)
     {
@@ -26,6 +27,14 @@ public class Signal : IPlottable
     }
 
     public AxisLimits GetAxisLimits() => Data.GetLimits();
+    public IList<LegendItem> GetLegendItems() => new LegendItem[] {
+        new LegendItem
+        {
+            Label = Label,
+            Marker = new(Style.MarkerShape.Circle, Color),
+            Line = new(Color, LineWidth)
+        }
+    };
 
     /// <summary>
     /// Return Y data limits for each pixel column in the data area

--- a/src/ScottPlot5/ScottPlot5/Plottables/ZoomRectangle.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/ZoomRectangle.cs
@@ -8,6 +8,7 @@ public class ZoomRectangle : IPlottable
     public bool IsVisible { get; set; } = false;
     public IAxes Axes { get; set; } = Axis.Axes.Default;
     public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
+    public IList<LegendItem> GetLegendItems() => Array.Empty<LegendItem>();
 
     public Color FillColor = new Color(255, 0, 0).WithAlpha(100);
     public Color EdgeColor = new Color(255, 0, 0).WithAlpha(200);

--- a/src/ScottPlot5/ScottPlot5/Plottables/ZoomRectangle.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/ZoomRectangle.cs
@@ -8,7 +8,7 @@ public class ZoomRectangle : IPlottable
     public bool IsVisible { get; set; } = false;
     public IAxes Axes { get; set; } = Axis.Axes.Default;
     public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
-    public IList<LegendItem> GetLegendItems() => Array.Empty<LegendItem>();
+    public IEnumerable<LegendItem> LegendItems => Enumerable.Empty<LegendItem>();
 
     public Color FillColor = new Color(255, 0, 0).WithAlpha(100);
     public Color EdgeColor = new Color(255, 0, 0).WithAlpha(200);

--- a/src/ScottPlot5/ScottPlot5/ScopedTransform.cs
+++ b/src/ScottPlot5/ScottPlot5/ScopedTransform.cs
@@ -1,0 +1,26 @@
+﻿using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot
+{
+    internal class ScopedTransform : IDisposable // TODO: I'm a little uneasy on this name?
+    {
+        private readonly SKCanvas canvas;
+        private readonly int restoreIndex;
+
+        public ScopedTransform(SKCanvas canvas)
+        {
+            this.canvas = canvas;
+            restoreIndex = canvas.Save();
+        }
+
+        public void Dispose()
+        {
+            canvas.RestoreToCount(restoreIndex);
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Style/Marker.cs
+++ b/src/ScottPlot5/ScottPlot5/Style/Marker.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Style
+{
+    public enum MarkerShape
+    {
+        Circle
+    }
+
+    public struct Marker
+    {
+        public Color Color { get; set; } = Colors.Black;
+
+        public float Size { get; set; } = 5;
+
+        public MarkerShape Shape { get; set; } = MarkerShape.Circle;
+
+        public Marker()
+        {
+        }
+
+        public Marker(MarkerShape shape, Color color, float size = 5)
+        {
+            Shape = shape;
+            Color = color;
+            Size = size;
+        }
+    }
+}


### PR DESCRIPTION
**Purpose:**
Adds legends to ScottPlot 5

```cs
var legend = new Legend(new[]
{
    new LegendItem { Label = "Blue", Fill = new Fill(Colors.Blue) },
    new LegendItem { Label = "Gray", Fill = new Fill(Colors.Gray) },
    new LegendItem { Label = "Line", Line = new Stroke(Colors.Sienna, 1)},
    new LegendItem {
        Label = "Marker and Line", Line = new Stroke(Colors.Blue, 1),
        Marker = new Marker(MarkerShape.Circle, Colors.Blue, 5),
        Children = new[] {
            new LegendItem { Label = "Red", Fill = new Fill(Colors.Red), Children = new[] {
                new LegendItem { Label = "Blue", Fill = new Fill(Colors.Blue) },
                new LegendItem { Label = "Cyan", Fill = new Fill(Colors.Cyan) },
            }},
            new LegendItem { Label = "Green", Fill = new Fill(Colors.Green) },
        }
    },
    new LegendItem { Label = "Marker", Marker = new Marker(MarkerShape.Circle, Colors.Blue, 5)},
    new LegendItem { Label = "Blue", Fill = new Fill(Colors.Blue) },
    new LegendItem { Label = "Nothing" },
    new LegendItem { Label = "Blue", Fill = new Fill(Colors.Blue) },
});

avaPlot.Plot.Plottables.Add(legend);
```

![image](https://user-images.githubusercontent.com/8635304/190542119-8b409dc4-a10f-4dc5-b379-6a0d2bdda495.png)