### PR TITLE
Add pallete based on xgfs_normal6 from Anton Tsitsulin

### DIFF
--- a/src/ScottPlot4/ScottPlot/Palettes/Normal.cs
+++ b/src/ScottPlot4/ScottPlot/Palettes/Normal.cs
@@ -1,0 +1,19 @@
+﻿/* A color palette based on Anton Tsitsulin's 6-color palette
+ * http://tsitsul.in/blog/coloropt
+ * https://github.com/xgfs/coloropt
+ */
+
+namespace ScottPlot.Palettes;
+
+public class Normal : HexPaletteBase, IPalette
+{
+    public override string Name => "XgfsNormal6";
+
+    public override string Description => "A color palette adapted from Tsitsulin's 6-color normal xgfs palette: http://tsitsul.in/blog/coloropt";
+
+    internal override string[] HexColors => new string[]
+    {
+        "#4053d3", "#ddb310", "#b51d14",
+        "#00beff", "#fb49b0", "#00b25d", "#cacaca",
+    };
+}


### PR DESCRIPTION
This commit will add the normal pallette based on xgfs_normal6 from Anton Tsitsulin as described in issue #2010. 
