### PR TITLE
Scatter gl improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 _not yet published on NuGet..._
 * Signal Plot: Support X and Y offset (#2378) _Thanks @minjjKang_
 * WebAssembly: New sandbox demonstrates interactive ScottPlot in a browser (#2380, #2374) _Thanks rafntor_
-* OpenGL: Added experimental support for direct GPU rendering (#2383) _Thanks @StendProg_
+* OpenGL: Added experimental support for direct GPU rendering (#2383, #2397) _Thanks @StendProg_
 * Finance Plots: Added OHLC and Candlestick plot types (#2386) _Thanks @bclehmann_
 * Style: Improved Plot.Style.Background() color configuration (#2398) _Thanks @Jonathanio123_
+* WPF: Added OpenGL support to the WPF control (#2395) _Thanks @StendProg_
 
 ## ScottPlot 5.0.1-beta
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2023-02-09_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.axaml.cs
@@ -25,6 +25,8 @@ public partial class AvaPlot : UserControl, IPlotControl
 
     public Interaction Interaction { get; private set; }
 
+    public GRContext? GRContext => null;
+
     private readonly List<FileDialogFilter> fileDialogFilters = new()
     {
         new() { Name = "PNG Files", Extensions = new List<string> { "png" } },

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Eto/EtoPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Eto/EtoPlot.cs
@@ -14,6 +14,8 @@ public class EtoPlot : Drawable, IPlotControl
 {
     public Plot Plot { get; } = new();
 
+    public GRContext? GRContext => null;
+
     public Interaction Interaction { get; private set; }
 
     private readonly List<FileFilter> fileDialogFilters = new()

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/AddPlottableExtensions.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/AddPlottableExtensions.cs
@@ -1,17 +1,20 @@
-﻿namespace ScottPlot;
+﻿using System;
+
+namespace ScottPlot;
 
 /// <summary>
 /// This class extends Plot.Add.* to add additional plottables provided by this NuGet package
 /// </summary>
 public static class AddPlottableExtensions
 {
-    public static void ScatterGL(this AddPlottable add, SkiaSharp.GRContext context, double[] xs, double[] ys)
+    public static Plottables.ScatterGL ScatterGL(this AddPlottable add, Func<SkiaSharp.GRContext> contextRequest, double[] xs, double[] ys)
     {
         DataSources.ScatterSourceXsYs data = new(xs, ys);
-        Plottables.ScatterGL sp = new(data, context);
+        Plottables.ScatterGL sp = new(data, contextRequest);
         Color nextColor = add.NextColor;
         sp.LineStyle.Color = nextColor;
         sp.MarkerStyle.Fill.Color = nextColor;
         add.Plottable(sp);
+        return sp;
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/AddPlottableExtensions.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/AddPlottableExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ScottPlot.Control;
+using System;
 
 namespace ScottPlot;
 
@@ -7,10 +8,10 @@ namespace ScottPlot;
 /// </summary>
 public static class AddPlottableExtensions
 {
-    public static Plottables.ScatterGL ScatterGL(this AddPlottable add, Func<SkiaSharp.GRContext> getContext, double[] xs, double[] ys)
+    public static Plottables.ScatterGL ScatterGL(this AddPlottable add, IPlotControl control, double[] xs, double[] ys)
     {
         DataSources.ScatterSourceXsYs data = new(xs, ys);
-        Plottables.ScatterGL sp = new(data, getContext);
+        Plottables.ScatterGL sp = new(data, control);
         Color nextColor = add.NextColor;
         sp.LineStyle.Color = nextColor;
         sp.MarkerStyle.Fill.Color = nextColor;

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/AddPlottableExtensions.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/AddPlottableExtensions.cs
@@ -7,10 +7,10 @@ namespace ScottPlot;
 /// </summary>
 public static class AddPlottableExtensions
 {
-    public static Plottables.ScatterGL ScatterGL(this AddPlottable add, Func<SkiaSharp.GRContext> contextRequest, double[] xs, double[] ys)
+    public static Plottables.ScatterGL ScatterGL(this AddPlottable add, Func<SkiaSharp.GRContext> getContext, double[] xs, double[] ys)
     {
         DataSources.ScatterSourceXsYs data = new(xs, ys);
-        Plottables.ScatterGL sp = new(data, contextRequest);
+        Plottables.ScatterGL sp = new(data, getContext);
         Color nextColor = add.NextColor;
         sp.LineStyle.Color = nextColor;
         sp.MarkerStyle.Fill.Color = nextColor;

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/FallbackStrategy.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/FallbackStrategy.cs
@@ -1,0 +1,8 @@
+﻿namespace ScottPlot.WinForms.OpenGL
+{
+    public enum FallbackStrategy
+    {
+        Skip,
+        Software,
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/FallbackStrategy.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/FallbackStrategy.cs
@@ -1,8 +1,0 @@
-﻿namespace ScottPlot.WinForms.OpenGL
-{
-    public enum FallbackStrategy
-    {
-        Skip,
-        Software,
-    }
-}

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/GLFallbackRenderStrategy.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/GLFallbackRenderStrategy.cs
@@ -1,0 +1,17 @@
+﻿namespace ScottPlot.WinForms.OpenGL;
+
+/// <summary>
+/// Defines behavior to use when OpenGL is not available
+/// </summary>
+public enum GLFallbackRenderStrategy
+{
+    /// <summary>
+    /// Do not render anything
+    /// </summary>
+    Skip,
+
+    /// <summary>
+    /// Use software rendering (may be slow)
+    /// </summary>
+    Software,
+}

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/GLShader.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/GLShader.cs
@@ -104,6 +104,8 @@ public class GLShader : IDisposable
         }
     }
 
+    public void GLFinish() => GL.Finish();
+
     public void Dispose()
     {
         Dispose(true);

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/ScatterGL.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/ScatterGL.cs
@@ -4,7 +4,6 @@ using ScottPlot.DataSources;
 using ScottPlot.WinForms.OpenGL;
 using SkiaSharp;
 using System;
-using System.Linq;
 
 namespace ScottPlot.Plottables;
 
@@ -27,11 +26,13 @@ public class ScatterGL : Scatter, IPlottableGL
     public ScatterGL(IScatterSource data, GRContext context) : base(data)
     {
         _context = context;
-        Vertices = data.GetScatterPoints().Select(p =>
+        var dataPoints = data.GetScatterPoints();
+        Vertices = new double[dataPoints.Count];
+        for (int i = 0; i < dataPoints.Count; i++)
         {
-            return new double[] { p.X, p.Y };
-        }).
-        SelectMany(t => t).ToArray();
+            Vertices[i * 2] = dataPoints[i].X;
+            Vertices[i * 2 + 1] = dataPoints[i].Y;
+        }
         VerticesCount = Vertices.Length / 2;
     }
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/ScatterGL.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/ScatterGL.cs
@@ -105,4 +105,9 @@ public class ScatterGL : Scatter, IPlottableGL
         GL.BindVertexArray(VertexArrayObject);
         GL.DrawArrays(PrimitiveType.LineStrip, 0, VerticesCount);
     }
+
+    public void FinishRender()
+    {
+        GL.Finish();
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/ScatterGL.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/ScatterGL.cs
@@ -5,7 +5,6 @@ using ScottPlot.DataSources;
 using ScottPlot.WinForms.OpenGL;
 using SkiaSharp;
 using System;
-using System.Reflection.Emit;
 
 namespace ScottPlot.Plottables;
 
@@ -122,9 +121,5 @@ public class ScatterGL : Scatter, IPlottableGL
         GL.DrawArrays(PrimitiveType.LineStrip, 0, VerticesCount);
     }
 
-    public void GLFinish()
-    {
-        if (PlotControl.GRContext is not null)
-            GL.Finish();
-    }
+    public void GLFinish() => Shader?.GLFinish();
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/ScatterGL.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/OpenGL/ScatterGL.cs
@@ -14,7 +14,7 @@ namespace ScottPlot.Plottables;
 /// </summary>
 public class ScatterGL : Scatter, IPlottableGL
 {
-    private readonly IPlotControl PlotControl;
+    public IPlotControl PlotControl { get; }
     private int VertexBufferObject;
     private int VertexArrayObject;
     private GLShader? Shader;
@@ -122,11 +122,9 @@ public class ScatterGL : Scatter, IPlottableGL
         GL.DrawArrays(PrimitiveType.LineStrip, 0, VerticesCount);
     }
 
-    public void RenderFinish()
+    public void GLFinish()
     {
-        if (PlotControl.GRContext is null)
-            return;
-
-        GL.Finish();
+        if (PlotControl.GRContext is not null)
+            GL.Finish();
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/ScottPlot.WinForms.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/ScottPlot.WinForms.csproj
@@ -47,8 +47,5 @@
         <PackageReference Include="SkiaSharp.Views.WindowsForms" Version="2.*" />
         <ProjectReference Include="..\..\ScottPlot5\ScottPlot.csproj" />
     </ItemGroup>
-    <ItemGroup>
-        <Folder Include="Plottables\" />
-    </ItemGroup>
 
 </Project>

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/WinUIPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/WinUIPlot.cs
@@ -19,6 +19,8 @@ public partial class WinUIPlot : UserControl, IPlotControl
 
     public Plot Plot { get; } = new();
 
+    public SkiaSharp.GRContext? GRContext => null;
+
     public Interaction Interaction { get; private set; }
 
     public Window? AppWindow { get; set; } // https://stackoverflow.com/a/74286947

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPerformance.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPerformance.cs
@@ -43,7 +43,8 @@ public partial class SignalPerformance : Form, IDemoWindow
             int pointCount = 1_000_000;
             double[] ys = ScottPlot.Generate.NoisySin(new Random(), pointCount);
             double[] xs = ScottPlot.Generate.Consecutive(pointCount);
-            formsPlot1.Plot.Add.ScatterGL(formsPlot1.GRContext, xs, ys);
+            var spGL = formsPlot1.Plot.Add.ScatterGL(() => formsPlot1.GRContext, xs, ys);
+            spGL.MarkerStyle = MarkerStyle.None;
             formsPlot1.Plot.Title.Label.Text = "ScatterGL plot with one million points";
         }
 

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPerformance.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPerformance.cs
@@ -43,7 +43,8 @@ public partial class SignalPerformance : Form, IDemoWindow
             int pointCount = 1_000_000;
             double[] ys = ScottPlot.Generate.NoisySin(new Random(), pointCount);
             double[] xs = ScottPlot.Generate.Consecutive(pointCount);
-            var spGL = formsPlot1.Plot.Add.ScatterGL(() => formsPlot1.GRContext, xs, ys);
+            Func<SkiaSharp.GRContext> getContext = () => formsPlot1.GRContext;
+            var spGL = formsPlot1.Plot.Add.ScatterGL(getContext, xs, ys);
             spGL.MarkerStyle = MarkerStyle.None;
             formsPlot1.Plot.Title.Label.Text = "ScatterGL plot with one million points";
         }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPerformance.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPerformance.cs
@@ -43,8 +43,7 @@ public partial class SignalPerformance : Form, IDemoWindow
             int pointCount = 1_000_000;
             double[] ys = ScottPlot.Generate.NoisySin(new Random(), pointCount);
             double[] xs = ScottPlot.Generate.Consecutive(pointCount);
-            Func<SkiaSharp.GRContext> getContext = () => formsPlot1.GRContext;
-            var spGL = formsPlot1.Plot.Add.ScatterGL(getContext, xs, ys);
+            var spGL = formsPlot1.Plot.Add.ScatterGL(formsPlot1, xs, ys);
             spGL.MarkerStyle = MarkerStyle.None;
             formsPlot1.Plot.Title.Label.Text = "ScatterGL plot with one million points";
         }

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.Wasm/Sandbox.Wasm.csproj
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.Wasm/Sandbox.Wasm.csproj
@@ -3,7 +3,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
-        <NoWarn>NU1701</NoWarn>
+        <NoWarn>NU1701;Uno0001</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/ScottPlot5/ScottPlot5/Control/IPlotControl.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/IPlotControl.cs
@@ -26,4 +26,9 @@ public interface IPlotControl
     /// Launch the default pop-up menu (typically in response to a right-click) at the given position in the control
     /// </summary>
     void ShowContextMenu(Pixel position);
+
+    /// <summary>
+    /// Context for hardware-accelerated graphics (if available)
+    /// </summary>
+    GRContext? GRContext { get; }
 }

--- a/src/ScottPlot5/ScottPlot5/Control/IPlotControl.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/IPlotControl.cs
@@ -28,7 +28,7 @@ public interface IPlotControl
     void ShowContextMenu(Pixel position);
 
     /// <summary>
-    /// Context for hardware-accelerated graphics (if available)
+    /// Context for hardware-accelerated graphics (or null if not available)
     /// </summary>
     GRContext? GRContext { get; }
 }

--- a/src/ScottPlot5/ScottPlot5/IPlottableGL.cs
+++ b/src/ScottPlot5/ScottPlot5/IPlottableGL.cs
@@ -1,9 +1,20 @@
-﻿namespace ScottPlot;
+﻿using ScottPlot.Control;
+
+namespace ScottPlot;
 
 /// <summary>
 /// This interface is applied to plottables which can be rendered directly on the GPU using an OpenGL shader
 /// </summary>
 public interface IPlottableGL : IPlottable
 {
-    void RenderFinish();
+    /// <summary>
+    /// The control used to display this plottable.
+    /// It is used to access the <see cref="GRContext"/> at render time.
+    /// </summary>
+    IPlotControl PlotControl { get; }
+
+    /// <summary>
+    /// Used to manually synchronize rendering
+    /// </summary>
+    void GLFinish();
 }

--- a/src/ScottPlot5/ScottPlot5/IPlottableGL.cs
+++ b/src/ScottPlot5/ScottPlot5/IPlottableGL.cs
@@ -3,9 +3,7 @@
 /// <summary>
 /// This interface is applied to plottables which can be rendered directly on the GPU using an OpenGL shader
 /// </summary>
-public interface IPlottableGL
+public interface IPlottableGL : IPlottable
 {
-    GRContext GRContext { get; }
-    void Render(SKSurface surface, GRContext context);
-    void FinishRender(GRContext context);
+    void RenderFinish();
 }

--- a/src/ScottPlot5/ScottPlot5/IPlottableGL.cs
+++ b/src/ScottPlot5/ScottPlot5/IPlottableGL.cs
@@ -7,4 +7,5 @@ public interface IPlottableGL
 {
     GRContext GRContext { get; }
     void Render(SKSurface surface, GRContext context);
+    void FinishRender();
 }

--- a/src/ScottPlot5/ScottPlot5/IPlottableGL.cs
+++ b/src/ScottPlot5/ScottPlot5/IPlottableGL.cs
@@ -7,5 +7,5 @@ public interface IPlottableGL
 {
     GRContext GRContext { get; }
     void Render(SKSurface surface, GRContext context);
-    void FinishRender();
+    void FinishRender(GRContext context);
 }

--- a/src/ScottPlot5/ScottPlot5/Rendering/Common.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/Common.cs
@@ -109,4 +109,10 @@ public static class Common
     {
         plot.Benchmark.Render(surface.Canvas, dataRect);
     }
+
+    public static void SyncGLPlottables(Plot plot)
+    {
+        var glPlottable = plot.Plottables.FirstOrDefault(p => p is IPlottableGL);
+        (glPlottable as IPlottableGL)?.FinishRender();
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Rendering/Common.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/Common.cs
@@ -112,8 +112,8 @@ public static class Common
 
     public static void SyncGLPlottables(Plot plot)
     {
-        var anyGL = plot.Plottables.FirstOrDefault(p => p is IPlottableGL);
-        if (anyGL is IPlottableGL plottableGL)
-            plottableGL.RenderFinish();
+        var glPlottables = plot.Plottables.OfType<IPlottableGL>();
+        if (glPlottables.Any())
+            glPlottables.First().GLFinish();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Rendering/Common.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/Common.cs
@@ -112,7 +112,8 @@ public static class Common
 
     public static void SyncGLPlottables(Plot plot)
     {
-        var glPlottable = plot.Plottables.FirstOrDefault(p => p is IPlottableGL);
-        (glPlottable as IPlottableGL)?.FinishRender();
+        var anyGL = plot.Plottables.FirstOrDefault(p => p is IPlottableGL);
+        if (anyGL is IPlottableGL plottableGL)
+            plottableGL.FinishRender(plottableGL.GRContext);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Rendering/Common.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/Common.cs
@@ -65,7 +65,7 @@ public static class Common
 
             if (plottable is IPlottableGL plottableGL)
             {
-                plottableGL.Render(surface, plottableGL.GRContext);
+                plottableGL.Render(surface);
             }
             else
             {
@@ -114,6 +114,6 @@ public static class Common
     {
         var anyGL = plot.Plottables.FirstOrDefault(p => p is IPlottableGL);
         if (anyGL is IPlottableGL plottableGL)
-            plottableGL.FinishRender(plottableGL.GRContext);
+            plottableGL.RenderFinish();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Rendering/StandardRenderer.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/StandardRenderer.cs
@@ -1,5 +1,4 @@
 ﻿using ScottPlot.Layouts;
-using System.Linq;
 
 namespace ScottPlot.Rendering;
 

--- a/src/ScottPlot5/ScottPlot5/Rendering/StandardRenderer.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/StandardRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using ScottPlot.Layouts;
+using System.Linq;
 
 namespace ScottPlot.Rendering;
 
@@ -26,6 +27,7 @@ public class StandardRenderer : IRenderer
         Common.RenderLegends(surface, dataRect, plot);
         Common.RenderPanels(surface, dataRect, panels, layout);
         Common.RenderZoomRectangle(surface, dataRect, plot);
+        Common.SyncGLPlottables(plot);
         plot.Benchmark.Stop();
 
         Common.RenderBenchmark(surface, dataRect, plot);


### PR DESCRIPTION
**Purpose:**
Some improvements for ScatterGL:
1. Before `Benchmark.Stop()` we call `GL.Finish()`. This block CPU thread until all GPU operations finished. So benchmark now shows correct numbers when using ScatterGL plottables.
2. Optimization for  data to Vertices array copy.
3. `GRContext` => `Func<GRContext>`. This allow us create `ScatterGL` at form constructor. GRContext is null at creation time.
4. `ScatterGL` can be configured to skip render or make `Scatter.Render()` if `GRContext` is null.
5. `Add.ScatterGL` extension method now return added `ScatterGL`.

Extends:
* #2383