### PR TITLE
Pie: Fixes explode for slices of 100%

### DIFF
--- a/src/ScottPlot4/ScottPlot/Plottable/PiePlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/PiePlot.cs
@@ -153,22 +153,26 @@ namespace ScottPlot.Plottable
                     labelStrings[i] = $"{sliceLabelValue}\n{sliceLabelPercentage}\n{sliceLabelName}".Trim();
 
                     using var sliceFillBrush = GDI.Brush(SliceFillColors[i], HatchOptions?[i].Color, HatchOptions?[i].Pattern ?? Drawing.HatchStyle.None);
-                    gfx.FillPie(brush: sliceFillBrush,
-                        x: (int)(boundingRectangle.X + xOffset),
-                        y: (int)(boundingRectangle.Y + yOffset),
-                        width: boundingRectangle.Width,
-                        height: boundingRectangle.Height,
-                        startAngle: (float)start,
-                        sweepAngle: (float)(sweep + sweepOffset));
 
-                    if (Explode)
+                    var offsetRectangle = new Rectangle((int)(boundingRectangle.X + xOffset), (int)(boundingRectangle.Y + yOffset), (int)boundingRectangle.Width, (int)boundingRectangle.Height);
+                    if (sweep != 360)
+                    {
+                        gfx.FillPie(brush: sliceFillBrush,
+                            rect: offsetRectangle,
+                            startAngle: (float)start,
+                            sweepAngle: (float)(sweep + sweepOffset));
+                    }
+                    else
+                    {
+                        gfx.FillEllipse(sliceFillBrush, offsetRectangle);
+                    }
+
+
+                    if (Explode && sweep != 360)
                     {
                         gfx.DrawPie(
                             pen: backgroundPen,
-                            x: (int)(boundingRectangle.X + xOffset),
-                            y: (int)(boundingRectangle.Y + yOffset),
-                            width: boundingRectangle.Width,
-                            height: boundingRectangle.Height,
+                            rect: offsetRectangle,
                             startAngle: (float)start,
                             sweepAngle: (float)(sweep + sweepOffset));
                     }


### PR DESCRIPTION
**Purpose:**
#2248

```cs
plt.AddPie(new double[] { 1 }).Explode = true;
```

Before:
![image](https://user-images.githubusercontent.com/8635304/200969088-e9899001-7307-4a06-a10e-fbb7c5923f7f.png)

After:
![image](https://user-images.githubusercontent.com/8635304/200969037-16a3a384-bdb3-4074-ac18-21a8ae2b637e.png)