### PR TITLE
GetMaskColorFilter: Corrects alpha channel

### DIFF
--- a/src/ScottPlot5/ScottPlot5/ColorFilterHelpers.cs
+++ b/src/ScottPlot5/ScottPlot5/ColorFilterHelpers.cs
@@ -9,6 +9,7 @@ namespace ScottPlot
 {
     internal static class ColorFilterHelpers
     {
+        // This function and the math is explained here: https://bclehmann.github.io/2022/11/06/UnmaskingWithSKColorFilter.html
         public static SKColorFilter GetMaskColorFilter(Color foreground, Color? background = null)
         {
             background ??= Colors.Black;
@@ -26,7 +27,7 @@ namespace ScottPlot
                 redDifference / 255, 0, 0, 0, background.Value.Red / 255.0f,
                 0, greenDifference / 255, 0, 0, background.Value.Green / 255.0f,
                 0, 0, blueDifference / 255, 0, background.Value.Blue / 255.0f,
-                0, 0, 0, alphaDifference / 255, background.Value.Alpha / 255.0f,
+                alphaDifference / 255, 0, 0, 0, background.Value.Alpha / 255.0f,
             };
 
             var filter = SKColorFilter.CreateColorMatrix(mat);


### PR DESCRIPTION
**Purpose:**
In my math I forgot that black is the vector $[0, 0, 0, 255, 1]$, not $[0, 0, 0, 0, 1]$, so I couldn't treat the alpha channel the same as the other channels. This was fixed by simply moving the coefficient from the alpha channel to the red channel, because we just need a channel that is 0 in black, but 1 in white.

For what it's worth, this was pointed out by someone who read my blog post, so I guess that's another reason Scott was right about starting a blog.

While I was at it, I also added a link to that article, because I think a few months down the line it's going to be confusing where that matrix comes from and why it's correct.