### PR TITLE
Plot.AddBarSeries: new Bar[] overload

### DIFF
--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Add.cs
@@ -241,6 +241,16 @@ namespace ScottPlot
         }
 
         /// <summary>
+        /// Create a BarSeries filled with the given bars, add it to the plot, and return it.
+        /// </summary>
+        public BarSeries AddBarSeries(Bar[] bars)
+        {
+            BarSeries barSeries = new(bars.ToList());
+            Add(barSeries);
+            return barSeries;
+        }
+
+        /// <summary>
         /// Add an empty bubble plot. Call it's Add() method to add bubbles with custom position and styling.
         /// </summary>
         public BubblePlot AddBubblePlot()


### PR DESCRIPTION
**Purpose:**
Related to https://github.com/ScottPlot/ScottPlot/issues/2146  

Now you can use not only List<Bar> but also Bar[] argument.  
I'm not sure about corner cases related to .ToList() call - in the original approach you potentially can change the passed list after, but while converting an array to a list you can't do it. But in my opinion, we can skip this detail to not introduce additional complexity.