### PR TITLE
FunctionPlot: Massive performance boosts for functions with restricted domains

### DIFF
--- a/src/ScottPlot4/ScottPlot/DoubleExtensions.cs
+++ b/src/ScottPlot4/ScottPlot/DoubleExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot
+{
+    internal static class DoubleExtensions
+    {
+        public static bool IsFinite(this double x) => !double.IsNaN(x) && !double.IsInfinity(x);
+    }
+}

--- a/src/ScottPlot4/ScottPlot/Plottable/FunctionPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/FunctionPlot.cs
@@ -45,7 +45,7 @@ namespace ScottPlot.Plottable
             double xStart = XMin.IsFinite() ? XMin : dims.XMin;
             double xEnd = XMax.IsFinite() ? XMax : dims.XMax;
             double width = xEnd - xStart;
-            
+
             PointCount = (int)(width * dims.PxPerUnitX) + 1;
 
             for (int columnIndex = 0; columnIndex < PointCount; columnIndex++)
@@ -58,7 +58,7 @@ namespace ScottPlot.Plottable
                     Debug.WriteLine($"Y({x}) failed because y was null");
                     continue;
                 }
-                
+
                 if (double.IsNaN(y.Value) || double.IsInfinity(y.Value))
                 {
                     Debug.WriteLine($"Y({x}) failed because y was not a real number");

--- a/src/ScottPlot4/ScottPlot/Plottable/FunctionPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/FunctionPlot.cs
@@ -25,6 +25,9 @@ namespace ScottPlot.Plottable
         public string Label { get; set; }
         public Color Color { get; set; } = Color.Black;
         public Color LineColor { get; set; } = Color.Black;
+        public double XMin { get; set; } = double.NegativeInfinity;
+        public double XMax { get; set; } = double.PositiveInfinity;
+
         public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
 
         public FunctionPlot(Func<double, double?> function)
@@ -39,10 +42,15 @@ namespace ScottPlot.Plottable
             List<double> xList = new List<double>();
             List<double> yList = new List<double>();
 
-            PointCount = (int)dims.DataWidth;
-            for (int columnIndex = 0; columnIndex < dims.DataWidth; columnIndex++)
+            double xStart = XMin.IsFinite() ? XMin : dims.XMin;
+            double xEnd = XMax.IsFinite() ? XMax : dims.XMax;
+            double width = xEnd - xStart;
+            
+            PointCount = (int)(width * dims.PxPerUnitX) + 1;
+
+            for (int columnIndex = 0; columnIndex < PointCount; columnIndex++)
             {
-                double x = columnIndex * dims.UnitsPerPxX + dims.XMin;
+                double x = columnIndex * dims.UnitsPerPxX + xStart;
                 double? y = Function(x);
 
                 if (y is null)

--- a/src/ScottPlot4/ScottPlot/Plottable/FunctionPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/FunctionPlot.cs
@@ -43,24 +43,22 @@ namespace ScottPlot.Plottable
             for (int columnIndex = 0; columnIndex < dims.DataWidth; columnIndex++)
             {
                 double x = columnIndex * dims.UnitsPerPxX + dims.XMin;
-                try
+                double? y = Function(x);
+
+                if (y is null)
                 {
-                    double? y = Function(x);
-
-                    if (y is null)
-                        throw new NoNullAllowedException();
-
-                    if (double.IsNaN(y.Value) || double.IsInfinity(y.Value))
-                        throw new ArithmeticException("not a real number");
-
-                    xList.Add(x);
-                    yList.Add(y.Value);
-                }
-                catch (Exception e) //Domain error, such log(-1) or 1/0
-                {
-                    Debug.WriteLine($"Y({x}) failed because {e}");
+                    Debug.WriteLine($"Y({x}) failed because y was null");
                     continue;
                 }
+                
+                if (double.IsNaN(y.Value) || double.IsInfinity(y.Value))
+                {
+                    Debug.WriteLine($"Y({x}) failed because y was not a real number");
+                    continue;
+                }
+
+                xList.Add(x);
+                yList.Add(y.Value);
             }
 
             // create a temporary scatter plot and use it for rendering

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -9,6 +9,7 @@ _not yet published on NuGet..._
 * BarSeries: Improved rendering of negative values (#2147, #2152) _Thanks @fe-c_
 * Function Plot: Added optional `XMin` and `XMax` fields which limit function rendering to a defined horizontal span (#2158, #2156, #2138) _Thanks @bclehmann and @phil100vol_
 * FormsPlot: Plot viewer now has `RefreshLegendImage()` allowing the pop-out legend to be redrawn programmatically (#2157, #2153) _Thanks @rosdyana_
+* Function Plot: Improved performance for functions which return null (#2158, #2156, #2138) _Thanks @bclehmann_
 
 ## ScottPlot 4.1.58
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-09-08_

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -7,6 +7,7 @@ _not yet published on NuGet..._
 * Axis: `Plot.GetAxesMatching()` was created to obtain a given vertical or horizontal axis (#2133) _Thanks @bclehmann and Discord/Nick_
 * Axis: Corner label format can be customized for any axis by calling `CornerLabelFormat()` (#2134) _Thanks @ShannonZ_
 * BarSeries: Improved rendering of negative values (#2147, #2152) _Thanks @fe-c_
+* Function Plot: Added optional `XMin` and `XMax` fields which limit function rendering to a defined horizontal span (#2158, #2156, #2138) _Thanks @bclehmann and @phil100vol_
 
 ## ScottPlot 4.1.58
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-09-08_


### PR DESCRIPTION
**Purpose:**
#2156 

Most of the performance benefit comes from removing the exception-based code (that's my bad, it was my idea in the first place). `XMin` and `XMax` are just gravy, and they also are potentially useful in and of themselves, if someone only wants to consider a function on a narrow domain, this is probably an easier way to restrict that domain then manually modifying the function.

```cs
double? Normalised_Function_F(double z)
{
    return 0 <= z && z <= 1 ? z : null;
}
var f = plt.AddFunction(Normalised_Function_F);

f.XMin = 0.3;
f.XMax = 0.7;
```