### PR TITLE
ScottPlot 5: Refactor layout system to use IPanel, adds ColorBar

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Axis/AxisRendering.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/AxisRendering.cs
@@ -58,8 +58,6 @@ public static class AxisRendering
         surface.Canvas.DrawLine(x1, y1, x2, y2, paint);
     }
 
-    static int i = 0;
-    static int j = 0;
     public static void DrawLabel(SKSurface surface, PixelRect dataRect, Edge edge, Label label, float pixelSize)
     {
         using var paint = label.MakePaint();

--- a/src/ScottPlot5/ScottPlot5/Axis/AxisRendering.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/AxisRendering.cs
@@ -85,12 +85,6 @@ public static class AxisRendering
             _ => throw new InvalidEnumArgumentException()
         };
 
-        if (edge == Edge.Bottom)
-            surface.Canvas.DrawRect(dataRect.Left, dataRect.Bottom, dataRect.Width, pixelSize, new SKPaint() { Color = i++ % 2 == 0 ? SKColors.Cyan.WithAlpha(80) : SKColors.Pink.WithAlpha(80) });
-
-        if (edge == Edge.Left)
-            surface.Canvas.DrawRect(dataRect.Left - pixelSize, dataRect.Top, pixelSize, dataRect.Height, new SKPaint() { Color = j++ % 2 == 0 ? SKColors.Cyan.WithAlpha(80) : SKColors.Pink.WithAlpha(80) });
-
         label.Draw(surface, px, paint);
     }
 

--- a/src/ScottPlot5/ScottPlot5/Axis/AxisRendering.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/AxisRendering.cs
@@ -11,12 +11,12 @@ public static class AxisRendering
     /// <summary>
     /// Draw a line along the edge of an axis on the side of the data area
     /// </summary>
-    public static void DrawFrame(SKSurface surface, PixelRect dataRect, Edge edge, Color color, float offset)
+    public static void DrawFrame(SKSurface surface, PixelRect dataRect, Edge edge, Color color)
     {
         float x1 = edge switch
         {
-            Edge.Left => dataRect.Left - offset,
-            Edge.Right => dataRect.Right + offset,
+            Edge.Left => dataRect.Left,
+            Edge.Right => dataRect.Right,
             Edge.Top => dataRect.Left,
             Edge.Bottom => dataRect.Left,
             _ => throw new InvalidEnumArgumentException(),
@@ -24,8 +24,8 @@ public static class AxisRendering
 
         float x2 = edge switch
         {
-            Edge.Left => dataRect.Left - offset,
-            Edge.Right => dataRect.Right + offset,
+            Edge.Left => dataRect.Left,
+            Edge.Right => dataRect.Right,
             Edge.Top => dataRect.Right,
             Edge.Bottom => dataRect.Right,
             _ => throw new InvalidEnumArgumentException(),
@@ -35,8 +35,8 @@ public static class AxisRendering
         {
             Edge.Left => dataRect.Top,
             Edge.Right => dataRect.Top,
-            Edge.Top => dataRect.Top - offset,
-            Edge.Bottom => dataRect.Bottom + offset,
+            Edge.Top => dataRect.Top,
+            Edge.Bottom => dataRect.Bottom,
             _ => throw new InvalidEnumArgumentException(),
         };
 
@@ -44,8 +44,8 @@ public static class AxisRendering
         {
             Edge.Left => dataRect.Bottom,
             Edge.Right => dataRect.Bottom,
-            Edge.Top => dataRect.Top - offset,
-            Edge.Bottom => dataRect.Bottom + offset,
+            Edge.Top => dataRect.Top,
+            Edge.Bottom => dataRect.Bottom,
             _ => throw new InvalidEnumArgumentException(),
         };
 
@@ -58,27 +58,27 @@ public static class AxisRendering
         surface.Canvas.DrawLine(x1, y1, x2, y2, paint);
     }
 
-    public static void DrawLabel(SKSurface surface, PixelRect dataRect, Edge edge, Label label, float offset, float pixelSize)
+    public static void DrawLabel(SKSurface surface, PixelRect dataRect, Edge edge, Label label, float pixelSize)
     {
         using var paint = label.MakePaint();
 
         Pixel px = edge switch
         {
             Edge.Left => new(
-                x: dataRect.Left - offset - pixelSize,
+                x: dataRect.Left - pixelSize,
                 y: dataRect.VerticalCenter),
 
             Edge.Right => new(
-                x: dataRect.Right + offset + pixelSize - paint.FontSpacing,
+                x: dataRect.Right + pixelSize - paint.FontSpacing - 5,
                 y: dataRect.VerticalCenter),
 
             Edge.Bottom => new(
                 x: dataRect.HorizontalCenter,
-                y: dataRect.Bottom + offset + pixelSize - paint.FontSpacing - 5),
+                y: dataRect.Bottom + pixelSize - paint.FontSpacing - 5),
 
             Edge.Top => new(
                 x: dataRect.HorizontalCenter,
-                y: dataRect.Top - paint.FontSpacing - 16 - offset - pixelSize), // tick label size
+                y: dataRect.Top - pixelSize),
 
             _ => throw new InvalidEnumArgumentException()
         };
@@ -86,7 +86,7 @@ public static class AxisRendering
         label.Draw(surface, px, paint);
     }
 
-    private static void DrawTicksHorizontalAxis(SKSurface surface, SKFont font, PixelRect dataRect, Color color, float offset, IEnumerable<Tick> ticks, IAxis axis)
+    private static void DrawTicksHorizontalAxis(SKSurface surface, SKFont font, PixelRect dataRect, Color color, IEnumerable<Tick> ticks, IAxis axis)
     {
         if (axis.Edge != Edge.Bottom && axis.Edge != Edge.Top)
         {
@@ -104,7 +104,7 @@ public static class AxisRendering
         foreach (Tick tick in ticks)
         {
             float xPx = axis.GetPixel(tick.Position, dataRect);
-            float y = axis.Edge == Edge.Bottom ? dataRect.Bottom + offset : dataRect.Top - offset;
+            float y = axis.Edge == Edge.Bottom ? dataRect.Bottom : dataRect.Top;
             float yEdge = axis.Edge == Edge.Bottom ? y + 3 : y - 3;
             float fontSpacing = axis.Edge == Edge.Bottom ? paint.TextSize : -4;
 
@@ -115,7 +115,7 @@ public static class AxisRendering
         }
     }
 
-    private static void DrawTicksVerticalAxis(SKSurface surface, SKFont font, PixelRect dataRect, Color color, float offset, IEnumerable<Tick> ticks, IAxis axis)
+    private static void DrawTicksVerticalAxis(SKSurface surface, SKFont font, PixelRect dataRect, Color color, IEnumerable<Tick> ticks, IAxis axis)
     {
         if (axis.Edge != Edge.Left && axis.Edge != Edge.Right)
         {
@@ -131,7 +131,7 @@ public static class AxisRendering
 
         foreach (Tick tick in ticks)
         {
-            float x = axis.Edge == Edge.Left ? dataRect.Left - offset : dataRect.Right + offset;
+            float x = axis.Edge == Edge.Left ? dataRect.Left : dataRect.Right;
             float y = axis.GetPixel(tick.Position, dataRect);
 
             float majorTickLength = 5;
@@ -145,12 +145,12 @@ public static class AxisRendering
         }
     }
 
-    public static void DrawTicks(SKSurface surface, SKFont font, PixelRect dataRect, Color color, float offset, IEnumerable<Tick> ticks, IAxis axis)
+    public static void DrawTicks(SKSurface surface, SKFont font, PixelRect dataRect, Color color, IEnumerable<Tick> ticks, IAxis axis)
     {
         if (axis.Edge == Edge.Left || axis.Edge == Edge.Right)
-            DrawTicksVerticalAxis(surface, font, dataRect, color, offset, ticks, axis);
+            DrawTicksVerticalAxis(surface, font, dataRect, color, ticks, axis);
         else if (axis.Edge == Edge.Bottom || axis.Edge == Edge.Top)
-            DrawTicksHorizontalAxis(surface, font, dataRect, color, offset, ticks, axis);
+            DrawTicksHorizontalAxis(surface, font, dataRect, color, ticks, axis);
         else
             throw new InvalidEnumArgumentException();
     }

--- a/src/ScottPlot5/ScottPlot5/Axis/AxisRendering.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/AxisRendering.cs
@@ -58,6 +58,8 @@ public static class AxisRendering
         surface.Canvas.DrawLine(x1, y1, x2, y2, paint);
     }
 
+    static int i = 0;
+    static int j = 0;
     public static void DrawLabel(SKSurface surface, PixelRect dataRect, Edge edge, Label label, float pixelSize)
     {
         using var paint = label.MakePaint();
@@ -65,7 +67,7 @@ public static class AxisRendering
         Pixel px = edge switch
         {
             Edge.Left => new(
-                x: dataRect.Left - pixelSize,
+                x: dataRect.Left - pixelSize + 5,
                 y: dataRect.VerticalCenter),
 
             Edge.Right => new(
@@ -82,6 +84,12 @@ public static class AxisRendering
 
             _ => throw new InvalidEnumArgumentException()
         };
+
+        if (edge == Edge.Bottom)
+            surface.Canvas.DrawRect(dataRect.Left, dataRect.Bottom, dataRect.Width, pixelSize, new SKPaint() { Color = i++ % 2 == 0 ? SKColors.Cyan.WithAlpha(80) : SKColors.Pink.WithAlpha(80) });
+
+        if (edge == Edge.Left)
+            surface.Canvas.DrawRect(dataRect.Left - pixelSize, dataRect.Top, pixelSize, dataRect.Height, new SKPaint() { Color = j++ % 2 == 0 ? SKColors.Cyan.WithAlpha(80) : SKColors.Pink.WithAlpha(80) });
 
         label.Draw(surface, px, paint);
     }

--- a/src/ScottPlot5/ScottPlot5/Axis/IAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/IAxis.cs
@@ -1,4 +1,6 @@
-﻿namespace ScottPlot.Axis;
+﻿using ScottPlot.LayoutSystem;
+
+namespace ScottPlot.Axis;
 
 /// <summary>
 /// This interface describes a 1D axis (horizontal or vertical).
@@ -6,13 +8,8 @@
 /// tick generation (and rendering), axis label rendering, 
 /// and self-measurement for layout purposes.
 /// </summary>
-public interface IAxis
+public interface IAxis : IPanel
 {
-    /// <summary>
-    /// Describes which edge this 1D axis represents
-    /// </summary>
-    Edge Edge { get; }
-
     /// <summary>
     /// Min/Max range currently displayed by this axis
     /// </summary>
@@ -37,23 +34,7 @@ public interface IAxis
     ITickGenerator TickGenerator { get; set; }
 
     /// <summary>
-    /// Gets the size of the axis in pixels.
-    /// </summary>
-    float Measure();
-
-    /// <summary>
     /// The label is the text displayed distal to the ticks
     /// </summary>
     Label Label { get; }
-
-    /// <summary>
-    /// Distance from the data are to offset this axis (to make room for multiple axes)
-    /// </summary>
-    float Offset { get; set; }
-
-    // TODO: move the label and ticks into their own interfaces each with a Render()
-    /// <summary>
-    /// Draw axis label and tick marks
-    /// </summary>
-    void Render(SkiaSharp.SKSurface surface, PixelRect dataRect);
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/IAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/IAxis.cs
@@ -15,6 +15,9 @@ public interface IAxis : IPanel
     /// </summary>
     CoordinateRange Range { get; }
 
+    double Min { get; set; }
+    double Max { get; set; }
+
     /// <summary>
     /// Get the pixel position of a coordinate given the location and size of the data area
     /// </summary>

--- a/src/ScottPlot5/ScottPlot5/Axis/IAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/IAxis.cs
@@ -37,14 +37,9 @@ public interface IAxis
     ITickGenerator TickGenerator { get; set; }
 
     /// <summary>
-    /// Update the value of <see cref="PixelSize"/> 
+    /// Gets the size of the axis in pixels.
     /// </summary>
-    void Measure();
-
-    /// <summary>
-    /// Size required to draw this axis given the most recently generated ticks.
-    /// </summary>
-    float PixelSize { get; }
+    float Measure();
 
     /// <summary>
     /// The label is the text displayed distal to the ticks

--- a/src/ScottPlot5/ScottPlot5/Axis/IXAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/IXAxis.cs
@@ -6,6 +6,4 @@
 public interface IXAxis : IAxis
 {
     public double Width { get; }
-    public double Left { get; set; }
-    public double Right { get; set; }
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/IXAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/IXAxis.cs
@@ -8,5 +8,4 @@ public interface IXAxis : IAxis
     public double Width { get; }
     public double Left { get; set; }
     public double Right { get; set; }
-    float PixelHeight { get; }
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/IYAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/IYAxis.cs
@@ -8,5 +8,4 @@ public interface IYAxis : IAxis
     public double Height { get; }
     public double Bottom { get; set; }
     public double Top { get; set; }
-    float PixelWidth { get; }
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/IYAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/IYAxis.cs
@@ -6,6 +6,4 @@
 public interface IYAxis : IAxis
 {
     public double Height { get; }
-    public double Bottom { get; set; }
-    public double Top { get; set; }
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/MirroredXAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/MirroredXAxis.cs
@@ -5,7 +5,7 @@ public sealed class MirroredXAxis : XAxisBase, IXAxis
     private readonly Edge _edge;
     private readonly IXAxis _axis;
     public override Edge Edge => _edge;
-    public override CoordinateRange Range => _axis.Range;
+    public override CoordinateRange Range => new(_axis.Left, _axis.Right);
 
     public MirroredXAxis(IXAxis axis, Edge? edge)
     {

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/MirroredXAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/MirroredXAxis.cs
@@ -5,7 +5,7 @@ public sealed class MirroredXAxis : XAxisBase, IXAxis
     private readonly Edge _edge;
     private readonly IXAxis _axis;
     public override Edge Edge => _edge;
-    public override CoordinateRange Range => new(_axis.Left, _axis.Right);
+    public override CoordinateRange Range => new(_axis.Min, _axis.Max);
 
     public MirroredXAxis(IXAxis axis, Edge? edge)
     {

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/MirroredYAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/MirroredYAxis.cs
@@ -5,7 +5,7 @@ public sealed class MirroredYAxis : YAxisBase, IYAxis
     private readonly Edge _edge;
     private readonly IYAxis _axis;
     public override Edge Edge => _edge;
-    public override CoordinateRange Range => _axis.Range;
+    public override CoordinateRange Range => new(_axis.Bottom, _axis.Top);
 
     public MirroredYAxis(IYAxis axis, Edge? edge)
     {

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/MirroredYAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/MirroredYAxis.cs
@@ -5,7 +5,7 @@ public sealed class MirroredYAxis : YAxisBase, IYAxis
     private readonly Edge _edge;
     private readonly IYAxis _axis;
     public override Edge Edge => _edge;
-    public override CoordinateRange Range => new(_axis.Bottom, _axis.Top);
+    public override CoordinateRange Range => new(_axis.Min, _axis.Max);
 
     public MirroredYAxis(IYAxis axis, Edge? edge)
     {

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/XAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/XAxisBase.cs
@@ -38,10 +38,12 @@ public abstract class XAxisBase : IAxis
 
     public float Measure()
     {
-        float labelHeight = Label.Font.Size + 15;
+        using SKPaint paint = new(Label.Font.GetFont());
+
+        float labelHeight = Drawing.MeasureString(Label.Text, paint).Height;
         float largestTickHeight = MeasureTicks();
-        float extraPadding = Edge == Edge.Bottom ? 18 : 0;
-        return labelHeight + largestTickHeight + extraPadding;
+
+        return labelHeight + largestTickHeight + 15;
     }
 
     private float MeasureTicks()

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/XAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/XAxisBase.cs
@@ -23,8 +23,6 @@ public abstract class XAxisBase : IAxis
 
     public ITickGenerator TickGenerator { get; set; } = null!;
 
-    public float Offset { get; set; } = 0;
-
     public Label Label { get; private set; } = new()
     {
         Text = "Horizontal Axis",
@@ -82,9 +80,9 @@ public abstract class XAxisBase : IAxis
         var ticks = TickGenerator.GetVisibleTicks(Range);
         float tickSize = MeasureTicks();
 
-        AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Offset, Measure());
-        AxisRendering.DrawTicks(surface, tickFont, dataRect, Label.Color, Offset, ticks, this);
-        AxisRendering.DrawFrame(surface, dataRect, Edge, Label.Color, Offset);
+        AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Measure());
+        AxisRendering.DrawTicks(surface, tickFont, dataRect, Label.Color, ticks, this);
+        AxisRendering.DrawFrame(surface, dataRect, Edge, Label.Color);
     }
 
     public double GetPixelDistance(double distance, PixelRect dataArea)

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/XAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/XAxisBase.cs
@@ -25,10 +25,6 @@ public abstract class XAxisBase : IAxis
 
     public float Offset { get; set; } = 0;
 
-    public float PixelSize { get; private set; } = 50;
-
-    public float PixelHeight => PixelSize;
-
     public Label Label { get; private set; } = new()
     {
         Text = "Horizontal Axis",
@@ -42,12 +38,12 @@ public abstract class XAxisBase : IAxis
     public Font TickFont { get; set; } = new();
     public abstract Edge Edge { get; }
 
-    public void Measure()
+    public float Measure()
     {
         float labelHeight = Label.Font.Size + 15;
         float largestTickHeight = MeasureTicks();
         float extraPadding = Edge == Edge.Bottom ? 18 : 0;
-        PixelSize = labelHeight + largestTickHeight + extraPadding;
+        return labelHeight + largestTickHeight + extraPadding;
     }
 
     private float MeasureTicks()
@@ -86,7 +82,7 @@ public abstract class XAxisBase : IAxis
         var ticks = TickGenerator.GetVisibleTicks(Range);
         float tickSize = MeasureTicks();
 
-        AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Offset, PixelSize);
+        AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Offset, Measure());
         AxisRendering.DrawTicks(surface, tickFont, dataRect, Label.Color, Offset, ticks, this);
         AxisRendering.DrawFrame(surface, dataRect, Edge, Label.Color, Offset);
     }

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/XAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/XAxisBase.cs
@@ -5,13 +5,13 @@ namespace ScottPlot.Axis.StandardAxes;
 
 public abstract class XAxisBase : IAxis
 {
-    public double Left
+    public double Min
     {
         get => Range.Min;
         set => Range.Min = value;
     }
 
-    public double Right
+    public double Max
     {
         get => Range.Max;
         set => Range.Max = value;
@@ -63,7 +63,7 @@ public abstract class XAxisBase : IAxis
     public float GetPixel(double position, PixelRect dataArea)
     {
         double pxPerUnit = dataArea.Width / Width;
-        double unitsFromLeftEdge = position - Left;
+        double unitsFromLeftEdge = position - Min;
         float pxFromEdge = (float)(unitsFromLeftEdge * pxPerUnit);
         return dataArea.Left + pxFromEdge;
     }
@@ -73,7 +73,7 @@ public abstract class XAxisBase : IAxis
         double pxPerUnit = dataArea.Width / Width;
         float pxFromLeftEdge = pixel - dataArea.Left;
         double unitsFromEdge = pxFromLeftEdge / pxPerUnit;
-        return Left + unitsFromEdge;
+        return Min + unitsFromEdge;
     }
 
     public void Render(SKSurface surface, PixelRect dataRect)

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/YAxisBase.cs
@@ -23,10 +23,6 @@ public abstract class YAxisBase : IAxis
 
     public float Offset { get; set; } = 0;
 
-    public float PixelSize { get; private set; } = 50;
-
-    public float PixelWidth => PixelSize;
-
     public ITickGenerator TickGenerator { get; set; } = null!;
 
     public Label Label { get; private set; } = new()
@@ -60,12 +56,12 @@ public abstract class YAxisBase : IAxis
         return Bottom - unitsFromMinValue;
     }
 
-    public void Measure()
+    public float Measure()
     {
         float labelWidth = Label.Font.Size + 15;
         float largestTickWidth = MeasureTicks();
 
-        PixelSize = labelWidth + largestTickWidth;
+        return labelWidth + largestTickWidth;
     }
 
     private float MeasureTicks()
@@ -89,7 +85,7 @@ public abstract class YAxisBase : IAxis
         var ticks = TickGenerator.GetVisibleTicks(Range);
         float tickSize = MeasureTicks();
 
-        AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Offset, PixelSize);
+        AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Offset, Measure());
         AxisRendering.DrawTicks(surface, tickFont, dataRect, Label.Color, Offset, ticks, this);
         AxisRendering.DrawFrame(surface, dataRect, Edge, Label.Color, Offset);
     }

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/YAxisBase.cs
@@ -56,10 +56,12 @@ public abstract class YAxisBase : IAxis
 
     public float Measure()
     {
-        float labelWidth = Label.Font.Size + 15;
+        using SKPaint paint = new(Label.Font.GetFont());
+
+        float labelWidth = Drawing.MeasureString(Label.Text, paint).Height;
         float largestTickWidth = MeasureTicks();
 
-        return labelWidth + largestTickWidth;
+        return labelWidth + largestTickWidth + 15;
     }
 
     private float MeasureTicks()

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/YAxisBase.cs
@@ -21,8 +21,6 @@ public abstract class YAxisBase : IAxis
 
     public virtual CoordinateRange Range { get; private set; } = CoordinateRange.NotSet;
 
-    public float Offset { get; set; } = 0;
-
     public ITickGenerator TickGenerator { get; set; } = null!;
 
     public Label Label { get; private set; } = new()
@@ -85,9 +83,9 @@ public abstract class YAxisBase : IAxis
         var ticks = TickGenerator.GetVisibleTicks(Range);
         float tickSize = MeasureTicks();
 
-        AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Offset, Measure());
-        AxisRendering.DrawTicks(surface, tickFont, dataRect, Label.Color, Offset, ticks, this);
-        AxisRendering.DrawFrame(surface, dataRect, Edge, Label.Color, Offset);
+        AxisRendering.DrawLabel(surface, dataRect, Edge, Label, Measure());
+        AxisRendering.DrawTicks(surface, tickFont, dataRect, Label.Color, ticks, this);
+        AxisRendering.DrawFrame(surface, dataRect, Edge, Label.Color);
     }
     public double GetPixelDistance(double distance, PixelRect dataArea)
     {

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/YAxisBase.cs
@@ -5,13 +5,13 @@ namespace ScottPlot.Axis.StandardAxes;
 
 public abstract class YAxisBase : IAxis
 {
-    public double Bottom
+    public double Min
     {
         get => Range.Min;
         set => Range.Min = value;
     }
 
-    public double Top
+    public double Max
     {
         get => Range.Max;
         set => Range.Max = value;
@@ -41,7 +41,7 @@ public abstract class YAxisBase : IAxis
     public float GetPixel(double position, PixelRect dataArea)
     {
         double pxPerUnit = dataArea.Height / Height;
-        double unitsFromMinValue = position - Bottom;
+        double unitsFromMinValue = position - Min;
         float pxFromEdge = (float)(unitsFromMinValue * pxPerUnit);
         return dataArea.Bottom - pxFromEdge;
     }
@@ -51,7 +51,7 @@ public abstract class YAxisBase : IAxis
         double pxPerUnit = dataArea.Height / Height;
         float pxFromMinValue = pixel - dataArea.Bottom;
         double unitsFromMinValue = pxFromMinValue / pxPerUnit;
-        return Bottom - unitsFromMinValue;
+        return Min - unitsFromMinValue;
     }
 
     public float Measure()

--- a/src/ScottPlot5/ScottPlot5/IHasColorAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/IHasColorAxis.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot
+{
+    public interface IHasColorAxis
+    {
+        Range GetRange();
+        IColormap Colormap { get; }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Label.cs
+++ b/src/ScottPlot5/ScottPlot5/Label.cs
@@ -4,7 +4,7 @@ namespace ScottPlot;
 
 public class Label
 {
-    public string? Text { get; set; } = string.Empty;
+    public string Text { get; set; } = string.Empty;
     public Style.Font Font { get; set; } = new()
     {
         Family = "Consolas",

--- a/src/ScottPlot5/ScottPlot5/Label.cs
+++ b/src/ScottPlot5/ScottPlot5/Label.cs
@@ -4,7 +4,7 @@ namespace ScottPlot;
 
 public class Label
 {
-    public string Text { get; set; } = string.Empty;
+    public string? Text { get; set; } = string.Empty;
     public Style.Font Font { get; set; } = new()
     {
         Family = "Consolas",
@@ -39,7 +39,7 @@ public class Label
         surface.Canvas.Save();
         surface.Canvas.Translate(point.X, point.Y);
         surface.Canvas.RotateDegrees(Rotation);
-        surface.Canvas.DrawText(Text, 0, font.Size, font, paint);
+        surface.Canvas.DrawText(Text ?? "", 0, font.Size, font, paint);
         surface.Canvas.Restore();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/LayoutSystem/FinalLayout.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutSystem/FinalLayout.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.LayoutSystem
+{
+    public struct PanelWithOffset
+    {
+        public IPanel Panel { get; private set; }
+        public PixelSize Offset { get; private set; }
+
+        public PanelWithOffset(IPanel panel, PixelSize offset)
+        {
+            Panel = panel;
+            Offset = offset;
+        }
+    }
+
+    public struct FinalLayout
+    {
+        public PixelRect Area { get; private set; }
+        public IEnumerable<PanelWithOffset> Panels { get; private set; }
+
+        public FinalLayout(PixelRect area, IEnumerable<PanelWithOffset> panels)
+        {
+            Area = area;
+            Panels = panels;
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/LayoutSystem/ILayoutSystem.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutSystem/ILayoutSystem.cs
@@ -1,6 +1,8 @@
-﻿namespace ScottPlot.LayoutSystem;
+﻿using ScottPlot.Axis;
+
+namespace ScottPlot.LayoutSystem;
 
 public interface ILayoutSystem
 {
-    FinalLayout GetLayout(PixelRect figureRect, IEnumerable<Axis.IXAxis> xAxes, IEnumerable<Axis.IYAxis> yAxes);
+    public FinalLayout GetLayout(PixelRect figureRect, IEnumerable<IXAxis> xAxes, IEnumerable<IYAxis> yAxes, IEnumerable<IPanel> otherPanels);
 }

--- a/src/ScottPlot5/ScottPlot5/LayoutSystem/ILayoutSystem.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutSystem/ILayoutSystem.cs
@@ -2,5 +2,5 @@
 
 public interface ILayoutSystem
 {
-    PixelRect AutoSizeDataArea(PixelRect figureRect, IEnumerable<Axis.IXAxis> xAxes, IEnumerable<Axis.IYAxis> yAxes);
+    FinalLayout GetLayout(PixelRect figureRect, IEnumerable<Axis.IXAxis> xAxes, IEnumerable<Axis.IYAxis> yAxes);
 }

--- a/src/ScottPlot5/ScottPlot5/LayoutSystem/IPanel.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutSystem/IPanel.cs
@@ -12,7 +12,7 @@ namespace ScottPlot.LayoutSystem
         Edge Edge { get; }
         void Render(SkiaSharp.SKSurface surface, PixelRect rect);
     }
-    
+
     // Default interface implentationss aren't a thing yet on all of our targeted platforms :/
     public static class IPanelExtensions
     {

--- a/src/ScottPlot5/ScottPlot5/LayoutSystem/IPanel.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutSystem/IPanel.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.LayoutSystem
+{
+    public interface IPanel
+    {
+        float Measure();
+        Edge Edge { get; }
+        void Render(SkiaSharp.SKSurface surface, PixelRect rect);
+    }
+    
+    // Default interface implentationss aren't a thing yet on all of our targeted platforms :/
+    public static class IPanelExtensions
+    {
+        public static bool IsHorizontal(this IPanel panel) => panel.Edge == Edge.Bottom || panel.Edge == Edge.Top;
+        public static bool IsVertical(this IPanel panel) => panel.Edge == Edge.Bottom || panel.Edge == Edge.Top;
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/LayoutSystem/IPanel.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutSystem/IPanel.cs
@@ -17,6 +17,6 @@ namespace ScottPlot.LayoutSystem
     public static class IPanelExtensions
     {
         public static bool IsHorizontal(this IPanel panel) => panel.Edge == Edge.Bottom || panel.Edge == Edge.Top;
-        public static bool IsVertical(this IPanel panel) => panel.Edge == Edge.Bottom || panel.Edge == Edge.Top;
+        public static bool IsVertical(this IPanel panel) => !panel.IsHorizontal();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/LayoutSystem/StandardLayoutSystem.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutSystem/StandardLayoutSystem.cs
@@ -83,6 +83,8 @@ public class StandardLayoutSystem : ILayoutSystem
         }
 
         // TODO: manual reduction remove this
+        panelSizeByEdge.Left += 20;
+        panelSizeByEdge.Bottom += 20;
         panelSizeByEdge.Right += 20;
         panelSizeByEdge.Top += 20;
 

--- a/src/ScottPlot5/ScottPlot5/LayoutSystem/StandardLayoutSystem.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutSystem/StandardLayoutSystem.cs
@@ -8,7 +8,6 @@ public class StandardLayoutSystem : ILayoutSystem
     public PixelRect AutoSizeDataArea(PixelRect figureRect, IEnumerable<IXAxis> xAxes, IEnumerable<IYAxis> yAxes)
     {
         RegenerateTicksForAllAxes(figureRect, xAxes, yAxes);
-        RemeasureAllAxes(figureRect, xAxes, yAxes);
         PixelRect dataArea = GetTotalAxisPadding(figureRect, xAxes, yAxes);
         return dataArea;
     }
@@ -25,18 +24,6 @@ public class StandardLayoutSystem : ILayoutSystem
         }
     }
 
-    private void RemeasureAllAxes(PixelRect figureRect, IEnumerable<IXAxis> xAxes, IEnumerable<IYAxis> yAxes)
-    {
-        foreach (IXAxis xAxis in xAxes)
-        {
-            xAxis.Measure();
-        }
-        foreach (IYAxis yAxis in yAxes)
-        {
-            yAxis.Measure();
-        }
-    }
-
     private PixelRect GetTotalAxisPadding(PixelRect figureRect, IEnumerable<IXAxis> xAxes, IEnumerable<IYAxis> yAxes)
     {
         PixelPadding axisSizeByEdge = new();
@@ -44,33 +31,41 @@ public class StandardLayoutSystem : ILayoutSystem
         float bottomOffset = 0;
         foreach (IXAxis xAxis in xAxes.Where(x => x.Edge == Edge.Bottom))
         {
-            axisSizeByEdge.Bottom += xAxis.PixelHeight;
+            var pxHeight = xAxis.Measure();
+            
+            axisSizeByEdge.Bottom += pxHeight;
             xAxis.Offset = bottomOffset;
-            bottomOffset += xAxis.PixelHeight;
+            bottomOffset += pxHeight;
         }
 
         float topOffset = 0;
         foreach (IXAxis xAxis in xAxes.Where(x => x.Edge == Edge.Top))
         {
-            axisSizeByEdge.Top += xAxis.PixelHeight;
+            var pxHeight = xAxis.Measure();
+
+            axisSizeByEdge.Top += pxHeight;
             xAxis.Offset = topOffset;
-            topOffset += xAxis.PixelHeight;
+            topOffset += pxHeight;
         }
 
         float leftOffset = 0;
         foreach (IYAxis yAxis in yAxes.Where(x => x.Edge == Edge.Left))
         {
-            axisSizeByEdge.Left += yAxis.PixelWidth;
+            var pxWidth = yAxis.Measure();
+
+            axisSizeByEdge.Left += pxWidth;
             yAxis.Offset = leftOffset;
-            leftOffset += yAxis.PixelWidth;
+            leftOffset += pxWidth;
         }
 
         float rightOffset = 0;
         foreach (IYAxis yAxis in yAxes.Where(x => x.Edge == Edge.Right))
         {
-            axisSizeByEdge.Right += yAxis.PixelWidth;
+            var pxWidth = yAxis.Measure();
+            
+            axisSizeByEdge.Right += pxWidth;
             yAxis.Offset = rightOffset;
-            rightOffset += yAxis.PixelWidth;
+            rightOffset += pxWidth;
         }
 
         // TODO: manual reduction remove this

--- a/src/ScottPlot5/ScottPlot5/LayoutSystem/StandardLayoutSystem.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutSystem/StandardLayoutSystem.cs
@@ -42,9 +42,9 @@ public class StandardLayoutSystem : ILayoutSystem
         foreach (var panel in xPanels.Where(x => x.Edge == Edge.Bottom))
         {
             var pxHeight = panel.Measure();
-            
+
             panelSizeByEdge.Bottom += pxHeight;
-            
+
             offsets.Add(new(panel, new(0, bottomOffset)));
             bottomOffset += pxHeight;
         }
@@ -66,7 +66,7 @@ public class StandardLayoutSystem : ILayoutSystem
             var pxWidth = panel.Measure();
 
             panelSizeByEdge.Left += pxWidth;
-            
+
             offsets.Add(new(panel, new(leftOffset, 0)));
             leftOffset -= pxWidth;
         }
@@ -75,7 +75,7 @@ public class StandardLayoutSystem : ILayoutSystem
         foreach (var panel in yPanels.Where(x => x.Edge == Edge.Right))
         {
             var pxWidth = panel.Measure();
-            
+
             panelSizeByEdge.Right += pxWidth;
 
             offsets.Add(new(panel, new(rightOffset, 0)));

--- a/src/ScottPlot5/ScottPlot5/LayoutSystem/StandardLayoutSystem.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutSystem/StandardLayoutSystem.cs
@@ -5,11 +5,10 @@ namespace ScottPlot.LayoutSystem;
 
 public class StandardLayoutSystem : ILayoutSystem
 {
-    public PixelRect AutoSizeDataArea(PixelRect figureRect, IEnumerable<IXAxis> xAxes, IEnumerable<IYAxis> yAxes)
+    public FinalLayout GetLayout(PixelRect figureRect, IEnumerable<IXAxis> xAxes, IEnumerable<IYAxis> yAxes)
     {
         RegenerateTicksForAllAxes(figureRect, xAxes, yAxes);
-        PixelRect dataArea = GetTotalAxisPadding(figureRect, xAxes, yAxes);
-        return dataArea;
+        return GetPanelPositionsAndPadding(figureRect, xAxes, yAxes);
     }
 
     private void RegenerateTicksForAllAxes(PixelRect figureRect, IEnumerable<IXAxis> xAxes, IEnumerable<IYAxis> yAxes)
@@ -24,54 +23,59 @@ public class StandardLayoutSystem : ILayoutSystem
         }
     }
 
-    private PixelRect GetTotalAxisPadding(PixelRect figureRect, IEnumerable<IXAxis> xAxes, IEnumerable<IYAxis> yAxes)
+    private FinalLayout GetPanelPositionsAndPadding(PixelRect figureRect, IEnumerable<IPanel> xPanels, IEnumerable<IPanel> yPanels)
     {
-        PixelPadding axisSizeByEdge = new();
+        PixelPadding panelSizeByEdge = new();
+        List<PanelWithOffset> panels = new();
 
         float bottomOffset = 0;
-        foreach (IXAxis xAxis in xAxes.Where(x => x.Edge == Edge.Bottom))
+        foreach (var panel in xPanels.Where(x => x.Edge == Edge.Bottom))
         {
-            var pxHeight = xAxis.Measure();
+            var pxHeight = panel.Measure();
             
-            axisSizeByEdge.Bottom += pxHeight;
-            xAxis.Offset = bottomOffset;
+            panelSizeByEdge.Bottom += pxHeight;
+            
+            panels.Add(new(panel, new(0, bottomOffset)));
             bottomOffset += pxHeight;
         }
 
         float topOffset = 0;
-        foreach (IXAxis xAxis in xAxes.Where(x => x.Edge == Edge.Top))
+        foreach (var panel in xPanels.Where(x => x.Edge == Edge.Top))
         {
-            var pxHeight = xAxis.Measure();
+            var pxHeight = panel.Measure();
 
-            axisSizeByEdge.Top += pxHeight;
-            xAxis.Offset = topOffset;
-            topOffset += pxHeight;
+            panelSizeByEdge.Top += pxHeight;
+
+            panels.Add(new(panel, new(0, topOffset)));
+            topOffset -= pxHeight;
         }
 
         float leftOffset = 0;
-        foreach (IYAxis yAxis in yAxes.Where(x => x.Edge == Edge.Left))
+        foreach (var panel in yPanels.Where(x => x.Edge == Edge.Left))
         {
-            var pxWidth = yAxis.Measure();
+            var pxWidth = panel.Measure();
 
-            axisSizeByEdge.Left += pxWidth;
-            yAxis.Offset = leftOffset;
-            leftOffset += pxWidth;
+            panelSizeByEdge.Left += pxWidth;
+            
+            panels.Add(new(panel, new(leftOffset, 0)));
+            leftOffset -= pxWidth;
         }
 
         float rightOffset = 0;
-        foreach (IYAxis yAxis in yAxes.Where(x => x.Edge == Edge.Right))
+        foreach (var panel in yPanels.Where(x => x.Edge == Edge.Right))
         {
-            var pxWidth = yAxis.Measure();
+            var pxWidth = panel.Measure();
             
-            axisSizeByEdge.Right += pxWidth;
-            yAxis.Offset = rightOffset;
+            panelSizeByEdge.Right += pxWidth;
+
+            panels.Add(new(panel, new(rightOffset, 0)));
             rightOffset += pxWidth;
         }
 
         // TODO: manual reduction remove this
-        axisSizeByEdge.Right += 20;
-        axisSizeByEdge.Top += 20;
+        panelSizeByEdge.Right += 20;
+        panelSizeByEdge.Top += 20;
 
-        return figureRect.Contract(axisSizeByEdge);
+        return new(figureRect.Contract(panelSizeByEdge), panels);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Panels/BoxPanel.cs
+++ b/src/ScottPlot5/ScottPlot5/Panels/BoxPanel.cs
@@ -1,0 +1,39 @@
+﻿using ScottPlot.LayoutSystem;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Panels
+{
+    public class BoxPanel : IPanel
+    {
+        public Edge Edge { get; set; }
+        public float Size { get; set; }
+
+        public float Measure() => Size;
+
+        public BoxPanel(Edge edge, float size)
+        {
+            Edge = edge;
+            Size = size;
+        }
+
+        public void Render(SKSurface surface, PixelRect rect)
+        {
+            using var paint = new SKPaint() { Color = SKColors.LightGray };
+
+
+            if (Edge == Edge.Left)
+                surface.Canvas.DrawRect(rect.Left - Size, rect.Top, Size, rect.Height, paint);
+            else if (Edge == Edge.Right)
+                surface.Canvas.DrawRect(rect.Right, rect.Top, Size, rect.Height, paint);
+            else if (Edge == Edge.Bottom)
+                surface.Canvas.DrawRect(rect.Left, rect.Bottom, rect.Width, Size, paint);
+            else if (Edge == Edge.Top)
+                surface.Canvas.DrawRect(rect.Left, rect.Top - Size, rect.Width, Size, paint);
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Panels/ColorBar.cs
+++ b/src/ScottPlot5/ScottPlot5/Panels/ColorBar.cs
@@ -29,7 +29,8 @@ namespace ScottPlot.Panels
 
         public void Render(SKSurface surface, PixelRect rect)
         {
-            SKRect colorbarRect = Edge switch {
+            SKRect colorbarRect = Edge switch
+            {
                 Edge.Left => new(rect.Left - Width, rect.Top, rect.Left, rect.Top + rect.Height),
                 Edge.Right => new(rect.Right, rect.Top, rect.Right + Width, rect.Top + rect.Height),
                 Edge.Bottom => new(rect.Left, rect.Bottom, rect.Left + rect.Width, rect.Bottom + Width),
@@ -48,7 +49,7 @@ namespace ScottPlot.Panels
 
             using var bmp = GetBitmap();
             surface.Canvas.DrawBitmap(bmp, colorbarRect);
-            
+
             var colorbarLength = Edge.IsVertical() ? rect.Height : rect.Width;
             var axis = GetAxis(colorbarLength);
 
@@ -81,7 +82,7 @@ namespace ScottPlot.Panels
             };
 
             axis.Label.Text = null;
-            
+
             var range = Source.GetRange();
             axis.Min = range.Min;
             axis.Max = range.Max;

--- a/src/ScottPlot5/ScottPlot5/Panels/ColorBar.cs
+++ b/src/ScottPlot5/ScottPlot5/Panels/ColorBar.cs
@@ -1,0 +1,94 @@
+﻿using ScottPlot.Axis;
+using ScottPlot.Axis.StandardAxes;
+using ScottPlot.LayoutSystem;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Panels
+{
+    public class ColorBar : IPanel
+    {
+        public IHasColorAxis Source { get; set; }
+
+        public Edge Edge { get; set; }
+        public float Width { get; set; } = 50;
+
+        public ColorBar(IHasColorAxis source, Edge edge = Edge.Right)
+        {
+            Source = source;
+            Edge = edge;
+        }
+
+        // Unfortunately the size of the axis depends on the size of the plotting window, so we just have to guess here. 2000 should be larger than most
+        public float Measure() => GetAxis(2000).Measure() + Width;
+
+        public void Render(SKSurface surface, PixelRect rect)
+        {
+            SKRect colorbarRect = Edge switch {
+                Edge.Left => new(rect.Left - Width, rect.Top, rect.Left, rect.Top + rect.Height),
+                Edge.Right => new(rect.Right, rect.Top, rect.Right + Width, rect.Top + rect.Height),
+                Edge.Bottom => new(rect.Left, rect.Bottom, rect.Left + rect.Width, rect.Bottom + Width),
+                Edge.Top => new(rect.Left, rect.Top - Width, rect.Left + rect.Width, rect.Top),
+                _ => throw new ArgumentOutOfRangeException(nameof(Edge))
+            };
+
+            SKPoint axisTranslation = Edge switch
+            {
+                Edge.Left => new(-Width, 0),
+                Edge.Right => new(Width, 0),
+                Edge.Bottom => new(0, Width),
+                Edge.Top => new(0, -Width),
+                _ => throw new ArgumentOutOfRangeException(nameof(Edge))
+            };
+
+            using var bmp = GetBitmap();
+            surface.Canvas.DrawBitmap(bmp, colorbarRect);
+            
+            var colorbarLength = Edge.IsVertical() ? rect.Height : rect.Width;
+            var axis = GetAxis(colorbarLength);
+
+            using var _ = new SKAutoCanvasRestore(surface.Canvas);
+
+            surface.Canvas.Translate(axisTranslation);
+            axis.Render(surface, rect);
+
+        }
+
+        public SKBitmap GetBitmap()
+        {
+            uint[] argbs = Enumerable.Range(0, 256).Select(i => Source.Colormap.GetColor((Edge.IsVertical() ? 255 - i : i) / 255f).ARGB).ToArray();
+
+            int bmpWidth = Edge.IsVertical() ? 1 : 256;
+            int bmpHeight = !Edge.IsVertical() ? 1 : 256;
+
+            return SKBitmapHelpers.BitmapFromArgbs(argbs, bmpWidth, bmpHeight);
+        }
+
+        public IAxis GetAxis(float length)
+        {
+            IAxis axis = Edge switch
+            {
+                Edge.Left => new LeftAxis(),
+                Edge.Right => new RightAxis(),
+                Edge.Bottom => new BottomAxis(),
+                Edge.Top => new TopAxis(),
+                _ => throw new ArgumentOutOfRangeException(nameof(Edge))
+            };
+
+            axis.Label.Text = null;
+            
+            var range = Source.GetRange();
+            axis.Min = range.Min;
+            axis.Max = range.Max;
+
+            axis.TickGenerator.Regenerate(axis.Range, length);
+
+            return axis;
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -69,11 +69,11 @@ public class Plot
     public void SetAxisLimits(double left, double right, double bottom, double top)
     {
         // TODO: move set limits inside XAxis and YAxis
-        XAxis.Left = left;
-        XAxis.Right = right;
+        XAxis.Min = left;
+        XAxis.Max = right;
 
-        YAxis.Bottom = bottom;
-        YAxis.Top = top;
+        YAxis.Min = bottom;
+        YAxis.Max = top;
     }
 
     //[Obsolete("WARNING: NOT ALL LIMITS ARE AFFECTED")]
@@ -90,14 +90,14 @@ public class Plot
 
     public AxisLimits GetAxisLimits()
     {
-        return new AxisLimits(XAxis.Left, XAxis.Right, YAxis.Bottom, YAxis.Top);
+        return new AxisLimits(XAxis.Min, XAxis.Max, YAxis.Min, YAxis.Max);
     }
 
     public MultiAxisLimits GetMultiAxisLimits()
     {
         MultiAxisLimits limits = new();
-        XAxes.ForEach(xAxis => limits.RememberLimits(xAxis, xAxis.Left, xAxis.Right));
-        YAxes.ForEach(yAxis => limits.RememberLimits(yAxis, yAxis.Bottom, yAxis.Top));
+        XAxes.ForEach(xAxis => limits.RememberLimits(xAxis, xAxis.Min, xAxis.Max));
+        YAxes.ForEach(yAxis => limits.RememberLimits(yAxis, yAxis.Min, yAxis.Max));
         return limits;
     }
 

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -11,6 +11,9 @@ public class Plot
 {
     public readonly List<IXAxis> XAxes = new();
     public readonly List<IYAxis> YAxes = new();
+
+    public readonly List<IPanel> Panels = new();
+
     public readonly List<IGrid> Grids = new();
     public readonly List<IPlottable> Plottables = new();
 

--- a/src/ScottPlot5/ScottPlot5/PlottableFactory.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableFactory.cs
@@ -1,4 +1,5 @@
-﻿using ScottPlot.Plottables;
+﻿using ScottPlot.Panels;
+using ScottPlot.Plottables;
 using ScottPlot.Style;
 
 namespace ScottPlot;
@@ -121,5 +122,13 @@ public class PlottableFactory
         series.Add(serie);
 
         return Bar(series);
+    }
+
+    public ColorBar ColorBar(IHasColorAxis source, Edge edge = Edge.Right)
+    {
+        ColorBar colorBar = new(source, edge);
+
+        Plot.Panels.Add(colorBar);
+        return colorBar;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Rendering/Common.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/Common.cs
@@ -33,10 +33,10 @@ public static class Common
             if (!plottable.Axes.XAxis.Range.HasBeenSet || !plottable.Axes.YAxis.Range.HasBeenSet)
             {
                 AxisLimits limits = plottable.GetAxisLimits();
-                plottable.Axes.XAxis.Left = limits.Rect.XMin;
-                plottable.Axes.XAxis.Right = limits.Rect.XMax;
-                plottable.Axes.YAxis.Bottom = limits.Rect.YMin;
-                plottable.Axes.YAxis.Top = limits.Rect.YMax;
+                plottable.Axes.XAxis.Min = limits.Rect.XMin;
+                plottable.Axes.XAxis.Max = limits.Rect.XMax;
+                plottable.Axes.YAxis.Min = limits.Rect.YMin;
+                plottable.Axes.YAxis.Max = limits.Rect.YMax;
             }
         }
     }

--- a/src/ScottPlot5/ScottPlot5/Rendering/Common.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/Common.cs
@@ -1,7 +1,9 @@
-﻿using SkiaSharp;
+﻿using ScottPlot.LayoutSystem;
+using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -39,11 +41,6 @@ public static class Common
         }
     }
 
-    public static PixelRect AutoSizeDataArea(PixelRect figureRect, Plot plot)
-    {
-        return plot.Layout.AutoSizeDataArea(figureRect, plot.XAxes, plot.YAxes);
-    }
-
     public static void RenderBackground(SKSurface surface, PixelRect dataRect, Plot plot)
     {
         surface.Canvas.Clear(SKColors.White);
@@ -69,18 +66,13 @@ public static class Common
         }
     }
 
-    public static void RenderAxes(SKSurface surface, PixelRect dataRect, Plot plot)
+    public static void RenderPanels(SKSurface surface, PixelRect area, IEnumerable<PanelWithOffset> panels)
     {
-        // TODO: axes should render their own frame edges
-
-        foreach (var xAxis in plot.XAxes)
+        foreach (var panel in panels)
         {
-            xAxis.Render(surface, dataRect);
-        }
-
-        foreach (var yAxis in plot.YAxes)
-        {
-            yAxis.Render(surface, dataRect);
+            using SKAutoCanvasRestore _ = new(surface.Canvas);
+            surface.Canvas.Translate(panel.Offset.Width, panel.Offset.Height);
+            panel.Panel.Render(surface, area);
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5/Rendering/StandardRenderer.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/StandardRenderer.cs
@@ -14,7 +14,7 @@ public class StandardRenderer : IRenderer
 
         PixelRect figureRect = PixelRect.FromSKRect(surface.Canvas.LocalClipBounds);
 
-        FinalLayout layout = plot.Layout.GetLayout(figureRect, plot.XAxes, plot.YAxes);
+        FinalLayout layout = plot.Layout.GetLayout(figureRect, plot.XAxes, plot.YAxes, plot.Panels);
         PixelRect area = layout.Area;
 
         plot.XAxis.TickGenerator.Regenerate(plot.XAxis.Range, area.Width);

--- a/src/ScottPlot5/ScottPlot5/Rendering/StandardRenderer.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/StandardRenderer.cs
@@ -1,4 +1,5 @@
-﻿using SkiaSharp;
+﻿using ScottPlot.LayoutSystem;
+using SkiaSharp;
 
 namespace ScottPlot.Rendering;
 
@@ -12,20 +13,23 @@ public class StandardRenderer : IRenderer
         Common.AutoAxisAnyUnsetAxes(plot);
 
         PixelRect figureRect = PixelRect.FromSKRect(surface.Canvas.LocalClipBounds);
-        PixelRect dataRect = Common.AutoSizeDataArea(figureRect, plot);
-        plot.XAxis.TickGenerator.Regenerate(plot.XAxis.Range, dataRect.Width);
-        plot.YAxis.TickGenerator.Regenerate(plot.YAxis.Range, dataRect.Height);
 
-        Common.RenderBackground(surface, dataRect, plot);
-        Common.RenderGrids(surface, dataRect, plot, beneathPlottables: true);
-        Common.RenderPlottables(surface, dataRect, plot);
-        Common.RenderGrids(surface, dataRect, plot, beneathPlottables: false);
-        Common.RenderAxes(surface, dataRect, plot);
-        Common.RenderZoomRectangle(surface, dataRect, plot);
+        FinalLayout layout = plot.Layout.GetLayout(figureRect, plot.XAxes, plot.YAxes);
+        PixelRect area = layout.Area;
+
+        plot.XAxis.TickGenerator.Regenerate(plot.XAxis.Range, area.Width);
+        plot.YAxis.TickGenerator.Regenerate(plot.YAxis.Range, area.Height);
+
+        Common.RenderBackground(surface, area, plot);
+        Common.RenderGrids(surface, area, plot, beneathPlottables: true);
+        Common.RenderPlottables(surface, area, plot);
+        Common.RenderGrids(surface, area, plot, beneathPlottables: false);
+        Common.RenderPanels(surface, area, layout.Panels);
+        Common.RenderZoomRectangle(surface, area, plot);
         sw.Stop();
 
-        Common.RenderBenchmark(surface, dataRect, sw.Elapsed, plot);
+        Common.RenderBenchmark(surface, area, sw.Elapsed, plot);
 
-        return new RenderDetails(figureRect, dataRect, sw.Elapsed);
+        return new RenderDetails(figureRect, area, sw.Elapsed);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/SKBitmapHelpers.cs
+++ b/src/ScottPlot5/ScottPlot5/SKBitmapHelpers.cs
@@ -1,0 +1,29 @@
+﻿using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot
+{
+    internal class SKBitmapHelpers
+    {
+        public static SKBitmap BitmapFromArgbs(uint[] argbs, int width, int height)
+        {
+            GCHandle handle = GCHandle.Alloc(argbs, GCHandleType.Pinned);
+
+            var imageInfo = new SKImageInfo(width, height);
+            var bmp = new SKBitmap(imageInfo);
+            bmp.InstallPixels(
+                info: imageInfo,
+                pixels: handle.AddrOfPinnedObject(),
+                rowBytes: imageInfo.RowBytes,
+                releaseProc: (IntPtr _, object _) => handle.Free());
+
+            return bmp;
+        }
+    }
+}


### PR DESCRIPTION
**Purpose:**
This refactors `ILayoutSystem` to act on `IPanel` rather than `IAxis`. It also strips a lot of rendering state from `IAxis` like `Offset`, which is instead stored separately. This means we don't expose (and have to keep in sync) rendering state to the user.

~~This PR is intended to enable colorbar axes, but currently the only non-axis plot is a `BoxPanel` intended for debugging purposes.~~

This enables ColorBars (warning, garish):
<img width="959" alt="image" src="https://user-images.githubusercontent.com/8635304/204164251-acc3a133-f056-4eb4-83b7-dac9887c89b0.png">

Source:
```cs
int width = 100;
int height = 100;

double[,] intensities = new double[width, height];

for (int x = 0; x < width; x++)
    for (int y = 0; y < height; y++)
        intensities[x, y] = (Math.Sin(x * .2) + Math.Cos(y * .2)) * 100;

avaPlot.Plot.Plottables.Add(DebugPoint);
var hm = avaPlot.Plot.Add.Heatmap(intensities);

avaPlot.Plot.Add.ColorBar(hm, Edge.Top);
avaPlot.Plot.Add.ColorBar(hm, Edge.Right);
avaPlot.Plot.Add.ColorBar(hm, Edge.Bottom);
avaPlot.Plot.Add.ColorBar(hm, Edge.Left);
```