### PR TITLE
fixed "vaues" typo in source files.

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Categories/PlotTypes/SignalXY.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Categories/PlotTypes/SignalXY.cs
@@ -6,6 +6,6 @@ public class SignalXY : ICategory
 
     public string Folder => "plottable-signalxy";
 
-    public string Description => "SignalXY is a speed-optimized plot for displaying Y vaues " +
+    public string Description => "SignalXY is a speed-optimized plot for displaying Y values " +
         "with unevenly-spaced (but always increasing) X positions.";
 }

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/SignalXY.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/SignalXY.cs
@@ -12,7 +12,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string ID => "signalxy_quickstart";
         public string Title => "SignalXY Quickstart";
         public string Description =>
-            "SignalXY is a speed-optimized plot for displaying vaues (Ys) with unevenly-spaced positions (Xs) " +
+            "SignalXY is a speed-optimized plot for displaying values (Ys) with unevenly-spaced positions (Xs) " +
             "that are in ascending order. If your data is evenly-spaced, Signal and SignalConst is faster.";
 
         public void ExecuteRecipe(Plot plt)

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/SignalXYConst.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/SignalXYConst.cs
@@ -12,7 +12,7 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string ID => "signalxyconst_quickstart";
         public string Title => "SignalConst with X and Y data";
         public string Description =>
-            "SignalXYConst is a speed-optimized plot for displaying vaues (Ys) with unevenly-spaced positions (Xs) " +
+            "SignalXYConst is a speed-optimized plot for displaying values (Ys) with unevenly-spaced positions (Xs) " +
             "that are in ascending order. If your data is evenly-spaced, Signal and SignalConst is faster.";
 
         public void ExecuteRecipe(Plot plt)


### PR DESCRIPTION
**Purpose:**
* Fix "vaues" typo to "values" in source classes so auto doc generation builds with corrections.

closes #3011 