### PR TITLE
Correction for median calculation in population plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2023-01-01_
 _not yet published on NuGet..._
 * Axis: Throw exception immediately upon setting invalid axis limits (#2327) _Thanks @mjpz_
 * Heatmap: Added support for transparent single-color heatmaps (#2336) _Thanks @bukkideme_
+* Statistics: Improved median calculation method in population plots (#2363) _Thanks @Syntaxrabbit_
 
 ## ScottPlot 4.1.60
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2022-12-23_

--- a/src/ScottPlot4/ScottPlot/Statistics/Population.cs
+++ b/src/ScottPlot4/ScottPlot/Statistics/Population.cs
@@ -78,7 +78,9 @@ namespace ScottPlot.Statistics
 
             min = sortedValues.First();
             max = sortedValues.Last();
-            median = sortedValues[count / 2];
+
+            // median is average of the two values in the middle if value count is even
+            median = count % 2 == 0 ? ((sortedValues[(count / 2) - 1] + sortedValues[count / 2]) / 2d) : sortedValues[count / 2];
 
             Q1 = sortedValues[QSize];
             Q3 = sortedValues[sortedValues.Length - QSize - 1];


### PR DESCRIPTION
This small correction lets the population plot calculate the median in the correct way.
(If the value count is even, the two values in the middle of a sorted array need to be averaged.)