### PR TITLE
Fix typo in ArrowCoordinated function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## ScottPlot 4.1.68 (in development)
 * Axis: Added `IsReverse` property to let users invert the orientation of an axis (#2958) _Thanks @HandsomeGoldenKnight_
 * Text: Exposed `LastRenderRectangleCoordinates` to improve mouse interactivity (#2994) _Thanks @DaveMartel_
+* Arrow: Fixed bug in constructor overload (#2976, #3001) _Thanks @Gray-lab_
 
 ## ScottPlot 5.0.9-beta
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2023-10-03_

--- a/src/ScottPlot4/ScottPlot/Plottable/ArrowCoordinated.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/ArrowCoordinated.cs
@@ -81,7 +81,7 @@ namespace ScottPlot.Plottable
         public ArrowCoordinated(Coordinate arrowBase, Coordinate arrowTip)
         {
             Base.X = arrowBase.X;
-            Base.Y = arrowTip.Y;
+            Base.Y = arrowBase.Y;
             Tip.X = arrowTip.X;
             Tip.Y = arrowTip.Y;
         }


### PR DESCRIPTION
**Purpose:**
- fix typo in `ArrowCoordinated(Coordinate arrowBase, Coordinate arrowTip)`

**Testing:**
- test suite passed - but since this particular overload isn't referenced anywhere it would be quite surprising if it broke something
