### PR TITLE
ScottPlot 5: dashed lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Controls: Added right-click context menus (#2350) _Thanks @bclehmann_
 * Rendering: Added support for saving bitmap files (#2350) _Thanks @bclehmann_
 * Axes: Added support for DateTime Axes (#2369) _Thanks @bclehmann_
+* Rendering: Added support for line styles (#2373) _Thanks @bclehmann_
 
 ## ScottPlot 5.0.0-beta
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2023-01-01_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
@@ -161,4 +161,32 @@ internal class Styling : RecipePageBase
             }
         }
     }
+
+    internal class LineStyles : RecipeTestBase
+    {
+        public override string Name => "Line Styles";
+        public override string Description => "Many plot types have a LineStyle which can be customized.";
+
+        [Test]
+        public override void Recipe()
+        {
+            int count = 21;
+            double[] xs = Generate.Consecutive(count);
+            double[] ys = Generate.Sin(count);
+
+            LinePattern[] linePatterns = Enum.GetValues<LinePattern>().ToArray();
+
+            for (int i = 0; i < linePatterns.Length; i++)
+            {
+                double[] data = ys.Select(y => linePatterns.Length - y + i).ToArray();
+
+                var scatter = myPlot.Add.Scatter(xs, data);
+
+                scatter.Label = linePatterns[i].ToString();
+                scatter.LineStyle.Width = 2;
+                scatter.LineStyle.Pattern = linePatterns[i];
+                scatter.MarkerStyle = MarkerStyle.None;
+            }
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Extensions/SkiaSharpExtensions.cs
+++ b/src/ScottPlot5/ScottPlot5/Extensions/SkiaSharpExtensions.cs
@@ -69,6 +69,7 @@ public static class SkiaSharpExtensions
         paint.IsStroke = true;
         paint.Color = style.Color.ToSKColor();
         paint.StrokeWidth = style.Width;
+        paint.PathEffect = style.Pattern.GetPathEffect();
     }
 
     public static void ApplyToPaint(this FillStyle fs, SKPaint paint)
@@ -97,5 +98,16 @@ public static class SkiaSharpExtensions
         paint.TextSize = fontStyle.Size;
         paint.Color = fontStyle.Color.ToSKColor();
         paint.IsAntialias = fontStyle.AntiAlias;
+    }
+
+    public static SKPathEffect? GetPathEffect(this LinePattern pattern)
+    {
+        return pattern switch
+        {
+            LinePattern.Solid => null,
+            LinePattern.Dash => SKPathEffect.CreateDash(new float[] { 10, 10 }, 0),
+            LinePattern.Dot => SKPathEffect.CreateDash(new float[] { 3, 5 }, 0),
+            _ => throw new NotImplementedException(),
+        };
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Extensions/SkiaSharpExtensions.cs
+++ b/src/ScottPlot5/ScottPlot5/Extensions/SkiaSharpExtensions.cs
@@ -70,6 +70,7 @@ public static class SkiaSharpExtensions
         paint.Color = style.Color.ToSKColor();
         paint.StrokeWidth = style.Width;
         paint.PathEffect = style.Pattern.GetPathEffect();
+        paint.IsAntialias = style.AntiAlias;
     }
 
     public static void ApplyToPaint(this FillStyle fs, SKPaint paint)

--- a/src/ScottPlot5/ScottPlot5/LineStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/LineStyle.cs
@@ -11,4 +11,5 @@ public class LineStyle
     public LinePattern Pattern { get; set; } = LinePattern.Solid;
     public bool IsVisible => Color != Colors.Transparent && Width > 0; // TODO: make this a settable property
     public static LineStyle NoLine => new() { Width = 0 };
+    public bool AntiAlias { get; set; } = true;
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -111,10 +111,7 @@ public class Signal : IPlottable
         foreach (Pixel point in points)
             path.LineTo(point.ToSKPoint());
 
-        using SKPaint paint = new()
-        {
-            IsAntialias = true,
-        };
+        using SKPaint paint = new();
         LineStyle.ApplyToPaint(paint);
 
         surface.Canvas.DrawPath(path, paint);
@@ -136,10 +133,7 @@ public class Signal : IPlottable
     /// </summary>
     private void RenderHighDensity(SKSurface surface)
     {
-        using SKPaint paint = new()
-        {
-            IsAntialias = true,
-        };
+        using SKPaint paint = new();
         LineStyle.ApplyToPaint(paint);
 
         PixelRangeY[] verticalBars = GetVerticalBars();

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -114,10 +114,8 @@ public class Signal : IPlottable
         using SKPaint paint = new()
         {
             IsAntialias = true,
-            Style = SKPaintStyle.Stroke,
-            Color = LineStyle.Color.ToSKColor(),
-            StrokeWidth = LineStyle.Width,
         };
+        LineStyle.ApplyToPaint(paint);
 
         surface.Canvas.DrawPath(path, paint);
 
@@ -141,10 +139,8 @@ public class Signal : IPlottable
         using SKPaint paint = new()
         {
             IsAntialias = true,
-            Style = SKPaintStyle.Stroke,
-            Color = LineStyle.Color.ToSKColor(),
-            StrokeWidth = LineStyle.Width,
         };
+        LineStyle.ApplyToPaint(paint);
 
         PixelRangeY[] verticalBars = GetVerticalBars();
         for (int i = 0; i < verticalBars.Length; i++)

--- a/src/ScottPlot5/ScottPlot5/TODO.cs
+++ b/src/ScottPlot5/ScottPlot5/TODO.cs
@@ -7,7 +7,6 @@ internal static class TODO
      *   IAxis.cs has lots of tick styling that should be a Axis.TickStyle
      * Manual tick generator
      * Make more marker class
-     * LinePattern is not currently supported
      * Improve signal plot rendering when several repeated values produce a vertical height of zero
      * AutoScale() is called in the first render if SetAxisLimits() was used to set only a single axis value
      * Add offset X and offset Y support to signal plots


### PR DESCRIPTION
**Purpose:**
Allows dotted/dashed lines using `SKPathEffect`

```cs
WpfPlot.Plot.Add.Signal(Generate.Sin(51)).LineStyle.Pattern = LinePattern.Dot;
WpfPlot.Plot.Add.Signal(Generate.Cos(51)).LineStyle.Pattern = LinePattern.Dash;
```

![image](https://user-images.githubusercontent.com/8635304/216783309-0bdcab52-7e57-425c-8eae-c42465d204ee.png)
