### PR TITLE
AvaPlot: fix subscription to ContexMenu property changes

### DIFF
--- a/src/ScottPlot4/ScottPlot.Avalonia/AvaPlot.axaml.cs
+++ b/src/ScottPlot4/ScottPlot.Avalonia/AvaPlot.axaml.cs
@@ -75,6 +75,11 @@ namespace ScottPlot.Avalonia
         [Obsolete("Reference Plot instead of plt")]
         public ScottPlot.Plot plt => Plot;
 
+        static AvaPlot()
+        {
+            ContextMenuProperty.Changed.AddClassHandler<AvaPlot>((plot, args) => plot.ContextMenuChanged(args));
+        }
+
         public AvaPlot()
         {
             InitializeComponent();
@@ -103,7 +108,6 @@ namespace ScottPlot.Avalonia
             Backend.Configuration.ScaleChanged += new EventHandler(OnScaleChanged);
             Configuration = Backend.Configuration;
 
-            ContextMenuProperty.Changed.Subscribe(ContextMenuChanged);
             ContextMenu = GetDefaultContextMenu();
 
             InitializeLayout();

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -17,6 +17,7 @@ _not yet published on NuGet..._
 * Signal Plot: Use correct marker when displaying in legend (#2172, #2173) _Thanks @bclehmann_
 * Data Generation: Improved floating point precision of `RandomNormalValue` randomness (#2189, #2206) _Thanks @arthurits and @bclehmann__
 * Finance Plot: Improved SMA calculations for charts with unordered candlesticks (#2199, #2207) _Thanks @zachesposito and @xenedia_
+* Avalonia Control: Fixed subscription to ContexMenu property changes (#2215) _Thanks @DmitryZhelnin_
 
 ## ScottPlot 4.1.58
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-09-08_


### PR DESCRIPTION
**Purpose:**
* This PR fixes subscription to changes of `ContextMenu` property of `AvaPlot` control
* Previous implementations subscribes to `ContextMenu` changes of **ALL** controls which is wrong. As a result custom logic of `AvaPlot` `ContextMenu` opening applies to another controls and breaks their behavior.