### PR TITLE
BarSeries rectangle calculation for negative values fixed.

### DIFF
--- a/src/ScottPlot4/ScottPlot/Plottable/BarSeries.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/BarSeries.cs
@@ -56,6 +56,11 @@ public class BarSeries : IPlottable
             float top = dims.GetPixelY(bar.Value);
             float width = right - left;
             float height = bottom - top;
+            if (bar.Value < 0)
+            {
+                (top, _) = (bottom, top);
+                height = -height;
+            }
             return new RectangleF(left, top, width, height);
         }
         else

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -6,6 +6,7 @@ _not yet published on NuGet..._
 * Axis: `Plot.AddAxis()` now uses auto-incremented axis index unless one is explicitly defined (#2133) _Thanks @bclehmann and Discord/Nick_
 * Axis: `Plot.GetAxesMatching()` was created to obtain a given vertical or horizontal axis (#2133) _Thanks @bclehmann and Discord/Nick_
 * Axis: Corner label format can be customized for any axis by calling `CornerLabelFormat()` (#2134) _Thanks @ShannonZ_
+* BarSeries: Improved rendering of negative values (#2147, #2152) _Thanks @fe-c_
 
 ## ScottPlot 4.1.58
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-09-08_


### PR DESCRIPTION
Before:
![Before](https://user-images.githubusercontent.com/3897693/194144063-54ca2703-96ad-415d-83e4-c3a316ebe365.png)

After:
![After](https://user-images.githubusercontent.com/3897693/194144155-6f222e46-ee7f-40e7-a602-880402092cd3.png)
