### PR TITLE
ScottPlot 5: Box Plots

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Box.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Box.cs
@@ -1,0 +1,41 @@
+﻿namespace ScottPlotCookbook.Recipes.PlotTypes;
+
+internal class Box : RecipePageBase
+{
+    public override RecipePageDetails PageDetails => new()
+    {
+        Chapter = Chapter.PlotTypes,
+        PageName = "Box Plot",
+        PageDescription = "Box plots show a distribution at a glance",
+    };
+
+    internal class Quickstart : RecipeTestBase
+    {
+        public override string Name => "Box Plot Quickstart";
+        public override string Description => "Box plots can be added from a series of values.";
+
+        [Test]
+        public override void Recipe()
+        {
+            int N = 50;
+            double[] values = Generate.RandomNormal(N);
+            Array.Sort(values);
+            double min = values[0];
+            double q1 = values[N / 4];
+            double median = values[N / 2];
+            double q3 = values[3 * N / 4];
+            double max = values[N - 1];
+
+            var box = new ScottPlot.Plottables.Box
+            {
+                BoxMin = q1,
+                BoxMiddle = median,
+                BoxMax = q3,
+            };
+            
+            myPlot.Add.Box(box);
+            myPlot.AutoScale();
+            myPlot.SetAxisLimits(bottom: 0);
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/BoxPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/BoxPlot.cs
@@ -1,0 +1,161 @@
+﻿using ScottPlot.Axis;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Plottables
+{
+    public struct Box
+    {
+        public double Position { get; set; }
+        public double BoxMin { get; set; }
+        public double BoxMiddle { get; set; }
+        public double BoxMax { get; set; }
+        public double? WhiskerMin { get; set; }
+        public double? WhiskerMax { get; set; }
+    }
+
+    public class BoxSeries
+    {
+        public IList<Box> Boxes { get; set; } = Array.Empty<Box>();
+        public string? Label { get; set; }
+        public FillStyle Fill { get; set; } = new();
+        public LineStyle Stroke { get; set; } = new();
+    }
+
+    public class BoxPlot : IPlottable
+    {
+        public bool IsVisible { get; set; } = true;
+        public IAxes Axes { get; set; } = Axis.Axes.Default;
+        public string? Label { get; set; }
+        public IList<BoxSeries> Series { get; set; }
+        public Orientation Orientation { get; set; } = Orientation.Vertical;
+
+        public double Padding { get; set; } = 0.05;
+        private double MaxBoxWidth => 1 - Padding * 2;
+
+        public BoxPlot(IList<BoxSeries> series)
+        {
+            Series = series;
+        }
+
+        public IEnumerable<LegendItem> LegendItems => EnumerableExtensions.One(
+            new LegendItem
+            {
+                Label = Label,
+                Children = Series.Select(boxSeries => new LegendItem
+                {
+                    Label = boxSeries.Label,
+                    Fill = boxSeries.Fill
+                })
+            });
+
+        public AxisLimits GetAxisLimits()
+        {
+            AxisLimits limits = new(double.PositiveInfinity, double.NegativeInfinity, double.PositiveInfinity, double.NegativeInfinity);
+
+            foreach (var s in Series)
+            {
+                foreach (var b in s.Boxes)
+                {
+                    if (Orientation == Orientation.Vertical)
+                    {
+                        limits.ExpandX(b.Position);
+                        limits.ExpandY(b.BoxMin);
+                        limits.ExpandY(b.BoxMiddle);
+                        limits.ExpandY(b.BoxMax);
+                        limits.ExpandY(b.WhiskerMin ?? limits.Rect.YMin);
+                        limits.ExpandY(b.WhiskerMax ?? limits.Rect.YMin);
+                    }
+                    else
+                    {
+                        limits.ExpandY(b.Position);
+                        limits.ExpandX(b.BoxMin);
+                        limits.ExpandX(b.BoxMiddle);
+                        limits.ExpandX(b.BoxMax);
+                        limits.ExpandX(b.WhiskerMin ?? limits.Rect.YMin);
+                        limits.ExpandX(b.WhiskerMax ?? limits.Rect.YMin);
+                    }
+                }
+            }
+
+            limits.Rect.XMin -= MaxBoxWidth / 2;
+            limits.Rect.XMax += MaxBoxWidth / 2;
+            limits.Rect.YMin -= MaxBoxWidth / 2;
+            limits.Rect.YMax += MaxBoxWidth / 2;
+
+
+            return limits;
+        }
+
+        public void Render(SKSurface surface)
+        {
+            using var paint = new SKPaint();
+            var boxesByXCoordinate = Series
+                .SelectMany(s => s.Boxes.Select(b => (Box: b, Series: s)))
+                .ToLookup(t => t.Box.Position);
+
+            int maxPerXCoordinate = boxesByXCoordinate.Max(g => g.Count());
+            double widthPerGroup = 1 - (maxPerXCoordinate + 1) * Padding;
+            double boxWidth = widthPerGroup / maxPerXCoordinate;
+
+            foreach (IGrouping<double, (Box Box, BoxSeries Series)>? group in boxesByXCoordinate)
+            {
+                int barsInGroup = group.Count();
+                int i = 0;
+                foreach (var t in group)
+                {
+                    double boxWidthAndPadding = boxWidth + Padding;
+                    double groupWidth = boxWidthAndPadding * barsInGroup;
+
+                    double newPosition = group.Key - groupWidth / 2 + (i + 0.5) * boxWidthAndPadding;
+
+                    DrawBox(surface, paint, t.Box, t.Series, newPosition, boxWidth);
+                    i++;
+                }
+            }
+        }
+
+        public (SKRect, SKRect) GetRects(Box box, double x, double width)
+        {
+            if (Orientation == Orientation.Vertical)
+            {
+                var topLeft = Axes.GetPixel(new Coordinates(x - width / 2, box.BoxMax));
+                var midRight = Axes.GetPixel(new Coordinates(x + width / 2, box.BoxMiddle));
+                var botLeft = Axes.GetPixel(new Coordinates(x - width / 2, box.BoxMin));
+
+                var topRect = new PixelRect(topLeft, midRight);
+                var botRect = new PixelRect(midRight, botLeft);
+
+                return (topRect.ToSKRect(), botRect.ToSKRect());
+            }
+            else
+            {
+                var topLeft = Axes.GetPixel(new Coordinates(box.BoxMin, x - width / 2));
+                var midRight = Axes.GetPixel(new Coordinates(box.BoxMiddle, x + width / 2));
+                var botLeft = Axes.GetPixel(new Coordinates(box.BoxMax, x - width / 2));
+
+                var topRect = new PixelRect(topLeft, midRight);
+                var botRect = new PixelRect(midRight, botLeft);
+
+                return (topRect.ToSKRect(), botRect.ToSKRect());
+            }
+        }
+
+        public void DrawBox(SKSurface surface, SKPaint paint, Box box, BoxSeries series, double x, double width)
+        {
+            (SKRect topRect, SKRect botRect) = GetRects(box, x, width);
+
+            series.Fill.ApplyToPaint(paint);
+            surface.Canvas.DrawRect(topRect, paint);
+            surface.Canvas.DrawRect(botRect, paint);
+
+            series.Stroke.ApplyToPaint(paint);
+            surface.Canvas.DrawRect(topRect, paint);
+            surface.Canvas.DrawRect(botRect, paint);
+        }
+    }
+}

--- a/src/Shared/ScottPlot/Generate.cs
+++ b/src/Shared/ScottPlot/Generate.cs
@@ -172,6 +172,14 @@ public static class Generate
             .ToArray();
     }
 
+    public static double[] RandomNormal(int count, double mean = 0, double stdDev = 1, int seed = 0)
+    {
+        RandomDataGenerator gen = new(seed);
+        return Enumerable.Range(0, count)
+            .Select(_ => gen.RandomNormal(mean, stdDev))
+            .ToArray();
+    }
+
     #endregion
 
     #region DateTime

--- a/src/Shared/ScottPlot/RandomDataGenerator.cs
+++ b/src/Shared/ScottPlot/RandomDataGenerator.cs
@@ -48,4 +48,18 @@ public class RandomDataGenerator
             data[i] = data[i - 1] + (Rand.NextDouble() * 2 - 1) * mult;
         return data;
     }
+
+    public double RandomNormal(double mean = 0, double stdDev = 1)
+    {
+        double u1;
+        double u2;
+        
+        // This is what too much C/C++ development does to you
+        while((u1 = Rand.NextDouble()) == 0) { }
+        while((u2 = Rand.NextDouble()) == 0) { }
+        
+        
+        double randStdNormal = Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Sin(2.0 * Math.PI * u2);
+        return mean + stdDev * randStdNormal;
+    }
 }


### PR DESCRIPTION
**Purpose:**
Adds box plots to ScottPlot 5

You'll notice I haven't added whiskers yet, this is still a WIP.
```cs
int N = 50;
double[] values = Generate.RandomNormal(N);
Array.Sort(values);
double min = values[0];
double q1 = values[N / 4];
double median = values[N / 2];
double q3 = values[3 * N / 4];
double max = values[N - 1];

var box = new ScottPlot.Plottables.Box
{
    BoxMin = q1,
    BoxMiddle = median,
    BoxMax = q3,
};

var boxPlot = avaPlot.Plot.Add.Box(box);
```
<img width="595" alt="image" src="https://user-images.githubusercontent.com/8635304/227265729-2523c0ea-23c7-413c-b652-b4643dbdc5ca.png">
