### PR TITLE
SP5: improve tick label format customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Controls: Disabled context menu in non-interactive mode (#2475) _Thanks @KroMignon_
 * Histogram: Improved constructor argument validation and support for small bins(#2490) _Thanks @Margulieuxd and @bukkideme_
 * WpfPlot: Control now appears in the Visual Studio Toolbox (#2535, #1966) _Thanks Valkyre_
+* Axis: Improved tick label format customization (#2500) _Thanks @chhh_
 
 ## ScottPlot 4.1.62 (in development)
 * Ellipse and Circle: New plot types demonstrated in the cookbook. (#2413, #2437) _Thanks @bukkideme_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/CustomizingTicks.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/CustomizingTicks.cs
@@ -9,11 +9,50 @@ internal class CustomizingTicks : RecipePageBase
         PageDescription = "Advanced customization of tick marks and tick labels",
     };
 
+    internal class CustomTickFormatter : RecipeTestBase
+    {
+        public override string Name => "Custom Tick Formatters";
+        public override string Description => "Users can customize the logic used to create " +
+            "tick labels from tick positions.";
+
+        [Test]
+        public override void Recipe()
+        {
+            double[] xs = Generate.Consecutive(100, 1, -50);
+            myPlot.Add.Scatter(xs, Generate.Sin(100));
+            myPlot.Add.Scatter(xs, Generate.Cos(100));
+
+            // create a static function containing the string formatting logic
+            static string CustomFormatter(double position)
+            {
+                if (position == 0)
+                    return "0";
+                else if (position > 0)
+                    return $"+{position}";
+                else
+                    return $"({-position})";
+            }
+
+            // create a custom tick generator using your custom label formatter
+            ScottPlot.TickGenerators.NumericAutomatic myTickGenerator = new()
+            {
+                LabelFormatter = CustomFormatter
+            };
+
+            // tell an axis to use the custom tick generator
+            myPlot.XAxis.TickGenerator = myTickGenerator;
+        }
+    }
+
     internal class AltTickGen : RecipeTestBase
     {
         public override string Name => "Custom Tick Generators";
-        public override string Description => "Alternative tick generators can be created and assigned to axes. " +
-            "Some common tick generators are provided with ScottPlot, and users also have the option create their own.";
+        public override string Description =>
+            "Tick generators determine where ticks are to be placed and also " +
+            "contain logic for generating tick labels from tick positions. " +
+            "Alternative tick generators can be created and assigned to axes. " +
+            "Some common tick generators are provided with ScottPlot, " +
+            "and users also have the option create their own.";
 
         [Test]
         public override void Recipe()
@@ -21,9 +60,7 @@ internal class CustomizingTicks : RecipePageBase
             myPlot.Add.Signal(Generate.Sin(51));
             myPlot.Add.Signal(Generate.Cos(51));
 
-            ITickGenerator customTickGenerator = new ScottPlot.TickGenerators.NumericFixedInterval(11);
-
-            myPlot.XAxis.TickGenerator = customTickGenerator;
+            myPlot.XAxis.TickGenerator = new ScottPlot.TickGenerators.NumericFixedInterval(11);
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/BottomAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/BottomAxis.cs
@@ -6,6 +6,6 @@ public class BottomAxis : XAxisBase, IXAxis
 
     public BottomAxis()
     {
-        TickGenerator = new TickGenerators.NumericAutomatic(false);
+        TickGenerator = new TickGenerators.NumericAutomatic();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/LeftAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/LeftAxis.cs
@@ -6,6 +6,6 @@ public class LeftAxis : YAxisBase, IYAxis
 
     public LeftAxis()
     {
-        TickGenerator = new TickGenerators.NumericAutomatic(true);
+        TickGenerator = new TickGenerators.NumericAutomatic();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/RightAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/RightAxis.cs
@@ -6,6 +6,6 @@ public class RightAxis : YAxisBase, IYAxis
 
     public RightAxis()
     {
-        TickGenerator = new TickGenerators.NumericAutomatic(true);
+        TickGenerator = new TickGenerators.NumericAutomatic();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/TopAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Axis/StandardAxes/TopAxis.cs
@@ -6,6 +6,6 @@ public class TopAxis : XAxisBase, IXAxis
 
     public TopAxis()
     {
-        TickGenerator = new TickGenerators.NumericAutomatic(false);
+        TickGenerator = new TickGenerators.NumericAutomatic();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/ITickGenerator.cs
+++ b/src/ScottPlot5/ScottPlot5/ITickGenerator.cs
@@ -16,5 +16,5 @@ public interface ITickGenerator
     /// Logic for generating ticks automatically.
     /// Generated ticks are stored in <see cref="Ticks"/>.
     /// </summary>
-    void Regenerate(CoordinateRange range, PixelLength size);
+    void Regenerate(CoordinateRange range, Edge edge, PixelLength size);
 }

--- a/src/ScottPlot5/ScottPlot5/Layouts/StandardLayoutMaker.cs
+++ b/src/ScottPlot5/ScottPlot5/Layouts/StandardLayoutMaker.cs
@@ -13,11 +13,11 @@ public class StandardLayoutMaker : ILayoutMaker
 
         panels.OfType<IXAxis>()
             .ToList()
-            .ForEach(xAxis => xAxis.TickGenerator.Regenerate(xAxis.Range, figureRect.Width));
+            .ForEach(xAxis => xAxis.TickGenerator.Regenerate(xAxis.Range, xAxis.Edge, figureRect.Width));
 
         panels.OfType<IYAxis>()
             .ToList()
-            .ForEach(yAxis => yAxis.TickGenerator.Regenerate(yAxis.Range, figureRect.Height));
+            .ForEach(yAxis => yAxis.TickGenerator.Regenerate(yAxis.Range, yAxis.Edge, figureRect.Height));
 
         Layout layout = MakeFinalLayout(figureRect, panels);
 

--- a/src/ScottPlot5/ScottPlot5/Panels/ColorBar.cs
+++ b/src/ScottPlot5/ScottPlot5/Panels/ColorBar.cs
@@ -99,7 +99,7 @@ public class ColorBar : IPanel
         axis.Min = range.Min;
         axis.Max = range.Max;
 
-        axis.TickGenerator.Regenerate(axis.Range, length);
+        axis.TickGenerator.Regenerate(axis.Range, axis.Edge, length);
 
         return axis;
     }

--- a/src/ScottPlot5/ScottPlot5/Rendering/StandardRenderer.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/StandardRenderer.cs
@@ -16,8 +16,8 @@ public class StandardRenderer : IRenderer
         Layout layout = plot.Layout.GetLayout(figureRect, panels);
         PixelRect dataRect = layout.DataRect;
 
-        plot.XAxis.TickGenerator.Regenerate(plot.XAxis.Range, dataRect.Width);
-        plot.YAxis.TickGenerator.Regenerate(plot.YAxis.Range, dataRect.Height);
+        plot.XAxis.TickGenerator.Regenerate(plot.XAxis.Range, plot.XAxis.Edge, dataRect.Width);
+        plot.YAxis.TickGenerator.Regenerate(plot.YAxis.Range, plot.YAxis.Edge, dataRect.Height);
 
         Common.RenderBackground(surface, dataRect, plot);
         Common.RenderGridsBelowPlottables(surface, dataRect, plot);

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/DateTimeFixedInterval.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/DateTimeFixedInterval.cs
@@ -1,10 +1,9 @@
-﻿using ScottPlot.Axis.TimeUnits;
-
-namespace ScottPlot.TickGenerators
+﻿namespace ScottPlot.TickGenerators
 {
     public class DateTimeFixedInterval : IDateTickGenerator
     {
         public ITimeUnit Interval { get; set; }
+
         public int IntervalsPerTick { get; set; } = 1;
 
         public DateTimeFixedInterval(ITimeUnit interval, int intervalsPerTick = 1)
@@ -14,6 +13,7 @@ namespace ScottPlot.TickGenerators
         }
 
         public Tick[] Ticks { get; set; } = Array.Empty<Tick>();
+
         public int MaxTickCount { get; set; } = 10_000;
 
         public IEnumerable<double> ConvertToCoordinateSpace(IEnumerable<DateTime> dates)
@@ -21,7 +21,7 @@ namespace ScottPlot.TickGenerators
             return dates.Select(dt => dt.ToNumber());
         }
 
-        public void Regenerate(CoordinateRange range, PixelLength size)
+        public void Regenerate(CoordinateRange range, Edge edge, PixelLength size)
         {
             List<Tick> ticks = new();
 

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/ITimeUnit.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/ITimeUnit.cs
@@ -1,4 +1,4 @@
-﻿namespace ScottPlot.Axis.TimeUnits;
+﻿namespace ScottPlot.TickGenerators;
 
 public interface ITimeUnit
 {

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
@@ -13,7 +13,7 @@ public class NumericFixedInterval : ITickGenerator
         Interval = interval;
     }
 
-    public void Regenerate(CoordinateRange range, PixelLength size)
+    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size)
     {
         List<Tick> ticks = new();
 

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Centisecond.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Centisecond.cs
@@ -1,7 +1,4 @@
-﻿using System.Globalization;
-using ScottPlot.TickGenerators.TimeUnits;
-
-namespace ScottPlot.Axis.TimeUnits;
+﻿namespace ScottPlot.TickGenerators.TimeUnits;
 
 public class Centisecond : ITimeUnit
 {

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Day.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Day.cs
@@ -1,7 +1,4 @@
-﻿using System.Globalization;
-using ScottPlot.TickGenerators.TimeUnits;
-
-namespace ScottPlot.Axis.TimeUnits;
+﻿namespace ScottPlot.TickGenerators.TimeUnits;
 
 public class Day : ITimeUnit
 {

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Decisecond.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Decisecond.cs
@@ -1,7 +1,4 @@
-﻿using System.Globalization;
-using ScottPlot.TickGenerators.TimeUnits;
-
-namespace ScottPlot.Axis.TimeUnits;
+﻿namespace ScottPlot.TickGenerators.TimeUnits;
 
 public class Decisecond : ITimeUnit
 {

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Hour.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Hour.cs
@@ -1,7 +1,4 @@
-﻿using System.Globalization;
-using ScottPlot.TickGenerators.TimeUnits;
-
-namespace ScottPlot.Axis.TimeUnits;
+﻿namespace ScottPlot.TickGenerators.TimeUnits;
 
 public class Hour : ITimeUnit
 {

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Millisecond.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Millisecond.cs
@@ -1,7 +1,4 @@
-﻿using System.Globalization;
-using ScottPlot.TickGenerators.TimeUnits;
-
-namespace ScottPlot.Axis.TimeUnits;
+﻿namespace ScottPlot.TickGenerators.TimeUnits;
 
 public class Millisecond : ITimeUnit
 {

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Minute.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Minute.cs
@@ -1,7 +1,4 @@
-﻿using System.Globalization;
-using ScottPlot.TickGenerators.TimeUnits;
-
-namespace ScottPlot.Axis.TimeUnits;
+﻿namespace ScottPlot.TickGenerators.TimeUnits;
 
 public class Minute : ITimeUnit
 {

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Month.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Month.cs
@@ -1,6 +1,4 @@
-﻿using ScottPlot.TickGenerators.TimeUnits;
-
-namespace ScottPlot.Axis.TimeUnits;
+﻿namespace ScottPlot.TickGenerators.TimeUnits;
 
 public class Month : ITimeUnit
 {

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Second.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Second.cs
@@ -1,7 +1,4 @@
-﻿using System.Globalization;
-using ScottPlot.TickGenerators.TimeUnits;
-
-namespace ScottPlot.Axis.TimeUnits;
+﻿namespace ScottPlot.TickGenerators.TimeUnits;
 
 public class Second : ITimeUnit
 {

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Year.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/TimeUnits/Year.cs
@@ -1,7 +1,4 @@
-﻿using System.Globalization;
-using ScottPlot.TickGenerators.TimeUnits;
-
-namespace ScottPlot.Axis.TimeUnits;
+﻿namespace ScottPlot.TickGenerators.TimeUnits;
 
 public class Year : ITimeUnit
 {

--- a/src/ScottPlot5/ScottPlot5/Usings.cs
+++ b/src/ScottPlot5/ScottPlot5/Usings.cs
@@ -7,3 +7,4 @@ global using System.Text;
 global using ScottPlot.Extensions;
 global using System.Diagnostics;
 global using SkiaSharp;
+global using System.Globalization;


### PR DESCRIPTION
* modify `ITickGenerator` so the `Edge` is passed into the tick generation function instead of being stored
* modify the `DateTimeAutomatic` tick generator to store time units in a list (created not using reflection), making them easier to modify or replace individually
* added cookbook demo showing how to customize tick label format
* resolves #2500