### PR TITLE
ScottPlot5: Error Bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ScottPlot Changelog
 
 ## ScottPlot 5.0.1-beta
+* Error Bar: New plot type (#2346) _Thanks @bclehmann_
 * Namespace: DataSource → DataSources
 
 ## ScottPlot 5.0.0-beta

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/ErrorBar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/ErrorBar.cs
@@ -22,6 +22,27 @@ internal class ErrorBar : RecipePageBase
             double[] xs = Generate.Consecutive(N);
             double[] ys = Generate.RandomWalk(N);
 
+            double[] yErrPositive = Generate.Random(N, 0.1, 0.25);
+            double[] yErrNegative = Generate.Random(N, 0.1, 0.25);
+
+            var scatter = myPlot.Add.Scatter(xs, ys);
+            var errorBars = myPlot.Add.ErrorBar(xs, ys, yErrorPositive: yErrPositive, yErrorNegative: yErrNegative, color: scatter.LineStyle.Color);
+        }
+    }
+
+    internal class MultiDimensionalErrorBars : RecipeTestBase
+    {
+        public override string Name => "MultiDimensional ErrorBars";
+        public override string Description => "You can mix and match x and y error bars.";
+
+        [Test]
+        public override void Recipe()
+        {
+            int N = 50;
+
+            double[] xs = Generate.Consecutive(N);
+            double[] ys = Generate.RandomWalk(N);
+
             double[] xErrPositive = Generate.Random(N, 0.1, 0.25);
             double[] xErrNegative = Generate.Random(N, 0.1, 0.25);
             double[] yErrPositive = Generate.Random(N, 0.1, 0.25);
@@ -31,5 +52,4 @@ internal class ErrorBar : RecipePageBase
             var errorBars = myPlot.Add.ErrorBar(xs, ys, xErrPositive, xErrNegative, yErrPositive, yErrNegative, scatter.LineStyle.Color);
         }
     }
-
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/ErrorBar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/ErrorBar.cs
@@ -1,42 +1,35 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace ScottPlotCookbook.Recipes.PlotTypes;
 
-namespace ScottPlotCookbook.Recipes.PlotTypes
+internal class ErrorBar : RecipePageBase
 {
-    internal class ErrorBar : RecipePageBase
+    public override RecipePageDetails PageDetails => new()
     {
-        public override RecipePageDetails PageDetails => new()
+        Chapter = Chapter.PlotTypes,
+        PageName = "Error Bars",
+        PageDescription = "Error Bars communicate the range of possible values for a measurement",
+    };
+
+    internal class Quickstart : RecipeTestBase
+    {
+        public override string Name => "Error Bar Quickstart";
+        public override string Description => "Error Bars go well with scatter plots.";
+
+        [Test]
+        public override void Recipe()
         {
-            Chapter = Chapter.PlotTypes,
-            PageName = "Error Bars",
-            PageDescription = "Error Bars communicate the range of possible values for a measurement.",
-        };
+            int N = 50;
 
-        internal class Quickstart : RecipeTestBase
-        {
-            public override string Name => "Error Bar Quickstart";
-            public override string Description => "Error Bars go well with scatter plots.";
+            double[] xs = Generate.Consecutive(N);
+            double[] ys = Generate.RandomWalk(N);
 
-            [Test]
-            public override void Recipe()
-            {
-                int N = 50;
+            double[] xErrPositive = Generate.Random(N, 0.1, 0.25);
+            double[] xErrNegative = Generate.Random(N, 0.1, 0.25);
+            double[] yErrPositive = Generate.Random(N, 0.1, 0.25);
+            double[] yErrNegative = Generate.Random(N, 0.1, 0.25);
 
-                double[] xs = Generate.Consecutive(N);
-                double[] ys = Generate.RandomWalk(N);
-
-                double[] xErrPositive = Generate.Random(N, 0.1, 0.25);
-                double[] xErrNegative = Generate.Random(N, 0.1, 0.25);
-                double[] yErrPositive = Generate.Random(N, 0.1, 0.25);
-                double[] yErrNegative = Generate.Random(N, 0.1, 0.25);
-
-                var scatter = myPlot.Add.Scatter(xs, ys);
-                var errorBars = myPlot.Add.ErrorBar(xs, ys, xErrPositive, xErrNegative, yErrPositive, yErrNegative, scatter.LineStyle.Color);
-            }
+            var scatter = myPlot.Add.Scatter(xs, ys);
+            var errorBars = myPlot.Add.ErrorBar(xs, ys, xErrPositive, xErrNegative, yErrPositive, yErrNegative, scatter.LineStyle.Color);
         }
-
     }
+
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/ErrorBar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/ErrorBar.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlotCookbook.Recipes.PlotTypes
+{
+    internal class ErrorBar : RecipePageBase
+    {
+        public override RecipePageDetails PageDetails => new()
+        {
+            Chapter = Chapter.PlotTypes,
+            PageName = "Error Bars",
+            PageDescription = "Error Bars communicate the range of possible values for a measurement.",
+        };
+
+        internal class Quickstart : RecipeTestBase
+        {
+            public override string Name => "Error Bar Quickstart";
+            public override string Description => "Error Bars go well with scatter plots.";
+
+            [Test]
+            public override void Recipe()
+            {
+                int N = 50;
+
+                double[] xs = Generate.Consecutive(N);
+                double[] ys = Generate.RandomWalk(N);
+
+                double[] xErrPositive = Generate.Random(N, 0.1, 0.25);
+                double[] xErrNegative = Generate.Random(N, 0.1, 0.25);
+                double[] yErrPositive = Generate.Random(N, 0.1, 0.25);
+                double[] yErrNegative = Generate.Random(N, 0.1, 0.25);
+
+                var scatter = myPlot.Add.Scatter(xs, ys);
+                var errorBars = myPlot.Add.ErrorBar(xs, ys, xErrPositive, xErrNegative, yErrPositive, yErrNegative, scatter.LineStyle.Color);
+            }
+        }
+
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/AddPlottable.cs
+++ b/src/ScottPlot5/ScottPlot5/AddPlottable.cs
@@ -109,4 +109,12 @@ public class AddPlottable
         Plot.Panels.Add(colorBar);
         return colorBar;
     }
+
+    public ErrorBar ErrorBar(IReadOnlyList<double> xs, IReadOnlyList<double> ys, IReadOnlyList<double>? xErrorPositive, IReadOnlyList<double>? xErrorNegative, IReadOnlyList<double>? yErrorPositive, IReadOnlyList<double>? yErrorNegative, Color? color = null)
+    {
+        color = color ?? NextColor;
+        ErrorBar errorBar = new(xs, ys, xErrorPositive, xErrorNegative, yErrorPositive, yErrorNegative, color.Value);
+        Plot.Plottables.Add(errorBar);
+        return errorBar;
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/AddPlottable.cs
+++ b/src/ScottPlot5/ScottPlot5/AddPlottable.cs
@@ -110,7 +110,7 @@ public class AddPlottable
         return colorBar;
     }
 
-    public ErrorBar ErrorBar(IReadOnlyList<double> xs, IReadOnlyList<double> ys, IReadOnlyList<double>? xErrorPositive, IReadOnlyList<double>? xErrorNegative, IReadOnlyList<double>? yErrorPositive, IReadOnlyList<double>? yErrorNegative, Color? color = null)
+    public ErrorBar ErrorBar(IReadOnlyList<double> xs, IReadOnlyList<double> ys, IReadOnlyList<double>? xErrorPositive = null, IReadOnlyList<double>? xErrorNegative = null, IReadOnlyList<double>? yErrorPositive = null, IReadOnlyList<double>? yErrorNegative = null, Color? color = null)
     {
         color = color ?? NextColor;
         ErrorBar errorBar = new(xs, ys, xErrorPositive, xErrorNegative, yErrorPositive, yErrorNegative, color.Value);

--- a/src/ScottPlot5/ScottPlot5/Generate.cs
+++ b/src/ScottPlot5/ScottPlot5/Generate.cs
@@ -160,4 +160,17 @@ public static class Generate
         RandomDataGenerator gen = new(seed);
         return gen.RandomWalk(count, mult, offset);
     }
+
+    /// <summary>
+    /// Return a series of values starting with <paramref name="offset"/> and
+    /// each randomly deviating from the previous by at most <paramref name="mult"/>.
+    /// Random values are deterministic based on the value of <paramref name="seed"/>.
+    /// </summary>
+    public static double[] Random(int count, double min = 0, double max = 1, int seed = 0)
+    {
+        RandomDataGenerator gen = new(seed);
+        return Enumerable.Range(0, count)
+            .Select(_ => gen.RandomNumber(min, max))
+            .ToArray();
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/ErrorBar.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/ErrorBar.cs
@@ -1,0 +1,105 @@
+﻿using ScottPlot.Axis;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Plottables
+{
+    public class ErrorBar : IPlottable
+    {
+        public bool IsVisible { get; set; } = true;
+        public IAxes Axes { get; set; } = Axis.Axes.Default;
+
+        public IReadOnlyList<double> Xs { get; set; }
+        public IReadOnlyList<double> Ys { get; set; }
+        public IReadOnlyList<double>? XErrorsPositive { get; set; }
+        public IReadOnlyList<double>? XErrorsNegative { get; set; }
+        public IReadOnlyList<double>? YErrorsPositive { get; set; }
+        public IReadOnlyList<double>? YErrorsNegative { get; set; }
+
+        public LineStyle LineStyle { get; set; } = new();
+        public float CapSize { get; set; } = 3;
+
+        public ErrorBar(IReadOnlyList<double> xs, IReadOnlyList<double> ys, IReadOnlyList<double>? xErrorsPositive, IReadOnlyList<double>? xErrorsNegative, IReadOnlyList<double>? yErrorsPositive, IReadOnlyList<double>? yErrorsNegative, Color color)
+        {
+            Xs = xs;
+            Ys = ys;
+            XErrorsPositive = xErrorsPositive;
+            XErrorsNegative = xErrorsNegative;
+            YErrorsPositive = yErrorsPositive;
+            YErrorsNegative = yErrorsNegative;
+            LineStyle.Color = color;
+        }
+
+        public IEnumerable<LegendItem> LegendItems => Enumerable.Empty<LegendItem>();
+
+        public AxisLimits GetAxisLimits()
+        {
+            AxisLimits limits = AxisLimits.NoLimits;
+
+            for (int i = 0; i < Xs.Count; i++)
+            {
+                double x = Xs[i];
+                double y = Ys[i];
+
+                limits.ExpandX(x - XErrorsNegative?[i] ?? 0);
+                limits.ExpandX(x + XErrorsPositive?[i] ?? 0);
+                limits.ExpandY(y - YErrorsNegative?[i] ?? 0);
+                limits.ExpandY(y + YErrorsPositive?[i] ?? 0);
+            }
+
+            return limits;
+        }
+
+        public void Render(SKSurface surface)
+        {
+            RenderErrorBars(surface.Canvas, Xs, Ys, YErrorsPositive, YErrorsNegative);
+            RenderErrorBars(surface.Canvas, Ys, Xs, XErrorsPositive, XErrorsNegative, true);
+        }
+
+        private void RenderErrorBars(SKCanvas canvas, IReadOnlyList<double> positions, IReadOnlyList<double> vals, IReadOnlyList<double>? errorPositive, IReadOnlyList<double>? errorNegative, bool horizontal = false)
+        {
+            using SKPaint paint = new();
+            using SKPath path = new();
+
+            LineStyle.ApplyToPaint(paint);
+
+            for(int i = 0; i < vals.Count; i++)
+            {
+                double bottom = vals[i] - errorNegative?[i] ?? 0;
+                double top = vals[i] + errorPositive?[i] ?? 0;
+
+                if (bottom == top && bottom == vals[i])
+                    continue;
+
+                Coordinates centreBottom = horizontal ? new Coordinates(bottom, positions[i]) : new Coordinates(positions[i], bottom);
+                Coordinates centreTop = horizontal ? new Coordinates(top, positions[i]) : new Coordinates(positions[i], top);
+
+
+                Pixel capOffset = horizontal ? new(0, CapSize) : new(CapSize, 0);
+
+                Pixel centreBottomPx = Axes.GetPixel(centreBottom);
+                Pixel leftBottomPx = centreBottomPx - capOffset;
+                Pixel rightBottomPx = centreBottomPx + capOffset;
+                
+                Pixel centreTopPx = Axes.GetPixel(centreTop);
+                Pixel leftTopPx = centreTopPx - capOffset;
+                Pixel rightTopPx = centreTopPx + capOffset;
+
+                path.MoveTo(leftBottomPx.ToSKPoint());
+                path.LineTo(rightBottomPx.ToSKPoint());
+                
+                path.MoveTo(centreBottomPx.ToSKPoint());
+                path.LineTo(centreTopPx.ToSKPoint());
+
+                path.MoveTo(leftTopPx.ToSKPoint());
+                path.LineTo(rightTopPx.ToSKPoint());
+
+            }
+
+            canvas.DrawPath(path, paint);
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/ErrorBar.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/ErrorBar.cs
@@ -66,7 +66,7 @@ namespace ScottPlot.Plottables
 
             LineStyle.ApplyToPaint(paint);
 
-            for(int i = 0; i < vals.Count; i++)
+            for (int i = 0; i < vals.Count; i++)
             {
                 double bottom = vals[i] - errorNegative?[i] ?? 0;
                 double top = vals[i] + errorPositive?[i] ?? 0;
@@ -83,14 +83,14 @@ namespace ScottPlot.Plottables
                 Pixel centreBottomPx = Axes.GetPixel(centreBottom);
                 Pixel leftBottomPx = centreBottomPx - capOffset;
                 Pixel rightBottomPx = centreBottomPx + capOffset;
-                
+
                 Pixel centreTopPx = Axes.GetPixel(centreTop);
                 Pixel leftTopPx = centreTopPx - capOffset;
                 Pixel rightTopPx = centreTopPx + capOffset;
 
                 path.MoveTo(leftBottomPx.ToSKPoint());
                 path.LineTo(rightBottomPx.ToSKPoint());
-                
+
                 path.MoveTo(centreBottomPx.ToSKPoint());
                 path.LineTo(centreTopPx.ToSKPoint());
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/ErrorBar.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/ErrorBar.cs
@@ -68,8 +68,8 @@ namespace ScottPlot.Plottables
 
             for (int i = 0; i < vals.Count; i++)
             {
-                double bottom = vals[i] - errorNegative?[i] ?? 0;
-                double top = vals[i] + errorPositive?[i] ?? 0;
+                double bottom = vals[i] - (errorNegative?[i] ?? 0);
+                double top = vals[i] + (errorPositive?[i] ?? 0);
 
                 if (bottom == top && bottom == vals[i])
                     continue;

--- a/src/ScottPlot5/ScottPlot5/PublicAPI.Unshipped.txt
+++ b/src/ScottPlot5/ScottPlot5/PublicAPI.Unshipped.txt
@@ -167,7 +167,7 @@ ScottPlot.AddPlottable.Bar(double[]! values) -> ScottPlot.Plottables.BarPlot!
 ScottPlot.AddPlottable.Bar(System.Collections.Generic.IList<ScottPlot.Plottables.Bar!>! bars, ScottPlot.Color? color = null, string? label = null) -> ScottPlot.Plottables.BarPlot!
 ScottPlot.AddPlottable.Bar(System.Collections.Generic.IList<ScottPlot.Plottables.BarSeries!>! series) -> ScottPlot.Plottables.BarPlot!
 ScottPlot.AddPlottable.ColorBar(ScottPlot.IHasColorAxis! source, ScottPlot.Edge edge = ScottPlot.Edge.Right) -> ScottPlot.Panels.ColorBar!
-ScottPlot.AddPlottable.ErrorBar(System.Collections.Generic.IReadOnlyList<double>! xs, System.Collections.Generic.IReadOnlyList<double>! ys, System.Collections.Generic.IReadOnlyList<double>? xErrorPositive, System.Collections.Generic.IReadOnlyList<double>? xErrorNegative, System.Collections.Generic.IReadOnlyList<double>? yErrorPositive, System.Collections.Generic.IReadOnlyList<double>? yErrorNegative, ScottPlot.Color? color = null) -> ScottPlot.Plottables.ErrorBar!
+ScottPlot.AddPlottable.ErrorBar(System.Collections.Generic.IReadOnlyList<double>! xs, System.Collections.Generic.IReadOnlyList<double>! ys, System.Collections.Generic.IReadOnlyList<double>? xErrorPositive = null, System.Collections.Generic.IReadOnlyList<double>? xErrorNegative = null, System.Collections.Generic.IReadOnlyList<double>? yErrorPositive = null, System.Collections.Generic.IReadOnlyList<double>? yErrorNegative = null, ScottPlot.Color? color = null) -> ScottPlot.Plottables.ErrorBar!
 ScottPlot.AddPlottable.Heatmap(double[,]! intensities) -> ScottPlot.Plottables.Heatmap!
 ScottPlot.AddPlottable.Palette.get -> ScottPlot.IPalette!
 ScottPlot.AddPlottable.Palette.set -> void

--- a/src/ScottPlot5/ScottPlot5/PublicAPI.Unshipped.txt
+++ b/src/ScottPlot5/ScottPlot5/PublicAPI.Unshipped.txt
@@ -167,6 +167,7 @@ ScottPlot.AddPlottable.Bar(double[]! values) -> ScottPlot.Plottables.BarPlot!
 ScottPlot.AddPlottable.Bar(System.Collections.Generic.IList<ScottPlot.Plottables.Bar!>! bars, ScottPlot.Color? color = null, string? label = null) -> ScottPlot.Plottables.BarPlot!
 ScottPlot.AddPlottable.Bar(System.Collections.Generic.IList<ScottPlot.Plottables.BarSeries!>! series) -> ScottPlot.Plottables.BarPlot!
 ScottPlot.AddPlottable.ColorBar(ScottPlot.IHasColorAxis! source, ScottPlot.Edge edge = ScottPlot.Edge.Right) -> ScottPlot.Panels.ColorBar!
+ScottPlot.AddPlottable.ErrorBar(System.Collections.Generic.IReadOnlyList<double>! xs, System.Collections.Generic.IReadOnlyList<double>! ys, System.Collections.Generic.IReadOnlyList<double>? xErrorPositive, System.Collections.Generic.IReadOnlyList<double>? xErrorNegative, System.Collections.Generic.IReadOnlyList<double>? yErrorPositive, System.Collections.Generic.IReadOnlyList<double>? yErrorNegative, ScottPlot.Color? color = null) -> ScottPlot.Plottables.ErrorBar!
 ScottPlot.AddPlottable.Heatmap(double[,]! intensities) -> ScottPlot.Plottables.Heatmap!
 ScottPlot.AddPlottable.Palette.get -> ScottPlot.IPalette!
 ScottPlot.AddPlottable.Palette.set -> void
@@ -1186,6 +1187,31 @@ ScottPlot.Plottables.BarSeries.Color.get -> ScottPlot.Color
 ScottPlot.Plottables.BarSeries.Color.set -> void
 ScottPlot.Plottables.BarSeries.Label.get -> string?
 ScottPlot.Plottables.BarSeries.Label.set -> void
+ScottPlot.Plottables.ErrorBar
+ScottPlot.Plottables.ErrorBar.Axes.get -> ScottPlot.Axis.IAxes!
+ScottPlot.Plottables.ErrorBar.Axes.set -> void
+ScottPlot.Plottables.ErrorBar.CapSize.get -> float
+ScottPlot.Plottables.ErrorBar.CapSize.set -> void
+ScottPlot.Plottables.ErrorBar.ErrorBar(System.Collections.Generic.IReadOnlyList<double>! xs, System.Collections.Generic.IReadOnlyList<double>! ys, System.Collections.Generic.IReadOnlyList<double>? xErrorsPositive, System.Collections.Generic.IReadOnlyList<double>? xErrorsNegative, System.Collections.Generic.IReadOnlyList<double>? yErrorsPositive, System.Collections.Generic.IReadOnlyList<double>? yErrorsNegative, ScottPlot.Color color) -> void
+ScottPlot.Plottables.ErrorBar.GetAxisLimits() -> ScottPlot.AxisLimits
+ScottPlot.Plottables.ErrorBar.IsVisible.get -> bool
+ScottPlot.Plottables.ErrorBar.IsVisible.set -> void
+ScottPlot.Plottables.ErrorBar.LegendItems.get -> System.Collections.Generic.IEnumerable<ScottPlot.LegendItem!>!
+ScottPlot.Plottables.ErrorBar.LineStyle.get -> ScottPlot.LineStyle!
+ScottPlot.Plottables.ErrorBar.LineStyle.set -> void
+ScottPlot.Plottables.ErrorBar.Render(SkiaSharp.SKSurface! surface) -> void
+ScottPlot.Plottables.ErrorBar.XErrorsNegative.get -> System.Collections.Generic.IReadOnlyList<double>?
+ScottPlot.Plottables.ErrorBar.XErrorsNegative.set -> void
+ScottPlot.Plottables.ErrorBar.XErrorsPositive.get -> System.Collections.Generic.IReadOnlyList<double>?
+ScottPlot.Plottables.ErrorBar.XErrorsPositive.set -> void
+ScottPlot.Plottables.ErrorBar.Xs.get -> System.Collections.Generic.IReadOnlyList<double>!
+ScottPlot.Plottables.ErrorBar.Xs.set -> void
+ScottPlot.Plottables.ErrorBar.YErrorsNegative.get -> System.Collections.Generic.IReadOnlyList<double>?
+ScottPlot.Plottables.ErrorBar.YErrorsNegative.set -> void
+ScottPlot.Plottables.ErrorBar.YErrorsPositive.get -> System.Collections.Generic.IReadOnlyList<double>?
+ScottPlot.Plottables.ErrorBar.YErrorsPositive.set -> void
+ScottPlot.Plottables.ErrorBar.Ys.get -> System.Collections.Generic.IReadOnlyList<double>!
+ScottPlot.Plottables.ErrorBar.Ys.set -> void
 ScottPlot.Plottables.Heatmap
 ScottPlot.Plottables.Heatmap.Axes.get -> ScottPlot.Axis.IAxes!
 ScottPlot.Plottables.Heatmap.Axes.set -> void
@@ -1533,6 +1559,7 @@ static ScottPlot.Generate.Cos(int count, double mult = 1, double offset = 0, dou
 static ScottPlot.Generate.Cos<T>(int count, double mult = 1, double offset = 0, double oscillations = 1, double phase = 0) -> T[]!
 static ScottPlot.Generate.NoisySin(System.Random! rand, int count, double noiseLevel = 1) -> double[]!
 static ScottPlot.Generate.Ramp2D(int width, int height, double min = 0, double max = 1) -> double[,]!
+static ScottPlot.Generate.Random(int count, double min = 0, double max = 1, int seed = 0) -> double[]!
 static ScottPlot.Generate.RandomWalk(int count, double mult = 1, double offset = 0, int seed = 0) -> double[]!
 static ScottPlot.Generate.Sin(int count, double mult = 1, double offset = 0, double oscillations = 1, double phase = 0) -> double[]!
 static ScottPlot.Generate.Sin2D(int width, int height, double xPeriod = 0.2, double yPeriod = 0.2, double multiple = 100) -> double[,]!


### PR DESCRIPTION
**Purpose:**
Adds an ErrorBar plottable with a similar API as the one in 4.1. This does not add errorbars to other plottables (scatter, signal, etc) although that may be a good enhancement.

```cs
int N = 50;

double[] xs = Generate.Consecutive(N);
double[] ys = Generate.RandomWalk(N);

double[] xErrPositive = Generate.Random(N, 0.1, 0.25);
double[] xErrNegative = Generate.Random(N, 0.1, 0.25);
double[] yErrPositive = Generate.Random(N, 0.1, 0.25);
double[] yErrNegative = Generate.Random(N, 0.1, 0.25);

var scatter = myPlot.Add.Scatter(xs, ys);
var errorBars = myPlot.Add.ErrorBar(xs, ys, xErrPositive, xErrNegative, yErrPositive, yErrNegative, scatter.LineStyle.Color);
```

<img width="854" alt="image" src="https://user-images.githubusercontent.com/8635304/210187575-45a7bf2a-b63a-4ff9-bc57-071676e77db6.png">
