### PR TITLE
SP4 WPF: Fix PlottableDragged add event accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Avalonia: Removed dependency on `Avalonia.Desktop` package (#2752, #2748) _Thanks @Fruchtzwerg94_
 * Cookbook: Remove "experimental" designator from ScatterPlotList (#2782) _Thanks @prime167_
 * Heatmap: Added `Rotation` and `CenterOfRotation` properties (#2814, #2815) _Thanks @bukkideme_
+* WPF: Improved the `PlottableDragged` event (#2820) _Thanks @tadmccorkle_
 
 ## ScottPlot 5.0.6-beta
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2023-07-09_

--- a/src/ScottPlot4/ScottPlot.WPF/WpfPlot.cs
+++ b/src/ScottPlot4/ScottPlot.WPF/WpfPlot.cs
@@ -113,7 +113,7 @@ namespace ScottPlot
         /// </summary>
         public event RoutedEventHandler PlottableDragged
         {
-            add { AddHandler(PlottableDroppedEvent, value); }
+            add { AddHandler(PlottableDraggedEvent, value); }
             remove { RemoveHandler(PlottableDraggedEvent, value); }
         }
 


### PR DESCRIPTION
Corrects the `PlottableDragged` event accessor adding a handler to the dropped event.