### PR TITLE
SP5 Signal: improve rendering for special cases

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
@@ -12,7 +12,7 @@ public partial class Form1 : Form
         formsPlot1.Plot.Add.Signal(clean);
 
         double[] noisy = Generate.SquareWave(low: 10, high: 15);
-        Generate.AddNoiseInPlace(noisy);
+        Generate.AddNoiseInPlace(noisy, magnitude: .001);
         formsPlot1.Plot.Add.Signal(noisy);
 
         formsPlot1.Plot.Grids.Clear();

--- a/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/SignalTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/SignalTests.cs
@@ -36,4 +36,14 @@ internal class SignalTests
         plt.Grids.Clear();
         plt.SaveTestImage();
     }
+
+    [Test]
+    public void Test_Signal_Offsets()
+    {
+        ScottPlot.Plot plt = new();
+        var sig = plt.Add.Signal(ScottPlot.Generate.Sin());
+        sig.Data.XOffset = 100;
+        sig.Data.YOffset = 10;
+        plt.SaveTestImage();
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/SignalTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/SignalTests.cs
@@ -25,12 +25,10 @@ internal class SignalTests
     {
         // https://github.com/ScottPlot/ScottPlot/issues/2933
         // https://github.com/ScottPlot/ScottPlot/pull/2935
+        // https://github.com/ScottPlot/ScottPlot/issues/2949
 
-        double[] data = Generate.Sin(10_000, oscillations: 100);
-        for (int i = (int)(data.Length * .3); i < (int)(data.Length * .7); i++)
-        {
-            data[i] = data[i] + 10;
-        }
+        double[] data = Generate.SquareWave(low: 10, high: 15);
+        Generate.AddNoiseInPlace(data, magnitude: .001);
 
         ScottPlot.Plot plt = new();
         var sig = plt.Add.Signal(data);

--- a/src/ScottPlot5/ScottPlot5/DataSources/ISignalSource.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/ISignalSource.cs
@@ -22,9 +22,9 @@ public interface ISignalSource : IHasAxisLimits
     double YOffset { get; set; }
 
     /// <summary>
-    /// Returns the min/max Y values between a range of Xs (inclusive)
+    /// Returns range information about the data at a specific pixel location
     /// </summary>
-    CoordinateRange GetYRange(CoordinateRange xRange);
+    PixelColumn GetPixelColumn(IAxes axes, int xPixelIndex);
 
     /// <summary>
     /// Returns the predicted index for the data point nearest a given X position.

--- a/src/ScottPlot5/ScottPlot5/Primitives/PixelColumn.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/PixelColumn.cs
@@ -1,16 +1,28 @@
 ﻿/// <summary>
-/// Represents a vertical range of pixels at a specific horizontal pixel location
+/// This data structure describes a single vertical column of pixels
+/// that represents the Y span of an X range of data points.
 /// </summary>
 public readonly struct PixelColumn
 {
-    public readonly float YBottom;
-    public readonly float YTop;
     public readonly float X;
+    public readonly float Enter;
+    public readonly float Exit;
+    public readonly float Bottom;
+    public readonly float Top;
 
-    public PixelColumn(float x, float yBottom, float yTop)
+    public bool HasData => !float.IsNaN(Enter);
+
+    public PixelColumn(float x, float enter, float exit, float bottom, float top)
     {
         X = x;
-        YBottom = yBottom;
-        YTop = yTop;
+        Enter = enter;
+        Exit = exit;
+        Bottom = bottom;
+        Top = top;
+    }
+
+    public static PixelColumn WithoutData(float x)
+    {
+        return new PixelColumn(x, float.NaN, float.NaN, float.NaN, float.NaN);
     }
 }


### PR DESCRIPTION
This PR changes how ScottPlot 5's signal plot draws lines to cover edge cases like extended repeated values and vertical gaps. 

Resolves #2949