### PR TITLE
SP4: Add markers support to DataLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## ScottPlot 4.1.67 (in development)
 * DataLogger: Improved appearance of legend items (#2829, #2850) _Thanks @KroMignon and @p4pravin_
 * Radial Gauge Plot: Improved layout for plots with a large number of gauges (#2722) _Thanks @tinuskotze_
+* DataLogger: Added support for markers (#2862) _Thanks @KroMignon_
 
 ## ScottPlot 5.0.7-beta
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2023-08-06_

--- a/src/ScottPlot4/ScottPlot.Cookbook/Categories/PlotTypes/DataLogger.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Categories/PlotTypes/DataLogger.cs
@@ -1,0 +1,13 @@
+﻿namespace ScottPlot.Cookbook.Categories.PlotTypes;
+
+public class DataLogger : ICategory
+{
+    public string Name => "Data Logger";
+
+    public string Description => "The DataLogger plot type facilitates displaying live data by giving the developer " +
+        "a simple way to Add() new data points by either shifting them in or appending them to a growing list. " +
+        "This plot type also has special options to manage axis limits as new data arrives. " +
+        "See code in the WinForms Demo app for advanced usage information.";
+
+    public string Folder => "plottable-datalogger";
+}

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/DataLogger.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/DataLogger.cs
@@ -1,0 +1,56 @@
+﻿using System;
+
+namespace ScottPlot.Cookbook.Recipes.Plottable
+{
+    public class DataLoggerQuickstart : IRecipe
+    {
+        public ICategory Category => new Categories.PlotTypes.DataLogger();
+        public string ID => "datalogger_quickstart";
+        public string Title => "DataLogger";
+        public string Description =>
+            "A DataLogger is a plot type designed for growing datasets. " +
+            "Unlike most other plot types, the DataLogger can automatically expand the axis limits " +
+            "to accommodate new data as it is added.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            var logger = plt.AddDataLogger();
+
+            for (int i = 0; i < 100; i++)
+            {
+                double x = i * .2;
+                double y = Math.Sin(x);
+                logger.Add(x, y); // data grows as new data is added
+            }
+        }
+    }
+
+    public class DataStreamerQuickstart : IRecipe
+    {
+        public ICategory Category => new Categories.PlotTypes.DataLogger();
+        public string ID => "datastreamer_quickstart";
+        public string Title => "DataStreamer";
+        public string Description =>
+            "A DataStreamer is a plot type designed for streaming datasets with a fixed length display " +
+            "and even X spacing between Y data points. " +
+            "As new data is shifted in, old data is shifted out, and the displayed trace is always the same size.";
+
+        public void ExecuteRecipe(Plot plt)
+        {
+            var streamer = plt.AddDataStreamer(length: 20);
+            streamer.SamplePeriod = 0.2;
+
+            for (int i = 0; i < 100; i++)
+            {
+                double y = Math.Sin(i * .2);
+                streamer.Add(y); // data remains same length as new data is shifted in
+            }
+
+            // Call different view methods to change the shift behavior
+            streamer.ViewWipeRight(); // new data overwrites old data left to right
+            streamer.ViewWipeLeft(); // new data overwrites old data right to left
+            streamer.ViewScrollRight(); // new data is inserted on the left
+            streamer.ViewScrollLeft(); // new data is inserted on the right
+        }
+    }
+}

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Add.cs
@@ -132,12 +132,14 @@ namespace ScottPlot
         /// <summary>
         /// Add a data logging scatter plot designed for growing collections of X/Y points.
         /// </summary>
-        public DataLogger AddDataLogger(Color? color = null, float lineWidth = 1, string label = null)
+        public DataLogger AddDataLogger(Color? color = null, float lineWidth = 1, float markerSize = 5, MarkerShape markerShape = MarkerShape.none, string label = null)
         {
             DataLogger dl = new(this)
             {
                 Color = color ?? GetNextColor(),
                 LineWidth = lineWidth,
+                MarkerSize = markerSize,
+                MarkerShape = markerShape,
                 Label = label
             };
             Add(dl);

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Add.cs
@@ -132,14 +132,12 @@ namespace ScottPlot
         /// <summary>
         /// Add a data logging scatter plot designed for growing collections of X/Y points.
         /// </summary>
-        public DataLogger AddDataLogger(Color? color = null, float lineWidth = 1, float markerSize = 5, MarkerShape markerShape = MarkerShape.none, string label = null)
+        public DataLogger AddDataLogger(Color? color = null, float lineWidth = 1, string label = null)
         {
             DataLogger dl = new(this)
             {
                 Color = color ?? GetNextColor(),
                 LineWidth = lineWidth,
-                MarkerSize = markerSize,
-                MarkerShape = markerShape,
                 Label = label
             };
             Add(dl);

--- a/src/ScottPlot4/ScottPlot/Plottable/DataLogger.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/DataLogger.cs
@@ -20,8 +20,8 @@ public class DataLogger : IPlottable, IHasColor, IHasLine, IHasMarker
     public Color MarkerColor { get; set; } = Color.Blue;
     public double LineWidth { get; set; } = 1;
     public LineStyle LineStyle { get; set; } = LineStyle.Solid;
-    public MarkerShape MarkerShape { get; set; } = MarkerShape.none;
-    public float MarkerSize { get; set; } = 5;
+    public MarkerShape MarkerShape { get; set; } = MarkerShape.filledCircle;
+    public float MarkerSize { get; set; } = 0;
     public float MarkerLineWidth { get; set; } = 1;
 
     /// <summary>

--- a/src/ScottPlot4/ScottPlot/Plottable/DataLogger.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/DataLogger.cs
@@ -9,16 +9,20 @@ namespace ScottPlot.Plottable;
 /// <summary>
 /// This plot type stores infinitely growing X/Y pairs and displays them as a scatter plot.
 /// </summary>
-public class DataLogger : IPlottable, IHasColor, IHasLine
+public class DataLogger : IPlottable, IHasColor, IHasLine, IHasMarker
 {
     public bool IsVisible { get; set; } = true;
     public int XAxisIndex { get; set; } = 0;
     public int YAxisIndex { get; set; } = 0;
     public string Label { get; set; } = string.Empty;
-    public Color Color { get => LineColor; set { LineColor = value; } }
+    public Color Color { get => LineColor; set { LineColor = value; MarkerColor = value; } }
     public Color LineColor { get; set; } = Color.Blue;
+    public Color MarkerColor { get; set; } = Color.Blue;
     public double LineWidth { get; set; } = 1;
     public LineStyle LineStyle { get; set; } = LineStyle.Solid;
+    public MarkerShape MarkerShape { get; set; } = MarkerShape.none;
+    public float MarkerSize { get; set; } = 5;
+    public float MarkerLineWidth { get; set; } = 1;
 
     /// <summary>
     /// Number of data points currently being tracked.
@@ -116,6 +120,8 @@ public class DataLogger : IPlottable, IHasColor, IHasLine
             color = LineColor,
             lineStyle = LineStyle,
             lineWidth = LineWidth,
+            markerShape = MarkerShape,
+            markerSize = MarkerSize,
         };
         return LegendItem.Single(singleItem);
     }
@@ -197,6 +203,11 @@ public class DataLogger : IPlottable, IHasColor, IHasLine
         if (points.Length > 1)
         {
             gfx.DrawLines(pen, points);
+            // draw a marker at each point
+            if ((MarkerSize > 0) && (MarkerShape != MarkerShape.none))
+            {
+                MarkerTools.DrawMarkers(gfx, points, MarkerShape, MarkerSize, MarkerColor, MarkerLineWidth);
+            }
         }
     }
 }


### PR DESCRIPTION
**Purpose:**

This PR is to enable `Markers` support for `DataLogger`.
Per default, markers are disabled to not change current behavior.

I know that SP4 is in "frozen" state, but it would be nice if this PR could be included 😄 