### PR TITLE
SP5: Improve SVG support for axis frame and tick marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Plot: Added `DisableGrid()` and `EnableGrid()` helper methods (#2947)
 * Render: Created `IRenderLast` plottables can implement to draw above axes (#2998, #2993)
 * Controls: Added `Interaction.Disable()` and `Interaction.Enable()` methods for easy control of mouse interactivity
+* Render: Improve axis frame and tick mark rendering for SVG export (#2944) _Thanks @Crown0815_
 
 ## ScottPlot 4.1.68 (in development)
 * Axis: Added `IsReverse` property to let users invert the orientation of an axis (#2958) _Thanks @HandsomeGoldenKnight_

--- a/src/ScottPlot5/ScottPlot5 Tests/RenderTests/FileFormatTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/RenderTests/FileFormatTests.cs
@@ -8,7 +8,7 @@ internal class FileFormatTests
         Plot plt = new();
         plt.Add.Signal(Generate.Sin(51));
         plt.Add.Signal(Generate.Cos(51));
-        plt.SaveBmp("test_save.bmp", 200, 100);
+        plt.SaveBmp("test-images/test_save.bmp", 200, 100);
     }
 
     [Test]
@@ -17,7 +17,7 @@ internal class FileFormatTests
         Plot plt = new();
         plt.Add.Signal(Generate.Sin(51));
         plt.Add.Signal(Generate.Cos(51));
-        plt.SaveJpeg("test_save.jpg", 200, 100);
+        plt.SaveJpeg("test-images/test_save.jpg", 200, 100);
     }
 
     [Test]
@@ -26,7 +26,7 @@ internal class FileFormatTests
         Plot plt = new();
         plt.Add.Signal(Generate.Sin(51));
         plt.Add.Signal(Generate.Cos(51));
-        plt.SavePng("test_save.png", 200, 100);
+        plt.SavePng("test-images/test_save.png", 200, 100);
     }
 
     [Test]
@@ -35,7 +35,7 @@ internal class FileFormatTests
         Plot plt = new();
         plt.Add.Signal(Generate.Sin(51));
         plt.Add.Signal(Generate.Cos(51));
-        plt.SaveWebp("test_save.webp", 200, 100);
+        plt.SaveWebp("test-images/test_save.webp", 200, 100);
     }
 
     [Test]
@@ -47,5 +47,14 @@ internal class FileFormatTests
         string img = plt.GetImageHtml(300, 200);
         string html = $"<html><body>{img}</body></html>";
         html.SaveTestString();
+    }
+
+    [Test]
+    public void Test_Save_Svg()
+    {
+        Plot plt = new();
+        plt.Add.Signal(Generate.Sin(51));
+        plt.Add.Signal(Generate.Cos(51));
+        plt.SaveSvg("test-images/test_save.svg", 400, 300);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
@@ -77,6 +77,7 @@ public abstract class AxisBase
             Color = lineStyle.Color.ToSKColor(),
             IsAntialias = true,
             StrokeWidth = lineStyle.Width,
+            IsStroke = true,
         };
 
         if (edge == Edge.Left)
@@ -143,13 +144,14 @@ public abstract class AxisBase
             float y = axis.Edge == Edge.Bottom ? panelRect.Top : panelRect.Bottom;
             float yEdge = axis.Edge == Edge.Bottom ? y + tickLength : y - tickLength;
             float fontSpacing = axis.Edge == Edge.Bottom ? paint.TextSize : -4;
-
+            paint.IsStroke = true;
             rp.Canvas.DrawLine(xPx, y, xPx, yEdge, paint);
 
             if (!string.IsNullOrWhiteSpace(tick.Label))
             {
                 foreach (string line in tick.Label.Split('\n'))
                 {
+                    paint.IsStroke = false;
                     rp.Canvas.DrawText(line, xPx, yEdge + fontSpacing, paint);
                     fontSpacing += paint.TextSize;
                 }
@@ -178,10 +180,12 @@ public abstract class AxisBase
             float x = axis.Edge == Edge.Left ? panelRect.Right : panelRect.Left;
             float y = axis.GetPixel(tick.Position, panelRect);
             float xEdge = axis.Edge == Edge.Left ? x - tickLength : x + tickLength;
+            paint.IsStroke = true;
             rp.Canvas.DrawLine(x, y, xEdge, y, paint);
 
             float majorTickLabelPadding = 7;
             float labelPos = axis.Edge == Edge.Left ? x - majorTickLabelPadding : x + majorTickLabelPadding;
+            paint.IsStroke = false;
             if (!string.IsNullOrWhiteSpace(tick.Label))
                 rp.Canvas.DrawText(tick.Label, labelPos, y + paint.TextSize * .4f, paint);
         }

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
@@ -82,7 +82,9 @@ public class RenderManager
             }
 
             sw.Restart();
+            rp.Canvas.Save();
             action.Render(rp);
+            rp.Canvas.Restore();
             actionTimes.Add((action.ToString() ?? string.Empty, sw.Elapsed));
         }
 


### PR DESCRIPTION
* resolves #2944

![image](https://github.com/ScottPlot/ScottPlot/assets/4165489/ae1b877b-f068-4a01-8714-0947a26fab62)
