### PR TITLE
SP4 Annotation: improve alignment options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Controls: Added `Configuration.RightClickDragZoomFromMouseDown` flag to enable right-click-drag zoom to scale relative to the cursor (#2296, #2573) _@pavlexander_
 * Finance: Improved DateTime position of random stock price sample data (#2574)
 * Axis: Improve tick spacing for extremely small plots (#2289) _Thanks @Xerxes004_
+* Annotation: Position is no longer defined as `X` and `Y` but instead `Alignment`, `MarginX`, and `MarginY` (#2302) _Thanks @EFeru_
 
 ## ScottPlot 5.0.4-beta
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2023-04-02_

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Annotation.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Annotation.cs
@@ -21,15 +21,17 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             plt.AddScatter(xs, DataGen.Cos(xs));
 
             // default placement is upper left
-            plt.AddAnnotation("Top Left", 10, 10);
+            plt.AddAnnotation("Top Left", Alignment.UpperLeft);
 
             // negative coordinates can be used to place text along different edges
-            plt.AddAnnotation("Lower Left", 10, -10);
-            plt.AddAnnotation("Top Right", -10, 10);
-            plt.AddAnnotation("Lower Right", -10, -10);
+            plt.AddAnnotation("Lower Left", Alignment.LowerLeft);
+            plt.AddAnnotation("Top Right", Alignment.UpperRight);
+            plt.AddAnnotation("Lower Right", Alignment.LowerRight);
 
             // Additional customizations are available
-            var fancy = plt.AddAnnotation("Fancy Annotation", 10, 40);
+            var fancy = plt.AddAnnotation("Fancy Annotation", Alignment.UpperLeft);
+            fancy.MarginX = 20;
+            fancy.MarginY = 40;
             fancy.Font.Size = 24;
             fancy.Font.Name = "Impact";
             fancy.Font.Color = Color.Red;

--- a/src/ScottPlot4/ScottPlot.Tests/PlotTypes/Annotation.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlotTypes/Annotation.cs
@@ -1,8 +1,7 @@
 ﻿using NUnit.Framework;
+using ScottPlot;
 using System;
-using System.Collections.Generic;
 using System.Drawing;
-using System.Text;
 
 namespace ScottPlotTests.PlotTypes
 {
@@ -11,22 +10,28 @@ namespace ScottPlotTests.PlotTypes
         [Test]
         public void Test_Annotation_Coordinates()
         {
-            var plt = new ScottPlot.Plot(400, 300);
+            ScottPlot.Plot plt = new(400, 300);
 
-            // negative coordinates snap text to the lower or right edges
-            plt.AddAnnotation("Top Left", 10, 10);
-            plt.AddAnnotation("Lower Left", 10, -10);
-            plt.AddAnnotation("Top Right", -10, 10);
-            plt.AddAnnotation("Lower Right", -10, -10);
+            foreach (Alignment alignment in Enum.GetValues(typeof(Alignment)))
+            {
+                plt.AddAnnotation(alignment.ToString(), alignment);
+            }
 
-            // customization of style
-            var a = plt.AddAnnotation("Fancy Annotation", 10, 40);
+            TestTools.SaveFig(plt);
+        }
+
+        [Test]
+        public void Test_Annotation_Styling()
+        {
+            ScottPlot.Plot plt = new(400, 300);
+
+            var a = plt.AddAnnotation("Fancy Annotation");
             a.Font.Size = 24;
             a.Font.Name = "Impact";
             a.Font.Color = Color.Red;
             a.Shadow = true;
             a.Background = true;
-            a.BackgroundColor = Color.White;
+            a.BackgroundColor = Color.Orange;
             a.BorderWidth = 2;
 
             TestTools.SaveFig(plt);

--- a/src/ScottPlot4/ScottPlot.Tests/PlottableRenderTests/Annotation.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlottableRenderTests/Annotation.cs
@@ -15,7 +15,7 @@ namespace ScottPlotTests.PlottableRenderTests
             var plt = new ScottPlot.Plot(400, 300);
 
             // start with default settings
-            var pa = new ScottPlot.Plottable.Annotation() { Label = "Hello", X = 10, Y = 10 };
+            var pa = new ScottPlot.Plottable.Annotation() { Label = "Hello" };
             pa.Font.Size = 36;
             plt.Add(pa);
             var bmp1 = TestTools.GetLowQualityBitmap(plt);
@@ -41,7 +41,7 @@ namespace ScottPlotTests.PlottableRenderTests
             var plt = new ScottPlot.Plot(400, 300);
 
             // start with default settings
-            var pa = new ScottPlot.Plottable.Annotation() { Label = "Hello", X = 10, Y = 10 };
+            var pa = new ScottPlot.Plottable.Annotation() { Label = "Hello" };
             plt.Add(pa);
             var bmp1 = TestTools.GetLowQualityBitmap(plt);
 
@@ -66,7 +66,7 @@ namespace ScottPlotTests.PlottableRenderTests
             var plt = new ScottPlot.Plot(400, 300);
 
             // start with default settings
-            var pa = new ScottPlot.Plottable.Annotation() { Label = "Hello", X = 10, Y = 10 };
+            var pa = new ScottPlot.Plottable.Annotation() { Label = "Hello" };
             plt.Add(pa);
             var bmp1 = TestTools.GetLowQualityBitmap(plt);
 
@@ -91,7 +91,7 @@ namespace ScottPlotTests.PlottableRenderTests
             var plt = new ScottPlot.Plot(400, 300);
 
             // start with default settings
-            var pa = new ScottPlot.Plottable.Annotation() { Label = "Hello", X = 10, Y = 10, BorderColor = System.Drawing.Color.Gray };
+            var pa = new ScottPlot.Plottable.Annotation() { Label = "Hello", BorderColor = System.Drawing.Color.Gray };
             plt.Add(pa);
             var bmp1 = TestTools.GetLowQualityBitmap(plt);
 
@@ -116,7 +116,7 @@ namespace ScottPlotTests.PlottableRenderTests
             var plt = new ScottPlot.Plot(400, 300);
 
             // start with default settings
-            var pa = new ScottPlot.Plottable.Annotation() { Label = "Hello", X = 10, Y = 10 };
+            var pa = new ScottPlot.Plottable.Annotation() { Label = "Hello" };
             plt.Add(pa);
             var bmp1 = TestTools.GetLowQualityBitmap(plt);
 

--- a/src/ScottPlot4/ScottPlot/Drawing/GDI.cs
+++ b/src/ScottPlot4/ScottPlot/Drawing/GDI.cs
@@ -444,6 +444,37 @@ namespace ScottPlot.Drawing
         }
 
         /// <summary>
+        /// Return the position of a small rectangle placed inside a larger rectangle according to the given alignment and margin.
+        /// </summary>
+        public static RectangleF GetAlignedRectangle(RectangleF outer, SizeF size, Alignment alignment, float paddingX, float paddingY)
+        {
+            float left = outer.Left + paddingX;
+            float right = outer.Right - paddingX;
+            float centerX = (outer.Left + outer.Right) / 2;
+
+            float top = outer.Top + paddingY;
+            float bottom = outer.Bottom - paddingY;
+            float centerY = (outer.Top + outer.Bottom) / 2;
+
+            float width = size.Width;
+            float height = size.Height;
+
+            return alignment switch
+            {
+                Alignment.UpperLeft => new RectangleF(left, top, width, height),
+                Alignment.UpperCenter => new RectangleF(centerX - width / 2, top, width, height),
+                Alignment.UpperRight => new RectangleF(right - width, top, width, height),
+                Alignment.MiddleLeft => new RectangleF(left, centerY - height / 2, width, height),
+                Alignment.MiddleCenter => new RectangleF(centerX - width / 2, centerY - height / 2, width, height),
+                Alignment.MiddleRight => new RectangleF(right - width, centerY - height / 2, width, height),
+                Alignment.LowerLeft => new RectangleF(left, bottom - height, width, height),
+                Alignment.LowerCenter => new RectangleF(centerX - width / 2, bottom - height, width, height),
+                Alignment.LowerRight => new RectangleF(right - width, bottom - height, width, height),
+                _ => throw new NotImplementedException(alignment.ToString()),
+            };
+        }
+
+        /// <summary>
         /// For some reason this overload is not present in System.Drawing.Common
         /// </summary>
         internal static void DrawRectangle(this Graphics gfx, Pen pen, RectangleF rect)

--- a/src/ScottPlot4/ScottPlot/Drawing/GDI.cs
+++ b/src/ScottPlot4/ScottPlot/Drawing/GDI.cs
@@ -442,5 +442,13 @@ namespace ScottPlot.Drawing
             using LinearGradientBrush brush = new(gradientRectangle, color1, color2, LinearGradientMode.Vertical);
             gfx.FillPolygon(brush, points);
         }
+
+        /// <summary>
+        /// For some reason this overload is not present in System.Drawing.Common
+        /// </summary>
+        internal static void DrawRectangle(this Graphics gfx, Pen pen, RectangleF rect)
+        {
+            gfx.DrawRectangle(pen, rect.X, rect.Y, rect.Width, rect.Height);
+        }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Enums/Alignment.cs
+++ b/src/ScottPlot4/ScottPlot/Enums/Alignment.cs
@@ -8,14 +8,14 @@ namespace ScottPlot
     public enum Alignment
     {
         UpperLeft,
-        UpperRight,
         UpperCenter,
+        UpperRight,
         MiddleLeft,
         MiddleCenter,
         MiddleRight,
         LowerLeft,
+        LowerCenter,
         LowerRight,
-        LowerCenter
     }
 
     [Obsolete("use Alignment", true)]

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Add.cs
@@ -26,9 +26,31 @@ namespace ScottPlot
         /// <summary>
         /// Display text in the data area at a pixel location (not a X/Y coordinates)
         /// </summary>
+        [Obsolete("This overload is deprecated.")]
         public Annotation AddAnnotation(string label, double x, double y)
         {
-            var plottable = new Annotation() { Label = label, X = x, Y = y };
+            var plottable = new Annotation() { Label = label };
+
+            // recreate old X/Y behavior using the new alignment property
+            if (x >= 0 && y >= 0)
+                plottable.Alignment = Alignment.UpperLeft;
+            else if (x < 0 && y >= 0)
+                plottable.Alignment = Alignment.UpperRight;
+            else if (x >= 0 && y < 0)
+                plottable.Alignment = Alignment.LowerLeft;
+            else if (x < 0 && y < 0)
+                plottable.Alignment = Alignment.LowerRight;
+
+            Add(plottable);
+            return plottable;
+        }
+
+        /// <summary>
+        /// Display text in the data area at a pixel location (not a X/Y coordinates)
+        /// </summary>
+        public Annotation AddAnnotation(string label, Alignment alignment = Alignment.UpperLeft)
+        {
+            Annotation plottable = new() { Label = label, Alignment = alignment };
             Add(plottable);
             return plottable;
         }

--- a/src/ScottPlot4/ScottPlot/PlotDimensions.cs
+++ b/src/ScottPlot4/ScottPlot/PlotDimensions.cs
@@ -35,13 +35,14 @@ namespace ScottPlot
         public readonly double UnitsPerPxX;
         public readonly double UnitsPerPxY;
 
-        public Pixel GetPixel(Coordinate coordinate) => new Pixel(GetPixelX(coordinate.X), GetPixelY(coordinate.Y));
+        public Pixel GetPixel(Coordinate coordinate) => new(GetPixelX(coordinate.X), GetPixelY(coordinate.Y));
         public float GetPixelX(double position) => (float)(DataOffsetX + ((position - XMin) * PxPerUnitX));
         public float GetPixelY(double position) => (float)(DataOffsetY + ((YMax - position) * PxPerUnitY));
         public Coordinate GetCoordinate(Pixel pixel) => new(GetCoordinateX(pixel.X), GetCoordinateY(pixel.Y));
         public Coordinate GetCoordinate(float xPixel, float yPixel) => new(GetCoordinateX(xPixel), GetCoordinateY(yPixel));
         public double GetCoordinateX(float pixel) => (pixel - DataOffsetX) / PxPerUnitX + XMin;
         public double GetCoordinateY(float pixel) => YMax - (pixel - DataOffsetY) / PxPerUnitY;
+        public RectangleF GetDataRect() => new(DataOffsetX, DataOffsetY, DataWidth, DataHeight);
 
         public PlotDimensions(SizeF figureSize, SizeF dataSize, PointF dataOffset, AxisLimits axisLimits, double scaleFactor)
         {

--- a/src/ScottPlot4/ScottPlot/Plottable/Annotation.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Annotation.cs
@@ -12,12 +12,30 @@ namespace ScottPlot.Plottable
         /// <summary>
         /// Horizontal location (in pixel units) relative to the data area
         /// </summary>
+        [Obsolete("Instead of setting X and Y, set Alignment and Margin", true)]
         public double X { get; set; }
 
         /// <summary>
         /// Vertical position (in pixel units) relative to the data area
         /// </summary>
+        [Obsolete("Instead of setting X and Y, set Alignment and Margin", true)]
         public double Y { get; set; }
+
+        /// <summary>
+        /// Defines which edge of the plot area the annotation will be placed along.
+        /// Distance from this edge is defined by <see cref="Margin"/>
+        /// </summary>
+        public Alignment Alignment { get => Font.Alignment; set => Font.Alignment = value; }
+
+        /// <summary>
+        /// Distance (in pixels) from the edge of the plot area to place the annotation
+        /// </summary>
+        public float MarginX { get; set; } = 5;
+
+        /// <summary>
+        /// Distance (in pixels) from the edge of the plot area to place the annotation
+        /// </summary>
+        public float MarginY { get; set; } = 5;
 
         /// <summary>
         /// Text displayed in the annotation
@@ -95,23 +113,21 @@ namespace ScottPlot.Plottable
             using var borderPen = new Pen(BorderColor, BorderWidth);
 
             SizeF size = GDI.MeasureString(gfx, Label, font);
-            double x = (X >= 0) ? X : dims.DataWidth + X - size.Width;
-            double y = (Y >= 0) ? Y : dims.DataHeight + Y - size.Height;
-            PointF location = new((float)x + dims.DataOffsetX, (float)y + dims.DataOffsetY);
-
-            RectangleF backgroundRect = new(location.X, location.Y, size.Width, size.Height);
-            RectangleF shadowRect = new(location.X + ShadowOffsetX, location.Y + ShadowOffsetY, size.Width, size.Height);
+            RectangleF rect = GDI.GetAlignedRectangle(dims.GetDataRect(), size, Alignment, MarginX, MarginY);
 
             if (Background && Shadow)
+            {
+                RectangleF shadowRect = new(rect.X + MarginX, rect.Y + MarginY, rect.Width, rect.Height);
                 gfx.FillRectangle(shadowBrush, shadowRect);
+            }
 
             if (Background)
-                gfx.FillRectangle(backgroundBrush, backgroundRect);
+                gfx.FillRectangle(backgroundBrush, rect);
 
             if (Border)
-                gfx.DrawRectangle(borderPen, backgroundRect);
+                gfx.DrawRectangle(borderPen, rect);
 
-            gfx.DrawString(Label, font, fontBrush, location);
+            gfx.DrawString(Label, font, fontBrush, rect.X, rect.Y);
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Plottable/Annotation.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Annotation.cs
@@ -78,17 +78,9 @@ namespace ScottPlot.Plottable
         public bool IsVisible { get; set; } = true;
         public int XAxisIndex { get; set; } = 0;
         public int YAxisIndex { get; set; } = 0;
-
-        public override string ToString() => $"PlottableAnnotation at ({X} px, {Y} px)";
-
-        public void ValidateData(bool deep = false)
-        {
-            if (double.IsNaN(X) || double.IsInfinity(X))
-                throw new InvalidOperationException("xPixel must be a valid number");
-
-            if (double.IsNaN(Y) || double.IsInfinity(Y))
-                throw new InvalidOperationException("xPixel must be a valid number");
-        }
+        public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
+        public LegendItem[] GetLegendItems() => LegendItem.None;
+        public void ValidateData(bool deep = false) { }
 
         public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
         {
@@ -107,20 +99,19 @@ namespace ScottPlot.Plottable
             double y = (Y >= 0) ? Y : dims.DataHeight + Y - size.Height;
             PointF location = new((float)x + dims.DataOffsetX, (float)y + dims.DataOffsetY);
 
+            RectangleF backgroundRect = new(location.X, location.Y, size.Width, size.Height);
+            RectangleF shadowRect = new(location.X + ShadowOffsetX, location.Y + ShadowOffsetY, size.Width, size.Height);
+
             if (Background && Shadow)
-                gfx.FillRectangle(shadowBrush, location.X + ShadowOffsetX, location.Y + ShadowOffsetY, size.Width, size.Height);
+                gfx.FillRectangle(shadowBrush, shadowRect);
 
             if (Background)
-                gfx.FillRectangle(backgroundBrush, location.X, location.Y, size.Width, size.Height);
+                gfx.FillRectangle(backgroundBrush, backgroundRect);
 
             if (Border)
-                gfx.DrawRectangle(borderPen, location.X, location.Y, size.Width, size.Height);
+                gfx.DrawRectangle(borderPen, backgroundRect);
 
             gfx.DrawString(Label, font, fontBrush, location);
         }
-
-        public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
-
-        public LegendItem[] GetLegendItems() => LegendItem.None;
     }
 }

--- a/src/ScottPlot4/ScottPlot/Plottable/Annotation.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Annotation.cs
@@ -24,16 +24,55 @@ namespace ScottPlot.Plottable
         /// </summary>
         public string Label { get; set; }
 
+        /// <summary>
+        /// Distance (pixels) the shadow will be to the right of the box
+        /// </summary>
+        public float ShadowOffsetX { get; set; } = 5;
+
+        /// <summary>
+        /// Distance (pixels) the shadow will be below the box
+        /// </summary>
+        public float ShadowOffsetY { get; set; } = 5;
+
+        /// <summary>
+        /// Font for the annotation text
+        /// </summary>
         public readonly Drawing.Font Font = new();
 
+        /// <summary>
+        /// If true, the rectangle behind the text will be filled with <see cref="BackgroundColor"/>
+        /// </summary>
         public bool Background { get; set; } = true;
+
+        /// <summary>
+        /// Color of the rectangle drawn beneath the annotation if <see cref="Background"/> is true
+        /// </summary>
         public Color BackgroundColor { get; set; } = Color.Yellow;
 
+        /// <summary>
+        /// If true, a rectangular shadow will be drawn behind the background rectangle filled with <see cref="ShadowColor"/>
+        /// </summary>
         public bool Shadow { get; set; } = true;
+
+        /// <summary>
+        /// Color of the rectangle drawn beneath the annotation if <see cref="Shadow"/> is true.
+        /// Semitransparent colors are recommended for shadows.
+        /// </summary>
         public Color ShadowColor { get; set; } = Color.FromArgb(25, Color.Black);
 
+        /// <summary>
+        /// If true, the rectangle around the text will be drawn according to <see cref="BorderWidth"/> and <see cref="BorderColor"/>
+        /// </summary>
         public bool Border { get; set; } = true;
+
+        /// <summary>
+        /// Thickness (in pixels) of the rectangular outline to draw around the text using <see cref="BorderColor"/>
+        /// </summary>
         public float BorderWidth { get; set; } = 1;
+
+        /// <summary>
+        /// Color of the rectangular outline drawn around the text
+        /// </summary>
         public Color BorderColor { get; set; } = Color.Black;
 
         public bool IsVisible { get; set; } = true;
@@ -64,13 +103,12 @@ namespace ScottPlot.Plottable
             using var borderPen = new Pen(BorderColor, BorderWidth);
 
             SizeF size = GDI.MeasureString(gfx, Label, font);
-
             double x = (X >= 0) ? X : dims.DataWidth + X - size.Width;
             double y = (Y >= 0) ? Y : dims.DataHeight + Y - size.Height;
-            PointF location = new PointF((float)x + dims.DataOffsetX, (float)y + dims.DataOffsetY);
+            PointF location = new((float)x + dims.DataOffsetX, (float)y + dims.DataOffsetY);
 
             if (Background && Shadow)
-                gfx.FillRectangle(shadowBrush, location.X + 5, location.Y + 5, size.Width, size.Height);
+                gfx.FillRectangle(shadowBrush, location.X + ShadowOffsetX, location.Y + ShadowOffsetY, size.Width, size.Height);
 
             if (Background)
                 gfx.FillRectangle(backgroundBrush, location.X, location.Y, size.Width, size.Height);


### PR DESCRIPTION
Deprecate `X` and `Y` positioning in favor of `Alignment` and `Margin`

* Resolves #2302