### PR TITLE
Add a public ErrorBarAlignment property in PopulationPlot.cs for boxplot.

### DIFF
--- a/src/ScottPlot4/ScottPlot/Plottable/PopulationPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/PopulationPlot.cs
@@ -45,6 +45,7 @@ namespace ScottPlot.Plottable
         public Color ScatterOutlineColor { get; set; } = Color.Black;
         public DisplayItems DataFormat { get; set; } = DisplayItems.BoxAndScatter;
         public BoxStyle DataBoxStyle { get; set; } = BoxStyle.BoxMedianQuartileOutlier;
+        public HorizontalAlignment ErrorBarAlignment { get; set; } = HorizontalAlignment.Center;
 
         public PopulationPlot(PopulationMultiSeries groupedSeries)
         {
@@ -183,10 +184,10 @@ namespace ScottPlot.Plottable
                             Bar(dims, bmp, lowQuality, population, rand, popLeft, popWidth, series.color, boxAlpha, boxPos, useStdErr: false);
                             break;
                         case BoxStyle.BoxMeanStdevStderr:
-                            Box(dims, bmp, lowQuality, population, rand, popLeft, popWidth, series.color, boxAlpha, boxPos, BoxFormat.StdevStderrMean);
+                            Box(dims, bmp, lowQuality, population, rand, popLeft, popWidth, series.color, boxAlpha, boxPos, BoxFormat.StdevStderrMean, ErrorBarAlignment);
                             break;
                         case BoxStyle.BoxMedianQuartileOutlier:
-                            Box(dims, bmp, lowQuality, population, rand, popLeft, popWidth, series.color, boxAlpha, boxPos, BoxFormat.OutlierQuartileMedian);
+                            Box(dims, bmp, lowQuality, population, rand, popLeft, popWidth, series.color, boxAlpha, boxPos, BoxFormat.OutlierQuartileMedian, ErrorBarAlignment);
                             break;
                         case BoxStyle.MeanAndStderr:
                             MeanAndError(dims, bmp, lowQuality, population, rand, popLeft, popWidth, series.color, boxAlpha, boxPos, useStdErr: true);


### PR DESCRIPTION
Box plot in population plots does not have public option for setting error bar alignment. Current setting is align to the right. Aligning to the center is by far the most common error bar alignment in box plots.  

Added public property `ErrorBarAlignment` that sets the `HorizontalAlignment` enum. Default value is now `Center`. 

Also added `errorAlignment: ErrorBarAlignment` parameter to two calls to `Box()` method. 

This is my first ever pull request, so I apologize if I'm not doing it right. 


