### PR TITLE
SP5: Linear Regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * PixelPadding: `TotalHorizontal` and `TotalVertical` renamed to `Horizontal` and `Vertical` (#2874, #2878) _Thanks @viktoriussuwandi_
 * CoordinateRect: Added `Expanded()` method for creating a copy of the rectangle expanded to include a given point (#2871, #2890) _Thanks @aespitia_
 * FillY: Added legend support (#2886, #2896) _Thanks @msroest_
+* Plot: Created `Add.Line(x1, x2, y1, y2)` and related overloads for adding straight lines to plots (#2901, #2915)
+* LinearRegression: Added `Statistics.Regression` (see cookbook) for fitting lines to collections of X/Y data points (#2901) _Thanks @anewton_
 
 ## ScottPlot 4.1.68 (in development)
 

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Chapter.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Chapter.cs
@@ -7,6 +7,7 @@ public enum Chapter
     Customization,
     PlotTypes,
     ChangingData,
+    Statistics,
     Misc,
     UNDEFINED,
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Box.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Box.cs
@@ -1,7 +1,4 @@
-﻿
-using ScottPlot.Palettes;
-
-namespace ScottPlotCookbook.Recipes.PlotTypes;
+﻿namespace ScottPlotCookbook.Recipes.PlotTypes;
 
 internal class Box : RecipePageBase
 {
@@ -178,7 +175,7 @@ internal class Box : RecipePageBase
             int numBoxesPerSeries = 3;
             int numSeries = 2;
             ScottPlot.Plottables.BoxGroup[] series = new ScottPlot.Plottables.BoxGroup[numSeries];
-            var colorPalette = new Category10();
+            var colorPalette = new ScottPlot.Palettes.Category10();
             for (int i = 0; i < series.Length; i++)
             {
                 series[i] = new ScottPlot.Plottables.BoxGroup

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Statistics/Regression.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Statistics/Regression.cs
@@ -1,0 +1,43 @@
+﻿namespace ScottPlotCookbook.Recipes.PlotTypes;
+
+internal class Regression : RecipePageBase
+{
+    public override RecipePageDetails PageDetails => new()
+    {
+        Chapter = Chapter.Statistics,
+        PageName = "Regression",
+        PageDescription = "Statistical operations to fit lines to data",
+    };
+
+    internal class Linear : RecipeTestBase
+    {
+        public override string Name => "LinearRegression";
+        public override string Description => "Fit a line to a collection of X/Y data points.";
+
+        [Test]
+        public override void Recipe()
+        {
+            double[] xs = new double[] { 1, 2, 3, 4, 5, 6, 7 };
+            double[] ys = new double[] { 2, 2, 3, 3, 3.8, 4.2, 4 };
+
+            // plot original data as a scatter plot
+            var sp = myPlot.Add.Scatter(xs, ys);
+            sp.LineStyle = LineStyle.None;
+            sp.MarkerStyle.Size = 10;
+
+            // calculate the regression line
+            ScottPlot.Statistics.LinearRegression reg = new(xs, ys);
+
+            // plot the regression line
+            Coordinates pt1 = new(xs.First(), reg.GetValue(xs.First()));
+            Coordinates pt2 = new(xs.Last(), reg.GetValue(xs.Last()));
+            var line = myPlot.Add.Line(pt1, pt2);
+            line.MarkerStyle = MarkerStyle.None;
+            line.LineStyle.Pattern = LinePattern.Dash;
+            line.LineStyle.Width = 2;
+
+            // note the formula at the top of the plot
+            myPlot.Title($"y = {reg.Slope:0.###}x + {reg.Offset:0.###} (r²={reg.Rsquared:0.###})");
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Tests/Statistics/LinearRegressionTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Statistics/LinearRegressionTests.cs
@@ -1,0 +1,17 @@
+﻿using FluentAssertions;
+
+namespace ScottPlotTests.Statistics;
+
+internal class LinearRegressionTests
+{
+    [Test]
+    public void Test_LinearRegression_MatchesExcel()
+    {
+        double[] x = new double[] { 1, 2, 3, 4, 5, 6, 7 };
+        double[] y = new double[] { 2, 2, 3, 3, 3.8, 4.2, 4 };
+        ScottPlot.Statistics.LinearRegression reg = new (x, y);
+        reg.Slope.Should().BeApproximately(0.4, precision: 0.0001);
+        reg.Offset.Should().BeApproximately(1.5429, precision: 0.0001);
+        reg.Rsquared.Should().BeApproximately(0.9074, precision: 0.0001);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Tests/Statistics/LinearRegressionTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Statistics/LinearRegressionTests.cs
@@ -7,9 +7,39 @@ internal class LinearRegressionTests
     [Test]
     public void Test_LinearRegression_MatchesExcel()
     {
-        double[] x = new double[] { 1, 2, 3, 4, 5, 6, 7 };
-        double[] y = new double[] { 2, 2, 3, 3, 3.8, 4.2, 4 };
-        ScottPlot.Statistics.LinearRegression reg = new (x, y);
+        double[] xs = new double[] { 1, 2, 3, 4, 5, 6, 7 };
+        double[] ys = new double[] { 2, 2, 3, 3, 3.8, 4.2, 4 };
+        ScottPlot.Statistics.LinearRegression reg = new(xs, ys);
+        reg.Slope.Should().BeApproximately(0.4, precision: 0.0001);
+        reg.Offset.Should().BeApproximately(1.5429, precision: 0.0001);
+        reg.Rsquared.Should().BeApproximately(0.9074, precision: 0.0001);
+    }
+
+    [Test]
+    public void Test_LinearRegression_Coordinates()
+    {
+        Coordinates[] coordinates =
+        {
+            new Coordinates(1, 2),
+            new Coordinates(2, 2),
+            new Coordinates(3, 3),
+            new Coordinates(4, 3),
+            new Coordinates(5, 3.8),
+            new Coordinates(6, 4.2),
+            new Coordinates(7, 4),
+        };
+
+        ScottPlot.Statistics.LinearRegression reg = new(coordinates);
+        reg.Slope.Should().BeApproximately(0.4, precision: 0.0001);
+        reg.Offset.Should().BeApproximately(1.5429, precision: 0.0001);
+        reg.Rsquared.Should().BeApproximately(0.9074, precision: 0.0001);
+    }
+
+    [Test]
+    public void Test_LinearRegression_YsOnly()
+    {
+        double[] ys = new double[] { 2, 2, 3, 3, 3.8, 4.2, 4 };
+        ScottPlot.Statistics.LinearRegression reg = new(ys, firstX: 1, xSpacing: 1);
         reg.Slope.Should().BeApproximately(0.4, precision: 0.0001);
         reg.Offset.Should().BeApproximately(1.5429, precision: 0.0001);
         reg.Rsquared.Should().BeApproximately(0.9074, precision: 0.0001);

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -39,6 +39,18 @@ public class PlottableAdder
         return heatmap;
     }
 
+    public Scatter Line(double x1, double y1, double x2, double y2)
+    {
+        Coordinates[] coordinates = { new(x1, y1), new(x2, y2) };
+        return Scatter(coordinates);
+    }
+
+    public Scatter Line(Coordinates pt1, Coordinates pt2)
+    {
+        Coordinates[] coordinates = { pt1, pt2 };
+        return Scatter(coordinates);
+    }
+
     public Pie Pie(IList<PieSlice> slices)
     {
         Pie pie = new(slices);

--- a/src/ScottPlot5/ScottPlot5/Plottables/Polygon.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Polygon.cs
@@ -16,7 +16,7 @@ public class Polygon : IPlottable
 
     public bool IsVisible { get; set; } = true;
 
-    public LineStyle LineStyle { get; set; } = LineStyle.NoLine;
+    public LineStyle LineStyle { get; set; } = LineStyle.None;
     public FillStyle FillStyle { get; set; } = new() { Color = Colors.LightGray };
     public MarkerStyle MarkerStyle { get; set; } = MarkerStyle.None;
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -11,7 +11,7 @@ public class Signal : IPlottable
 
     public readonly DataSources.ISignalSource Data;
 
-    public MarkerStyle Marker { get; set; } = new(MarkerShape.FilledCircle, 5) { Outline = LineStyle.NoLine };
+    public MarkerStyle Marker { get; set; } = new(MarkerShape.FilledCircle, 5) { Outline = LineStyle.None };
     public string? Label { get; set; }
 
     public LineStyle LineStyle { get; } = new();

--- a/src/ScottPlot5/ScottPlot5/Primitives/LineStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LineStyle.cs
@@ -10,6 +10,6 @@ public class LineStyle
     public Color Color { get; set; } = Colors.Black;
     public LinePattern Pattern { get; set; } = LinePattern.Solid;
     public bool IsVisible { get; set; } = true;
-    public static LineStyle NoLine => new() { Width = 0 };
+    public static LineStyle None => new() { IsVisible = false, Color = Colors.Transparent, Width = 0 };
     public bool AntiAlias { get; set; } = true;
 }

--- a/src/ScottPlot5/ScottPlot5/Statistics/LinearRegression.cs
+++ b/src/ScottPlot5/ScottPlot5/Statistics/LinearRegression.cs
@@ -1,48 +1,52 @@
 namespace ScottPlot.Statistics;
 
-public class LinearRegressionLine
+public class LinearRegression
 {
-    public readonly double slope;
-    public readonly double offset;
-    public readonly double rSquared;
+    public readonly double Slope;
+    public readonly double Offset;
+    public readonly double Rsquared;
 
     private readonly int pointCount;
-    private readonly double[] xs;
-    private readonly double[] ys;
+    private readonly double[] Xs;
+    private readonly double[] Ys;
 
-    public LinearRegressionLine(double[] xs, double[] ys)
+    public LinearRegression(double[] xs, double[] ys)
     {
-        if ((xs.Length != ys.Length) || (xs.Length < 2))
+        if (xs.Length != ys.Length)
         {
-            throw new ArgumentException("xs and ys must be the same length and have at least 2 points");
+            throw new ArgumentException("xs and ys must be the same length");
+        }
+
+        if (ys.Length < 2)
+        {
+            throw new ArgumentException("xs and ys must have at least 2 points");
         }
 
         pointCount = ys.Length;
-        this.xs = xs;
-        this.ys = ys;
-        (slope, offset, rSquared) = GetCoefficients(xs, ys);
+        Xs = xs;
+        Ys = ys;
+        (Slope, Offset, Rsquared) = GetCoefficients(xs, ys);
     }
 
-    public LinearRegressionLine(double[] ys, double firstX, double xSpacing)
+    public LinearRegression(double[] ys, double firstX, double xSpacing)
     {
-        // this constructor doesn't require an X array to be passed in at all
+        if (ys.Length < 2)
+        {
+            throw new ArgumentException("xs and ys must have at least 2 points");
+        }
+
         pointCount = ys.Length;
         double[] xs = new double[pointCount];
         for (int i = 0; i < pointCount; i++)
         {
             xs[i] = firstX + xSpacing * i;
         }
-        this.xs = xs;
-        this.ys = ys;
-        (slope, offset, rSquared) = GetCoefficients(xs, ys);
+        Xs = xs;
+        Ys = ys;
+        (Slope, Offset, Rsquared) = GetCoefficients(xs, ys);
     }
 
-    public override string ToString()
-    {
-        return $"Linear fit for {pointCount} points: Y = {slope}x + {offset} (R² = {rSquared})";
-    }
-
-    private static (double, double, double) GetCoefficients(double[] xs, double[] ys)
+    public static (double slope, double offset, double rSquared) GetCoefficients(double[] xs, double[] ys)
     {
         double sumXYResidual = 0;
         double sumXSquareResidual = 0;
@@ -56,7 +60,7 @@ public class LinearRegressionLine
             sumXSquareResidual += (xs[i] - meanX) * (xs[i] - meanX);
         }
 
-        // Note: least-squares regression line always passes through (x̅,y̅)
+        // Note: least-squares regression line always passes through (x̄, ȳ)
         double slope = sumXYResidual / sumXSquareResidual;
         double offset = meanY - (slope * meanX);
 
@@ -81,7 +85,7 @@ public class LinearRegressionLine
 
     public double GetValueAt(double x)
     {
-        return offset + slope * x;
+        return Offset + Slope * x;
     }
 
     public double[] GetValues()
@@ -89,20 +93,21 @@ public class LinearRegressionLine
         double[] values = new double[pointCount];
         for (int i = 0; i < pointCount; i++)
         {
-            values[i] = GetValueAt(xs[i]);
+            values[i] = GetValueAt(Xs[i]);
         }
         return values;
     }
 
+    /// <summary>
+    /// Residual is the difference between the actual and predicted value
+    /// </summary>
     public double[] GetResiduals()
     {
-        // the residual is the difference between the actual and predicted value
+        double[] residuals = new double[Ys.Length];
 
-        double[] residuals = new double[ys.Length];
-
-        for (int i = 0; i < ys.Length; i++)
+        for (int i = 0; i < Ys.Length; i++)
         {
-            residuals[i] = ys[i] - GetValueAt(xs[i]);
+            residuals[i] = Ys[i] - GetValueAt(Xs[i]);
         }
 
         return residuals;

--- a/src/ScottPlot5/ScottPlot5/Statistics/LinearRegressionLine
+++ b/src/ScottPlot5/ScottPlot5/Statistics/LinearRegressionLine
@@ -1,0 +1,110 @@
+namespace ScottPlot.Statistics;
+
+public class LinearRegressionLine
+{
+    public readonly double slope;
+    public readonly double offset;
+    public readonly double rSquared;
+
+    private readonly int pointCount;
+    private readonly double[] xs;
+    private readonly double[] ys;
+
+    public LinearRegressionLine(double[] xs, double[] ys)
+    {
+        if ((xs.Length != ys.Length) || (xs.Length < 2))
+        {
+            throw new ArgumentException("xs and ys must be the same length and have at least 2 points");
+        }
+
+        pointCount = ys.Length;
+        this.xs = xs;
+        this.ys = ys;
+        (slope, offset, rSquared) = GetCoefficients(xs, ys);
+    }
+
+    public LinearRegressionLine(double[] ys, double firstX, double xSpacing)
+    {
+        // this constructor doesn't require an X array to be passed in at all
+        pointCount = ys.Length;
+        double[] xs = new double[pointCount];
+        for (int i = 0; i < pointCount; i++)
+        {
+            xs[i] = firstX + xSpacing * i;
+        }
+        this.xs = xs;
+        this.ys = ys;
+        (slope, offset, rSquared) = GetCoefficients(xs, ys);
+    }
+
+    public override string ToString()
+    {
+        return $"Linear fit for {pointCount} points: Y = {slope}x + {offset} (R² = {rSquared})";
+    }
+
+    private static (double, double, double) GetCoefficients(double[] xs, double[] ys)
+    {
+        double sumXYResidual = 0;
+        double sumXSquareResidual = 0;
+
+        double meanX = xs.Average();
+        double meanY = ys.Average();
+
+        for (int i = 0; i < xs.Length; i++)
+        {
+            sumXYResidual += (xs[i] - meanX) * (ys[i] - meanY);
+            sumXSquareResidual += (xs[i] - meanX) * (xs[i] - meanX);
+        }
+
+        // Note: least-squares regression line always passes through (x̅,y̅)
+        double slope = sumXYResidual / sumXSquareResidual;
+        double offset = meanY - (slope * meanX);
+
+        // calcualte R squared (https://en.wikipedia.org/wiki/Coefficient_of_determination)
+        double ssTot = 0;
+        double ssRes = 0;
+        for (int i = 0; i < ys.Length; i++)
+        {
+            double thisY = ys[i];
+
+            double distanceFromMeanSquared = Math.Pow(thisY - meanY, 2);
+            ssTot += distanceFromMeanSquared;
+
+            double modelY = slope * xs[i] + offset;
+            double distanceFromModelSquared = Math.Pow(thisY - modelY, 2);
+            ssRes += distanceFromModelSquared;
+        }
+        double rSquared = 1 - ssRes / ssTot;
+
+        return (slope, offset, rSquared);
+    }
+
+    public double GetValueAt(double x)
+    {
+        return offset + slope * x;
+    }
+
+    public double[] GetValues()
+    {
+        double[] values = new double[pointCount];
+        for (int i = 0; i < pointCount; i++)
+        {
+            values[i] = GetValueAt(xs[i]);
+        }
+        return values;
+    }
+
+    public double[] GetResiduals()
+    {
+        // the residual is the difference between the actual and predicted value
+
+        double[] residuals = new double[ys.Length];
+
+        for (int i = 0; i < ys.Length; i++)
+        {
+            residuals[i] = ys[i] - GetValueAt(xs[i]);
+        }
+
+        return residuals;
+    }
+}


### PR DESCRIPTION
Please review.  Adds LinearRegressionLine to ScottPlot5.  So it can be used with code similar to the following:

``` cs
    // Linear regression line
    double firstDate = dates[0];
    double lastDate = dates[dates.Length - 1];
    var regressionLine = new ScottPlot.Statistics.LinearRegressionLine(dates, chartValues);
    AddLine(_plot.Plot, regressionLine.slope, regressionLine.offset, (firstDate, lastDate), lineWidth: 0.5F, color: XkcdColors.LightGreyBlue, label: "Trend");
}

private void AddLine(Plot plot, double slope, double offset, (double x1, double x2) xLimits, string label = "", Color? color = null, float lineWidth = 1)
{
    double y1 = xLimits.x1 * slope + offset;
    double y2 = xLimits.x2 * slope + offset;
    var scatter = plot.Add.Scatter(new double[] { xLimits.x1, xLimits.x2 }, new double[] { y1, y2 }, color);
    if (!string.IsNullOrWhiteSpace(label))
        scatter.Label = label;
}
```

**Purpose:**
* Use this space to describe what this pull request accomplishes
* If this PR references an issue be sure to link to it
* Consider including a picture if it would help clarify what this pull request does
* New contributors please review https://github.com/ScottPlot/ScottPlot/blob/main/CONTRIBUTING.md

```cs
// You can insert code examples like this
var newThing = new SpecialObject();
```