### PR TITLE
#2196 - add cookbook recipe for datetime axis on a signal plot

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Axis.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Axis.cs
@@ -221,4 +221,30 @@ namespace ScottPlot.Cookbook.Recipes.Ticks
             plt.XAxis.DateTimeFormat(true);
         }
     }
+    class TicksDateTimeSignal : IRecipe
+    {
+        public ICategory Category => new Categories.Axis();
+        public string ID => "ticks_dateTime_signal";
+        public string Title => "Plotting DateTime Data on a Signal Plot";
+        public string Description =>
+            "DateTime can be displayed on the horizontal axis of a signal plot by " +
+            "using the sample rate to set the time interval per data point, and then " +
+            "setting the OffsetX to the desired start date.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            // create data sample data
+            double[] ys = DataGen.RandomWalk(100);
+
+            TimeSpan ts = TimeSpan.FromSeconds(1); // time between data points
+            double sampleRate = (double)TimeSpan.TicksPerDay / ts.Ticks;
+            var signalPlot = plt.AddSignal(ys, sampleRate);
+
+            // Then tell the axis to display tick labels using a time format
+            plt.XAxis.DateTimeFormat(true);
+
+            // Set start date
+            signalPlot.OffsetX = new DateTime(1985, 10, 1).ToOADate();
+        }
+    }
 }


### PR DESCRIPTION
**Purpose:**
Addresses #2196 
New recipe when viewed locally: 
![image](https://user-images.githubusercontent.com/1486613/198500153-9a608379-626d-4976-ad3c-f43b79af5205.png)
