### PR TITLE
Bar Plot: Show negative values below bar

### DIFF
--- a/src/ScottPlot4/ScottPlot/Plottable/Bar.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Bar.cs
@@ -69,6 +69,14 @@ public class Bar
         double left = Position - Thickness / 2;
         double right = Position + Thickness / 2;
 
+        // Make room for labels, if present
+        if (Label is not null)
+        {
+            double span = top - bottom;
+            top += 0.1 * span;
+            bottom -= 0.1 * span;
+        }
+
         return IsVertical
             ? new AxisLimits(left, right, bottom, top)
             : new AxisLimits(bottom, top, left, right);

--- a/src/ScottPlot4/ScottPlot/Plottable/BarPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/BarPlot.cs
@@ -81,10 +81,19 @@ namespace ScottPlot.Plottable
             }
 
             if (ShowValuesAboveBars)
-                using (var valueTextFont = GDI.Font(Font))
-                using (var valueTextBrush = GDI.Brush(Font.Color))
-                using (var sf = new StringFormat() { LineAlignment = StringAlignment.Far, Alignment = StringAlignment.Center })
-                    gfx.DrawString(ValueFormatter(value), valueTextFont, valueTextBrush, centerPx, rect.Y, sf);
+            {
+                bool belowBar = value < 0;
+
+                using var valueTextFont = GDI.Font(Font);
+                using var valueTextBrush = GDI.Brush(Font.Color);
+                using var sf = new StringFormat() { 
+                    LineAlignment = belowBar ? StringAlignment.Near : StringAlignment.Far,
+                    Alignment = StringAlignment.Center
+                };
+
+                var y = belowBar ? rect.Bottom : rect.Top;
+                gfx.DrawString(ValueFormatter(value), valueTextFont, valueTextBrush, centerPx, y, sf);
+            }
         }
 
         private void RenderBarHorizontal(PlotDimensions dims, Graphics gfx, double position, double value, double valueError, double yOffset)
@@ -120,10 +129,19 @@ namespace ScottPlot.Plottable
             }
 
             if (ShowValuesAboveBars)
-                using (var valueTextFont = GDI.Font(Font))
-                using (var valueTextBrush = GDI.Brush(Font.Color))
-                using (var sf = new StringFormat() { LineAlignment = StringAlignment.Center, Alignment = StringAlignment.Near })
-                    gfx.DrawString(ValueFormatter(value), valueTextFont, valueTextBrush, rect.X + rect.Width, centerPx, sf);
+            {
+                bool belowBar = value < 0;
+
+                using var valueTextFont = GDI.Font(Font);
+                using var valueTextBrush = GDI.Brush(Font.Color);
+                using var sf = new StringFormat() { 
+                    LineAlignment = StringAlignment.Center,
+                    Alignment = belowBar ? StringAlignment.Far : StringAlignment.Near
+                };
+
+                var x = belowBar ? rect.Left : rect.Right;
+                gfx.DrawString(ValueFormatter(value), valueTextFont, valueTextBrush, x, centerPx, sf);
+            }
         }
 
         protected void RenderBarFromRect(RectangleF rect, bool negative, Graphics gfx)

--- a/src/ScottPlot4/ScottPlot/Plottable/BarPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/BarPlot.cs
@@ -86,7 +86,8 @@ namespace ScottPlot.Plottable
 
                 using var valueTextFont = GDI.Font(Font);
                 using var valueTextBrush = GDI.Brush(Font.Color);
-                using var sf = new StringFormat() { 
+                using var sf = new StringFormat()
+                {
                     LineAlignment = belowBar ? StringAlignment.Near : StringAlignment.Far,
                     Alignment = StringAlignment.Center
                 };
@@ -134,7 +135,8 @@ namespace ScottPlot.Plottable
 
                 using var valueTextFont = GDI.Font(Font);
                 using var valueTextBrush = GDI.Brush(Font.Color);
-                using var sf = new StringFormat() { 
+                using var sf = new StringFormat()
+                {
                     LineAlignment = StringAlignment.Center,
                     Alignment = belowBar ? StringAlignment.Far : StringAlignment.Near
                 };

--- a/src/ScottPlot4/ScottPlot/Plottable/BarPlotBase.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/BarPlotBase.cs
@@ -121,7 +121,14 @@ namespace ScottPlot.Plottable
             }
 
             if (ShowValuesAboveBars)
-                valueMax += (valueMax - valueMin) * .1; // increase by 10% to accommodate label
+            {
+                double span = valueMax - valueMin;
+                if (valueMax > 0)
+                    valueMax += span * .1; // increase by 10% to accommodate label
+
+                if (valueMin < 0)
+                    valueMin -= span * .1;
+            }
 
             positionMin -= BarWidth / 2;
             positionMax += BarWidth / 2;

--- a/src/ScottPlot4/ScottPlot/Plottable/BarSeries.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/BarSeries.cs
@@ -71,6 +71,11 @@ public class BarSeries : IPlottable
             float bottom = dims.GetPixelY(bar.Position - bar.Thickness / 2);
             float width = right - left;
             float height = bottom - top;
+            if (bar.Value < 0)
+            {
+                left = right;
+                width = -width;
+            }
             return new RectangleF(left, top, width, height);
         }
     }

--- a/src/ScottPlot4/ScottPlot/Plottable/BarSeries.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/BarSeries.cs
@@ -102,8 +102,6 @@ public class BarSeries : IPlottable
         using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
         using Brush brush = GDI.Brush(Color.Black);
         using Pen pen = GDI.Pen(Color.Black);
-        using StringFormat sfVert = GDI.StringFormat(Alignment.LowerCenter);
-        using StringFormat sfHoriz = GDI.StringFormat(Alignment.MiddleLeft);
 
         foreach (Bar bar in Bars)
         {
@@ -126,14 +124,21 @@ public class BarSeries : IPlottable
             {
                 using var font = GDI.Font(bar.Font);
                 ((SolidBrush)brush).Color = bar.Font.Color;
+                bool drawBelow = bar.Value < 0;
 
                 if (bar.IsVertical)
                 {
-                    gfx.DrawString(bar.Label, font, brush, rect.Left + rect.Width / 2, rect.Top, sfVert);
+                    using StringFormat sfVert = GDI.StringFormat(HorizontalAlignment.Center, drawBelow ? VerticalAlignment.Upper : VerticalAlignment.Lower);
+
+                    var pos = drawBelow ? rect.Bottom : rect.Top;
+                    gfx.DrawString(bar.Label, font, brush, rect.Left + rect.Width / 2, pos, sfVert);
                 }
                 else
                 {
-                    gfx.DrawString(bar.Label, font, brush, rect.Right, rect.Top + rect.Height / 2, sfHoriz);
+                    using StringFormat sfHoriz = GDI.StringFormat(drawBelow ? HorizontalAlignment.Right : HorizontalAlignment.Left, VerticalAlignment.Middle);
+
+                    var pos = drawBelow ? rect.Left: rect.Right;
+                    gfx.DrawString(bar.Label, font, brush, pos, rect.Top + rect.Height / 2, sfHoriz);
                 }
             }
         }

--- a/src/ScottPlot4/ScottPlot/Plottable/BarSeries.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/BarSeries.cs
@@ -137,7 +137,7 @@ public class BarSeries : IPlottable
                 {
                     using StringFormat sfHoriz = GDI.StringFormat(drawBelow ? HorizontalAlignment.Right : HorizontalAlignment.Left, VerticalAlignment.Middle);
 
-                    var pos = drawBelow ? rect.Left: rect.Right;
+                    var pos = drawBelow ? rect.Left : rect.Right;
                     gfx.DrawString(bar.Label, font, brush, pos, rect.Top + rect.Height / 2, sfHoriz);
                 }
             }

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -10,6 +10,9 @@ _not yet published on NuGet..._
 * Function Plot: Added optional `XMin` and `XMax` fields which limit function rendering to a defined horizontal span (#2158, #2156, #2138) _Thanks @bclehmann and @phil100vol_
 * FormsPlot: Plot viewer now has `RefreshLegendImage()` allowing the pop-out legend to be redrawn programmatically (#2157, #2153) _Thanks @rosdyana_
 * Function Plot: Improved performance for functions which return null (#2158, #2156, #2138) _Thanks @bclehmann_
+* BarSeries: improve support for negative and horizontal bar labels (#2148, #2159, #2152) _Thanks @bclehmann_
+* Palette: Added `Normal` Palette based on [Anton Tsitsulin's Normal 6-color palette](http://tsitsul.in/blog/coloropt/) (#2161, #2010) _Thanks @martinkleppe_
+* BarSeries: Added helper function to create a bar series from an array of values (#2161) _Thanks @KonH_
 
 ## ScottPlot 4.1.58
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-09-08_


### PR DESCRIPTION
**Purpose:**
#2148 

~~Note that this PR doesn't yet add this for `BarSeries`, I'm writing this between classes so I'll add it later.~~

The other question is whether this should be customizable, is drawing the text above negative bars always wrong (i.e. this is a bug fix), or should the user be able to choose that behaviour (i.e. this is a new feature). If it's the latter, I think we should preserve the previous behaviour of `ShowValuesAboveBars` and add `ShowValuesAtTipOfBar` or something similar.

```cs
double[] values = { 27.3, 23.1, -21.2, 16.1, 6.4, 19.2, 18.7, 17.3, 20.3, 13.1 };

var bar = plt.AddBar(values);
bar.ShowValuesAboveBars = true;
bar.Orientation = Orientation.Horizontal;
```
![image](https://user-images.githubusercontent.com/8635304/194647993-f1619e81-3ca6-4c62-9e50-0d5250eefd14.png)
