### PR TITLE
ScottPlot 5: Font abstraction

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Axis/AxisRendering.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/AxisRendering.cs
@@ -74,11 +74,11 @@ public static class AxisRendering
 
             Edge.Bottom => new(
                 x: dataRect.HorizontalCenter,
-                y: dataRect.Bottom + paint.FontSpacing + offset),
+                y: dataRect.Bottom + offset + pixelSize - paint.FontSpacing - 5),
 
             Edge.Top => new(
                 x: dataRect.HorizontalCenter,
-                y: dataRect.Top - paint.FontSpacing - 16 - offset), // tick label size
+                y: dataRect.Top - paint.FontSpacing - 16 - offset - pixelSize), // tick label size
 
             _ => throw new InvalidEnumArgumentException()
         };
@@ -100,14 +100,16 @@ public static class AxisRendering
             Color = color.ToSKColor(),
         };
 
+
         foreach (Tick tick in ticks)
         {
             float xPx = axis.GetPixel(tick.Position, dataRect);
-            float yEdge = axis.Edge == Edge.Bottom ? dataRect.Bottom + offset + 3: dataRect.Top - offset - 3;
-            float fontSpacing = axis.Edge == Edge.Bottom ? paint.FontSpacing : -4;
+            float y = axis.Edge == Edge.Bottom ? dataRect.Bottom + offset : dataRect.Top - offset;
+            float yEdge = axis.Edge == Edge.Bottom ? y + 3: y - 3;
+            float fontSpacing = axis.Edge == Edge.Bottom ? paint.TextSize : -4;
 
-            surface.Canvas.DrawLine(xPx, yEdge, xPx, yEdge, paint);
-            
+            surface.Canvas.DrawLine(xPx, y, xPx, yEdge, paint);
+
             if (!string.IsNullOrWhiteSpace(tick.Label))
                 surface.Canvas.DrawText(tick.Label, xPx, yEdge + fontSpacing, paint);
         }

--- a/src/ScottPlot5/ScottPlot5/Axis/AxisRendering.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/AxisRendering.cs
@@ -86,9 +86,14 @@ public static class AxisRendering
         label.Draw(surface, px, paint);
     }
 
-    public static void DrawTicksBottom(SKSurface surface, PixelRect dataRect, Color color, float offset, IEnumerable<Tick> ticks, IXAxis axis)
+    private static void DrawTicksHorizontalAxis(SKSurface surface, SKFont font, PixelRect dataRect, Color color, float offset, IEnumerable<Tick> ticks, IAxis axis)
     {
-        using SKPaint paint = new()
+        if (axis.Edge != Edge.Bottom && axis.Edge != Edge.Top)
+        {
+            throw new InvalidEnumArgumentException();
+        }
+
+        using SKPaint paint = new(font)
         {
             IsAntialias = true,
             TextAlign = SKTextAlign.Center,
@@ -98,73 +103,53 @@ public static class AxisRendering
         foreach (Tick tick in ticks)
         {
             float xPx = axis.GetPixel(tick.Position, dataRect);
-            float yEdge = dataRect.Bottom + offset;
-            surface.Canvas.DrawLine(xPx, yEdge, xPx, yEdge + 3, paint);
-            surface.Canvas.DrawText(tick.Label, xPx, yEdge + 3 + paint.FontSpacing, paint);
+            float yEdge = axis.Edge == Edge.Bottom ? dataRect.Bottom + offset + 3: dataRect.Top - offset - 3;
+            float fontSpacing = axis.Edge == Edge.Bottom ? paint.FontSpacing : -4;
+
+            surface.Canvas.DrawLine(xPx, yEdge, xPx, yEdge, paint);
+            
+            if (!string.IsNullOrWhiteSpace(tick.Label))
+                surface.Canvas.DrawText(tick.Label, xPx, yEdge + fontSpacing, paint);
         }
     }
 
-    public static void DrawTicksTop(SKSurface surface, PixelRect dataRect, Color color, float offset, IEnumerable<Tick> ticks, IXAxis axis)
+    private static void DrawTicksVerticalAxis(SKSurface surface, SKFont font, PixelRect dataRect, Color color, float offset, IEnumerable<Tick> ticks, IAxis axis)
     {
-        using SKPaint paint = new()
+        if (axis.Edge != Edge.Left && axis.Edge != Edge.Right)
+        {
+            throw new InvalidEnumArgumentException();
+        }
+
+        using SKPaint paint = new(font)
         {
             IsAntialias = true,
-            TextAlign = SKTextAlign.Center,
+            TextAlign = axis.Edge == Edge.Left ? SKTextAlign.Right : SKTextAlign.Left,
             Color = color.ToSKColor(),
         };
 
         foreach (Tick tick in ticks)
         {
-            float xPx = axis.GetPixel(tick.Position, dataRect);
-            float yEdge = dataRect.Top - offset;
-            surface.Canvas.DrawLine(xPx, yEdge, xPx, yEdge - 3, paint);
-            surface.Canvas.DrawText(tick.Label, xPx, yEdge - 7, paint);
-        }
-    }
-
-    public static void DrawTicksLeft(SKSurface surface, PixelRect dataRect, Color color, float offset, IEnumerable<Tick> ticks, IYAxis axis)
-    {
-        using SKPaint paint = new()
-        {
-            IsAntialias = true,
-            TextAlign = SKTextAlign.Right,
-            Color = color.ToSKColor(),
-        };
-
-        foreach (Tick tick in ticks)
-        {
-            float x = dataRect.Left - offset;
+            float x = axis.Edge == Edge.Left ? dataRect.Left - offset : dataRect.Right + offset;
             float y = axis.GetPixel(tick.Position, dataRect);
 
             float majorTickLength = 5;
-            surface.Canvas.DrawLine(x, y, x - majorTickLength, y, paint);
+            float xEdge = axis.Edge == Edge.Left ? x - majorTickLength : x + majorTickLength;
+            surface.Canvas.DrawLine(x, y, xEdge, y, paint);
 
             float majorTickLabelPadding = 7;
+            float labelPos = axis.Edge == Edge.Left ? x - majorTickLabelPadding : x + majorTickLabelPadding;
             if (!string.IsNullOrWhiteSpace(tick.Label))
-                surface.Canvas.DrawText(tick.Label, x - majorTickLabelPadding, y + paint.TextSize * .4f, paint);
+                surface.Canvas.DrawText(tick.Label, labelPos, y + paint.TextSize * .4f, paint);
         }
     }
 
-    public static void DrawTicksRight(SKSurface surface, PixelRect dataRect, Color color, float offset, IEnumerable<Tick> ticks, IYAxis axis)
+    public static void DrawTicks(SKSurface surface, SKFont font, PixelRect dataRect, Color color, float offset, IEnumerable<Tick> ticks, IAxis axis)
     {
-        using SKPaint paint = new()
-        {
-            IsAntialias = true,
-            TextAlign = SKTextAlign.Left,
-            Color = color.ToSKColor(),
-        };
-
-        foreach (Tick tick in ticks)
-        {
-            float x = dataRect.Right + offset;
-            float y = axis.GetPixel(tick.Position, dataRect);
-
-            float majorTickLength = 5;
-            surface.Canvas.DrawLine(x, y, x + majorTickLength, y, paint);
-
-            float majorTickLabelPadding = 7;
-            if (!string.IsNullOrWhiteSpace(tick.Label))
-                surface.Canvas.DrawText(tick.Label, x + majorTickLabelPadding, y + paint.TextSize * .4f, paint);
-        }
+        if (axis.Edge == Edge.Left || axis.Edge == Edge.Right)
+            DrawTicksVerticalAxis(surface, font, dataRect, color, offset, ticks, axis);
+        else if (axis.Edge == Edge.Bottom || axis.Edge == Edge.Top)
+            DrawTicksHorizontalAxis(surface, font, dataRect, color, offset, ticks, axis);
+        else
+            throw new InvalidEnumArgumentException();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/AxisRendering.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/AxisRendering.cs
@@ -105,7 +105,7 @@ public static class AxisRendering
         {
             float xPx = axis.GetPixel(tick.Position, dataRect);
             float y = axis.Edge == Edge.Bottom ? dataRect.Bottom + offset : dataRect.Top - offset;
-            float yEdge = axis.Edge == Edge.Bottom ? y + 3: y - 3;
+            float yEdge = axis.Edge == Edge.Bottom ? y + 3 : y - 3;
             float fontSpacing = axis.Edge == Edge.Bottom ? paint.TextSize : -4;
 
             surface.Canvas.DrawLine(xPx, y, xPx, yEdge, paint);

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/BottomAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/BottomAxis.cs
@@ -4,19 +4,10 @@ namespace ScottPlot.Axis.StandardAxes;
 
 public class BottomAxis : XAxisBase, IXAxis
 {
-    public Edge Edge => Edge.Bottom;
+    public override Edge Edge => Edge.Bottom;
 
     public BottomAxis()
     {
         TickGenerator = new TickGenerators.ScottPlot4.NumericTickGenerator(false);
-    }
-
-    public void Render(SKSurface surface, PixelRect dataRect)
-    {
-        var ticks = TickGenerator.GetVisibleTicks(Range);
-
-        AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Offset, PixelSize);
-        AxisRendering.DrawTicksBottom(surface, dataRect, Label.Color, Offset, ticks, this);
-        AxisRendering.DrawFrame(surface, dataRect, Edge, Label.Color, Offset);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/LeftAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/LeftAxis.cs
@@ -4,18 +4,10 @@ namespace ScottPlot.Axis.StandardAxes;
 
 public class LeftAxis : YAxisBase, IYAxis
 {
-    public Edge Edge { get; } = Edge.Left;
+    public override Edge Edge { get; } = Edge.Left;
 
     public LeftAxis()
     {
         TickGenerator = new TickGenerators.ScottPlot4.NumericTickGenerator(true);
-    }
-
-    public void Render(SKSurface surface, PixelRect dataRect)
-    {
-        var ticks = TickGenerator.GetVisibleTicks(Range);
-        AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Offset, PixelSize);
-        AxisRendering.DrawTicksLeft(surface, dataRect, Label.Color, Offset, ticks, this);
-        AxisRendering.DrawFrame(surface, dataRect, Edge, Label.Color, Offset);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/RightAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/RightAxis.cs
@@ -4,18 +4,10 @@ namespace ScottPlot.Axis.StandardAxes;
 
 public class RightAxis : YAxisBase, IYAxis
 {
-    public Edge Edge { get; } = Edge.Right;
+    public override Edge Edge { get; } = Edge.Right;
 
     public RightAxis()
     {
         TickGenerator = new TickGenerators.ScottPlot4.NumericTickGenerator(true);
-    }
-
-    public void Render(SKSurface surface, PixelRect dataRect)
-    {
-        var ticks = TickGenerator.GetVisibleTicks(Range);
-        AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Offset, PixelSize);
-        AxisRendering.DrawTicksRight(surface, dataRect, Label.Color, Offset, ticks, this);
-        AxisRendering.DrawFrame(surface, dataRect, Edge, Label.Color, Offset);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/TopAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/TopAxis.cs
@@ -4,19 +4,10 @@ namespace ScottPlot.Axis.StandardAxes;
 
 public class TopAxis : XAxisBase, IXAxis
 {
-    public Edge Edge => Edge.Top;
+    public override Edge Edge => Edge.Top;
 
     public TopAxis()
     {
         TickGenerator = new TickGenerators.ScottPlot4.NumericTickGenerator(false);
-    }
-
-    public void Render(SKSurface surface, PixelRect dataRect)
-    {
-        var ticks = TickGenerator.GetVisibleTicks(Range);
-
-        AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Offset, PixelSize);
-        AxisRendering.DrawTicksTop(surface, dataRect, Label.Color, Offset, ticks, this);
-        AxisRendering.DrawFrame(surface, dataRect, Edge, Label.Color, Offset);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/XAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/XAxisBase.cs
@@ -1,6 +1,8 @@
-﻿namespace ScottPlot.Axis.StandardAxes;
+﻿using SkiaSharp;
 
-public abstract class XAxisBase
+namespace ScottPlot.Axis.StandardAxes;
+
+public abstract class XAxisBase : IAxis
 {
     public double Left
     {
@@ -29,14 +31,19 @@ public abstract class XAxisBase
     public Label Label { get; private set; } = new()
     {
         Text = "Horizontal Axis",
-        Bold = true,
-        FontSize = 16
+        Font = new Style.Font()
+        {
+            Family = "Consolas",
+            Size = 16,
+            Bold = true
+        },
     };
+    public abstract Edge Edge { get; }
 
     public void Measure()
     {
-        float labelHeight = Label.FontSize;
-        float largestTickHeight = Label.FontSize;
+        float labelHeight = Label.Font.Size;
+        float largestTickHeight = Label.Font.Size;
         PixelSize = labelHeight + largestTickHeight + 18;
     }
 
@@ -54,5 +61,15 @@ public abstract class XAxisBase
         float pxFromLeftEdge = pixel - dataArea.Left;
         double unitsFromEdge = pxFromLeftEdge / pxPerUnit;
         return Left + unitsFromEdge;
+    }
+
+    public void Render(SKSurface surface, PixelRect dataRect)
+    {
+        using SKFont font = Label.Font.GetFont();
+        var ticks = TickGenerator.GetVisibleTicks(Range);
+
+        AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Offset, PixelSize);
+        AxisRendering.DrawTicks(surface, font, dataRect, Label.Color, Offset, ticks, this);
+        AxisRendering.DrawFrame(surface, dataRect, Edge, Label.Color, Offset);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/XAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/XAxisBase.cs
@@ -1,4 +1,5 @@
-﻿using SkiaSharp;
+﻿using ScottPlot.Style;
+using SkiaSharp;
 
 namespace ScottPlot.Axis.StandardAxes;
 
@@ -38,13 +39,15 @@ public abstract class XAxisBase : IAxis
             Bold = true
         },
     };
+    public Font TickFont { get; set; } = new();
     public abstract Edge Edge { get; }
 
     public void Measure()
     {
         float labelHeight = Label.Font.Size;
         float largestTickHeight = Label.Font.Size;
-        PixelSize = labelHeight + largestTickHeight + 18;
+        float extraPadding = Edge == Edge.Bottom ? 18 : 0;
+        PixelSize = labelHeight + largestTickHeight + extraPadding;
     }
 
     public float GetPixel(double position, PixelRect dataArea)
@@ -65,11 +68,11 @@ public abstract class XAxisBase : IAxis
 
     public void Render(SKSurface surface, PixelRect dataRect)
     {
-        using SKFont font = Label.Font.GetFont();
+        using SKFont tickFont = TickFont.GetFont();
         var ticks = TickGenerator.GetVisibleTicks(Range);
 
         AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Offset, PixelSize);
-        AxisRendering.DrawTicks(surface, font, dataRect, Label.Color, Offset, ticks, this);
+        AxisRendering.DrawTicks(surface, tickFont, dataRect, Label.Color, Offset, ticks, this);
         AxisRendering.DrawFrame(surface, dataRect, Edge, Label.Color, Offset);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/XAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/XAxisBase.cs
@@ -44,10 +44,24 @@ public abstract class XAxisBase : IAxis
 
     public void Measure()
     {
-        float labelHeight = Label.Font.Size;
-        float largestTickHeight = Label.Font.Size;
+        float labelHeight = Label.Font.Size + 15;
+        float largestTickHeight = MeasureTicks();
         float extraPadding = Edge == Edge.Bottom ? 18 : 0;
         PixelSize = labelHeight + largestTickHeight + extraPadding;
+    }
+
+    private float MeasureTicks()
+    {
+        using SKPaint paint = new(TickFont.GetFont());
+        float largestTickHeight = 0;
+
+        foreach (Tick tick in TickGenerator.GetVisibleTicks(Range))
+        {
+            PixelSize tickLabelSize = Drawing.MeasureString(tick.Label, paint);
+            largestTickHeight = Math.Max(largestTickHeight, tickLabelSize.Height + 10);
+        }
+
+        return largestTickHeight;
     }
 
     public float GetPixel(double position, PixelRect dataArea)
@@ -70,6 +84,7 @@ public abstract class XAxisBase : IAxis
     {
         using SKFont tickFont = TickFont.GetFont();
         var ticks = TickGenerator.GetVisibleTicks(Range);
+        float tickSize = MeasureTicks();
 
         AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Offset, PixelSize);
         AxisRendering.DrawTicks(surface, tickFont, dataRect, Label.Color, Offset, ticks, this);

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/YAxisBase.cs
@@ -2,7 +2,7 @@
 
 namespace ScottPlot.Axis.StandardAxes;
 
-public abstract class YAxisBase
+public abstract class YAxisBase : IAxis
 {
     public double Bottom
     {
@@ -31,10 +31,15 @@ public abstract class YAxisBase
     public Label Label { get; private set; } = new()
     {
         Text = "Vertical Axis",
-        Bold = true,
-        FontSize = 16,
+        Font = new Style.Font()
+        {
+            Family = "Consolas",
+            Size = 16,
+            Bold = true
+        },
         Rotation = -90
     };
+    public abstract Edge Edge { get; }
 
     public float GetPixel(double position, PixelRect dataArea)
     {
@@ -54,7 +59,7 @@ public abstract class YAxisBase
 
     public void Measure()
     {
-        float labelWidth = Label.FontSize;
+        float labelWidth = Label.Font.Size;
         float largestTickWidth = 0;
 
         using SKPaint paint = Label.MakePaint();
@@ -67,4 +72,15 @@ public abstract class YAxisBase
 
         PixelSize = labelWidth + largestTickWidth;
     }
+
+    public void Render(SKSurface surface, PixelRect dataRect)
+    {
+        using SKFont font = Label.Font.GetFont();
+
+        var ticks = TickGenerator.GetVisibleTicks(Range);
+        AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Offset, PixelSize);
+        AxisRendering.DrawTicks(surface, font, dataRect, Label.Color, Offset, ticks, this);
+        AxisRendering.DrawFrame(surface, dataRect, Edge, Label.Color, Offset);
+    }
+
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/YAxisBase.cs
@@ -1,4 +1,5 @@
-﻿using SkiaSharp;
+﻿using ScottPlot.Style;
+using SkiaSharp;
 
 namespace ScottPlot.Axis.StandardAxes;
 
@@ -39,6 +40,8 @@ public abstract class YAxisBase : IAxis
         },
         Rotation = -90
     };
+    public Font TickFont { get; set; } = new();
+
     public abstract Edge Edge { get; }
 
     public float GetPixel(double position, PixelRect dataArea)
@@ -75,11 +78,11 @@ public abstract class YAxisBase : IAxis
 
     public void Render(SKSurface surface, PixelRect dataRect)
     {
-        using SKFont font = Label.Font.GetFont();
+        using SKFont tickFont = TickFont.GetFont();
 
         var ticks = TickGenerator.GetVisibleTicks(Range);
         AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Offset, PixelSize);
-        AxisRendering.DrawTicks(surface, font, dataRect, Label.Color, Offset, ticks, this);
+        AxisRendering.DrawTicks(surface, tickFont, dataRect, Label.Color, Offset, ticks, this);
         AxisRendering.DrawFrame(surface, dataRect, Edge, Label.Color, Offset);
     }
 

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/YAxisBase.cs
@@ -62,10 +62,16 @@ public abstract class YAxisBase : IAxis
 
     public void Measure()
     {
-        float labelWidth = Label.Font.Size;
-        float largestTickWidth = 0;
+        float labelWidth = Label.Font.Size + 15;
+        float largestTickWidth = MeasureTicks();
 
-        using SKPaint paint = Label.MakePaint();
+        PixelSize = labelWidth + largestTickWidth;
+    }
+
+    private float MeasureTicks()
+    {
+        using SKPaint paint = new(TickFont.GetFont());
+        float largestTickWidth = 0;
 
         foreach (Tick tick in TickGenerator.GetVisibleTicks(Range))
         {
@@ -73,7 +79,7 @@ public abstract class YAxisBase : IAxis
             largestTickWidth = Math.Max(largestTickWidth, tickLabelSize.Width + 10);
         }
 
-        PixelSize = labelWidth + largestTickWidth;
+        return largestTickWidth;
     }
 
     public void Render(SKSurface surface, PixelRect dataRect)
@@ -81,6 +87,8 @@ public abstract class YAxisBase : IAxis
         using SKFont tickFont = TickFont.GetFont();
 
         var ticks = TickGenerator.GetVisibleTicks(Range);
+        float tickSize = MeasureTicks();
+
         AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Offset, PixelSize);
         AxisRendering.DrawTicks(surface, tickFont, dataRect, Label.Color, Offset, ticks, this);
         AxisRendering.DrawFrame(surface, dataRect, Edge, Label.Color, Offset);

--- a/src/ScottPlot5/ScottPlot5/Label.cs
+++ b/src/ScottPlot5/ScottPlot5/Label.cs
@@ -5,20 +5,18 @@ namespace ScottPlot;
 public class Label
 {
     public string Text { get; set; } = string.Empty;
-    public float FontSize { get; set; } = 12;
-    public string Font { get; set; } = "Consolas";
+    public Style.Font Font { get; set; } = new() { 
+        Family = "Consolas",
+        Size = 12,
+    };
     public Color Color { get; set; } = Colors.Black;
-    public bool Bold { get; set; } = false;
-    public bool Italic { get; set; } = false;
     public bool AntiAlias { get; set; } = true;
     public float Rotation { get; set; } = 0;
 
     public SKPaint MakePaint()
     {
-        return new SKPaint()
+        return new SKPaint(MakeFont())
         {
-            TextSize = FontSize,
-            FakeBoldText = Bold,
             Color = Color.ToSKColor(),
             IsAntialias = AntiAlias,
             TextAlign = SKTextAlign.Center,
@@ -27,7 +25,7 @@ public class Label
 
     public SKFont MakeFont()
     {
-        return new SKFont(SKTypeface.FromFamilyName(Font), FontSize);
+        return Font.GetFont();
     }
 
     public Label()
@@ -37,11 +35,10 @@ public class Label
     public void Draw(SKSurface surface, Pixel point, SKPaint paint)
     {
         using SKFont font = MakeFont();
-        font.Embolden = Bold;
         surface.Canvas.Save();
         surface.Canvas.Translate(point.X, point.Y);
         surface.Canvas.RotateDegrees(Rotation);
-        surface.Canvas.DrawText(Text, 0, FontSize, font, paint);
+        surface.Canvas.DrawText(Text, 0, font.Size, font, paint);
         surface.Canvas.Restore();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Label.cs
+++ b/src/ScottPlot5/ScottPlot5/Label.cs
@@ -5,7 +5,8 @@ namespace ScottPlot;
 public class Label
 {
     public string Text { get; set; } = string.Empty;
-    public Style.Font Font { get; set; } = new() { 
+    public Style.Font Font { get; set; } = new()
+    {
         Family = "Consolas",
         Size = 12,
     };

--- a/src/ScottPlot5/ScottPlot5/Plottables/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Legend.cs
@@ -35,7 +35,7 @@ namespace ScottPlot.Plottables
         {
             using SKFont font = Font.GetFont();
             using SKPaint paint = new(font);
-            
+
             PixelSize size = Measure(paint);
 
             Pixel topLeftCorner = Position.GetPosition(Axes.DataRect, size);

--- a/src/ScottPlot5/ScottPlot5/ScopedTransform.cs
+++ b/src/ScottPlot5/ScottPlot5/ScopedTransform.cs
@@ -26,7 +26,8 @@ namespace ScottPlot
                 if (disposing)
                 {
                     canvas.RestoreToCount(restoreIndex);
-                } else
+                }
+                else
                 {
                     System.Diagnostics.Debug.WriteLine("ScopedTransform was not disposed before finalizer ran. This will likely cause incorrect drawing.");
                     // We shouldn't RestoreToCount here, as a) it's probably even harder to debug, and b) this.canvas has likely been disposed already

--- a/src/ScottPlot5/ScottPlot5/ScopedTransform.cs
+++ b/src/ScottPlot5/ScottPlot5/ScopedTransform.cs
@@ -7,10 +7,11 @@ using System.Threading.Tasks;
 
 namespace ScottPlot
 {
-    internal class ScopedTransform : IDisposable // TODO: I'm a little uneasy on this name?
+    internal class ScopedTransform : IDisposable
     {
         private readonly SKCanvas canvas;
         private readonly int restoreIndex;
+        private bool _disposed;
 
         public ScopedTransform(SKCanvas canvas)
         {
@@ -18,9 +19,34 @@ namespace ScottPlot
             restoreIndex = canvas.Save();
         }
 
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    canvas.RestoreToCount(restoreIndex);
+                } else
+                {
+                    System.Diagnostics.Debug.WriteLine("ScopedTransform was not disposed before finalizer ran. This will likely cause incorrect drawing.");
+                    // We shouldn't RestoreToCount here, as a) it's probably even harder to debug, and b) this.canvas has likely been disposed already
+                }
+
+                _disposed = true;
+            }
+        }
+
+        ~ScopedTransform()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: false);
+        }
+
         public void Dispose()
         {
-            canvas.RestoreToCount(restoreIndex);
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Style/Font.cs
+++ b/src/ScottPlot5/ScottPlot5/Style/Font.cs
@@ -16,8 +16,9 @@ namespace ScottPlot.Style
         public string Family { get; set; } = SKTypeface.Default.FamilyName;
         public int Size { get; set; } = 12;
         public SKFontStyleWeight Weight { get; set; } = SKFontStyleWeight.Normal;
-        public bool Bold { 
-            get => Weight >= SKFontStyleWeight.Bold; 
+        public bool Bold
+        {
+            get => Weight >= SKFontStyleWeight.Bold;
             set => Weight = value ? SKFontStyleWeight.Bold : SKFontStyleWeight.Normal;
         }
         public bool Italic { get; set; } = false;

--- a/src/ScottPlot5/ScottPlot5/Style/Font.cs
+++ b/src/ScottPlot5/ScottPlot5/Style/Font.cs
@@ -28,6 +28,6 @@ namespace ScottPlot.Style
         // SKFontStyle implements IDisposable, but `FromFamilyName` adopts the font style and prevents disposal, so we don't need a using block here
         public SKTypeface GetTypeface() => SKTypeface.FromFamilyName(Family, skFontStyle);
         public SKFont GetFont() => new(GetTypeface(), Size);
-        public bool FontAvailable(string fontFamily) => fontManager.FontFamilies.Contains(fontFamily);
+        public static bool FontAvailable(string fontFamily) => fontManager.FontFamilies.Contains(fontFamily);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Style/Font.cs
+++ b/src/ScottPlot5/ScottPlot5/Style/Font.cs
@@ -1,0 +1,33 @@
+﻿using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Style
+{
+    public struct Font
+    {
+        private static readonly SKFontManager fontManager = SKFontManager.Default;
+
+        public Font() { } // Required since we have field initializers
+
+        public string Family { get; set; } = SKTypeface.Default.FamilyName;
+        public int Size { get; set; } = 12;
+        public SKFontStyleWeight Weight { get; set; } = SKFontStyleWeight.Normal;
+        public bool Bold { 
+            get => Weight >= SKFontStyleWeight.Bold; 
+            set => Weight = value ? SKFontStyleWeight.Bold : SKFontStyleWeight.Normal;
+        }
+        public bool Italic { get; set; } = false;
+
+        private SKFontStyleSlant skFontSlant => Italic ? SKFontStyleSlant.Italic : SKFontStyleSlant.Upright;
+        private SKFontStyle skFontStyle => new(Weight, SKFontStyleWidth.Normal, skFontSlant);
+
+        // SKFontStyle implements IDisposable, but `FromFamilyName` adopts the font style and prevents disposal, so we don't need a using block here
+        public SKTypeface GetTypeface() => SKTypeface.FromFamilyName(Family, skFontStyle);
+        public SKFont GetFont() => new(GetTypeface(), Size);
+        public bool FontAvailable(string fontFamily) => fontManager.FontFamilies.Contains(fontFamily);
+    }
+}


### PR DESCRIPTION
**Purpose:**
Adds a `Font` struct for abstracting `SKFont` and `SKTypeface`. #2144

```cs
const int N = 51;

avaPlot.Plot.Plottables.Add(DebugPoint);
avaPlot.Plot.Add.Scatter(Generate.Consecutive(N), Generate.Sin(N), Colors.Blue).Label = "Scatter";
avaPlot.Plot.Add.Scatter(Generate.Consecutive(N), Generate.Cos(N), Colors.Red).Label = "Scatter 2";
avaPlot.Plot.Add.Scatter(Generate.Consecutive(N), Generate.Sin(N, 0.5), Colors.Green).Label = "Scatter 3";

avaPlot.Plot.Add.Pie(new PieSlice[]
{
new() { Value = 6, Fill = new() { Color = Colors.Red}, Label = "Red" },
new() { Value = 4, Fill = new() { Color = Colors.Blue }, Label = "Blue" },
new() { Value = 3, Fill = new() { Color = Colors.Green }, Label = "Green" },
new() { Value = 1, Fill = new() { Color = Colors.DarkCyan }, Label = "Dark Cyan" },
}).Label = "Pie Chart";

avaPlot.Plot.Add.Signal(Generate.NoisySin(new(), N, 0.1)).Label = "Signal";

var leg = avaPlot.Plot.Add.Legend();
leg.Font = new()
{
    Family = "Arial",
    Size = 26,
    Italic = true,
    Weight = SkiaSharp.SKFontStyleWeight.Black
};
```
<img width="600" alt="image" src="https://user-images.githubusercontent.com/8635304/198851871-b4fa8808-73b8-43f4-8108-3c477447d155.png">
