### PR TITLE
SP5 Controls: shared axis and layout functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Rename: `XMin`, `XMax`, `YMin`, and `YMax` properties are now `Left`, `Right`, `Bottom`, `Top` for all coordinate primitives (#2840)
 * Plot: Improve `AutoScale()` customization using `Margins()` to define whitespace area (#2857)
 * Primitives: Improved equality checks (#2855)
+* Controls: Added a `RenderQueue` to allow cross-control render requests that would otherwise cause render artifacts or infinite loops
+* Controls: Created `SharedAxisManager` and `SharedLayoutManager` to facilitate pairing controls together
 
 ## ScottPlot 4.1.67 (in development)
 * DataLogger: Improved appearance of legend items (#2829, #2850) _Thanks @KroMignon and @p4pravin_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
@@ -25,6 +25,9 @@ public class AvaPlot : Controls.Control, IPlotControl
 
     public float DisplayScale { get; set; }
 
+    public RenderQueue RenderQueue { get; } = new();
+
+
     private static readonly List<FilePickerFileType> filePickerFileTypes = new()
     {
         new("PNG Files") { Patterns = new List<string> { "*.png" } },
@@ -132,6 +135,7 @@ public class AvaPlot : Controls.Control, IPlotControl
     public void Refresh()
     {
         InvalidateVisual();
+        RenderQueue.RefreshAll();
     }
 
     public void ShowContextMenu(Pixel position)

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Eto/EtoPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Eto/EtoPlot.cs
@@ -16,7 +16,11 @@ public class EtoPlot : Drawable, IPlotControl
     public GRContext? GRContext => null;
 
     public Interaction Interaction { get; private set; }
+
     public float DisplayScale { get; set; }
+
+    public RenderQueue RenderQueue { get; } = new();
+
 
     private readonly List<FileFilter> fileDialogFilters = new()
     {
@@ -75,6 +79,7 @@ public class EtoPlot : Drawable, IPlotControl
     public void Refresh()
     {
         Invalidate();
+        RenderQueue.RefreshAll();
     }
 
     public void ShowContextMenu(Pixel position)

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlot.cs
@@ -25,6 +25,8 @@ namespace ScottPlot.WPF
 
         public float DisplayScale { get; set; }
 
+        public RenderQueue RenderQueue { get; } = new();
+
         static WpfPlot()
         {
             DefaultStyleKeyProperty.OverrideMetadata(
@@ -113,6 +115,7 @@ namespace ScottPlot.WPF
         public void Refresh()
         {
             SKElement?.InvalidateVisual();
+            RenderQueue.RefreshAll();
         }
 
         public void ShowContextMenu(Pixel position)

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlot.cs
@@ -3,11 +3,8 @@ using ScottPlot.Extensions;
 using SkiaSharp;
 using SkiaSharp.Views.Desktop;
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
-using System.Linq;
 using System.Windows.Forms;
 
 namespace ScottPlot.WinForms;
@@ -24,7 +21,7 @@ public class FormsPlot : UserControl, IPlotControl
 
     public float DisplayScale { get; set; }
 
-    private readonly Queue<IPlotControl> ControlsNeedingRefresh = new();
+    public RenderQueue RenderQueue { get; } = new();
 
     public FormsPlot()
     {
@@ -112,23 +109,7 @@ public class FormsPlot : UserControl, IPlotControl
     {
         SKElement.Invalidate();
         base.Refresh();
-
-        while (ControlsNeedingRefresh.Any())
-        {
-            ControlsNeedingRefresh.Dequeue().Refresh();
-        }
-    }
-
-    /// <summary>
-    /// The next time this control is refreshed, 
-    /// also refresh the given control.
-    /// </summary>
-    public void RefreshQueue(IPlotControl other)
-    {
-        if (!ControlsNeedingRefresh.Contains(other))
-        {
-            ControlsNeedingRefresh.Enqueue(other);
-        }
+        RenderQueue.RefreshAll();
     }
 
     public void ShowContextMenu(Pixel position)

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/WinUIPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/WinUIPlot.cs
@@ -24,7 +24,10 @@ public partial class WinUIPlot : UserControl, IPlotControl
     public Interaction Interaction { get; private set; }
 
     public Window? AppWindow { get; set; } // https://stackoverflow.com/a/74286947
+
     public float DisplayScale { get; set; }
+
+    public RenderQueue RenderQueue { get; } = new();
 
     public WinUIPlot()
     {
@@ -90,6 +93,7 @@ public partial class WinUIPlot : UserControl, IPlotControl
     public void Refresh()
     {
         _canvas.Invalidate();
+        RenderQueue.RefreshAll();
     }
 
     public void ShowContextMenu(Pixel position)

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SharedAxes.Designer.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SharedAxes.Designer.cs
@@ -1,6 +1,6 @@
 ﻿namespace WinForms_Demo.Demos;
 
-partial class SharedAxes
+partial class SharedAxesForm
 {
     /// <summary>
     /// Required designer variable.

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SharedAxes.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SharedAxes.cs
@@ -2,44 +2,23 @@
 
 namespace WinForms_Demo.Demos;
 
-public partial class SharedAxes : Form, IDemoWindow
+public partial class SharedAxesForm : Form, IDemoWindow
 {
-    public SharedAxes()
+    SharedAxisManager SharedAxes = new(shareX: true, shareY: false);
+    SharedLayoutManager SharedLayout = new(shareX: true, shareY: false);
+
+    public SharedAxesForm()
     {
         InitializeComponent();
 
         formsPlot1.Plot.Add.Signal(ScottPlot.Generate.Sin(mult: 100_000));
-
         formsPlot2.Plot.Add.Signal(ScottPlot.Generate.Cos());
 
-        // configure the second control to always use the same layout as the first control
-        formsPlot2.Plot.MatchLayout(formsPlot1.Plot);
+        SharedAxes.Add(formsPlot1);
+        SharedAxes.Add(formsPlot2);
 
-        // TODO: to ILayoutMaker add a method for getting the layout with a user defined data area
-
-        formsPlot1.Plot.RenderManager.RenderFinished += (s, e) =>
-        {
-            AxisLimits originalLimits = formsPlot2.Plot.GetAxisLimits();
-            formsPlot2.Plot.MatchAxisLimits(formsPlot1.Plot, x: true, y: false);
-            bool limitsChanged = !formsPlot2.Plot.GetAxisLimits().Equals(originalLimits);
-
-            if (limitsChanged)
-            {
-                formsPlot1.RefreshQueue(formsPlot2); // update plot 2 next time plot 1 draws
-            }
-        };
-
-        formsPlot2.Plot.RenderManager.RenderFinished += (object? sender, ScottPlot.Rendering.RenderDetails plot2Info) =>
-        {
-            AxisLimits originalLimits = formsPlot1.Plot.GetAxisLimits();
-            formsPlot1.Plot.MatchAxisLimits(formsPlot2.Plot, x: true, y: false);
-            bool limitsChanged = !formsPlot1.Plot.GetAxisLimits().Equals(originalLimits);
-
-            if (limitsChanged)
-            {
-                formsPlot2.RefreshQueue(formsPlot1); // update plot 2 next time plot 1 draws
-            }
-        };
+        SharedLayout.Add(formsPlot1);
+        SharedLayout.Add(formsPlot2);
     }
 
     public string Title => "Shared Axes";

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SharedAxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SharedAxisManager.cs
@@ -36,7 +36,7 @@ public class SharedAxisManager
 
             if (childLimitsChanged)
             {
-                parentControl.RefreshQueue(childControl);
+                parentControl.RenderQueue.Enqueue(childControl);
             }
         }
     }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SharedAxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SharedAxisManager.cs
@@ -1,0 +1,43 @@
+﻿using ScottPlot;
+using ScottPlot.WinForms;
+
+namespace WinForms_Demo.Demos;
+
+public class SharedAxisManager
+{
+    private readonly List<FormsPlot> PlotControls = new();
+    public readonly bool ShareX;
+    public readonly bool ShareY;
+
+    public SharedAxisManager(bool shareX, bool shareY)
+    {
+        ShareX = shareX;
+        ShareY = shareY;
+    }
+
+    public void Add(FormsPlot plotControl)
+    {
+        PlotControls.Add(plotControl);
+
+        plotControl.Plot.RenderManager.RenderFinished += (s, e) =>
+        {
+            UpdateOtherControls(plotControl);
+        };
+    }
+
+    public void UpdateOtherControls(FormsPlot parentControl)
+    {
+        foreach (var childControl in PlotControls)
+        {
+            AxisLimits childLimitsBefore = childControl.Plot.GetAxisLimits();
+            childControl.Plot.MatchAxisLimits(parentControl.Plot, ShareX, ShareY);
+            AxisLimits childLimitsAfter = childControl.Plot.GetAxisLimits();
+            bool childLimitsChanged = childLimitsBefore != childLimitsAfter;
+
+            if (childLimitsChanged)
+            {
+                parentControl.RefreshQueue(childControl);
+            }
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SharedLayoutManager.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SharedLayoutManager.cs
@@ -1,0 +1,47 @@
+﻿using ScottPlot;
+using ScottPlot.WinForms;
+
+namespace WinForms_Demo.Demos;
+
+public class SharedLayoutManager
+{
+    private readonly List<FormsPlot> ChildControls = new();
+    private FormsPlot? ParentControl = null;
+    public readonly bool ShareX;
+    public readonly bool ShareY;
+
+    public SharedLayoutManager(bool shareX, bool shareY)
+    {
+        ShareX = shareX;
+        ShareY = shareY;
+    }
+
+    public void Add(FormsPlot plotControl)
+    {
+        if (ParentControl is null)
+        {
+            ParentControl = plotControl;
+            plotControl.Plot.RenderManager.RenderFinished += (s, e) =>
+            {
+                UpdateChildLayouts();
+            };
+        }
+        else
+        {
+            ChildControls.Add(plotControl);
+        }
+    }
+
+    public void UpdateChildLayouts()
+    {
+        if (ParentControl is null)
+            return;
+
+        PixelRect dataRect = ParentControl.Plot.RenderManager.LastRender.DataRect;
+
+        foreach (var childControl in ChildControls)
+        {
+            childControl.Plot.FixedLayout(dataRect);
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Control/RenderQueue.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/RenderQueue.cs
@@ -1,0 +1,30 @@
+﻿namespace ScottPlot.Control;
+
+public class RenderQueue
+{
+    private readonly Queue<IPlotControl> ControlsNeedingRefresh = new();
+
+    /// <summary>
+    /// Render the <paramref name="other"/> plot after this control is rendered next.
+    /// This method can invoked from inside events where calling <see cref="Refresh"/> 
+    /// would cause infinite loops or artifacts from two controls rendering at the same time.
+    /// </summary>
+    public void Enqueue(IPlotControl other)
+    {
+        if (!ControlsNeedingRefresh.Contains(other))
+        {
+            ControlsNeedingRefresh.Enqueue(other);
+        }
+    }
+
+    /// <summary>
+    /// Refresh and remove all controls in the queue.
+    /// </summary>
+    public void RefreshAll()
+    {
+        while (ControlsNeedingRefresh.Any())
+        {
+            ControlsNeedingRefresh.Dequeue().Refresh();
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IPlotControl.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IPlotControl.cs
@@ -10,9 +10,16 @@ public interface IPlotControl
     Plot Plot { get; }
 
     /// <summary>
-    /// Request a re-render of the <see cref="Plot"/>
+    /// Render the plot and update the image
     /// </summary>
     void Refresh();
+
+    /// <summary>
+    /// This object contains methods which allow plots to be rendered in sequence.
+    /// This avoids render artifacts caused by two plots rendering at the same time 
+    /// or infinite loops caused by renderes being requested from in-render events.
+    /// </summary>
+    RenderQueue RenderQueue { get; }
 
     /// <summary>
     /// Advanced options for configuring how user inputs manipulate the plot

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -607,14 +607,6 @@ public class Plot : IDisposable
     }
 
     /// <summary>
-    /// Set the layout of this plot to always match that of a given plot
-    /// </summary>
-    public void MatchLayout(Plot other)
-    {
-        LayoutEngine = new LayoutEngines.Matched(other);
-    }
-
-    /// <summary>
     /// Apply a fixed layout using the given rectangle to define the data area
     /// </summary>
     public void FixedLayout(PixelRect dataRect)


### PR DESCRIPTION
This PR makes several changes that facilitate synchronizing axis limits and layouts across multiple controls:

* Created a `RenderQueue` manager (required by `IPlotControl` now) to make it easy for one control to request a render of another control the next time it's rendered. This prevents infinite loops and artifacts from simultaneous renders.

* Created `SharedAxisManager` and `SharedLayoutManager` classes to make it easy to sync across multiple controls

This WinForms example shows how to share axes/layouts

```cs
public partial class SharedAxesForm : Form, IDemoWindow
{
    SharedAxisManager SharedAxes = new(shareX: true, shareY: false);
    SharedLayoutManager SharedLayout = new(shareX: true, shareY: false);

    public SharedAxesForm()
    {
        InitializeComponent();

        formsPlot1.Plot.Add.Signal(ScottPlot.Generate.Sin(mult: 100_000));
        formsPlot2.Plot.Add.Signal(ScottPlot.Generate.Cos());

        // connect the axes of these plots together
        SharedAxes.Add(formsPlot1);
        SharedAxes.Add(formsPlot2);

        // apply the layout of the first plot to all subsequent plots
        SharedLayout.Add(formsPlot1);
        SharedLayout.Add(formsPlot2);
    }
}
```