### PR TITLE
WPF: fix XAML component naming

### DIFF
--- a/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/CookbookControl.xaml
+++ b/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/CookbookControl.xaml
@@ -19,12 +19,12 @@
         </Grid.RowDefinitions>
 
         <StackPanel Grid.Column="0" Grid.Row="0">
-            <Label Name="DemoNameLabel" Content="Box and Whisker Quickstart" FontSize="18" FontWeight="SemiBold"/>
+            <Label x:Name="DemoNameLabel" Content="Box and Whisker Quickstart" FontSize="18" FontWeight="SemiBold"/>
             <TextBox Background="Transparent" x:Name="DescriptionTextbox" Text="description" TextWrapping="Wrap" BorderThickness="0" Margin="2, -5, 2, 5"/>
         </StackPanel>
 
         <Border Grid.Column="0" Grid.Row="1" Margin="5" BorderThickness="2" BorderBrush="LightGray" Background="LightGray" >
-            <ScottPlot:WpfPlot Name="wpfPlot1"/>
+            <ScottPlot:WpfPlot x:Name="wpfPlot1"/>
         </Border>
 
         <Border Grid.Column="0" Grid.Row="2" Margin="5" BorderThickness="2" BorderBrush="#2a3a56" Background="#2a3a56" >

--- a/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/AxisLimits.xaml
+++ b/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/AxisLimits.xaml
@@ -7,6 +7,6 @@
         mc:Ignorable="d"
         Title="Axis Limits" Height="450" Width="800">
     <Grid>
-        <ScottPlot:WpfPlot Name="wpfPlot1"/>
+        <ScottPlot:WpfPlot x:Name="wpfPlot1"/>
     </Grid>
 </Window>

--- a/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/DisplayScaling.xaml
+++ b/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/DisplayScaling.xaml
@@ -10,6 +10,6 @@
         <Viewbox Height="16" DockPanel.Dock="Top" HorizontalAlignment="Left" Margin="10">
             <CheckBox IsChecked="True" Content="DPI Stretch" Checked="CheckBox_Checked" Unchecked="CheckBox_Unchecked"/>
         </Viewbox>
-        <WpfPlot Name="WpfPlot1" />
+        <WpfPlot x:Name="WpfPlot1" />
     </DockPanel>
 </Window>

--- a/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/Layout.xaml
+++ b/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/Layout.xaml
@@ -17,8 +17,8 @@
             <RowDefinition Height="2*"></RowDefinition>
             <RowDefinition></RowDefinition>
         </Grid.RowDefinitions>
-        <WpfPlot Name="mainPlot" Grid.Column="0" Grid.Row="0" />
-        <WpfPlot Name="rightPlot" Grid.Column="1" Grid.Row="0" />
-        <WpfPlot Name="lowerPlot" Grid.Column="0" Grid.Row="1" />
+        <WpfPlot x:Name="mainPlot" Grid.Column="0" Grid.Row="0" />
+        <WpfPlot x:Name="rightPlot" Grid.Column="1" Grid.Row="0" />
+        <WpfPlot x:Name="lowerPlot" Grid.Column="0" Grid.Row="1" />
     </Grid>
 </Window>

--- a/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/LinkedPlots.xaml
+++ b/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/LinkedPlots.xaml
@@ -18,7 +18,7 @@
         </Grid.RowDefinitions>
 
         <Label Content="This example demonstrates how to link axes of two separate plots." Grid.Column="0" Grid.Row="0"/>
-        <ScottPlot:WpfPlot Grid.Column="0" Grid.Row="1" Name="wpfPlot1"/>
-        <ScottPlot:WpfPlot Grid.Column="0" Grid.Row="2" Name="wpfPlot2"/>
+        <ScottPlot:WpfPlot Grid.Column="0" Grid.Row="1" x:Name="wpfPlot1"/>
+        <ScottPlot:WpfPlot Grid.Column="0" Grid.Row="2" x:Name="wpfPlot2"/>
     </Grid>
 </Window>

--- a/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/LiveDataFixed.xaml
+++ b/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/LiveDataFixed.xaml
@@ -9,6 +9,6 @@
         Title="Live Data (fixed array size)" Height="450" Width="800">
     <DockPanel>
         <Label Content="This example uses a fixed-size array and updates its values with time" DockPanel.Dock="Top"/>
-        <ScottPlot:WpfPlot Name="wpfPlot1"/>
+        <ScottPlot:WpfPlot x:Name="wpfPlot1"/>
     </DockPanel>
 </Window>

--- a/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/LiveDataGrowing.xaml
+++ b/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/LiveDataGrowing.xaml
@@ -16,6 +16,6 @@
             <TextBox x:Name="LatestValueTextbox" IsEnabled="False" VerticalAlignment="Center" Width="60"/>
             <CheckBox x:Name="AutoAxisCheckbox" Content="Auto-axis on each update" IsChecked="True" VerticalAlignment="Center" Unchecked="DisableAutoAxis"/>
         </StackPanel>
-        <ScottPlot:WpfPlot Name="wpfPlot1"/>
+        <ScottPlot:WpfPlot x:Name="wpfPlot1"/>
     </DockPanel>
 </Window>

--- a/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/MouseTracker.xaml
+++ b/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/MouseTracker.xaml
@@ -26,17 +26,17 @@
 
             <Label Content="Pixel" Grid.Row="0" Grid.Column="1" FontWeight="Bold" Width="100"/>
             <Label Content="Coordinate" Grid.Row="0" Grid.Column="2" FontWeight="Bold" Width="100"/>
-            <Label Name="MouseTrackLabel" Content="Mouse not yet tracked..." Grid.Row="0" Grid.Column="3" FontWeight="Bold"/>
+            <Label x:Name="MouseTrackLabel" Content="Mouse not yet tracked..." Grid.Row="0" Grid.Column="3" FontWeight="Bold"/>
 
-            <Label Name="XPixelLabel" Content="123.456" Grid.Row="1" Grid.Column="1" FontFamily="consolas" />
-            <Label Name="YPixelLabel" Content="123.456" Grid.Row="2" Grid.Column="1" FontFamily="consolas" />
+            <Label x:Name="XPixelLabel" Content="123.456" Grid.Row="1" Grid.Column="1" FontFamily="consolas" />
+            <Label x:Name="YPixelLabel" Content="123.456" Grid.Row="2" Grid.Column="1" FontFamily="consolas" />
 
-            <Label Name="XCoordinateLabel" Content="123.456" Grid.Row="1" Grid.Column="2" FontFamily="consolas" />
-            <Label Name="YCoordinateLabel" Content="123.456" Grid.Row="2" Grid.Column="2" FontFamily="consolas" />
+            <Label x:Name="XCoordinateLabel" Content="123.456" Grid.Row="1" Grid.Column="2" FontFamily="consolas" />
+            <Label x:Name="YCoordinateLabel" Content="123.456" Grid.Row="2" Grid.Column="2" FontFamily="consolas" />
 
         </Grid>
         <ScottPlot:WpfPlot 
-            Name="wpfPlot1" 
+            x:Name="wpfPlot1" 
             MouseMove="OnMouseMove" 
             MouseEnter="wpfPlot1_MouseEnter"
             MouseLeave="wpfPlot1_MouseLeave"

--- a/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/MultiAxisLock.xaml
+++ b/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/MultiAxisLock.xaml
@@ -45,6 +45,6 @@
                 />
             
         </WrapPanel>
-        <WpfPlot Name="WpfPlot1"/>
+        <WpfPlot x:Name="WpfPlot1"/>
     </DockPanel>
 </Window>

--- a/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/PlotInScrollViewer.xaml
+++ b/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/PlotInScrollViewer.xaml
@@ -35,9 +35,9 @@
         
         <ScrollViewer PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
             <StackPanel>
-                <ScottPlot:WpfPlot Height="300" Name="wpfPlot1"/>
-                <ScottPlot:WpfPlot Height="300" Name="wpfPlot2"/>
-                <ScottPlot:WpfPlot Height="300" Name="wpfPlot3"/>
+                <ScottPlot:WpfPlot Height="300" x:Name="wpfPlot1"/>
+                <ScottPlot:WpfPlot Height="300" x:Name="wpfPlot2"/>
+                <ScottPlot:WpfPlot Height="300" x:Name="wpfPlot3"/>
             </StackPanel>
         </ScrollViewer>
     </DockPanel>

--- a/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/RightClickMenu.xaml
+++ b/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/RightClickMenu.xaml
@@ -8,5 +8,5 @@
         Title="Custom Right-Click Menu" Height="450" Width="800"
         WindowStartupLocation="CenterOwner"
         >
-    <ScottPlot:WpfPlot Name="wpfPlot1" />
+    <ScottPlot:WpfPlot x:Name="wpfPlot1" />
 </Window>

--- a/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/ShowValueOnHover.xaml
+++ b/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/ShowValueOnHover.xaml
@@ -8,7 +8,7 @@
         mc:Ignorable="d"
         Title="Show Value Under Cursor" Height="450" Width="800">
     <DockPanel>
-        <Label Name="label1" Content="Hover over a data point to begin..." FontSize="18" DockPanel.Dock="Top"/>
-        <ScottPlot:WpfPlot Name="wpfPlot1" MouseMove="wpfPlot1_MouseMove"/>
+        <Label x:Name="label1" Content="Hover over a data point to begin..." FontSize="18" DockPanel.Dock="Top"/>
+        <ScottPlot:WpfPlot x:Name="wpfPlot1" MouseMove="wpfPlot1_MouseMove"/>
     </DockPanel>
 </Window>

--- a/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/StyleBrowser.xaml
+++ b/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/StyleBrowser.xaml
@@ -9,10 +9,10 @@
         Title="ScottPlot Style Browser" Height="450" Width="900">
     <DockPanel Margin="10">
         <GroupBox Header="Styles" FontSize="16" DockPanel.Dock="Left" Width="200" >
-            <ListBox Name="ListBoxStyle" SelectionChanged="ListBox_SelectionChanged" FontSize="12" BorderThickness="0" />
+            <ListBox x:Name="ListBoxStyle" SelectionChanged="ListBox_SelectionChanged" FontSize="12" BorderThickness="0" />
         </GroupBox>
         <GroupBox Header="Palettes" FontSize="16" DockPanel.Dock="Left" Width="200" >
-            <ListBox Name="ListBoxPalette" SelectionChanged="ListBox_SelectionChanged" FontSize="12" BorderThickness="0" />
+            <ListBox x:Name="ListBoxPalette" SelectionChanged="ListBox_SelectionChanged" FontSize="12" BorderThickness="0" />
         </GroupBox>
         <ScottPlot:WpfPlot x:Name="WpfPlot1" Margin="10"/>
     </DockPanel>

--- a/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/TransparentBackground.xaml
+++ b/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/TransparentBackground.xaml
@@ -26,7 +26,7 @@
             </Label.RenderTransform>
         </Label>
 
-        <ScottPlot:WpfPlot Name="wpfPlot1"/>
+        <ScottPlot:WpfPlot x:Name="wpfPlot1"/>
     </Grid>
         
 </Window>

--- a/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/WpfConfig.xaml
+++ b/src/ScottPlot4/ScottPlot.Demo/ScottPlot.Demo.WPF/WpfDemos/WpfConfig.xaml
@@ -25,6 +25,6 @@
                 <CheckBox Content="Double-click Benchmark" Margin="5" IsChecked="True" Checked="DoubleClickBenchmarkEnable" Unchecked="DoubleClickBenchmarkDisable"/>
             </StackPanel>
         </StackPanel>
-        <ScottPlot:WpfPlot Name="wpfPlot1"/>
+        <ScottPlot:WpfPlot x:Name="wpfPlot1"/>
     </DockPanel>
 </Window>

--- a/src/ScottPlot4/ScottPlot.Sandbox/WpfApp/MainWindow.xaml
+++ b/src/ScottPlot4/ScottPlot.Sandbox/WpfApp/MainWindow.xaml
@@ -15,7 +15,7 @@
             <RowDefinition />
             <RowDefinition />
         </Grid.RowDefinitions>
-        <ScottPlot:WpfPlot Name="WpfPlot1" Grid.Row="0"/>
-        <ScottPlot:WpfPlot Name="WpfPlot2" Grid.Row="1"/>
+        <ScottPlot:WpfPlot x:Name="WpfPlot1" Grid.Row="0"/>
+        <ScottPlot:WpfPlot x:Name="WpfPlot2" Grid.Row="1"/>
     </Grid>
 </Window>

--- a/src/ScottPlot4/ScottPlot.WPF/README.md
+++ b/src/ScottPlot4/ScottPlot.WPF/README.md
@@ -5,7 +5,7 @@
 Add a `WpfPlot` to your window and give it a unique name:
 
 ```xml
-<WpfPlot Name="WpfPlot1" />
+<WpfPlot x:Name="WpfPlot1" />
 ```
 
 Add the following to your start-up sequence:

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml
@@ -8,5 +8,5 @@
         mc:Ignorable="d"
         WindowStartupLocation="CenterScreen"
         Title="ScottPlot 5 - WPF Sandbox" Height="450" Width="800">
-    <ScottPlot:WpfPlot Name="WpfPlot" />
+    <ScottPlot:WpfPlot x:Name="WpfPlot" />
 </Window>


### PR DESCRIPTION
Always use `x:Name` for naming components in XAML code.

This is to most "common" way to name components in XAML/WPF as the XAML compiler will ensure this name will be unique and it cannot be changed later in code behind via `SetValue()`. 

This way, any naming conflicts would be avoid.