### PR TITLE
ScottPlot 5: Fix pies of 100%

### DIFF
--- a/src/ScottPlot5/ScottPlot5/PlottableFactory.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableFactory.cs
@@ -11,7 +11,8 @@ public class PlottableFactory
     private readonly Plot Plot;
 
     public IPalette Palette { get; set; } = new Palettes.Category10();
-    private Color NextColor => Palette.GetColor(Plot.Plottables.Count);
+    private int colorsUsed = 0;
+    private Color NextColor => Palette.GetColor(colorsUsed++);
 
     public PlottableFactory(Plot plot)
     {
@@ -37,6 +38,16 @@ public class PlottableFactory
         Pie pie = new(slices);
         Plot.Plottables.Add(pie);
         return pie;
+    }
+
+    public Pie Pie(IEnumerable<double> values)
+    {
+        var slices = values.Select(v => new PieSlice
+        {
+            Value = v,
+            Fill = new(NextColor)
+        }).ToList();
+        return Pie(slices);
     }
 
     public Scatter Scatter(IReadOnlyList<double> xs, IReadOnlyList<double> ys, Color? color = null)

--- a/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
@@ -80,9 +80,16 @@ namespace ScottPlot.Plottables
                 surface.Canvas.RotateDegrees(rotation);
                 surface.Canvas.Translate(explosionRadius, 0);
 
-                path.MoveTo(0, 0);
-                path.ArcTo(rect, -sweeps[i] / 2, sweeps[i], false);
-                path.Close();
+                if (sweeps[i] != 360)
+                {
+                    path.MoveTo(0, 0);
+                    path.ArcTo(rect, -sweeps[i] / 2, sweeps[i], false);
+                    path.Close();
+                }
+                else
+                {
+                    path.AddOval(rect);
+                }
 
                 paint.SetFill(Slices[i].Fill);
                 paint.Shader = paint.Shader?.WithLocalMatrix(SKMatrix.CreateRotationDegrees(-rotation));


### PR DESCRIPTION
**Purpose:**
Pie slices taking up 100% were broken:
<img width="598" alt="image" src="https://user-images.githubusercontent.com/8635304/200970723-25d0018b-bb52-4bc6-9fb4-a2251f9d9389.png">

They are now fixed:
<img width="599" alt="image" src="https://user-images.githubusercontent.com/8635304/200970782-944850bd-8070-4af7-8c5f-d018c346f258.png">

```cs
avaPlot.Plot.Add.Pie(new double[] { 1 });
```

Unlike #2248, they were broken even for non-exploded pies.