### PR TITLE
ScottPlot.WPF based on GL accelerated control

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/SKGLElement.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/SKGLElement.cs
@@ -1,0 +1,274 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using OpenTK.Graphics;
+using System.Windows.Media.Media3D;
+using SkiaSharp.Views.Desktop;
+using OpenTK.Wpf;
+using SkiaSharp;
+using OpenTK.Graphics.OpenGL;
+using OpenTK.Platform.Windows;
+using OpenTK;
+using System.Windows.Interop;
+using OpenTK.Platform;
+#if NETCOREAPP || NET
+using OpenTK.Mathematics;
+#endif
+
+#nullable disable
+
+namespace SkiaSharp.Views.WPF
+{
+    [DefaultEvent("PaintSurface")]
+    [DefaultProperty("Name")]
+    public class SKGLElement : GLWpfControl, IDisposable
+    {
+        private const SKColorType colorType = SKColorType.Rgba8888;
+        private const GRSurfaceOrigin surfaceOrigin = GRSurfaceOrigin.BottomLeft;
+
+        private bool designMode;
+
+        private GRContext grContext;
+        private GRGlFramebufferInfo glInfo;
+        private GRBackendRenderTarget renderTarget;
+        private SKSurface surface;
+        private SKCanvas canvas;
+
+        private SKSizeI lastSize;
+        private SKGLElementWindowListener listener;
+
+        public SKGLElement()
+            : base()
+        {
+            Initialize();
+        }
+
+        private void Initialize()
+        {
+            designMode = DesignerProperties.GetIsInDesignMode(this);
+            var settings = new GLWpfControlSettings() { MajorVersion = 2, MinorVersion = 1, RenderContinuously = false };
+
+            this.Render += OnPaint;
+
+            this.Loaded += (s, e) =>
+            {
+                SKGLElementWindowListener listener = new SKGLElementWindowListener(this);
+                this.listener = listener;
+            };
+
+            Start(settings);
+        }
+
+
+        private class SKGLElementWindowListener : IDisposable
+        {
+            private WeakReference<SKGLElement> toDestroy;
+            private WeakReference<Window> theWindow;
+            public SKGLElementWindowListener(SKGLElement toDestroy)
+            {
+                this.toDestroy = new WeakReference<SKGLElement>(toDestroy);
+                var window = System.Windows.Window.GetWindow(toDestroy);
+                if (window != null)
+                {
+                    theWindow = new WeakReference<Window>(window);
+                    window.Closing += Window_Closing;
+                }
+            }
+
+            private void Window_Closing(object sender, CancelEventArgs e)
+            {
+                SKGLElement target = null;
+                if (toDestroy.TryGetTarget(out target))
+                {
+                    if (target != null)
+                    {
+                        target.Dispose();
+                    }
+                }
+
+            }
+
+            private bool disposed = false;
+
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (disposed)
+                {
+                    return;
+                }
+
+                Window window;
+                if (theWindow != null && theWindow.TryGetTarget(out window))
+                {
+                    if (window != null)
+                    {
+                        window.Closing -= Window_Closing;
+                    }
+                }
+                theWindow = null;
+
+                disposed = true;
+            }
+
+            public void Dispose()
+            {
+                Dispose(true);
+            }
+        }
+
+
+        public SKSize CanvasSize => lastSize;
+
+        public GRContext GRContext => grContext;
+
+        [Category("Appearance")]
+        public event EventHandler<SKPaintGLSurfaceEventArgs> PaintSurface;
+
+        private SKSizeI GetSize()
+        {
+            var currentWidth = ActualWidth;
+            var currentHeight = ActualHeight;
+
+            if (currentWidth < 0 ||
+                currentHeight < 0)
+            {
+                currentWidth = 0;
+                currentHeight = 0;
+            }
+
+            PresentationSource source = PresentationSource.FromVisual(this);
+
+            double dpiX = 1.0;
+            double dpiY = 1.0;
+            if (source != null)
+            {
+                dpiX = source.CompositionTarget.TransformToDevice.M11;
+                dpiY = source.CompositionTarget.TransformToDevice.M22;
+            }
+
+            return new SKSizeI((int)(currentWidth * dpiX), (int)(currentHeight * dpiY));
+        }
+
+        protected override void OnRender(DrawingContext drawingContext)
+        {
+            if (grContext != null)
+            {
+                grContext.ResetContext();
+            }
+            base.OnRender(drawingContext);
+        }
+
+        protected virtual void OnPaint(TimeSpan e)
+        {
+            if (disposed)
+            {
+                return;
+            }
+            if (designMode)
+            {
+                return;
+            }
+
+            // create the contexts if not done already
+            if (grContext == null)
+            {
+                var glInterface = GRGlInterface.Create();
+                grContext = GRContext.CreateGl(glInterface);
+            }
+
+            // get the new surface size
+            var newSize = GetSize();
+
+            GL.ClearColor(Color4.Transparent);
+            GL.Clear(ClearBufferMask.ColorBufferBit);
+            GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit);
+
+            // manage the drawing surface
+            if (renderTarget == null || lastSize != newSize || !renderTarget.IsValid)
+            {
+
+                // create or update the dimensions
+                lastSize = newSize;
+
+                GL.GetInteger(GetPName.FramebufferBinding, out var framebuffer);
+                GL.GetInteger(GetPName.StencilBits, out var stencil);
+                GL.GetInteger(GetPName.Samples, out var samples);
+                var maxSamples = grContext.GetMaxSurfaceSampleCount(colorType);
+                if (samples > maxSamples)
+                    samples = maxSamples;
+                glInfo = new GRGlFramebufferInfo((uint)framebuffer, colorType.ToGlSizedFormat());
+
+                // destroy the old surface
+                surface?.Dispose();
+                surface = null;
+                canvas = null;
+
+                // re-create the render target
+                renderTarget?.Dispose();
+                renderTarget = new GRBackendRenderTarget(newSize.Width, newSize.Height, samples, stencil, glInfo);
+            }
+
+            // create the surface
+            if (surface == null)
+            {
+                surface = SKSurface.Create(grContext, renderTarget, surfaceOrigin, colorType);
+                canvas = surface.Canvas;
+            }
+
+            using (new SKAutoCanvasRestore(canvas, true))
+            {
+                // start drawing
+#pragma warning disable CS0618 // Type or member is obsolete
+                OnPaintSurface(new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType, glInfo));
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+
+            // update the control
+            canvas.Flush();
+        }
+
+        protected virtual void OnPaintSurface(SKPaintGLSurfaceEventArgs e)
+        {
+            // invoke the event
+            PaintSurface?.Invoke(this, e);
+        }
+
+        private bool disposed = false;
+
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+
+            canvas = null;
+            surface?.Dispose();
+            surface = null;
+            renderTarget?.Dispose();
+            renderTarget = null;
+            grContext?.Dispose();
+            grContext = null;
+            listener?.Dispose();
+            listener = null;
+
+            disposed = true;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+    }
+
+}

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/ScottPlot.WPF.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/ScottPlot.WPF.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
@@ -36,6 +36,14 @@
     </ItemGroup>
 
     <!-- Package dependencies -->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+		<PackageReference Include="OpenTK" Version="3.3.1" NoWarn="NU1701" />
+		<PackageReference Include="OpenTK.GLWpfControl" Version="3.3.0" NoWarn="NU1701" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0-windows'">
+		<PackageReference Include="OpenTK" Version="4.3.0" NoWarn="NU1701" />
+		<PackageReference Include="OpenTK.GLWpfControl" Version="4.2.2" />
+	</ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
             <PrivateAssets>all</PrivateAssets>

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlot.xaml
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlot.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:skia="clr-namespace:SkiaSharp.Views.WPF;assembly=SkiaSharp.Views.WPF"
+             xmlns:skiaPreview="clr-namespace:SkiaSharp.Views.WPF"
              xmlns:local="clr-namespace:ScottPlot.WPF"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
@@ -11,8 +12,8 @@
              KeyDown="OnKeyDown"
              KeyUp="OnKeyUp"
              >
-    <skia:SKElement 
-        Name="SKElement" 
+    <skiaPreview:SKGLElement 
+        x:Name="SKElement" 
         PaintSurface="OnPaintSurface" 
         MouseDown="OnMouseDown" 
         MouseUp="OnMouseUp" 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlot.xaml.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlot.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Microsoft.Win32;
 using ScottPlot.Control;
+using SkiaSharp;
 using SkiaSharp.Views.Desktop;
 
 namespace ScottPlot.WPF;
@@ -23,6 +24,8 @@ public partial class WpfPlot : UserControl, IPlotControl
     public Plot Plot { get; } = new();
 
     public Interaction Interaction { get; private set; }
+
+    public GRContext GRContext => SKElement.GRContext;
 
     public WpfPlot()
     {
@@ -73,7 +76,7 @@ public partial class WpfPlot : UserControl, IPlotControl
         menu.IsOpen = true;
     }
 
-    private void OnPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+    private void OnPaintSurface(object sender, SKPaintGLSurfaceEventArgs e)
     {
         Plot.Render(e.Surface);
     }

--- a/src/ScottPlot5/ScottPlot5-wpf.slnf
+++ b/src/ScottPlot5/ScottPlot5-wpf.slnf
@@ -1,0 +1,12 @@
+{
+  "solution": {
+    "path": "ScottPlot5.sln",
+    "projects": [
+      "ScottPlot5 Controls\\ScottPlot.WPF\\ScottPlot.WPF.csproj",
+      "ScottPlot5 Cookbook\\ScottPlot Cookbook.csproj",
+      "ScottPlot5 Sandbox\\Sandbox.WPF\\Sandbox.WPF.csproj",
+      "ScottPlot5 Tests\\ScottPlot Tests.csproj",
+      "ScottPlot5\\ScottPlot.csproj"
+    ]
+  }
+}


### PR DESCRIPTION
**Purpose:**
SkiaSharp haven't GPU accelerated control for WPF.
But there is PR in SkiaSharp with such control started at Nov 22. https://github.com/mono/SkiaSharp/pull/2317
I tested a bit, and it looks finished.
So i grab the code and place it in ScottPlot.WPF.
If and when the PR is approved we can simply remove the code and change the link.
