### PR TITLE
ScottPlot 5: Mirrored Axes

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/MirroredXAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/MirroredXAxis.cs
@@ -1,0 +1,16 @@
+﻿
+namespace ScottPlot.Axis.StandardAxes;
+public sealed class MirroredXAxis : XAxisBase, IXAxis
+{
+    private readonly Edge _edge;
+    private readonly IXAxis _axis;
+    public override Edge Edge => _edge;
+    public override CoordinateRange Range => _axis.Range;
+
+    public MirroredXAxis(IXAxis axis, Edge? edge)
+    {
+        _axis = axis;
+        _edge = edge ?? axis.Edge;
+        TickGenerator = axis.TickGenerator;
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/MirroredYAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/MirroredYAxis.cs
@@ -1,0 +1,16 @@
+﻿
+namespace ScottPlot.Axis.StandardAxes;
+public sealed class MirroredYAxis : YAxisBase, IYAxis
+{
+    private readonly Edge _edge;
+    private readonly IYAxis _axis;
+    public override Edge Edge => _edge;
+    public override CoordinateRange Range => _axis.Range;
+
+    public MirroredYAxis(IYAxis axis, Edge? edge)
+    {
+        _axis = axis;
+        _edge = edge ?? axis.Edge;
+        TickGenerator = axis.TickGenerator;
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/XAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/XAxisBase.cs
@@ -19,7 +19,7 @@ public abstract class XAxisBase : IAxis
 
     public double Width => Range.Span;
 
-    public CoordinateRange Range { get; private set; } = CoordinateRange.NotSet;
+    public virtual CoordinateRange Range { get; private set; } = CoordinateRange.NotSet;
 
     public ITickGenerator TickGenerator { get; set; } = null!;
 

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/YAxisBase.cs
@@ -19,7 +19,7 @@ public abstract class YAxisBase : IAxis
 
     public double Height => Range.Span;
 
-    public CoordinateRange Range { get; private set; } = CoordinateRange.NotSet;
+    public virtual CoordinateRange Range { get; private set; } = CoordinateRange.NotSet;
 
     public float Offset { get; set; } = 0;
 


### PR DESCRIPTION
**Purpose:**
In ScottPlot 5 there isn't a way to associate multiple x-axes or multiple y-axes with a single plottable, and this makes it difficult to have (for example) a bottom and a top axis showing the same ticks.

My solution was to simply create a `MirroredXAxis` and `MirroredYAxis`, which mirror the given axis onto the given edge. It derives its ticks and range entirely from the axis it is mirroring.

```cs
var xaxis2 = new MirroredXAxis(avaPlot.Plot.XAxis, Edge.Top);
avaPlot.Plot.XAxes.Add(xaxis2);

var yaxis2 = new MirroredYAxis(avaPlot.Plot.YAxis, Edge.Right);
avaPlot.Plot.YAxes.Add(yaxis2);
```
<img width="400" alt="image" src="https://user-images.githubusercontent.com/8635304/199852080-edc8a657-6d3e-47c4-a298-69b21841f637.png">
