### PR TITLE
SP4: Custom alpha for population plots

### DIFF
--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Population.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Population.cs
@@ -263,9 +263,11 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
             populationSeries[0].color = Color.FromArgb(alpha: 100, red: 255, green: 0, blue: 0);
             populationSeries[1].color = Color.FromArgb(alpha: 255, red: 0, green: 0, blue: 255);
 
-            // Manually define transparency for boxes and markers
-            populationPlot.BoxAlphaOverride = 150;
-            populationPlot.MarkerAlpha = 75;
+            // Manually define transparency for boxes and markers - alpha values will now be set using the series colors
+            populationPlot.AutomaticOpacity = false;
+
+            // Make scatter markers 75% as opaque as box plots
+            populationPlot.MarkerOpacityRatio = 0.75;
         }
     }
 }

--- a/src/ScottPlot4/ScottPlot.Tests/PlotTypes/Population.cs
+++ b/src/ScottPlot4/ScottPlot.Tests/PlotTypes/Population.cs
@@ -1,7 +1,10 @@
 ﻿using NUnit.Framework;
 using ScottPlotTests;
 using System;
+using System.Linq;
+using System.Drawing;
 using System.Runtime.Intrinsics.X86;
+using System.ComponentModel.DataAnnotations;
 
 namespace ScottPlot.Tests.PlotTypes;
 
@@ -78,80 +81,81 @@ internal class Population
     }
 
     [Test]
-    public void Test_Population_MarkerAlpha()
+    public void Test_Population_CustomOpacity()
     {
         // issue #2967 - custom alpha values for population plots
         // https://github.com/ScottPlot/ScottPlot/issues/2967
 
-        Random rand = new(0);
-        double[] valuesA = DataGen.RandomNormal(rand, 35, 85, 5);
-        double[] valuesB = DataGen.RandomNormal(rand, 42, 87, 3);
-        double[] valuesC = DataGen.RandomNormal(rand, 23, 92, 3);
+        // Redscale: the argbs contain different alpha values.
+        var seriesColors = new Color[] {
+        Color.FromArgb(225, 255, 0, 0),
+        Color.FromArgb(175, 255, 0, 0),
+        Color.FromArgb(125, 255, 0, 0),
+        Color.FromArgb(75, 255, 0, 0),
+        Color.FromArgb(25, 255, 0, 0)};
 
-        var popA = new Statistics.Population(valuesA);
-        var popB = new Statistics.Population(valuesB);
-        var popC = new Statistics.Population(valuesC);
+        // 3 groups
+        var groupNames = new[] { "Group A", "Group B", "Group C" };
 
-        var populations = new Statistics.Population[] { popA, popB, popC };
+        // Get some data
+        var seriesData = GetSeriesData(
+            seriesCount: seriesColors.Length,
+            groupCount: groupNames.Length);
 
-        ScottPlot.Plot plt = new(600, 400);
-        var pplt = plt.AddPopulations(populations);
+        Plot plt = new(600, 400);
 
-        // plot with default semitransparency
+        plt.XTicks(groupNames);
+        plt.Legend();
+
+        var populations = seriesData.Select(series => series.Select(seriesData => new Statistics.Population(seriesData)).ToArray()).ToArray();
+        var populationSeries = populations.Select((p, i) => new Statistics.PopulationSeries(p, seriesLabel: $"Series {i + 1}")).ToArray();
+        var populationMultiSeries = new Statistics.PopulationMultiSeries(populationSeries.ToArray());
+        var populationPlot = plt.AddPopulations(populationMultiSeries);
+
+        // Set the colours
+        for (var i = 0; i < populationPlot.MultiSeries.seriesCount; i++)
+        {
+            populationPlot.MultiSeries.multiSeries[i].color = seriesColors[i];
+        }
+
         var bmp1 = TestTools.GetLowQualityBitmap(plt);
-
-        // plot with no transparency
-        pplt.MarkerAlpha = 255;
+        // Turn off automatic opacity - colors should now match seriesColors alpha values
+        populationPlot.AutomaticOpacity = false;
         var bmp2 = TestTools.GetLowQualityBitmap(plt);
 
-        // measure what changed
-        // TestTools.SaveFig(bmp1, "1");
-        // TestTools.SaveFig(bmp2, "2");
         var before = new MeanPixel(bmp1);
         var after = new MeanPixel(bmp2);
-        Console.WriteLine($"Before: {before}");
-        Console.WriteLine($"After: {after}");
-
-        // less transparent markers -> darker image
-        Assert.That(after.IsDarkerThan(before));
-    }
-
-    [Test]
-    public void Test_Population_BoxAlphaOverride()
-    {
-        // issue #2967 - custom alpha values for population plots
-        // https://github.com/ScottPlot/ScottPlot/issues/2967
-
-        Random rand = new(0);
-        double[] valuesA = DataGen.RandomNormal(rand, 35, 85, 5);
-        double[] valuesB = DataGen.RandomNormal(rand, 42, 87, 3);
-        double[] valuesC = DataGen.RandomNormal(rand, 23, 92, 3);
-
-        var popA = new Statistics.Population(valuesA);
-        var popB = new Statistics.Population(valuesB);
-        var popC = new Statistics.Population(valuesC);
-
-        var populations = new Statistics.Population[] { popA, popB, popC };
-
-        ScottPlot.Plot plt = new(600, 400);
-        var pplt = plt.AddPopulations(populations);
-
-        // plot with default semitransparency
-        var bmp1 = TestTools.GetLowQualityBitmap(plt);
-
-        // plot nearly transparent boxes
-        pplt.BoxAlphaOverride = 20;
-        var bmp2 = TestTools.GetLowQualityBitmap(plt);
-
-        // measure what changed
-        // TestTools.SaveFig(bmp1, "1");
-        // TestTools.SaveFig(bmp2, "2");
-        var before = new MeanPixel(bmp1);
-        var after = new MeanPixel(bmp2);
-        Console.WriteLine($"Before: {before}");
-        Console.WriteLine($"After: {after}");
-
-        // more transparent boxes -> lighter image
+        // more transparent red -> lighter image
         Assert.That(before.IsDarkerThan(after));
+
+        // Use fraction to make markers half the opacity of the boxes
+        populationPlot.MarkerOpacityRatio = 0.5;
+        var bmp3 = TestTools.GetLowQualityBitmap(plt);
+
+        before = new MeanPixel(bmp2);
+        after = new MeanPixel(bmp3);
+        // more transparent red -> lighter image
+        Assert.That(before.IsDarkerThan(after));
+
+        // Turn Automatic Opacity back on - MarkerOpacityRatio should no longer have an effect
+        populationPlot.AutomaticOpacity = true;
+        var bmp4 = TestTools.GetLowQualityBitmap(plt);
+
+        before = new MeanPixel(bmp1);
+        after = new MeanPixel(bmp4);
+        // Should be back to default values
+        Assert.That(before.IsEqualTo(after));
+
+        // TestTools.SaveFig(bmp1, "1");
+        // TestTools.SaveFig(bmp2, "2");
+        // TestTools.SaveFig(bmp3, "3");
+        // TestTools.SaveFig(bmp4, "4");
+
+        double[][][] GetSeriesData(int seriesCount, int groupCount)
+        {
+            return Enumerable.Range(1, seriesCount)
+                .Select(si => Enumerable.Range(1, groupCount)
+                    .Select(gi => Enumerable.Range(gi + si, 3).Select(x => Convert.ToDouble(x)).ToArray()).ToArray()).ToArray();
+        }
     }
 }

--- a/src/ScottPlot4/ScottPlot/Plottable/PopulationPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/PopulationPlot.cs
@@ -48,27 +48,14 @@ namespace ScottPlot.Plottable
         public Color ErrorStDevBarColor { get; set; } = Color.Black;
 
         /// <summary>
-        /// Alpha value of scatter plot markers.
-        /// By default MarkerAlpha = 128 (semi-transparent)
-        /// </summary>
-        public byte MarkerAlpha { get; set; } = 128;
-
-        /// <summary>
-        /// Transparency (alpha) of boxes depends on the <see cref="DataFormat"/> by default.
-        /// If this value is defined, all box plots will be rendered using this alpha value.
-        /// Values range from 0 (transparent) to 255 (opaque).
-        /// </summary>
-        public byte? BoxAlphaOverride { get; set; } = null;
-
-        /// <summary>
-        /// If true, marker and box transparency (alpha) is set to defaults (marker aplha = 128, box alpha depending on <see cref="DataFormat"/>.
+        /// If true, marker and box transparency (alpha) is set to defaults (marker alpha = 128, box alpha depending on <see cref="DataFormat"/>.
         /// If false, alpha values from the series argb color will be used instead.
         /// </summary>
         public bool AutomaticOpacity { get; set; } = true;
 
         /// <summary>
-        /// Sets the ratio of marker to box opacity when <see cref="AutomaticOpacity"/> is false. Default is 1.0, or box and marker having equal opacity. 
-        /// With a value of 0.5, markers will be half as opaque as boxes. A value of 0 will make markers completely transparent (invisible).
+        /// Sets the ratio of marker to box opacity when <see cref="AutomaticOpacity"/> is false. Default is 1.0 which sets the box and marker to have equal opacity. 
+        /// With a value of 0.5 markers will be half as opaque as boxes. A value of 0 will make markers completely transparent.
         /// </summary>
         public double MarkerOpacityRatio { get; set; } = 1.0;
 
@@ -126,7 +113,7 @@ namespace ScottPlot.Plottable
                 .Select(x => new LegendItem(this)
                 {
                     label = x.seriesLabel,
-                    color = BoxAlphaOverride.HasValue ? Color.FromArgb(BoxAlphaOverride.Value, x.color) : x.color,
+                    color = x.color,
                     lineWidth = 10
                 })
                 .ToArray();
@@ -185,6 +172,7 @@ namespace ScottPlot.Plottable
 
                     Position scatterPos, boxPos;
                     byte boxAlpha = 0;
+                    byte markerAlpha = 128;
                     switch (DataFormat)
                     {
                         case DisplayItems.BoxAndScatter:
@@ -218,11 +206,11 @@ namespace ScottPlot.Plottable
                     // Override default opacity values with alpha from series argb
                     if (!AutomaticOpacity)
                     {
-                        MarkerAlpha = (byte)Math.Max(series.color.A * MarkerOpacityRatio, byte.MaxValue);
+                        markerAlpha = (byte)Math.Min(series.color.A * MarkerOpacityRatio, byte.MaxValue);
                         boxAlpha = series.color.A;
                     }
 
-                    Scatter(dims, bmp, lowQuality, population, rand, popLeft, popWidth, series.color, ScatterOutlineColor, MarkerAlpha, scatterPos);
+                    Scatter(dims, bmp, lowQuality, population, rand, popLeft, popWidth, series.color, ScatterOutlineColor, markerAlpha, scatterPos);
 
                     if (DistributionCurve)
                         Distribution(dims, bmp, lowQuality, population, rand, popLeft, popWidth, DistributionCurveColor, scatterPos, DistributionCurveLineStyle);

--- a/src/ScottPlot4/ScottPlot/Plottable/PopulationPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/PopulationPlot.cs
@@ -59,6 +59,19 @@ namespace ScottPlot.Plottable
         /// Values range from 0 (transparent) to 255 (opaque).
         /// </summary>
         public byte? BoxAlphaOverride { get; set; } = null;
+
+        /// <summary>
+        /// If true, marker and box transparency (alpha) is set to defaults (marker aplha = 128, box alpha depending on <see cref="DataFormat"/>.
+        /// If false, alpha values from the series argb color will be used instead.
+        /// </summary>
+        public bool AutomaticOpacity { get; set; } = true;
+
+        /// <summary>
+        /// Sets the ratio of marker to box opacity when <see cref="AutomaticOpacity"/> is false. Default is 1.0, or box and marker having equal opacity. 
+        /// With a value of 0.5, markers will be half as opaque as boxes. A value of 0 will make markers completely transparent (invisible).
+        /// </summary>
+        public double MarkerOpacityRatio { get; set; } = 1.0;
+
         public DisplayItems DataFormat { get; set; } = DisplayItems.BoxAndScatter;
         public BoxStyle DataBoxStyle { get; set; } = BoxStyle.BoxMedianQuartileOutlier;
         public HorizontalAlignment ErrorBarAlignment { get; set; } = HorizontalAlignment.Right;
@@ -202,9 +215,12 @@ namespace ScottPlot.Plottable
                             throw new NotImplementedException();
                     }
 
-                    // Overide boxAlpha with public field BoxAlphaOverride if the field has been set
-                    if (BoxAlphaOverride.HasValue)
-                        boxAlpha = BoxAlphaOverride.Value;
+                    // Override default opacity values with alpha from series argb
+                    if (!AutomaticOpacity)
+                    {
+                        MarkerAlpha = (byte)Math.Max(series.color.A * MarkerOpacityRatio, byte.MaxValue);
+                        boxAlpha = series.color.A;
+                    }
 
                     Scatter(dims, bmp, lowQuality, population, rand, popLeft, popWidth, series.color, ScatterOutlineColor, MarkerAlpha, scatterPos);
 


### PR DESCRIPTION
**Purpose:**
* Add option to use custom alpha values from series colors in population plots via `AutomaticOpacity` field
* Add option to set ratio of marker alpha to box alpha via `MarkerOpacityRatio` field
* Add test for these two fields
* Remove the now redundant `MarkerAlpha` and `BoxAlphaOverride` fields
* Remove deprecated tests
* Update relevant cookbook example
* resolve #2967 (previously closed, but it is the relevant issue to this pull request)
