### PR TITLE
SP5: Correct zero-size axes inside the render loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ScottPlot Changelog
 
 ## ScottPlot 5.0.7-beta (in development)
+* Axis: Fixed issue where axes with zero span would cause renders to fail (#2714) _Thanks @ahmad-qamar_
 
 ## ScottPlot 4.1.66 (in development)
 * DataLogger: Improved support for single-point datasets (#2733) _Thanks @KroMignon_

--- a/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/ScatterTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/ScatterTests.cs
@@ -1,0 +1,43 @@
+﻿namespace ScottPlotTests.RenderTests.Plottable;
+
+internal class ScatterTests
+{
+    [Test]
+    public void Test_Scatter_Empty_Render()
+    {
+        // TODO: https://github.com/ScottPlot/ScottPlot/issues/2714
+
+        ScottPlot.Plot plt = new();
+        double[] xs = { };
+        double[] ys = { };
+        plt.Add.Scatter(xs, ys);
+        Assert.Throws<InvalidOperationException>(() => plt.Render());
+    }
+
+    [Test]
+    public void Test_Scatter_SinglePoint_Render()
+    {
+        ScottPlot.Plot plt = new();
+        double[] xs = { 1 };
+        double[] ys = { 1 };
+        plt.Add.Scatter(xs, ys);
+        plt.Render();
+        plt.SaveTestImage();
+
+        Assert.That(plt.GetAxisLimits().Rect.Area, Is.Not.Zero);
+    }
+
+
+    [Test]
+    public void Test_Scatter_RepeatedYs_Render()
+    {
+        ScottPlot.Plot plt = new();
+        double[] xs = { 1, 2, 3, 4, 5 };
+        double[] ys = { 7, 7, 7, 7, 7 };
+        plt.Add.Scatter(xs, ys);
+        plt.Render();
+        plt.SaveTestImage();
+
+        Assert.That(plt.GetAxisLimits().Rect.Area, Is.Not.Zero);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -327,6 +327,14 @@ public class Plot : IDisposable
 
     #region Rendering and Image Creation
 
+    /// <summary>
+    /// Force the plot to render once by calling <see cref="GetImage(int, int)"/> but don't return what was rendered.
+    /// </summary>
+    public void Render(int width = 400, int height = 300)
+    {
+        GetImage(width, height);
+    }
+
     public void Render(SKSurface surface)
     {
         LastRenderInfo = Renderer.Render(surface, this);

--- a/src/ScottPlot5/ScottPlot5/Rendering/Common.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/Common.cs
@@ -1,4 +1,6 @@
-﻿namespace ScottPlot.Rendering;
+﻿using ScottPlot.Axis;
+
+namespace ScottPlot.Rendering;
 
 /// <summary>
 /// Common rendering tasks
@@ -29,6 +31,15 @@ public static class Common
         if (!plot.XAxis.Range.HasBeenSet) // may occur when there are no plottables with data
         {
             plot.SetAxisLimits(AxisLimits.Default);
+        }
+    }
+
+    public static void EnsureAxesHaveArea(Plot plot)
+    {
+        foreach (CoordinateRange range in plot.GetAllAxes().Where(x => x.Range.Span == 0).Select(x => x.Range))
+        {
+            range.Min -= 1;
+            range.Max += 1;
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5/Rendering/StandardRenderer.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/StandardRenderer.cs
@@ -9,6 +9,7 @@ public class StandardRenderer : IRenderer
         plot.Benchmark.Restart();
         Common.ReplaceNullAxesWithDefaults(plot);
         Common.AutoAxisAnyUnsetAxes(plot);
+        Common.EnsureAxesHaveArea(plot);
 
         PixelRect figureRect = surface.GetPixelRect();
 


### PR DESCRIPTION
* Resolves #2714