### PR TITLE
Always initialize DateTimeTIckUnit.culture

### DIFF
--- a/src/ScottPlot4/ScottPlot/Ticks/DateTimeTickUnits/DateTimeTickUnitBase.cs
+++ b/src/ScottPlot4/ScottPlot/Ticks/DateTimeTickUnits/DateTimeTickUnitBase.cs
@@ -15,7 +15,7 @@ namespace ScottPlot.Ticks.DateTimeTickUnits
 
         public DateTimeTickUnitBase(CultureInfo culture, int maxTickCount, int? manualSpacing)
         {
-            this.culture = culture;
+            this.culture = culture ?? CultureInfo.CurrentCulture;
             this.maxTickCount = maxTickCount;
             if (manualSpacing.HasValue)
                 deltas = new int[] { manualSpacing.Value };


### PR DESCRIPTION
**Purpose:**
Under some circumstances (not quite clear when), `DateTimeTickUnitBase.culture` can be null. This prevents a null reference exception that can be triggered by zooming far enough into a plot with DateTime axes (it happens in `Tools.Uses24HourClock`, so you need to zoom in far enough to bring up centiseconds or finer units).
