### PR TITLE
SP5 OpenGL Control: Fix keyboard input bug #2609

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## ScottPlot 5.0.5-beta (in development)
 * Box Plot: New plot type for displaying multiple collections of population data (#2589) _Thanks @bclehmann_
+* OpenGL Control: Prevent exceptions on keyboard input (#2609, #2616) _Thanks @stendprog_
 
 ## ScottPlot 4.1.64 (in development)
 * Ellipse: Added `Rotation` property (#2588, #2595) _Thanks @JohniMIEP and @bclehmann_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/SKGLElement.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/SKGLElement.cs
@@ -1,23 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
 using OpenTK.Graphics;
-using System.Windows.Media.Media3D;
 using SkiaSharp.Views.Desktop;
 using OpenTK.Wpf;
-using SkiaSharp;
 using OpenTK.Graphics.OpenGL;
-using OpenTK.Platform.Windows;
-using OpenTK;
-using System.Windows.Interop;
-using OpenTK.Platform;
 #if NETCOREAPP || NET
 using OpenTK.Mathematics;
 #endif
@@ -57,7 +45,7 @@ namespace SkiaSharp.Views.WPF
             RegisterToEventsDirectly = false;
             CanInvokeOnHandledEvents = false;
 #endif
-            var settings = new GLWpfControlSettings() { MajorVersion = 2, MinorVersion = 1, RenderContinuously = false};
+            var settings = new GLWpfControlSettings() { MajorVersion = 2, MinorVersion = 1, RenderContinuously = false };
 
             this.Render += OnPaint;
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/SKGLElement.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/SKGLElement.cs
@@ -53,7 +53,11 @@ namespace SkiaSharp.Views.WPF
         private void Initialize()
         {
             designMode = DesignerProperties.GetIsInDesignMode(this);
-            var settings = new GLWpfControlSettings() { MajorVersion = 2, MinorVersion = 1, RenderContinuously = false };
+#if NETCOREAPP || NET
+            RegisterToEventsDirectly = false;
+            CanInvokeOnHandledEvents = false;
+#endif
+            var settings = new GLWpfControlSettings() { MajorVersion = 2, MinorVersion = 1, RenderContinuously = false};
 
             this.Render += OnPaint;
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/ScottPlot.WPF.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/ScottPlot.WPF.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
@@ -42,7 +42,7 @@
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0-windows'">
 		<PackageReference Include="OpenTK" Version="4.3.0" NoWarn="NU1701" />
-		<PackageReference Include="OpenTK.GLWpfControl" Version="4.2.2" />
+		<PackageReference Include="OpenTK.GLWpfControl" Version="4.2.3" />
 	</ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">


### PR DESCRIPTION
**Purpose:**
Two plot control and keyboard input will stackoverflow #2609

This bug refers to `GLWPFControl`. https://github.com/opentk/GLWpfControl/issues/82
They made it possible to bypass incorrect keypress handling in version 4.2.3.
This PR updates the version of `GLWPFControl`, and disables incorrect event handling by `GLWPFControl` itself. ScottPlot.WPF's keyboard handlers continue to work correctly if the control gets focus.