### PR TITLE
Cookbook: fix datetime recipe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Consider creating an issue to discuss your pull request _before_ investing a lot
 
 ### Run the AutoFormatter
 
-**If your code is not auto-formatted, the build will fail** when you create your pull request. Use [autoformat.bat](src/autoformat.bat) or run these commands to autoformat the entire code base:
+**If your code is not auto-formatted, the build will fail** when you create your pull request. Use [autoformat.bat](src/ScottPlot4/autoformat.bat) or run these commands to autoformat the entire code base:
 
 ```sh
 dotnet tool update -g dotnet-format

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Axis.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Axis.cs
@@ -221,6 +221,7 @@ namespace ScottPlot.Cookbook.Recipes.Ticks
             plt.XAxis.DateTimeFormat(true);
         }
     }
+    
     class TicksDateTimeSignal : IRecipe
     {
         public ICategory Category => new Categories.Axis();

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Axis.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Axis.cs
@@ -221,7 +221,7 @@ namespace ScottPlot.Cookbook.Recipes.Ticks
             plt.XAxis.DateTimeFormat(true);
         }
     }
-    
+
     class TicksDateTimeSignal : IRecipe
     {
         public ICategory Category => new Categories.Axis();


### PR DESCRIPTION
Add newline before `class TicksDateTimeSignal` so that .cs file parses correctly for the website.

Related:
* https://github.com/ScottPlot/ScottPlot.NET/pull/25