### PR TITLE
CI: Bump actions

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -19,9 +19,9 @@ jobs:
     name: 🧪 Test on ${{ matrix.osName }}
     steps:
       - name: 🛒 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: ✨ Setup .NET 6.0
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: "6.0.x"
       - name: 🚚 Restore

--- a/.github/workflows/ci-v4.yaml
+++ b/.github/workflows/ci-v4.yaml
@@ -17,9 +17,9 @@ jobs:
     name: Check Formatting
     steps:
       - name: 🛒 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: ✨ Set up .NET 6.0
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: "6.0.x"
       - name: ✒️ Set up dotnet-format
@@ -43,9 +43,9 @@ jobs:
     name: Test on ${{ matrix.osName }}
     steps:
       - name: 🛒 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: ✨ Setup .NET 6.0
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: "6.0.x"
 

--- a/.github/workflows/ci-v5.yaml
+++ b/.github/workflows/ci-v5.yaml
@@ -17,9 +17,9 @@ jobs:
     name: Check Formatting
     steps:
       - name: 🛒 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: ✨ Set up .NET 6.0
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: "6.0.x"
       - name: ✒️ Set up dotnet-format
@@ -45,9 +45,9 @@ jobs:
     name: Test on ${{ matrix.osName }}
     steps:
       - name: 🛒 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: ✨ Setup .NET 6.0
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: "6.0.x"
 

--- a/.github/workflows/cookbook.yaml
+++ b/.github/workflows/cookbook.yaml
@@ -26,9 +26,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: 🛒 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: ✨ Set up .NET 6.0
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: "6.0.x"
 

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: 🛒 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: ✨ Setup .NET 6
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: "6.0.x"
 
@@ -57,7 +57,7 @@ jobs:
           nuget push "src\ScottPlot4\ScottPlot.Eto\bin\Release\*.nupkg" -SkipDuplicate -Source https://api.nuget.org/v3/index.json
 
       - name: 💾 Store Packages
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ScottPlot-Packages
           retention-days: 1

--- a/src/ScottPlot5/todo.md
+++ b/src/ScottPlot5/todo.md
@@ -20,3 +20,7 @@ plt.SaveJpeg("test.jpg", width: 500, height: 400, quality: 85);
 plt.SavePng("test.png", width: 500, height: 400);
 plt.SaveWebp("test.png", width: 500, height: 400);
 ```
+
+### CI
+
+Figure out how to enable auto-merge for _optional_ status checks


### PR DESCRIPTION
**Purpose:**
Node.js 12 actions are deprecated. The versions of the actions involved have been updated in this PR.

**Details:**
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
