### PR TITLE
ScottPlot 5 Legend: Fixes symbols, reduces remeasuring

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Quickstart.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Quickstart.cs
@@ -105,4 +105,32 @@ internal class Quickstart : RecipePageBase
             sig2.Label = "Cos";
         }
     }
+
+    internal class ManualLegend : RecipeTestBase
+    {
+        public override string Name => "Manual Legend";
+        public override string Description => "Legends may be constructed manually.";
+
+        [Test]
+        public override void Recipe()
+        {
+            myPlot.Add.Signal(Generate.Sin(51));
+            myPlot.Add.Signal(Generate.Cos(51));
+
+            LegendItem item1 = new()
+            {
+                Label = "alpha",
+                Line = new ScottPlot.Style.Stroke(Colors.Magenta, 2),
+            };
+
+            LegendItem item2 = new()
+            {
+                Label = "beta",
+                Line = new ScottPlot.Style.Stroke(Colors.Green, 4),
+            };
+
+            var legend = myPlot.GetLegend();
+            legend.ManualLegendItems = new[] { item1, item2 };
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
@@ -139,7 +139,8 @@ internal class Styling : RecipePageBase
             sig2.Label = "Cos";
 
             var legend = myPlot.GetLegend();
-            legend.Stroke = new(Colors.Navy, 2);
+            legend.LineColor = Colors.Navy;
+            legend.LineWidth = 2;
             legend.BackgroundColor = Colors.LightBlue;
             legend.ShadowColor = Colors.Blue.WithOpacity(.5);
             legend.FontSize = 16;

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
@@ -139,8 +139,7 @@ internal class Styling : RecipePageBase
             sig2.Label = "Cos";
 
             var legend = myPlot.GetLegend();
-            legend.LineColor = Colors.Navy;
-            legend.LineWidth = 2;
+            legend.Stroke = new(Colors.Navy, 2);
             legend.BackgroundColor = Colors.LightBlue;
             legend.ShadowColor = Colors.Blue.WithOpacity(.5);
             legend.FontSize = 16;

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
@@ -1,6 +1,4 @@
-﻿using ScottPlot.Legends;
-
-namespace ScottPlotCookbook.Recipes.PlotTypes;
+﻿namespace ScottPlotCookbook.Recipes.PlotTypes;
 
 internal class Bar : RecipePageBase
 {
@@ -13,35 +11,60 @@ internal class Bar : RecipePageBase
 
     internal class Quickstart : RecipeTestBase
     {
-
         public override string Name => "Bar Plot Quickstart";
         public override string Description => "Bar plots can be added from a series of values.";
 
         [Test]
         public override void Recipe()
         {
-            Random rand = new(0);
+            double[] values = { 5, 10, 7, 13 };
+            myPlot.Add.Bar(values);
+            myPlot.AutoScale();
+            myPlot.SetAxisLimits(bottom: 0);
+        }
+    }
 
-            var series = Enumerable.Range(0, 4).Select(i => new ScottPlot.Plottables.BarSeries
+    internal class BarPosition : RecipeTestBase
+    {
+        public override string Name => "Bar Positioning";
+        public override string Description => "The exact position and size of each bar may be customized.";
+
+        [Test]
+        public override void Recipe()
+        {
+            List<ScottPlot.Plottables.Bar> bars = new()
             {
-                Bars = Enumerable.Range(0, rand.Next(3, 10)).Select(j => new ScottPlot.Plottables.Bar
-                {
-                    Position = j,
-                    Value = rand.NextDouble() * 10
-                }).ToArray(),
-                Fill = new(myPlot.Palette.GetColor(i))
-                {
-                    HatchColor = myPlot.Palette.GetColor(i + 1),
-                    Hatch = new ScottPlot.Style.Hatches.Striped(ScottPlot.Style.Hatches.StripeDirection.DiagonalDown)
-                },
-                Label = $"Series {i + 1}"
-            }).ToArray();
+                new() { Position = 5, Value = 5, ValueBase = 3, },
+                new() { Position = 10, Value = 7, ValueBase = 0, },
+                new() { Position = 15, Value = 3, ValueBase = 2, },
+            };
 
-            foreach (var s in series)
-                for (int i = 1; i < s.Bars.Count; i++)
-                    s.Bars[i].ValueBase = s.Bars[i - 1].Value;
+            myPlot.Add.Bar(bars);
+        }
+    }
 
-            myPlot.Add.Bar(series);
+    internal class BarSeries : RecipeTestBase
+    {
+        public override string Name => "Bar Series";
+        public override string Description => "Bar plots can be grouped into bar series and plotted together.";
+
+        [Test]
+        public override void Recipe()
+        {
+            List<ScottPlot.Plottables.Bar> bars1 = new() { new() { Value = 5 }, new() { Value = 7 }, new() { Value = 9 }, };
+            List<ScottPlot.Plottables.Bar> bars2 = new() { new() { Value = 3 }, new() { Value = 8 }, new() { Value = 5 }, };
+            List<ScottPlot.Plottables.Bar> bars3 = new() { new() { Value = 7 }, new() { Value = 10 }, new() { Value = 7 }, };
+
+            ScottPlot.Plottables.BarSeries series1 = new() { Bars = bars1, Label = "Series 1", Color = Colors.Red };
+            ScottPlot.Plottables.BarSeries series2 = new() { Bars = bars2, Label = "Series 2", Color = Colors.Green };
+            ScottPlot.Plottables.BarSeries series3 = new() { Bars = bars3, Label = "Series 3", Color = Colors.Blue };
+
+            List<ScottPlot.Plottables.BarSeries> seriesList = new() { series1, series2, series3 };
+
+            myPlot.Add.Bar(seriesList);
+
+            myPlot.AutoScale();
+            myPlot.SetAxisLimits(bottom: 0);
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
@@ -1,4 +1,6 @@
-﻿namespace ScottPlotCookbook.Recipes.PlotTypes;
+﻿using ScottPlot.Legends;
+
+namespace ScottPlotCookbook.Recipes.PlotTypes;
 
 internal class Bar : RecipePageBase
 {
@@ -39,7 +41,7 @@ internal class Bar : RecipePageBase
                 for (int i = 1; i < s.Bars.Count; i++)
                     s.Bars[i].ValueBase = s.Bars[i - 1].Value;
 
-            myPlot.Add.Bar(series);
+            myPlot.Add.Bar(series).Label = "Currently this will not render if I remove this";
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
@@ -41,7 +41,7 @@ internal class Bar : RecipePageBase
                 for (int i = 1; i < s.Bars.Count; i++)
                     s.Bars[i].ValueBase = s.Bars[i - 1].Value;
 
-            myPlot.Add.Bar(series).Label = "Currently this will not render if I remove this";
+            myPlot.Add.Bar(series);
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/LegendItem.cs
+++ b/src/ScottPlot5/ScottPlot5/LegendItem.cs
@@ -1,18 +1,14 @@
 ﻿using ScottPlot.Style;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace ScottPlot
+namespace ScottPlot;
+
+public class LegendItem
 {
-    public class LegendItem // TODO: Should this be a struct?
-    {
-        public string? Label { get; set; } // TODO: I waffled on whether to make these init-only setters. I think there's enough value to in letting them be mutable
-        public Stroke? Line { get; set; }
-        public Marker? Marker { get; set; }
-        public Fill? Fill { get; set; }
-        public IEnumerable<LegendItem> Children { get; set; } = Array.Empty<LegendItem>();
-    }
+    public string? Label { get; set; }
+    public Stroke? Line { get; set; }
+    public Marker? Marker { get; set; }
+    public Fill? Fill { get; set; }
+    public IEnumerable<LegendItem> Children { get; set; } = Array.Empty<LegendItem>();
+    public bool HasSymbol => Line.HasValue || Marker.HasValue || Fill.HasValue;
+    public bool IsVisible => !string.IsNullOrEmpty(Label);
 }

--- a/src/ScottPlot5/ScottPlot5/Legends/LegendItemSize.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/LegendItemSize.cs
@@ -1,0 +1,13 @@
+﻿namespace ScottPlot.Legends;
+
+public struct LegendItemSize
+{
+    public PixelSize OwnSize { get; }
+    public PixelSize WithChildren { get; }
+
+    public LegendItemSize(PixelSize ownSize, PixelSize withChildren)
+    {
+        OwnSize = ownSize;
+        WithChildren = withChildren;
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Legends/LegendRendering.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/LegendRendering.cs
@@ -1,0 +1,119 @@
+﻿namespace ScottPlot.Legends;
+
+/// <summary>
+/// Common methods which legends may choose to use for rendering
+/// </summary>
+public static class LegendRendering
+{
+    /// <summary>
+    /// Render a leger item: its label, symbol, and all its children
+    /// </summary>
+    public static void RenderItem(
+        SKCanvas canvas,
+        SKPaint paint,
+        SizedLegendItem sizedItem,
+        float x,
+        float y,
+        float symbolWidth,
+        float symbolPadRight,
+        PixelPadding itemPadding)
+    {
+        LegendItem item = sizedItem.Item;
+
+        SKPoint textPoint = new(x, y + paint.TextSize);
+        float ownHeight = sizedItem.Size.OwnSize.Height;
+
+        if (item.HasSymbol)
+        {
+            RenderSymbol(
+                canvas: canvas,
+                item: item,
+                x: x,
+                y: y + itemPadding.Bottom,
+                height: ownHeight - itemPadding.TotalVertical,
+                symbolWidth: symbolWidth);
+
+            textPoint.X += symbolWidth + symbolPadRight;
+        }
+
+        using SKAutoCanvasRestore _ = new(canvas);
+        if (!string.IsNullOrEmpty(item.Label))
+        {
+            canvas.DrawText(item.Label, textPoint, paint);
+            canvas.Translate(itemPadding.Left, 0);
+        }
+
+        y += ownHeight;
+        foreach (var curr in sizedItem.Children)
+        {
+            RenderItem(canvas, paint, curr, x, y, symbolWidth, symbolPadRight, itemPadding);
+            y += curr.Size.WithChildren.Height;
+        }
+    }
+
+    /// <summary>
+    /// Render just the symbol of a legend
+    /// </summary>
+    public static void RenderSymbol(
+        SKCanvas canvas,
+        LegendItem item,
+        float x,
+        float y,
+        float height,
+        float symbolWidth)
+    {
+        // TODO: make LegendSymbol its own object that include size and padding
+
+        PixelRect rect = new(x, x + symbolWidth, y + height, y);
+
+        using SKPaint paint = new();
+
+        if (item.Line.HasValue)
+        {
+            paint.SetStroke(item.Line.Value);
+            canvas.DrawLine(new(rect.Left, rect.VerticalCenter), new(rect.Right, rect.VerticalCenter), paint);
+        }
+
+        if (item.Marker.HasValue)
+        {
+            paint.Style = SKPaintStyle.Fill;
+            paint.Color = item.Marker.Value.Color.ToSKColor();
+            Drawing.DrawMarkers(canvas, item.Marker.Value, EnumerableHelpers.One<Pixel>(new(rect.HorizontalCenter, rect.VerticalCenter)));
+        }
+
+        if (item.Fill.HasValue)
+        {
+            paint.SetFill(item.Fill.Value);
+            canvas.DrawRect(rect.ToSKRect(), paint);
+        }
+    }
+
+    /// <summary>
+    /// Return the size of the given item including all its children
+    /// </summary>
+    public static LegendItemSize Measure(
+        LegendItem item,
+        SKPaint paint,
+        SizedLegendItem[] children,
+        float symbolWidth,
+        float symbolPadRight,
+        PixelPadding Padding,
+        PixelPadding ItemPadding)
+    {
+        PixelSize labelRect = !string.IsNullOrWhiteSpace(item.Label) ? Drawing.MeasureString(item.Label, paint) : new(0, 0);
+
+        float width2 = item.HasSymbol ? symbolWidth : 0;
+        float width = width2 + symbolPadRight + labelRect.Width + ItemPadding.TotalHorizontal;
+        float height = paint.TextSize + Padding.TotalVertical;
+
+        PixelSize ownSize = new(width, height);
+
+        foreach (SizedLegendItem childItem in children)
+        {
+            width = Math.Max(width, Padding.Left + childItem.Size.WithChildren.Width);
+            height += childItem.Size.WithChildren.Height;
+        }
+
+        return new LegendItemSize(ownSize, new(width, height));
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Legends/SizedLegendItem.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/SizedLegendItem.cs
@@ -1,0 +1,15 @@
+﻿namespace ScottPlot.Legends;
+
+public struct SizedLegendItem
+{
+    public LegendItem Item { get; }
+    public LegendItemSize Size { get; }
+    public SizedLegendItem[] Children { get; }
+
+    public SizedLegendItem(LegendItem item, LegendItemSize size, SizedLegendItem[] children)
+    {
+        Item = item;
+        Size = size;
+        Children = children;
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
@@ -63,10 +63,10 @@ public class StandardLegend : ILegend
         // measure all items to determine dimensions of the legend
         using SKPaint paint = new() { Typeface = Font.ToSKTypeface(), TextSize = Font.Size, IsAntialias = true };
         SizedLegendItem[] sizedItems = GetSizedLegendItems(items, paint);
-        
+
         float maxWidth = sizedItems.Select(x => x.Size.WithChildren.Width).Max();
         float totalheight = sizedItems.Select(x => x.Size.WithChildren.Height).Sum();
-        
+
         PixelSize legendSize = new PixelSize(maxWidth, totalheight).Expand(Padding);
         PixelRect legendRect = legendSize.AlignedInside(dataRect, Alignment.LowerRight, Margin);
         PixelRect legendShadowRect = legendRect.WithDelta(ShadowOffset, ShadowOffset, Alignment);

--- a/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
@@ -174,6 +174,9 @@ public class StandardLegend : ILegend
             if (!string.IsNullOrWhiteSpace(item.Label))
             {
                 visibleItems.Add(item);
+            } else
+            {
+                visibleItems.AddRange(item.Children);
             }
         }
 

--- a/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
@@ -1,4 +1,6 @@
-﻿namespace ScottPlot.Legends;
+﻿using ScottPlot.Style;
+
+namespace ScottPlot.Legends;
 
 internal struct LegendItemSize
 {
@@ -42,8 +44,7 @@ public class StandardLegend : ILegend
     public bool FontItalic = false;
     public Font Font => new(FontName, FontSize, FontBold ? 800 : 400, FontItalic);
 
-    public float LineWidth = 1;
-    public Color LineColor = Colors.Black;
+    public Stroke Stroke = new();
     public Color BackgroundColor = Colors.White;
 
     public Color ShadowColor = Colors.Black.WithOpacity(.2);
@@ -73,7 +74,7 @@ public class StandardLegend : ILegend
         // render the legend panel
         Drawing.Fillectangle(canvas, legendShadowRect, ShadowColor);
         Drawing.Fillectangle(canvas, legendRect, BackgroundColor);
-        Drawing.DrawRectangle(canvas, legendRect, LineColor, LineWidth);
+        Drawing.DrawRectangle(canvas, legendRect, Stroke.Color, Stroke.Width);
 
         // render all items inside the legend
         float yOffset = legendRect.Top + Padding.Top;

--- a/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
@@ -179,7 +179,8 @@ public class StandardLegend : ILegend
             if (!string.IsNullOrWhiteSpace(item.Label))
             {
                 visibleItems.Add(item);
-            } else
+            }
+            else
             {
                 visibleItems.AddRange(item.Children);
             }

--- a/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
@@ -68,18 +68,19 @@ public class StandardLegend : ILegend
             throw new ArgumentNullException(nameof(item.Label));
 
         SKPoint textPoint = new(x, y + paint.TextSize);
+        var height = Measure(item, paint, includeChildren: false).Height;
 
         bool hasSymbol = item.Line.HasValue || item.Marker.HasValue || item.Fill.HasValue;
         if (hasSymbol)
         {
-            RenderSymbol(canvas, item, x, y, paint.TextSize);
+            RenderSymbol(canvas, item, x, y + ItemPadding.Bottom, height - ItemPadding.TotalVertical);
             textPoint.X += SymbolWidth + SymbolLabelSeparation;
         }
 
         canvas.DrawText(item.Label, textPoint, paint);
 
         // TODO: use child measurements that were already made
-        y += Measure(item, paint, includeChildren: false).Height;
+        y += height;
         foreach (var curr in item.Children)
         {
             RenderItem(canvas, paint, curr, x, y);
@@ -89,9 +90,7 @@ public class StandardLegend : ILegend
 
     private void RenderSymbol(SKCanvas canvas, LegendItem item, float x, float y, float height)
     {
-        // TODO: symbol/text alignment is pretty wonky
-
-        PixelRect rect = new(x, x + SymbolWidth, y + height * 1.5f, y);
+        PixelRect rect = new(x, x + SymbolWidth, y + height, y);
 
         using SKPaint paint = new();
 

--- a/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
@@ -178,7 +178,7 @@ public class StandardLegend : ILegend
             }
             else
             {
-                visibleItems.AddRange(item.Children);
+                visibleItems.AddRange(GetVisibleItems(item.Children));
             }
         }
 

--- a/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
@@ -26,8 +26,13 @@ public class StandardLegend : ILegend
     private const float SymbolWidth = 20;
     private const float SymbolLabelSeparation = 5;
 
+    public LegendItem[]? ManualLegendItems { get; set; } = null;
+
     public void Render(SKCanvas canvas, PixelRect dataRect, LegendItem[] items)
     {
+        if (ManualLegendItems is not null)
+            items = ManualLegendItems.ToArray();
+
         items = GetAllLegendItems(items).Where(x => x.IsVisible).ToArray();
         if (!items.Any())
             return;

--- a/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
@@ -104,6 +104,9 @@ public class StandardLegend : ILegend
         canvas.DrawText(item.Label, textPoint, paint);
 
         y += ownHeight;
+        using SKAutoCanvasRestore _ = new(canvas);
+        canvas.Translate(ItemPadding.Left, 0);
+
         foreach (var curr in sizedItem.Children)
         {
             RenderItem(canvas, paint, curr, x, y);

--- a/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
@@ -95,8 +95,7 @@ public class StandardLegend : ILegend
         SKPoint textPoint = new(x, y + paint.TextSize);
         var ownHeight = sizedItem.Size.OwnSize.Height;
 
-        bool hasSymbol = item.Line.HasValue || item.Marker.HasValue || item.Fill.HasValue;
-        if (hasSymbol)
+        if (HasSymbol(item))
         {
             RenderSymbol(canvas, item, x, y + ItemPadding.Bottom, ownHeight - ItemPadding.TotalVertical);
             textPoint.X += SymbolWidth + SymbolLabelSeparation;
@@ -111,6 +110,8 @@ public class StandardLegend : ILegend
             y += curr.Size.WithChildren.Height;
         }
     }
+
+    private bool HasSymbol(LegendItem item) => item.Line.HasValue || item.Marker.HasValue || item.Fill.HasValue;
 
     private void RenderSymbol(SKCanvas canvas, LegendItem item, float x, float y, float height)
     {
@@ -151,7 +152,8 @@ public class StandardLegend : ILegend
 
         PixelSize labelRect = Drawing.MeasureString(item.Label, paint);
 
-        float width = SymbolWidth + SymbolLabelSeparation + labelRect.Width + ItemPadding.TotalHorizontal;
+        var symbolWidth = HasSymbol(item) ? SymbolWidth : 0;
+        float width = symbolWidth + SymbolLabelSeparation + labelRect.Width + ItemPadding.TotalHorizontal;
         float height = paint.TextSize + Padding.TotalVertical;
 
         PixelSize ownSize = new(width, height);

--- a/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
@@ -81,7 +81,7 @@ public class StandardLegend : ILegend
 
         // TODO: use child measurements that were already made
         y += height;
-        foreach (var curr in item.Children)
+        foreach (var curr in GetVisibleItems(item.Children))
         {
             RenderItem(canvas, paint, curr, x, y);
             y += Measure(curr, paint).Height;
@@ -147,8 +147,6 @@ public class StandardLegend : ILegend
             {
                 visibleItems.Add(item);
             }
-
-            visibleItems.AddRange(GetVisibleItems(item.Children));
         }
 
         return visibleItems.ToArray();

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -128,12 +128,19 @@ public class Plot : IDisposable
     //[Obsolete("WARNING: NOT ALL LIMITS ARE AFFECTED")]
     public void SetAxisLimits(double left, double right, double bottom, double top)
     {
-        // TODO: move set limits inside XAxis and YAxis
         XAxis.Min = left;
         XAxis.Max = right;
-
         YAxis.Min = bottom;
         YAxis.Max = top;
+    }
+
+    //[Obsolete("WARNING: NOT ALL LIMITS ARE AFFECTED")]
+    public void SetAxisLimits(double? left = null, double? right = null, double? bottom = null, double? top = null)
+    {
+        XAxis.Min = left ?? XAxis.Min;
+        XAxis.Max = right ?? XAxis.Max;
+        YAxis.Min = bottom ?? YAxis.Min;
+        YAxis.Max = top ?? YAxis.Max;
     }
 
     //[Obsolete("WARNING: NOT ALL LIMITS ARE AFFECTED")]

--- a/src/ScottPlot5/ScottPlot5/PlottableFactory.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableFactory.cs
@@ -84,6 +84,12 @@ public class PlottableFactory
         return scatter;
     }
 
+    public BarPlot Bar(double[] values)
+    {
+        IList<Bar> bars = values.Select(x => new Bar() { Value = x }).ToList();
+        return Bar(bars);
+    }
+
     public BarPlot Bar(IList<BarSeries> series)
     {
         var barPlot = new BarPlot(series);
@@ -91,19 +97,18 @@ public class PlottableFactory
         return barPlot;
     }
 
-    public BarPlot Bar(IList<Bar> bars, Fill? fill = null, string? label = null)
+    public BarPlot Bar(IList<Bar> bars, Color? color = null, string? label = null)
     {
-        var serie = new BarSeries()
+        var series = new BarSeries()
         {
             Bars = bars,
-            Fill = fill ?? new(NextColor),
+            Color = color ?? NextColor,
             Label = label
         };
 
-        var series = new List<BarSeries>(1);
-        series.Add(serie);
+        List<BarSeries> seriesList = new() { series };
 
-        return Bar(series);
+        return Bar(seriesList);
     }
 
     public ColorBar ColorBar(IHasColorAxis source, Edge edge = Edge.Right)

--- a/src/ScottPlot5/ScottPlot5/Plottables/BarPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/BarPlot.cs
@@ -1,11 +1,4 @@
 ﻿using ScottPlot.Axis;
-using ScottPlot.Style;
-using SkiaSharp;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ScottPlot.Plottables
 {
@@ -20,7 +13,7 @@ namespace ScottPlot.Plottables
     {
         public IList<Bar> Bars { get; set; } = Array.Empty<Bar>();
         public string? Label { get; set; }
-        public Fill Fill { get; set; }
+        public Color Color { get; set; }
     }
 
     public class BarPlot : IPlottable
@@ -32,7 +25,8 @@ namespace ScottPlot.Plottables
         public double Padding { get; set; } = 0.05;
         private double MaxBarWidth => 1 - Padding * 2;
         public Orientation Orientation { get; set; } = Orientation.Vertical;
-        public Stroke Stroke { get; set; } = new();
+        public float LineWidth = 1;
+        public Color LineColor = Colors.Black;
         public bool GroupBarsWithSameXPosition = true; // Disable for stacked bar charts
 
         public BarPlot(IList<BarSeries> series)
@@ -44,10 +38,10 @@ namespace ScottPlot.Plottables
             new LegendItem
             {
                 Label = Label,
-                Children = Series.Select(s => new LegendItem
+                Children = Series.Select(barSeries => new LegendItem
                 {
-                    Label = s.Label,
-                    Fill = s.Fill
+                    Label = barSeries.Label,
+                    Fill = new Style.Fill() { Color = barSeries.Color }
                 })
             });
 
@@ -104,14 +98,9 @@ namespace ScottPlot.Plottables
                         group.Key - groupWidth / 2 + (i + 0.5) * barWidthAndPadding :
                         group.Key;
 
-
-                    var rect = GetRect(t.Bar, newPosition, barWidth);
-
-                    paint.SetFill(t.Series.Fill);
-                    surface.Canvas.DrawRect(rect, paint);
-
-                    paint.SetStroke(Stroke);
-                    surface.Canvas.DrawRect(rect, paint);
+                    PixelRect rect = GetRect(t.Bar, newPosition, barWidth).ToPixelRect();
+                    Drawing.Fillectangle(surface.Canvas, rect, t.Series.Color);
+                    Drawing.DrawRectangle(surface.Canvas, rect, LineColor, LineWidth);
 
                     i++;
                 }
@@ -122,7 +111,6 @@ namespace ScottPlot.Plottables
         {
             return Orientation switch
             {
-                // Left, top, right, bottom
                 Orientation.Vertical => new SKRect(
                         Axes.GetPixelX(pos - barWidth / 2),
                         Axes.GetPixelY(bar.Value),

--- a/src/ScottPlot5/ScottPlot5/Style/Fill.cs
+++ b/src/ScottPlot5/ScottPlot5/Style/Fill.cs
@@ -19,4 +19,6 @@ public struct Fill
     }
 
     public SKShader? GetShader() => Hatch?.GetShader(Color, HatchColor);
+
+    public Fill WithColor(Color color) => new Fill() { Color = color, Hatch = Hatch, HatchColor = HatchColor };
 }

--- a/src/ScottPlot5/ScottPlot5/Style/Stroke.cs
+++ b/src/ScottPlot5/ScottPlot5/Style/Stroke.cs
@@ -1,5 +1,6 @@
 ﻿namespace ScottPlot.Style;
 
+[Obsolete()]
 public struct Stroke
 {
     public Color Color { get; set; } = Colors.Black;

--- a/src/ScottPlot5/ScottPlot5/TODO.cs
+++ b/src/ScottPlot5/ScottPlot5/TODO.cs
@@ -8,5 +8,6 @@ internal static class TODO
      * Marker class
      * Style classes to group common configuration options: LineStyle and FontStyle
      * Improve signal plot rendering when several repeated values produce a vertical height of zero
+     * AutoScale() is called in the first render if SetAxisLimits() was used to set only a single axis value
      */
 }


### PR DESCRIPTION
**Purpose:**
- Fixes an issue where children of a legend item could be duplicated
- Fixes an issue where legend symbols did not respect padding
- Eliminates remeasuring of child legend items
- Fixes indentation of child legend items

Outstanding issues:
- You cannot customize what items go in a legend (this might be out of scope for this issue)

Before:
![image](https://user-images.githubusercontent.com/8635304/210122204-a8ac68b7-411f-4fe7-b366-9cddd246df72.png)

After:
<img width="383" alt="image" src="https://user-images.githubusercontent.com/8635304/210125267-4575ebc2-5de0-49e7-84d2-1b6411beabfc.png">

