### PR TITLE
ScottPlot5: Fix Plot.Style.Background() bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _not yet published on NuGet..._
 * WebAssembly: New sandbox demonstrates interactive ScottPlot in a browser (#2380, #2374) _Thanks rafntor_
 * OpenGL: Added experimental support for direct GPU rendering (#2383) _Thanks @StendProg_
 * Finance Plots: Added OHLC and Candlestick plot types (#2386) _Thanks @bclehmann_
+* Style: Improved Plot.Style.Background() color configuration (#2398) _Thanks @Jonathanio123_
 
 ## ScottPlot 5.0.1-beta
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2023-02-09_

--- a/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
+++ b/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
@@ -20,8 +20,8 @@ public class PlotStyler
     /// </summary>
     public void Background(Color figure, Color data)
     {
-        Plot.FigureBackground = Color.FromHex("#07263b");
-        Plot.DataBackground = Color.FromHex("#0b3049");
+        Plot.FigureBackground = figure;
+        Plot.DataBackground = data;
     }
 
     /// <summary>


### PR DESCRIPTION
**Issue:** If I'm understanding this code correctly, then setting a custom background color currently does nothing. The arguments are simply not used and the colors are hard coded in. I noticed this when following the [Cookbook Style Helper Functions](https://scottplot.net/cookbook/5.0/styling-plots/#style-helper-functions). 

```cs
namespace ScottPlot.Stylers;
public class PlotStyler
{
...
    /// <summary>
    /// Apply background colors to the figure and data areas
    /// </summary>
    public void Background(Color figure, Color data)
    {
        Plot.FigureBackground = Color.FromHex("#07263b");
        Plot.DataBackground = Color.FromHex("#0b3049");
    }
...
```

This pull request simply replaces the hardcoded values with the function arguments.