### PR TITLE
Project: target System.Drawing.Common 4.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _not yet published on NuGet..._
 * FormsPlot: Improved support for horizontal legends in the pop-out legend viewer (#2300) _Thanks @rotger_
 * Axis: Added arguments to `AxisPan()` to improve multi-axis support (#2293)
 * Axis: Added `AxisPanCenter()` to center the view on a coordinate (#2293) _Thanks @dusko23_
+* Project: Use System.Drawing.Common version 4.7.2 to avoid CVE-2021-26701 (#2303, #1004, #1413) _Thanks @gobikulandaisamy_
 
 ## ScottPlot 4.1.59
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-11-06_

--- a/src/ScottPlot4/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj
+++ b/src/ScottPlot4/ScottPlot.Avalonia/ScottPlot.Avalonia.NUGET.csproj
@@ -38,7 +38,7 @@
       https://github.com/ScottPlot/ScottPlot/issues/1004
     -->
     <PackageVersion Condition="!$(TargetFramework.StartsWith('net4'))" Include="System.Drawing.Common" Version="5.0.2" />
-    <PackageVersion Condition="$(TargetFramework.StartsWith('net4'))" Include="System.Drawing.Common" Version="4.6.1" />
+    <PackageVersion Condition="$(TargetFramework.StartsWith('net4'))" Include="System.Drawing.Common" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ScottPlot4/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj
+++ b/src/ScottPlot4/ScottPlot.Eto/ScottPlot.Eto.NUGET.csproj
@@ -43,7 +43,7 @@
       https://github.com/ScottPlot/ScottPlot/issues/1004
     -->
     <PackageVersion Condition="!$(TargetFramework.StartsWith('net4'))" Include="System.Drawing.Common" Version="5.0.2" />
-    <PackageVersion Condition="$(TargetFramework.StartsWith('net4'))" Include="System.Drawing.Common" Version="4.6.1" />
+    <PackageVersion Condition="$(TargetFramework.StartsWith('net4'))" Include="System.Drawing.Common" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ScottPlot4/ScottPlot.Tests/data/sample.csproj
+++ b/src/ScottPlot4/ScottPlot.Tests/data/sample.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.8.64" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
     <None Include="icon.png" Pack="true" PackagePath="\" />
     <None Include="icon.ico" Pack="true" PackagePath="\" />
   </ItemGroup>

--- a/src/ScottPlot4/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj
+++ b/src/ScottPlot4/ScottPlot.WPF/ScottPlot.WPF.NUGET.csproj
@@ -46,7 +46,7 @@
       https://github.com/ScottPlot/ScottPlot/issues/1004
     -->
     <PackageVersion Condition="!$(TargetFramework.StartsWith('net4'))" Include="System.Drawing.Common" Version="5.0.2" />
-    <PackageVersion Condition="$(TargetFramework.StartsWith('net4'))" Include="System.Drawing.Common" Version="4.6.1" />
+    <PackageVersion Condition="$(TargetFramework.StartsWith('net4'))" Include="System.Drawing.Common" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ScottPlot4/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj
+++ b/src/ScottPlot4/ScottPlot.WinForms/ScottPlot.WinForms.NUGET.csproj
@@ -44,7 +44,7 @@
       https://github.com/ScottPlot/ScottPlot/issues/1004
     -->
     <PackageVersion Condition="!$(TargetFramework.StartsWith('net4'))" Include="System.Drawing.Common" Version="5.0.2" />
-    <PackageVersion Condition="$(TargetFramework.StartsWith('net4'))" Include="System.Drawing.Common" Version="4.6.1" />
+    <PackageVersion Condition="$(TargetFramework.StartsWith('net4'))" Include="System.Drawing.Common" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ScottPlot4/ScottPlot/ScottPlot.csproj
+++ b/src/ScottPlot4/ScottPlot/ScottPlot.csproj
@@ -40,7 +40,7 @@
       is associated with assembly issues that break .NET Framework projects on Windows.
       https://github.com/ScottPlot/ScottPlot/issues/1004
     -->
-        <PackageReference Include="System.Drawing.Common" Version="4.6.1" />
+        <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
         <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
The previously used version (4.6.1) has a vulnerability on non-Windows systems as described by https://github.com/advisories/GHSA-ghhp-997w-qr28

resolves #2303