### PR TITLE
SP5: Cache typefaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * https://scottplot.net/contributors/ shows all of ScottPlot's contributors
 
 ## ScottPlot 5.0.8-beta (in development)
+* Rendering: Improved performance by caching typefaces (#2833, #2848) _Thanks @KroMignon and @taya92413_
 
 ## ScottPlot 4.1.67 (in development)
 

--- a/src/ScottPlot5/ScottPlot5/Extensions/SkiaSharpExtensions.cs
+++ b/src/ScottPlot5/ScottPlot5/Extensions/SkiaSharpExtensions.cs
@@ -90,12 +90,7 @@ public static class SkiaSharpExtensions
 
     public static void ApplyToPaint(this FontStyle fontStyle, SKPaint paint)
     {
-        SKFontStyleWeight weight = fontStyle.Bold ? SKFontStyleWeight.Bold : SKFontStyleWeight.Normal;
-        SKFontStyleSlant slant = fontStyle.Italic ? SKFontStyleSlant.Italic : SKFontStyleSlant.Upright;
-        SKFontStyleWidth width = SKFontStyleWidth.Normal;
-        SKFontStyle skfs = new(weight, width, slant);
-        SKTypeface typeface = SKTypeface.FromFamilyName(fontStyle.Name, skfs);
-        paint.Typeface = typeface;
+        paint.Typeface = fontStyle.Typeface;
         paint.TextSize = fontStyle.Size;
         paint.Color = fontStyle.Color.ToSKColor();
         paint.IsAntialias = fontStyle.AntiAlias;

--- a/src/ScottPlot5/ScottPlot5/Primitives/FontStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/FontStyle.cs
@@ -1,4 +1,6 @@
-﻿namespace ScottPlot;
+﻿using System.Runtime.CompilerServices;
+
+namespace ScottPlot;
 
 /// <summary>
 /// This configuration object (reference type) permanently lives inside objects which require styling.
@@ -6,10 +8,45 @@
 /// </summary>
 public class FontStyle
 {
-    public string Name { get; set; } = Fonts.Default;
-    public float Size { get; set; } = 12;
+    protected bool SetField<T>(ref T fieldValue, T value)
+    {
+        if (Equals(fieldValue, value))
+            return false;
+        fieldValue = value;
+        _typeface = null;
+        return true;
+    }
+    protected SKTypeface GetTypeFace()
+    {
+        SKFontStyleWeight weight = Bold ? SKFontStyleWeight.Bold : SKFontStyleWeight.Normal;
+        SKFontStyleSlant slant = Italic ? SKFontStyleSlant.Italic : SKFontStyleSlant.Upright;
+        SKFontStyleWidth width = SKFontStyleWidth.Normal;
+        SKFontStyle skfs = new(weight, width, slant);
+        return SKTypeface.FromFamilyName(Name, skfs);
+    }
+
+    public SKTypeface Typeface => _typeface ??= GetTypeFace();
+    protected SKTypeface? _typeface = null;
+    public string Name
+    {
+        get => _name;
+        set => SetField(ref _name, value);
+    }
+    private string _name = Fonts.Default;
     public Color Color { get; set; } = Colors.Black;
-    public bool Bold { get; set; } = false;
-    public bool Italic { get; set; } = false;
+    public bool Bold
+    {
+        get => _bold;
+        set => SetField(ref _bold, value);
+    }
+    private bool _bold = false;
+    public bool Italic
+    {
+        get => _italic;
+        set => SetField(ref _italic, value);
+    }
+    private bool _italic = false;
+
+    public float Size { get; set; } = 12;
     public bool AntiAlias { get; set; } = true;
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/FontStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/FontStyle.cs
@@ -8,20 +8,70 @@ namespace ScottPlot;
 /// </summary>
 public class FontStyle
 {
-    protected bool SetField<T>(ref T fieldValue, T value)
+    /* Typefaces are cached to improve performance.
+     * https://github.com/ScottPlot/ScottPlot/issues/2833
+     * https://github.com/ScottPlot/ScottPlot/pull/2848
+     */
+
+    private SKTypeface? _typeface = null;
+
+    public SKTypeface Typeface => _typeface ??= GetTypeFace();
+
+    private string _name = Fonts.Default;
+    public string Name
     {
-        if (value is string)
+        get => _name;
+        set
         {
-            if (string.Compare(fieldValue as string, value as string) == 0)
-                return false;
+            bool fieldChanged = string.Compare(_name, value, StringComparison.InvariantCultureIgnoreCase) != 0;
+
+            if (fieldChanged)
+                ClearCachedTypeface();
+
+            _name = value;
         }
-        else if (Equals(fieldValue, value))
-            return false;
-        fieldValue = value;
-        _typeface = null;
-        return true;
     }
-    protected SKTypeface GetTypeFace()
+
+    private bool _bold = false;
+    public bool Bold
+    {
+        get => _bold;
+        set
+        {
+            bool fieldChanged = _bold != value;
+
+            if (fieldChanged)
+                ClearCachedTypeface();
+
+            _bold = value;
+        }
+    }
+
+    private bool _italic = false;
+    public bool Italic
+    {
+        get => _italic;
+        set
+        {
+            bool fieldChanged = (_italic != value);
+
+            if (fieldChanged)
+                ClearCachedTypeface();
+
+            _italic = value;
+        }
+    }
+
+    public Color Color { get; set; } = Colors.Black;
+    public float Size { get; set; } = 12;
+    public bool AntiAlias { get; set; } = true;
+
+    private void ClearCachedTypeface()
+    {
+        _typeface = null;
+    }
+
+    private SKTypeface GetTypeFace()
     {
         SKFontStyleWeight weight = Bold ? SKFontStyleWeight.Bold : SKFontStyleWeight.Normal;
         SKFontStyleSlant slant = Italic ? SKFontStyleSlant.Italic : SKFontStyleSlant.Upright;
@@ -29,29 +79,4 @@ public class FontStyle
         SKFontStyle skfs = new(weight, width, slant);
         return SKTypeface.FromFamilyName(Name, skfs);
     }
-
-    public SKTypeface Typeface => _typeface ??= GetTypeFace();
-    protected SKTypeface? _typeface = null;
-    public string Name
-    {
-        get => _name;
-        set => SetField(ref _name, value);
-    }
-    private string _name = Fonts.Default;
-    public Color Color { get; set; } = Colors.Black;
-    public bool Bold
-    {
-        get => _bold;
-        set => SetField(ref _bold, value);
-    }
-    private bool _bold = false;
-    public bool Italic
-    {
-        get => _italic;
-        set => SetField(ref _italic, value);
-    }
-    private bool _italic = false;
-
-    public float Size { get; set; } = 12;
-    public bool AntiAlias { get; set; } = true;
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/FontStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/FontStyle.cs
@@ -10,7 +10,12 @@ public class FontStyle
 {
     protected bool SetField<T>(ref T fieldValue, T value)
     {
-        if (Equals(fieldValue, value))
+        if (value is string)
+        {
+            if (string.Compare(fieldValue as string, value as string) == 0)
+                return false;
+        }
+        else if (Equals(fieldValue, value))
             return false;
         fieldValue = value;
         _typeface = null;


### PR DESCRIPTION
Update FontStyle to add a typeface cache to avoid to call too often the font face lookup table.

This should solve issue #2833
