### PR TITLE
#2199 - make FinancePlot sort OHLCs when getting SMA or Bollinger bands

### DIFF
--- a/src/ScottPlot4/ScottPlot.Tests/PlottableUnitTests/FinancePlotTests.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlottableUnitTests/FinancePlotTests.cs
@@ -1,0 +1,188 @@
+﻿using NUnit.Framework;
+using ScottPlot.Plottable;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Tests.PlottableUnitTests
+{
+    class FinancePlotTests
+    {
+        [Test]
+        public void Test_GetSMA_HandlesSortedOHLCs()
+        {
+            OHLC[] OHLCs =
+            {
+                new OHLC(0,0,0,1,new DateTime(2000,1,1), TimeSpan.Zero),
+                new OHLC(0,0,0,2,new DateTime(2000,1,2), TimeSpan.Zero),
+                new OHLC(0,0,0,3,new DateTime(2000,1,3), TimeSpan.Zero),
+                new OHLC(0,0,0,4,new DateTime(2000,1,4), TimeSpan.Zero),
+                new OHLC(0,0,0,5,new DateTime(2000,1,5), TimeSpan.Zero),
+                new OHLC(0,0,0,6,new DateTime(2000,1,6), TimeSpan.Zero)
+            };
+
+            var plot = new FinancePlot(OHLCs);
+            var (xs, ys) = plot.GetSMA(2);
+
+            double[] expectedXs =
+            {
+                OHLCs[2].DateTime.ToOADate(),
+                OHLCs[3].DateTime.ToOADate(),
+                OHLCs[4].DateTime.ToOADate(),
+                OHLCs[5].DateTime.ToOADate(),
+            };
+            Assert.AreEqual(expectedXs, xs);
+
+            double[] expectedYs =
+            {
+                2.5,
+                3.5,
+                4.5,
+                5.5
+            };
+            Assert.AreEqual(expectedYs, ys);
+        }
+
+        [Test]
+        public void Test_GetSMA_HandlesUnsortedOHLCs()
+        {
+            OHLC[] OHLCs =
+            {
+                new OHLC(0,0,0,1,new DateTime(2000,1,1), TimeSpan.Zero),
+                new OHLC(0,0,0,2,new DateTime(2000,1,2), TimeSpan.Zero),
+                new OHLC(0,0,0,4,new DateTime(2000,1,4), TimeSpan.Zero),
+                new OHLC(0,0,0,5,new DateTime(2000,1,5), TimeSpan.Zero),
+                new OHLC(0,0,0,6,new DateTime(2000,1,6), TimeSpan.Zero),
+                new OHLC(0,0,0,3,new DateTime(2000,1,3), TimeSpan.Zero)
+            };
+
+            var plot = new FinancePlot(OHLCs);
+            var (xs, ys) = plot.GetSMA(2);
+
+            double[] expectedXs =
+            {
+                OHLCs[5].DateTime.ToOADate(),
+                OHLCs[2].DateTime.ToOADate(),
+                OHLCs[3].DateTime.ToOADate(),
+                OHLCs[4].DateTime.ToOADate(),
+            };
+            Assert.AreEqual(expectedXs, xs);
+
+            double[] expectedYs =
+            {
+                2.5,
+                3.5,
+                4.5,
+                5.5
+            };
+            Assert.AreEqual(expectedYs, ys);
+        }
+        [Test]
+        public void Test_GetBollingerBands_HandlesSortedOHLCs()
+        {
+            OHLC[] OHLCs =
+            {
+                new OHLC(0,0,0,1,new DateTime(2000,1,1), TimeSpan.Zero),
+                new OHLC(0,0,0,2,new DateTime(2000,1,2), TimeSpan.Zero),
+                new OHLC(0,0,0,3,new DateTime(2000,1,3), TimeSpan.Zero),
+                new OHLC(0,0,0,4,new DateTime(2000,1,4), TimeSpan.Zero),
+                new OHLC(0,0,0,5,new DateTime(2000,1,5), TimeSpan.Zero),
+                new OHLC(0,0,0,6,new DateTime(2000,1,6), TimeSpan.Zero)
+            };
+
+            var plot = new FinancePlot(OHLCs);
+            var (xs, ys, lowers, uppers) = plot.GetBollingerBands(2);
+
+            double[] expectedXs =
+            {
+                OHLCs[2].DateTime.ToOADate(),
+                OHLCs[3].DateTime.ToOADate(),
+                OHLCs[4].DateTime.ToOADate(),
+                OHLCs[5].DateTime.ToOADate(),
+            };
+            Assert.AreEqual(expectedXs, xs);
+
+            double[] expectedYs =
+            {
+                2.5,
+                3.5,
+                4.5,
+                5.5
+            };
+            Assert.AreEqual(expectedYs, ys);
+
+            double[] expectedLowers =
+            {
+                1.5,
+                2.5,
+                3.5,
+                4.5
+            };
+            Assert.AreEqual(expectedLowers, lowers);
+
+            double[] expectedUppers =
+            {
+                3.5,
+                4.5,
+                5.5,
+                6.5
+            };
+            Assert.AreEqual(expectedUppers, uppers);
+        }
+
+        [Test]
+        public void Test_GetBollingerBands_HandlesUnsortedOHLCs()
+        {
+            OHLC[] OHLCs =
+            {
+                new OHLC(0,0,0,1,new DateTime(2000,1,1), TimeSpan.Zero),
+                new OHLC(0,0,0,2,new DateTime(2000,1,2), TimeSpan.Zero),
+                new OHLC(0,0,0,4,new DateTime(2000,1,4), TimeSpan.Zero),
+                new OHLC(0,0,0,5,new DateTime(2000,1,5), TimeSpan.Zero),
+                new OHLC(0,0,0,6,new DateTime(2000,1,6), TimeSpan.Zero),
+                new OHLC(0,0,0,3,new DateTime(2000,1,3), TimeSpan.Zero)
+            };
+
+            var plot = new FinancePlot(OHLCs);
+            var (xs, ys, lowers, uppers) = plot.GetBollingerBands(2);
+
+            double[] expectedXs =
+            {
+                OHLCs[5].DateTime.ToOADate(),
+                OHLCs[2].DateTime.ToOADate(),
+                OHLCs[3].DateTime.ToOADate(),
+                OHLCs[4].DateTime.ToOADate(),
+            };
+            Assert.AreEqual(expectedXs, xs);
+
+            double[] expectedYs =
+            {
+                2.5,
+                3.5,
+                4.5,
+                5.5
+            };
+            Assert.AreEqual(expectedYs, ys);
+
+            double[] expectedLowers =
+            {
+                1.5,
+                2.5,
+                3.5,
+                4.5
+            };
+            Assert.AreEqual(expectedLowers, lowers);
+
+            double[] expectedUppers =
+            {
+                3.5,
+                4.5,
+                5.5,
+                6.5
+            };
+            Assert.AreEqual(expectedUppers, uppers);
+        }
+    }
+}

--- a/src/ScottPlot4/ScottPlot/Plottable/FinancePlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/FinancePlot.cs
@@ -277,8 +277,9 @@ namespace ScottPlot.Plottable
             if (N >= OHLCs.Count)
                 throw new ArgumentException("can not analyze more points than are available in the OHLCs");
 
-            double[] xs = OHLCs.Skip(N).Select(x => x.DateTime.ToOADate()).ToArray();
-            double[] ys = Statistics.Finance.SMA(OHLCs.ToArray(), N);
+            var sortedOHLCs = GetSortedOHLCs();
+            double[] xs = sortedOHLCs.Skip(N).Select(x => x.DateTime.ToOADate()).ToArray();
+            double[] ys = Statistics.Finance.SMA(sortedOHLCs.ToArray(), N);
             return (xs, ys);
         }
 
@@ -294,9 +295,33 @@ namespace ScottPlot.Plottable
             if (N >= OHLCs.Count)
                 throw new ArgumentException("can not analyze more points than are available in the OHLCs");
 
-            double[] xs = OHLCs.Skip(N).Select(x => x.DateTime.ToOADate()).ToArray();
-            (var sma, var lower, var upper) = Statistics.Finance.Bollinger(OHLCs.ToArray(), N);
+            var sortedOHLCs = GetSortedOHLCs();
+            double[] xs = sortedOHLCs.Skip(N).Select(x => x.DateTime.ToOADate()).ToArray();
+            (var sma, var lower, var upper) = Statistics.Finance.Bollinger(sortedOHLCs.ToArray(), N);
             return (xs, sma, lower, upper);
+        }
+
+        private List<OHLC> GetSortedOHLCs()
+        {
+            if (OHLCsAreSorted())
+            {
+                return OHLCs;
+            }
+
+            return OHLCs.OrderBy(ohlc => ohlc.DateTime).ToList();
+        }
+
+        private bool OHLCsAreSorted()
+        {
+            for (var i = 0; i < OHLCs.Count - 1; i++)
+            {
+                if (OHLCs[i].DateTime > OHLCs[i + 1].DateTime)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -15,6 +15,7 @@ _not yet published on NuGet..._
 * BarSeries: Added helper function to create a bar series from an array of values (#2161) _Thanks @KonH_
 * SignalPlot: Add `Smooth` option (#2174, #2137) _Thanks @rosdyana_
 * Signal Plot: Use correct marker when displaying in legend (#2172, #2173) _Thanks @bclehmann_
+* Finance Plot: Improved SMA calculations for charts with unordered candlesticks (#2199, #2207) _Thanks @zachesposito and @xenedia_
 
 ## ScottPlot 4.1.58
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-09-08_


### PR DESCRIPTION
**Purpose:**
#2199 highlighted that `FinancePlot`'s assumption that its `OHLCs` are always sorted by datetime can be confusing to users. This change makes sure `OHLCs` gets sorted before trying to calculate SMAs or BollingerBands, so that those methods work even if the user doesn't provide sorted OHLCs.
