### PR TITLE
Ensure RandomNormalValue uses u1, u2 from (0,1), not [0,1)

### DIFF
--- a/src/ScottPlot4/ScottPlot/DataGen.cs
+++ b/src/ScottPlot4/ScottPlot/DataGen.cs
@@ -197,7 +197,7 @@ namespace ScottPlot
             double UniformOpenInterval()
             {
                 double subtrahend = 0;
-                while(subtrahend == 0)
+                while (subtrahend == 0)
                 {
                     subtrahend = rand.NextDouble();
                 }

--- a/src/ScottPlot4/ScottPlot/DataGen.cs
+++ b/src/ScottPlot4/ScottPlot/DataGen.cs
@@ -194,10 +194,21 @@ namespace ScottPlot
         /// <returns>A single value from a normal distribution.</returns>
         public static double RandomNormalValue(Random rand, double mean, double stdDev, double maxSdMultiple = 10)
         {
+            double UniformOpenInterval()
+            {
+                double subtrahend = 0;
+                while(subtrahend == 0)
+                {
+                    subtrahend = rand.NextDouble();
+                }
+                return 1.0 - rand.NextDouble();
+                // The simpler 1.0 - rand.NextDouble() actually grabs from the interval [0, 1), not (0, 1)
+            }
+
             while (true)
             {
-                double u1 = 1.0 - rand.NextDouble();
-                double u2 = 1.0 - rand.NextDouble();
+                double u1 = UniformOpenInterval();
+                double u2 = UniformOpenInterval();
                 double randStdNormal = Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Sin(2.0 * Math.PI * u2);
                 if (Math.Abs(randStdNormal) < maxSdMultiple)
                     return mean + stdDev * randStdNormal;

--- a/src/ScottPlot4/ScottPlot/DataGen.cs
+++ b/src/ScottPlot4/ScottPlot/DataGen.cs
@@ -201,7 +201,7 @@ namespace ScottPlot
                 {
                     subtrahend = rand.NextDouble();
                 }
-                return 1.0 - rand.NextDouble();
+                return 1.0 - subtrahend;
                 // The simpler 1.0 - rand.NextDouble() actually grabs from the interval [0, 1), not (0, 1)
             }
 

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -15,6 +15,7 @@ _not yet published on NuGet..._
 * BarSeries: Added helper function to create a bar series from an array of values (#2161) _Thanks @KonH_
 * SignalPlot: Add `Smooth` option (#2174, #2137) _Thanks @rosdyana_
 * Signal Plot: Use correct marker when displaying in legend (#2172, #2173) _Thanks @bclehmann_
+* Data Generation: Improved floating point precision of `RandomNormalValue` randomness (#2189, #2206) _Thanks @arthurits and @bclehmann__
 
 ## ScottPlot 4.1.58
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-09-08_


### PR DESCRIPTION
**Purpose:**
#2189
