### PR TITLE
Adds GetAxesMatching function

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/MultiAxis.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/MultiAxis.cs
@@ -59,8 +59,8 @@ namespace ScottPlot.Cookbook.Recipes
 
             // plot another set of data using an additional axis
             var sigBig = plt.AddSignal(DataGen.Cos(51, mult: 100));
-            var yAxis3 = plt.AddAxis(Renderable.Edge.Left, axisIndex: 2);
-            sigBig.YAxisIndex = 2;
+            var yAxis3 = plt.AddAxis(Renderable.Edge.Left);
+            sigBig.YAxisIndex = yAxis3.AxisIndex;
             yAxis3.Label("Additional Axis");
             yAxis3.Color(sigBig.Color);
         }

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Axis.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Axis.cs
@@ -255,30 +255,33 @@ namespace ScottPlot
         #endregion
 
         #region Axis creation
+        private int NextAxisIndex => settings.Axes.Select(a => a.AxisIndex).Max() + 1; // MaxBy isn't available on all targets
 
         /// <summary>
         /// Create and return an additional axis
         /// </summary>
         /// <param name="edge">Edge of the plot the new axis will belong to</param>
-        /// <param name="axisIndex">Only plottables with the same axis index will use this axis</param>
+        /// <param name="axisIndex">Only plottables with the same axis index will use this axis. Creates an auto-generated index if null.</param>
         /// <param name="title">defualt label to use for the axis</param>
         /// <param name="color">defualt color to use for the axis</param>
         /// <returns>The axis that was just created and added to the plot. You can further customize it by interacting with it.</returns>
-        public Renderable.Axis AddAxis(Renderable.Edge edge, int axisIndex, string title = null, Color? color = null)
+        public Renderable.Axis AddAxis(Renderable.Edge edge, int? axisIndex = null, string title = null, Color? color = null)
         {
+            axisIndex ??= NextAxisIndex;
+
             if (axisIndex <= 1)
                 throw new ArgumentException("The default axes already occupy indexes 0 and 1. Additional axes require higher indexes.");
 
             Renderable.Axis axis;
 
             if (edge == Renderable.Edge.Left)
-                axis = new Renderable.AdditionalLeftAxis(axisIndex, title);
+                axis = new Renderable.AdditionalLeftAxis(axisIndex.Value, title);
             else if (edge == Renderable.Edge.Right)
-                axis = new Renderable.AdditionalRightAxis(axisIndex, title);
+                axis = new Renderable.AdditionalRightAxis(axisIndex.Value, title);
             else if (edge == Renderable.Edge.Bottom)
-                axis = new Renderable.AdditionalBottomAxis(axisIndex, title);
+                axis = new Renderable.AdditionalBottomAxis(axisIndex.Value, title);
             else if (edge == Renderable.Edge.Top)
-                axis = new Renderable.AdditionalTopAxis(axisIndex, title);
+                axis = new Renderable.AdditionalTopAxis(axisIndex.Value, title);
             else
                 throw new NotImplementedException("unsupported edge");
 
@@ -296,7 +299,6 @@ namespace ScottPlot
         {
             settings.Axes.Remove(axis);
         }
-
 
         /// <summary>
         /// Returns axes matching the given axisIndex and isVertical.

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Axis.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Axis.cs
@@ -308,7 +308,8 @@ namespace ScottPlot
         {
             IEnumerable<Renderable.Axis> results = settings.Axes;
 
-            if (axisIndex.HasValue) {
+            if (axisIndex.HasValue)
+            {
                 results = results.Where(axis => axis.AxisIndex == axisIndex.Value);
             }
 

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Axis.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Axis.cs
@@ -10,6 +10,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
@@ -294,6 +295,29 @@ namespace ScottPlot
         public void RemoveAxis(Renderable.Axis axis)
         {
             settings.Axes.Remove(axis);
+        }
+
+
+        /// <summary>
+        /// Returns axes matching the given axisIndex and isVertical.
+        /// </summary>
+        /// <param name="axisIndex">The axis index to match, or null to allow any index</param>
+        /// <param name="isVertical">True to match only Y axes, false to match only X axes, or null to match either</param>
+        /// <returns>The axes matching the given properties</returns>
+        public IEnumerable<Renderable.Axis> GetAxesMatching(int? axisIndex = null, bool? isVertical = null)
+        {
+            IEnumerable<Renderable.Axis> results = settings.Axes;
+
+            if (axisIndex.HasValue) {
+                results = results.Where(axis => axis.AxisIndex == axisIndex.Value);
+            }
+
+            if (isVertical.HasValue)
+            {
+                results = results.Where(axis => axis.IsVertical == isVertical.Value);
+            }
+
+            return results;
         }
 
         #endregion

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -2,6 +2,9 @@
 
 ## ScottPlot 4.1.59
 _not yet published on NuGet..._
+* Axis: `Plot.AddAxis()` now uses auto-incremented axis index unless one is explicitly defined (#2133) _Thanks @bclehmann and Discord/Nick_
+* Axis: `Plot.GetAxesMatching()` was created to obtain a given vertical or horizontal axis (#2133) _Thanks @bclehmann and Discord/Nick_
+* Axis: Corner label format can be customized for any axis by calling `CornerLabelFormat()` (#2134) _Thanks @ShannonZ_
 
 ## ScottPlot 4.1.58
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-09-08_


### PR DESCRIPTION
**Purpose:**
#2130, though I elected not to create a `HasAxisMatching` because you can just do `GetAxesMatching(criteria).Any()`. This PR also makes the `axisIndex` parameter optional on `AddAxis`, opting to auto-increment them. This should simplify multi-axis code and the creation of valid axes without breaking existing code.

```cs
var axes = plt.GetAxesMatching(null, false); // IEnumerable holding all horizontal axes.
```