### PR TITLE
SP5: Simplifies MarkerStyle and adds hollow variants

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
@@ -1,4 +1,6 @@
-﻿namespace ScottPlotCookbook.Recipes.Introduction;
+﻿using ScottPlot.Style;
+
+namespace ScottPlotCookbook.Recipes.Introduction;
 
 internal class Styling : RecipePageBase
 {
@@ -133,16 +135,15 @@ internal class Styling : RecipePageBase
         {
             int count = 51;
             double[] xs = Generate.Consecutive(count);
-            double[] ys1 = Generate.Sin(count);
-            double[] ys2 = Generate.Cos(count);
+            double[] ys = Generate.Sin(count);
 
-            var scatter1 = myPlot.Add.Scatter(xs, ys1);
-            scatter1.MarkerStyle.Size = 10;
-            scatter1.MarkerStyle.Outline.Width = 2;
-            scatter1.MarkerStyle.Outline.Color = Colors.Navy;
-
-            var scatter2 = myPlot.Add.Scatter(xs, ys2);
-            scatter2.MarkerStyle = new(ScottPlot.Style.MarkerShape.Square, 6);
+            MarkerShape[] shapes = Enum.GetValues<MarkerShape>().Where(e => e != MarkerShape.None).ToArray();
+            for(int i = 0; i < shapes.Length; i++)
+            {
+                var shiftedYs = ys.Select(y => y + i).ToArray();
+                var scat = myPlot.Add.Scatter(xs, shiftedYs);
+                scat.MarkerStyle = new(shapes[i], 10, myPlot.Palette.GetColor(i));
+            }
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
@@ -142,8 +142,7 @@ internal class Styling : RecipePageBase
             scatter1.MarkerStyle.Outline.Color = Colors.Navy;
 
             var scatter2 = myPlot.Add.Scatter(xs, ys2);
-            scatter2.MarkerStyle.Size = 6;
-            scatter2.MarkerStyle.Shape = ScottPlot.Style.MarkerShape.Square;
+            scatter2.MarkerStyle = new(ScottPlot.Style.MarkerShape.Square, 6);
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPerformance.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPerformance.cs
@@ -1,4 +1,6 @@
-﻿namespace WinForms_Demo.Demos;
+﻿using ScottPlot.Style;
+
+namespace WinForms_Demo.Demos;
 
 public partial class SignalPerformance : Form, IDemoWindow
 {
@@ -34,7 +36,7 @@ public partial class SignalPerformance : Form, IDemoWindow
             double[] ys = ScottPlot.Generate.NoisySin(new Random(), pointCount);
             double[] xs = ScottPlot.Generate.Consecutive(pointCount);
             var sp = formsPlot1.Plot.Add.Scatter(xs, ys);
-            sp.MarkerStyle.Shape = ScottPlot.Style.MarkerShape.None;
+            sp.MarkerStyle = new(MarkerShape.None);
             formsPlot1.Plot.Title.Label.Text = "ten thousand points";
         }
 

--- a/src/ScottPlot5/ScottPlot5/Style/MarkerShape.cs
+++ b/src/ScottPlot5/ScottPlot5/Style/MarkerShape.cs
@@ -3,8 +3,10 @@
 public enum MarkerShape
 {
     None,
-    Circle,
-    Square,
+    FilledCircle,
+    OpenCircle,
+    FilledSquare,
+    OpenSquare,
 }
 
 public static class MarkerShapeExtensions
@@ -13,9 +15,18 @@ public static class MarkerShapeExtensions
     {
         return shape switch
         {
-            MarkerShape.Circle or MarkerShape.None => new MarkerRenderers.Circle(),
-            MarkerShape.Square => new MarkerRenderers.Square(),
+            MarkerShape.FilledCircle or MarkerShape.OpenCircle or MarkerShape.None => new MarkerRenderers.Circle(),
+            MarkerShape.FilledSquare or MarkerShape.OpenSquare => new MarkerRenderers.Square(),
             _ => throw new NotImplementedException(shape.ToString()),
+        };
+    }
+
+    public static bool IsOutlined(this MarkerShape shape)
+    {
+        return shape switch
+        {
+            MarkerShape.OpenCircle or MarkerShape.OpenSquare => true,
+            _ => false,
         };
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Style/MarkerShape.cs
+++ b/src/ScottPlot5/ScottPlot5/Style/MarkerShape.cs
@@ -13,7 +13,7 @@ public static class MarkerShapeExtensions
     {
         return shape switch
         {
-            MarkerShape.Circle => new MarkerRenderers.Circle(),
+            MarkerShape.Circle or MarkerShape.None => new MarkerRenderers.Circle(),
             MarkerShape.Square => new MarkerRenderers.Square(),
             _ => throw new NotImplementedException(shape.ToString()),
         };

--- a/src/ScottPlot5/ScottPlot5/Style/MarkerStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Style/MarkerStyle.cs
@@ -6,30 +6,21 @@
 /// </summary>
 public class MarkerStyle
 {
-    public bool IsVisible => Shape != MarkerShape.None && Size > 0;
+    public bool IsVisible { get; set; }
 
-    /// <summary>
-    /// Standard marker shape.
-    /// Ignored when using a custom marker renderer.
-    /// </summary>
-    public MarkerShape Shape
+    public MarkerStyle(MarkerShape shape = MarkerShape.Circle, float size = 5)
     {
-        get => _Shape;
-        set
-        {
-            _Shape = value;
-            MarkerRenderer = value.GetRenderer();
-        }
+        MarkerRenderer = shape.GetRenderer();
+        IsVisible = shape != MarkerShape.None;
+
+        Size = size;
     }
-
-    private MarkerShape _Shape = MarkerShape.Circle;
-
     /// <summary>
     /// Diameter of the marker (in pixels)
     /// </summary>
-    public float Size { get; set; } = 5;
+    public float Size { get; set; }
 
-    public IMarkerRenderer MarkerRenderer = new MarkerRenderers.Circle();
+    public IMarkerRenderer MarkerRenderer;
 
     public FillStyle Fill { get; set; } = new() { Color = Colors.Gray };
 

--- a/src/ScottPlot5/ScottPlot5/Style/MarkerStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Style/MarkerStyle.cs
@@ -8,19 +8,34 @@ public class MarkerStyle
 {
     public bool IsVisible { get; set; }
 
-    public MarkerStyle(MarkerShape shape = MarkerShape.Circle, float size = 5)
+    public MarkerStyle(MarkerShape shape = MarkerShape.FilledCircle, float size = 5) : this(shape, size, Colors.Gray)
+    { }
+
+    public MarkerStyle(MarkerShape shape, float size, Color color)
     {
         MarkerRenderer = shape.GetRenderer();
         IsVisible = shape != MarkerShape.None;
 
+        Outline.Color = color;
+        if (shape.IsOutlined())
+        {
+            Fill.Color = Colors.Transparent;
+            Outline.Width = 2;
+        }
+        else
+        {
+            Fill.Color = color;
+        }
+
         Size = size;
     }
+
     /// <summary>
     /// Diameter of the marker (in pixels)
     /// </summary>
     public float Size { get; set; }
 
-    public IMarkerRenderer MarkerRenderer;
+    public IMarkerRenderer MarkerRenderer { get; set; }
 
     public FillStyle Fill { get; set; } = new() { Color = Colors.Gray };
 


### PR DESCRIPTION
**Purpose:**
`MarkerStyle` no longer stores a `MarkerShape`, instead taking one in its constructor. Also adds hollow marker shapes.

<img width="838" alt="image" src="https://user-images.githubusercontent.com/8635304/210153215-9069b389-843c-4dff-9483-cd7cf2f79085.png">
