### PR TITLE
Consistent 12/24 hour clock in DateTime ticks

### DIFF
--- a/src/ScottPlot4/ScottPlot.Tests/Ticks/DateTimeTicksTests.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/Ticks/DateTimeTicksTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using ScottPlot.Ticks;
 using ScottPlot.Ticks.DateTimeTickUnits;
 using System;
 using System.Collections.Generic;
@@ -47,6 +48,37 @@ namespace ScottPlotTests.Ticks
                 });
 
                 dateUpper -= span / 2;
+            }
+        }
+
+        [Test]
+        public void TicksRespectLocale24HourClock()
+        {
+            DateTime almostMidnight = new DateTime(2000, 1, 1, 23, 59, 59);
+            CultureInfo culture12HourClock = new CultureInfo("en-US");
+            culture12HourClock.DateTimeFormat.ShortTimePattern = "hh:mm:ss";
+            culture12HourClock.DateTimeFormat.LongTimePattern = "hh:mm:ss";
+
+            CultureInfo culture24HourClock = new CultureInfo("en-US");
+            culture24HourClock.DateTimeFormat.ShortTimePattern = "HH:mm:ss";
+            culture24HourClock.DateTimeFormat.LongTimePattern = "HH:mm:ss";
+
+            DateTimeUnitFactory factory = new DateTimeUnitFactory();
+            // Yes I know this is janky, I was feeling lazy
+            IEnumerable<DateTimeUnit> dateTimeKinds = Enumerable.Range((int)DateTimeUnit.Hour, DateTimeUnit.Millisecond - DateTimeUnit.Hour + 1).Select(i => (DateTimeUnit)i);
+
+            var ticks12Hour = dateTimeKinds.Select(kind => factory.Create(kind, culture12HourClock, 1, null).GetTicksAndLabels(almostMidnight, almostMidnight, null));
+            var ticks24Hour = dateTimeKinds.Select(kind => factory.Create(kind, culture24HourClock, 1, null).GetTicksAndLabels(almostMidnight, almostMidnight, null));
+            
+            foreach(var label in ticks12Hour.SelectMany(c => c.Labels))
+            {
+                // The first line contains the date, the second line contains the time
+                StringAssert.StartsWith("11:59:59", label.Split('\n')[1]);
+            }
+
+            foreach (var label in ticks24Hour.SelectMany(c => c.Labels))
+            {
+                StringAssert.StartsWith("23:59:59", label.Split('\n')[1]);
             }
         }
     }

--- a/src/ScottPlot4/ScottPlot.Tests/Ticks/DateTimeTicksTests.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/Ticks/DateTimeTicksTests.cs
@@ -69,8 +69,8 @@ namespace ScottPlotTests.Ticks
 
             var ticks12Hour = dateTimeKinds.Select(kind => factory.Create(kind, culture12HourClock, 1, null).GetTicksAndLabels(almostMidnight, almostMidnight, null));
             var ticks24Hour = dateTimeKinds.Select(kind => factory.Create(kind, culture24HourClock, 1, null).GetTicksAndLabels(almostMidnight, almostMidnight, null));
-            
-            foreach(var label in ticks12Hour.SelectMany(c => c.Labels))
+
+            foreach (var label in ticks12Hour.SelectMany(c => c.Labels))
             {
                 // The first line contains the date, the second line contains the time
                 StringAssert.StartsWith("11:59:59", label.Split('\n')[1]);

--- a/src/ScottPlot4/ScottPlot/Ticks/DateTimeTickUnits/DateTimeTickUnitBase.cs
+++ b/src/ScottPlot4/ScottPlot/Ticks/DateTimeTickUnits/DateTimeTickUnitBase.cs
@@ -34,7 +34,7 @@ namespace ScottPlot.Ticks.DateTimeTickUnits
         protected virtual string GetTickLabel(DateTime value)
         {
             string date = value.ToString("d", culture); // short date
-            string time = value.ToString("t", culture); // short time
+            string time = value.ToString("T", culture); // long time
             return $"{date}\n{time}";
         }
 

--- a/src/ScottPlot4/ScottPlot/Ticks/DateTimeTickUnits/DateTimeTickUnitBase.cs
+++ b/src/ScottPlot4/ScottPlot/Ticks/DateTimeTickUnits/DateTimeTickUnitBase.cs
@@ -34,7 +34,7 @@ namespace ScottPlot.Ticks.DateTimeTickUnits
         protected virtual string GetTickLabel(DateTime value)
         {
             string date = value.ToString("d", culture); // short date
-            string time = value.ToString("T", culture); // long time
+            string time = value.ToString("t", culture); // short time
             return $"{date}\n{time}";
         }
 

--- a/src/ScottPlot4/ScottPlot/Ticks/DateTimeTickUnits/SecondsAndLess/DateTimeTickCentisecond.cs
+++ b/src/ScottPlot4/ScottPlot/Ticks/DateTimeTickUnits/SecondsAndLess/DateTimeTickCentisecond.cs
@@ -25,7 +25,9 @@ namespace ScottPlot.Ticks.DateTimeTickUnits
         protected override string GetTickLabel(DateTime value)
         {
             string date = value.ToString("d", culture); // short date
-            string time = value.ToString("hh:mm:ss.ff", culture); // long time
+
+            string hourSpecifier = Tools.Uses24HourClock(culture) ? "HH" : "hh";
+            string time = value.ToString($"{hourSpecifier}:mm:ss.ff", culture); // long time
             return $"{date}\n{time}";
         }
     }

--- a/src/ScottPlot4/ScottPlot/Ticks/DateTimeTickUnits/SecondsAndLess/DateTimeTickDecisecond.cs
+++ b/src/ScottPlot4/ScottPlot/Ticks/DateTimeTickUnits/SecondsAndLess/DateTimeTickDecisecond.cs
@@ -25,7 +25,9 @@ namespace ScottPlot.Ticks.DateTimeTickUnits
         protected override string GetTickLabel(DateTime value)
         {
             string date = value.ToString("d", culture); // short date
-            string time = value.ToString("hh:mm:ss.f", culture); // long time
+            string hourSpecifier = Tools.Uses24HourClock(culture) ? "HH" : "hh";
+
+            string time = value.ToString($"{hourSpecifier}:mm:ss.f", culture); // long time
             return $"{date}\n{time}";
         }
     }

--- a/src/ScottPlot4/ScottPlot/Ticks/DateTimeTickUnits/SecondsAndLess/DateTimeTickMillisecond.cs
+++ b/src/ScottPlot4/ScottPlot/Ticks/DateTimeTickUnits/SecondsAndLess/DateTimeTickMillisecond.cs
@@ -25,7 +25,9 @@ namespace ScottPlot.Ticks.DateTimeTickUnits
         protected override string GetTickLabel(DateTime value)
         {
             string date = value.ToString("d", culture); // short date
-            string time = value.ToString("hh:mm:ss.fff", culture); // long time
+            
+            string hourSpecifier = Tools.Uses24HourClock(culture) ? "HH" : "hh";
+            string time = value.ToString($"{hourSpecifier}:mm:ss.fff", culture); // long time
             return $"{date}\n{time}";
         }
     }

--- a/src/ScottPlot4/ScottPlot/Ticks/DateTimeTickUnits/SecondsAndLess/DateTimeTickMillisecond.cs
+++ b/src/ScottPlot4/ScottPlot/Ticks/DateTimeTickUnits/SecondsAndLess/DateTimeTickMillisecond.cs
@@ -25,7 +25,7 @@ namespace ScottPlot.Ticks.DateTimeTickUnits
         protected override string GetTickLabel(DateTime value)
         {
             string date = value.ToString("d", culture); // short date
-            
+
             string hourSpecifier = Tools.Uses24HourClock(culture) ? "HH" : "hh";
             string time = value.ToString($"{hourSpecifier}:mm:ss.fff", culture); // long time
             return $"{date}\n{time}";

--- a/src/ScottPlot4/ScottPlot/Tools.cs
+++ b/src/ScottPlot4/ScottPlot/Tools.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -461,5 +462,7 @@ namespace ScottPlot
 
             return output;
         }
+
+        public static bool Uses24HourClock(CultureInfo culture) => culture.DateTimeFormat.LongTimePattern.Contains("H");
     }
 }

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -2,6 +2,7 @@
 
 ## ScottPlot 4.1.59
 _not yet published on NuGet..._
+* Ticks: Improve datetime tick labels for systems with a 24-hour display format (#2132, #2135) _Thanks @MareMare and @bclehmann_
 
 ## ScottPlot 4.1.58
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-09-08_


### PR DESCRIPTION
**Purpose:**
#2132

This solution detects if a locale uses a 24-hour clock and adjusts some hard-coded time formats to generate 24-hour times.