### PR TITLE
ScatterPlottable which uses raw OpenL for rendering

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlot.cs
@@ -1,5 +1,6 @@
 ﻿using ScottPlot.Control;
 using ScottPlot.Extensions;
+using SkiaSharp;
 using SkiaSharp.Views.Desktop;
 using System;
 using System.ComponentModel;
@@ -12,6 +13,8 @@ namespace ScottPlot.WinForms;
 public class FormsPlot : UserControl, IPlotControl
 {
     readonly SKGLControl SKElement;
+
+    public GRContext GRContext => SKElement.GRContext;
 
     public Plot Plot { get; private set; }
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/GLShader.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/GLShader.cs
@@ -1,0 +1,107 @@
+﻿using OpenTK.Graphics.OpenGL;
+using System;
+
+namespace ScottPlot.WinForms
+{
+    public class GLShader : IDisposable
+    {
+        private int Handle;
+
+        string _vertexShaderSource =
+        @"# version 330 core
+        layout(location = 0) in vec3 aPosition;
+        uniform mat4 transform;
+
+        void main()
+        {
+            gl_Position = vec4(aPosition, 1.0) * transform;
+        }";
+
+        string _fragmentShaderSource =
+        @"#version 330 core
+        out vec4 FragColor;
+        uniform vec4 pathColor;
+
+        void main()
+        {
+            FragColor = pathColor;
+        }";
+
+        public GLShader()
+        {
+            var VertexShader = GL.CreateShader(ShaderType.VertexShader);
+            GL.ShaderSource(VertexShader, _vertexShaderSource);
+
+            var FragmentShader = GL.CreateShader(ShaderType.FragmentShader);
+            GL.ShaderSource(FragmentShader, _fragmentShaderSource);
+
+            GL.CompileShader(VertexShader);
+
+            GL.GetShader(VertexShader, ShaderParameter.CompileStatus, out int successVertex);
+            if (successVertex == 0)
+            {
+                string infoLog = GL.GetShaderInfoLog(VertexShader);
+                Console.WriteLine(infoLog);
+            }
+
+            GL.CompileShader(FragmentShader);
+
+            GL.GetShader(FragmentShader, ShaderParameter.CompileStatus, out int successFragment);
+            if (successFragment == 0)
+            {
+                string infoLog = GL.GetShaderInfoLog(FragmentShader);
+                Console.WriteLine(infoLog);
+            }
+
+            Handle = GL.CreateProgram();
+
+            GL.AttachShader(Handle, VertexShader);
+            GL.AttachShader(Handle, FragmentShader);
+
+            GL.LinkProgram(Handle);
+
+            GL.GetProgram(Handle, GetProgramParameterName.LinkStatus, out int success);
+            if (success == 0)
+            {
+                string infoLog = GL.GetProgramInfoLog(Handle);
+                Console.WriteLine(infoLog);
+            }
+
+            GL.DetachShader(Handle, VertexShader);
+            GL.DetachShader(Handle, FragmentShader);
+            GL.DeleteShader(FragmentShader);
+            GL.DeleteShader(VertexShader);
+        }
+        public void Use()
+        {
+            GL.UseProgram(Handle);
+        }
+
+        public int GetAttribLocation(string attribName)
+        {
+            return GL.GetAttribLocation(Handle, attribName);
+        }
+
+        public int GetUniformLocation(string attribName)
+        {
+            return GL.GetUniformLocation(Handle, attribName);
+        }
+
+        private bool disposedValue = false;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                GL.DeleteProgram(Handle);
+
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/ScatterGL.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/ScatterGL.cs
@@ -1,0 +1,79 @@
+﻿using OpenTK;
+using OpenTK.Graphics.OpenGL;
+using ScottPlot.DataSources;
+using ScottPlot.Plottables;
+using SkiaSharp;
+using System.Linq;
+
+namespace ScottPlot.WinForms
+{
+    public class ScatterGL : Scatter, IPlottableGL
+    {
+        private readonly GRContext _context;
+        private int VertexBufferObject;
+        private int VertexArrayObject;
+        private GLShader shader;
+        private float[] vertices;
+        private int verticesCount;
+
+        private bool _glInit = false;
+
+        public ScatterGL(IScatterSource data, GRContext context) : base(data)
+        {
+            _context = context;
+            vertices = data.GetScatterPoints().Select(p =>
+            {
+                return new float[] { (float)p.X, (float)p.Y, 0 };
+            }).
+            SelectMany(t => t).ToArray();
+            verticesCount = vertices.Length / 3;
+        }
+
+        private void InitGL()
+        {
+            shader = new GLShader();
+            VertexArrayObject = GL.GenVertexArray();
+            VertexBufferObject = GL.GenBuffer();
+            GL.BindVertexArray(VertexArrayObject);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, VertexBufferObject);
+            GL.BufferData(BufferTarget.ArrayBuffer, vertices.Length * sizeof(float), vertices, BufferUsageHint.StaticDraw);
+            GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, 3 * sizeof(float), 0);
+            GL.EnableVertexAttribArray(0);
+            vertices = null;
+            _glInit = true;
+        }
+
+        public override void Render(SKSurface surface)
+        {
+            int deviceHeight = (int)surface.Canvas.LocalClipBounds.Height;
+            _context.Flush();
+            _context.ResetContext();
+
+            if (!_glInit)
+                InitGL();
+
+            shader.Use();
+
+            GL.Viewport((int)Axes.DataRect.Left, (int)(deviceHeight - Axes.DataRect.Bottom), (int)Axes.DataRect.Width, (int)Axes.DataRect.Height);
+
+            var xRange = Axes.XAxis.Range;
+            var yRange = Axes.YAxis.Range;
+
+            float xTranslation = (float)(-1.0 * (xRange.Min + xRange.Max) / 2);
+            float yTranslation = (float)(-1.0 * (yRange.Min + yRange.Max) / 2);
+            float xScaling = (float)(2.0 / (xRange.Max - xRange.Min));
+            float yScaling = (float)(2.0 / (yRange.Max - yRange.Min));
+            Matrix4 translate = Matrix4.CreateTranslation(xTranslation, yTranslation, 0);
+            Matrix4 scale = Matrix4.CreateScale(xScaling, yScaling, 1.0f);
+            Matrix4 normGL = translate * scale;
+
+            int location = shader.GetUniformLocation("transform");
+            GL.UniformMatrix4(location, true, ref normGL);
+            int colorLocation = shader.GetUniformLocation("pathColor");
+            GL.Uniform4(colorLocation, OpenTK.Graphics.Color4.Blue);
+
+            GL.BindVertexArray(VertexArrayObject);
+            GL.DrawArrays(PrimitiveType.LineStrip, 0, verticesCount);
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPerformance.Designer.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPerformance.Designer.cs
@@ -31,6 +31,7 @@
             this.formsPlot1 = new ScottPlot.WinForms.FormsPlot();
             this.rbSignal = new System.Windows.Forms.RadioButton();
             this.rbScatter = new System.Windows.Forms.RadioButton();
+            this.rbScatterGL = new System.Windows.Forms.RadioButton();
             this.SuspendLayout();
             // 
             // formsPlot1
@@ -67,11 +68,23 @@
             this.rbScatter.UseVisualStyleBackColor = true;
             this.rbScatter.CheckedChanged += new System.EventHandler(this.rbScatter_CheckedChanged);
             // 
+            // rbScatterGL
+            // 
+            this.rbScatterGL.AutoSize = true;
+            this.rbScatterGL.Location = new System.Drawing.Point(190, 12);
+            this.rbScatterGL.Name = "rbScatterGL";
+            this.rbScatterGL.Size = new System.Drawing.Size(75, 19);
+            this.rbScatterGL.TabIndex = 3;
+            this.rbScatterGL.TabStop = true;
+            this.rbScatterGL.Text = "ScatterGL";
+            this.rbScatterGL.UseVisualStyleBackColor = true;
+            // 
             // SignalPerformance
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 450);
+            this.Controls.Add(this.rbScatterGL);
             this.Controls.Add(this.rbScatter);
             this.Controls.Add(this.rbSignal);
             this.Controls.Add(this.formsPlot1);
@@ -87,5 +100,6 @@
         private ScottPlot.WinForms.FormsPlot formsPlot1;
         private RadioButton rbSignal;
         private RadioButton rbScatter;
+        private RadioButton rbScatterGL;
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPerformance.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPerformance.cs
@@ -1,4 +1,6 @@
 ﻿using ScottPlot;
+using ScottPlot.DataSources;
+using ScottPlot.WinForms;
 
 namespace WinForms_Demo.Demos;
 
@@ -30,7 +32,7 @@ public partial class SignalPerformance : Form, IDemoWindow
             formsPlot1.Plot.Add.Signal(ys);
             formsPlot1.Plot.Title.Label.Text = "one million points";
         }
-        else
+        else if (rbScatter.Checked)
         {
             int pointCount = 10_000;
             double[] ys = ScottPlot.Generate.NoisySin(new Random(), pointCount);
@@ -38,6 +40,15 @@ public partial class SignalPerformance : Form, IDemoWindow
             var sp = formsPlot1.Plot.Add.Scatter(xs, ys);
             sp.MarkerStyle = MarkerStyle.None;
             formsPlot1.Plot.Title.Label.Text = "ten thousand points";
+        }
+        else if (rbScatterGL.Checked)
+        {
+            int pointCount = 20_000_000;
+            double[] ys = ScottPlot.Generate.NoisySin(new Random(), pointCount);
+            double[] xs = ScottPlot.Generate.Consecutive(pointCount);
+            var spGL = new ScatterGL(new ScatterSourceXsYs(xs, ys), formsPlot1.GRContext);
+            formsPlot1.Plot.Plottables.Add(spGL);
+            formsPlot1.Plot.Title.Label.Text = "two million points";
         }
 
         formsPlot1.Plot.AutoScale();

--- a/src/ScottPlot5/ScottPlot5/IPlottableGL.cs
+++ b/src/ScottPlot5/ScottPlot5/IPlottableGL.cs
@@ -1,0 +1,6 @@
+﻿namespace ScottPlot
+{
+    public interface IPlottableGL
+    {
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
@@ -30,7 +30,7 @@ public class Scatter : IPlottable
         Data = data;
     }
 
-    public void Render(SKSurface surface)
+    public virtual void Render(SKSurface surface)
     {
         IEnumerable<Pixel> pixels = Data.GetScatterPoints().Select(x => Axes.GetPixel(x));
 

--- a/src/ScottPlot5/ScottPlot5/Rendering/Common.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/Common.cs
@@ -62,7 +62,8 @@ public static class Common
         {
             plottable.Axes.DataRect = dataRect;
             surface.Canvas.Save();
-            surface.Canvas.ClipRect(dataRect.ToSKRect());
+            if (plottable is not IPlottableGL)
+                surface.Canvas.ClipRect(dataRect.ToSKRect());
             plottable.Render(surface);
             surface.Canvas.Restore();
         }


### PR DESCRIPTION
**Purpose:**
This PR add `ScatterGL` plottable which uses raw OpenGL for rendering.
A section for testing `ScatterGL` has been added to WinformsDeto.

`ScatterGL` is implemented in the `WinForms.Control` project so as not to bring the OpenTK dependency into the main project. And actually intended only for Winforms. WPF has no control with OpenL support.

In fact, this is actually `SkatterConst`. We cannot change the elements of the original array and immediately see the result (as I understand at the moment, ScottPlot 5 still does not allow this even for a regular `Scatter`).

How it works: 
The original dataset is loaded into GPU memory on the first render. When rendering, each time the transformation matrices are dynamically adjusted, which transform our original data array into screen coordinates. Then draw is called, which takes the data already in the GPU memory and applies transformations to them (a typical and very fast operation for the GPU).
The performance of this approach is very high, I was able to get interactive rendering speed for 20 million points on my hardware.

Supposed problems:
1. The GPU can only work with `float`, so visually visible rounding errors are possible, which are significantly higher than for calculations using `double`.
2. There are no checks for the presence of OpenGL. If the control is switched to the software rendering mode, then most likely the application will crash.
3. There are suspicions that this code may not work (work incorrectly) on many hardware configurations. I'm a complete newbie to OpenGL and can't answer any questions that come up.

![image](https://user-images.githubusercontent.com/53831487/218280482-6c425de8-539d-42b8-85f4-d6ab87ea27d1.png)


* Consider including a picture if it would help clarify what this pull request does


```cs
            int pointCount = 20_000_000;
            double[] ys = ScottPlot.Generate.NoisySin(new Random(), pointCount);
            double[] xs = ScottPlot.Generate.Consecutive(pointCount);
            var spGL = new ScatterGL(new ScatterSourceXsYs(xs, ys), formsPlot1.GRContext);
            formsPlot1.Plot.Plottables.Add(spGL);
```