### PR TITLE
AvaPlot: Do not crash on horizontal scroll-wheel inputs

### DIFF
--- a/src/ScottPlot4/ScottPlot.Avalonia/AvaPlot.axaml.cs
+++ b/src/ScottPlot4/ScottPlot.Avalonia/AvaPlot.axaml.cs
@@ -162,7 +162,10 @@ namespace ScottPlot.Avalonia
         private void OnMouseDown(object sender, PointerEventArgs e) { CaptureMouse(e.Pointer); Backend.MouseDown(GetInputState(e)); }
         private void OnMouseUp(object sender, PointerEventArgs e) { Backend.MouseUp(GetInputState(e)); UncaptureMouse(e.Pointer); }
         private void OnDoubleClick(object sender, RoutedEventArgs e) => Backend.DoubleClick();
-        private void OnMouseWheel(object sender, PointerWheelEventArgs e) => Backend.MouseWheel(GetInputState(e, e.Delta.Y));
+        private void OnMouseWheel(object sender, PointerWheelEventArgs e) {
+            if (e.Delta.Y != 0)
+                Backend.MouseWheel(GetInputState(e, e.Delta.Y));
+        }
         private void OnMouseMove(object sender, PointerEventArgs e) { Backend.MouseMove(GetInputState(e)); base.OnPointerMoved(e); }
         private void OnMouseEnter(object sender, PointerEventArgs e) => base.OnPointerEnter(e);
         private void OnMouseLeave(object sender, PointerEventArgs e) => base.OnPointerLeave(e);


### PR DESCRIPTION
**Purpose:**
Fixes an issue reported by Svetlana in the discord. This appears to only affect the v4 Avalonia control.

Before this change an attempt to scroll horizontally would reach this line: https://github.com/ScottPlot/ScottPlot/blob/521bbcf76cd26ac64fd15155011e4bf48967ccc4/src/ScottPlot4/ScottPlot/Control/Backend.cs#L731-L732

This is fixed by simply ignoring horizontal scroll inputs (which I believe is what we implicitly do on other platforms). In principle we could also treat horizontal inputs as if they were vertical, which may be preferable on MacOS when the shift key is pressed (and in my opinion at no other time): https://github.com/AvaloniaUI/Avalonia/pull/8628#issuecomment-1200061194