### PR TITLE
Remove "experimental" from Scatter List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Plot: Added optional arguments to `AddDataLogger()` and `AddDataStreamer()` for customizing style (#2733) _Thanks @KroMignon_
 * Version: Build information can now be accessed from the static `ScottPlot.Version` class
 * Avalonia: Removed dependency on `Avalonia.Desktop` package (#2752, #2748) _Thanks @Fruchtzwerg94_
+* Cookbook: Remove "experimental" designator from ScatterPlotList (#2782) _Thanks @prime167_
 
 ## ScottPlot 5.0.6-beta
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2023-07-09_

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/ScatterList.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/ScatterList.cs
@@ -11,7 +11,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string ID => "scatterList_quickstart";
         public string Title => "Scatter List Quickstart";
         public string Description =>
-            "This experimental plot type has add/remove/clear methods like typical lists.";
+            "This plot type has add/remove/clear methods like typical lists.";
 
         public void ExecuteRecipe(Plot plt)
         {
@@ -49,7 +49,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string ID => "scatterList_draggable";
         public string Title => "Scatter List Draggable";
         public string Description =>
-            "There exists an experimental Scatter Plot List with draggable points.";
+            "There exists a Scatter Plot List with draggable points.";
 
         public void ExecuteRecipe(Plot plt)
         {


### PR DESCRIPTION
The Scatter List as been added for over a year. I think it's time to graduate it from an experimental feature and make it an official fully launched feature.