### PR TITLE
Add CornerLabelFormat() for Axis

### DIFF
--- a/src/ScottPlot4/ScottPlot/Renderable/Axis.cs
+++ b/src/ScottPlot4/ScottPlot/Renderable/Axis.cs
@@ -241,6 +241,15 @@ namespace ScottPlot.Renderable
         }
 
         /// <summary>
+        /// Manually define the string format to use for translating exponential part of a number to corner label
+        /// </summary>
+        /// <param name="format"> String.Format(format,exponent)</param>
+        public void CornerLabelFormat(string format)
+        {
+            AxisTicks.TickCollection.CornerLabelFormat = format;
+        }
+
+        /// <summary>
         /// Customize string settings for the tick labels
         /// </summary>
         public void TickLabelNotation(

--- a/src/ScottPlot4/ScottPlot/Ticks/TickCollection.cs
+++ b/src/ScottPlot4/ScottPlot/Ticks/TickCollection.cs
@@ -390,7 +390,7 @@ namespace ScottPlot.Ticks
             return Math.Round(value, 10).ToString("G", culture);
         }
 
-        public virtual (string[], string) GetPrettyTickLabels(
+        public (string[], string) GetPrettyTickLabels(
                 double[] positions,
                 bool useMultiplierNotation,
                 bool useOffsetNotation,

--- a/src/ScottPlot4/ScottPlot/Ticks/TickCollection.cs
+++ b/src/ScottPlot4/ScottPlot/Ticks/TickCollection.cs
@@ -31,6 +31,11 @@ namespace ScottPlot.Ticks
         public string[] additionalTickLabels;
 
         /// <summary>
+        /// Controls how to translate exponential part of a number to strings
+        /// </summary>
+        public string CornerLabelFormat { get; set; } = "E{0}";
+
+        /// <summary>
         /// Label to show in the corner when using multiplier or offset notation
         /// </summary>
         public string CornerLabel { get; private set; }
@@ -385,7 +390,7 @@ namespace ScottPlot.Ticks
             return Math.Round(value, 10).ToString("G", culture);
         }
 
-        public (string[], string) GetPrettyTickLabels(
+        public virtual (string[], string) GetPrettyTickLabels(
                 double[] positions,
                 bool useMultiplierNotation,
                 bool useOffsetNotation,
@@ -434,7 +439,7 @@ namespace ScottPlot.Ticks
             if (useExponentialNotation)
             {
                 if (multiplier != 1)
-                    cornerLabel += $"e{exponent} ";
+                    cornerLabel += String.Format(CornerLabelFormat, exponent);
                 if (offset != 0)
                     cornerLabel += Tools.ScientificNotation(offset);
             }


### PR DESCRIPTION
Add CornerLabelFormat() for ScottPlot.Renderable.Axis


**Purpose:**
 Manually define the string format to use for translating exponential part of a number to corner label.

https://discord.com/channels/716448886889381919/998069111429013564/1022370316770615357

![image](https://user-images.githubusercontent.com/7865691/191876831-ad39cc46-ff54-403a-be7c-50e450db2ba1.png)

```cs
            double[] dataX = new double[] { 1, 2, 3, 4, 5 };
            double[] dataY = new double[] { 1E9, 4E9, 9E8, 16E9, 25E12 };
            wpfPlot.Plot.AddScatter(dataX, dataY);
            wpfPlot.Plot.YAxis.TickLabelNotation(true,offset:true);
            wpfPlot.Plot.YAxis.CornerLabelFormat("x 10^{0}");
            wpfPlot.Refresh();
```