### PR TITLE
CoordinateRange.Expand: Add NaN checks

### DIFF
--- a/src/ScottPlot5/ScottPlot5/CoordinateRange.cs
+++ b/src/ScottPlot5/ScottPlot5/CoordinateRange.cs
@@ -38,8 +38,14 @@ public class CoordinateRange
     /// </summary>
     public void Expand(double value)
     {
-        Min = Math.Min(Min, value);
-        Max = Math.Max(Max, value);
+        if (double.IsNaN(value))
+            return;
+
+        if (double.IsNaN(Min) || value < Min)
+            Min = value;
+
+        if (double.IsNaN(Max) || value > Max)
+            Max = value;
     }
 
     /// <summary>
@@ -47,8 +53,8 @@ public class CoordinateRange
     /// </summary>
     public void Expand(CoordinateRange range)
     {
-        Min = Math.Min(Min, range.Min);
-        Max = Math.Max(Max, range.Max);
+        Expand(range.Min);
+        Expand(range.Max);
     }
 
     /// <summary>


### PR DESCRIPTION
**Purpose:**
`Math.Min` and `Math.Max` will return `NaN` if either of its arguments are `NaN` (because `NaN` is by definition less than, greater than, and unequal to any other number, including `NaN`).

Explicit NaN checks prevent this, this fixes an issue where middle-clicking would not zoom out properly (as if the `tight` argument to `AutoScale` were set).