### PR TITLE
Fix AvaPlot rendering issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * FillY: Added legend support (#2886, #2896) _Thanks @msroest_
 * Plot: Created `Add.Line(x1, x2, y1, y2)` and related overloads for adding straight lines to plots (#2901, #2915)
 * LinearRegression: Added `Statistics.Regression` (see cookbook) for fitting lines to collections of X/Y data points (#2901) _Thanks @anewton_
+* Avalonia: Improve rendering in multi-control windows (#2920) _Thanks @nightfog-git_
 
 ## ScottPlot 4.1.68 (in development)
 * Heatmap: Added a `UseParallel` option which can improve `Update()` performance for large datasets (#2897) _Thanks @bukkideme_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
@@ -37,13 +37,9 @@ public class AvaPlot : Controls.Control, IPlotControl
         new("All Files") { Patterns = new List<string> { "*" } },
     };
 
-    static AvaPlot()
-    {
-        ClipToBoundsProperty.OverrideDefaultValue<AvaPlot>(true);
-    }
-
     public AvaPlot()
     {
+        ClipToBounds = true;
         DisplayScale = DetectDisplayScale();
 
         Interaction = new(this)
@@ -124,10 +120,6 @@ public class AvaPlot : Controls.Control, IPlotControl
             if (leaseFeature is null) return;
 
             using var lease = leaseFeature.Lease();
-
-            var surface = lease.SkSurface;
-            if (surface is null) return;
-
             ScottPlot.PixelRect rect = new(0, (float)Bounds.Width, (float)Bounds.Height, 0);
             _plot.Render(lease.SkCanvas, rect);
         }
@@ -135,8 +127,7 @@ public class AvaPlot : Controls.Control, IPlotControl
 
     public override void Render(DrawingContext context)
     {
-        Rect bounds = new(Bounds.Size);
-        context.Custom(new CustomDrawOp(bounds, Plot));
+        context.Custom(new CustomDrawOp(Bounds, Plot));
     }
 
     public void Refresh()

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
@@ -37,6 +37,11 @@ public class AvaPlot : Controls.Control, IPlotControl
         new("All Files") { Patterns = new List<string> { "*" } },
     };
 
+    static AvaPlot()
+    {
+        ClipToBoundsProperty.OverrideDefaultValue<AvaPlot>(true);
+    }
+
     public AvaPlot()
     {
         DisplayScale = DetectDisplayScale();
@@ -123,13 +128,15 @@ public class AvaPlot : Controls.Control, IPlotControl
             var surface = lease.SkSurface;
             if (surface is null) return;
 
-            _plot.Render(surface.Canvas, (int)surface.Canvas.LocalClipBounds.Width, (int)surface.Canvas.LocalClipBounds.Height);
+            ScottPlot.PixelRect rect = new(0, (float)Bounds.Width, (float)Bounds.Height, 0);
+            _plot.Render(lease.SkCanvas, rect);
         }
     }
 
     public override void Render(DrawingContext context)
     {
-        context.Custom(new CustomDrawOp(Bounds, Plot));
+        Rect bounds = new(Bounds.Size);
+        context.Custom(new CustomDrawOp(bounds, Plot));
     }
 
     public void Refresh()


### PR DESCRIPTION
For AvaPlot to be displayed correctly alongside other controls, ClipToBounds should be true.
Correct rendering size is Bounds.Size and correct rendering position is always origin (0,0).
