### PR TITLE
Making RefreshLegendImage become a public function

### DIFF
--- a/src/ScottPlot4/ScottPlot.WinForms/FormsPlotLegendViewer.cs
+++ b/src/ScottPlot4/ScottPlot.WinForms/FormsPlotLegendViewer.cs
@@ -28,16 +28,7 @@ namespace ScottPlot
             RefreshLegendImage();
             ResizeWindowToFitLegendImage();
         }
-
-        private void OnClosed(object sender, EventArgs e)
-        {
-            RemoveHighlightFromAllPlottables();
-            Legend.IsDetached = false;
-            FormsPlot.Plot.Legend(enable: LegendWasInitiallyVisible, location: null);
-            FormsPlot.Refresh();
-        }
-
-        private void RefreshLegendImage()
+        public void RefreshLegendImage()
         {
             FormsPlot.Refresh();
             Legend.UpdateLegendItems(FormsPlot.Plot, includeHidden: true);
@@ -48,6 +39,14 @@ namespace ScottPlot
 
             if (originalImage is not null)
                 originalImage.Dispose();
+        }
+
+        private void OnClosed(object sender, EventArgs e)
+        {
+            RemoveHighlightFromAllPlottables();
+            Legend.IsDetached = false;
+            FormsPlot.Plot.Legend(enable: LegendWasInitiallyVisible, location: null);
+            FormsPlot.Refresh();
         }
 
         private void ResizeWindowToFitLegendImage()

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -7,6 +7,7 @@ _not yet published on NuGet..._
 * Axis: `Plot.GetAxesMatching()` was created to obtain a given vertical or horizontal axis (#2133) _Thanks @bclehmann and Discord/Nick_
 * Axis: Corner label format can be customized for any axis by calling `CornerLabelFormat()` (#2134) _Thanks @ShannonZ_
 * BarSeries: Improved rendering of negative values (#2147, #2152) _Thanks @fe-c_
+* FormsPlot: Plot viewer now has `RefreshLegendImage()` allowing the pop-out legend to be redrawn programmatically (#2157, #2153) _Thanks @rosdyana_
 
 ## ScottPlot 4.1.58
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-09-08_


### PR DESCRIPTION
**Purpose:**
* Fixes: #2153
* Changing RefreshLegendImage from a private to a public function
* Re-ordering private and public functions

```cs
// From private to public function 
public void RefreshLegendImage()
```