### PR TITLE
SP4: Improves Generate class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Controls: Added `Interaction.Disable()` and `Interaction.Enable()` methods for easy control of mouse interactivity
 * Render: Improve axis frame and tick mark rendering for SVG export (#2944) _Thanks @Crown0815_
 * Controls: Created OpenGL controls `FormsPlotGL` and `WpfPlotGL` distinct from `FormsPlot` and `WpfPlot` (#3008, #3007, #2950, #2395, #2565)
+* Generate: Use a global Random number generator when seed is null to enforce values randomness (#2893) _Thanks @KroMignon_
 
 ## ScottPlot 4.1.68 (in development)
 * Axis: Added `IsReverse` property to let users invert the orientation of an axis (#2958) _Thanks @HandsomeGoldenKnight_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Plot: Added `LastRenderDimensions` for easy access to the latest figure dimensions (#3000, #3002) _Thanks @dhgigisoave_
 * DataLogger and DataStreamer: Added support for custom line styles (#2972, #2972) _Thanks @Gray-lab_
 * Population: Defining `BoxAlphaOverride` and `MarkerAlpha` allows for exact color representation (#2967, #3013) _Thanks @Gray-lab and @Em3a-c_
+* Generate: Use a global Random number generator when seed is null to enforce values randomness (#2893) _Thanks @KroMignon_
 
 ## ScottPlot 5.0.9-beta
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2023-10-03_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 * Render: Improve axis frame and tick mark rendering for SVG export (#2944) _Thanks @Crown0815_
 * Controls: Created OpenGL controls `FormsPlotGL` and `WpfPlotGL` distinct from `FormsPlot` and `WpfPlot` (#3008, #3007, #2950, #2395, #2565)
 * Markers: Added numerous additional marker types (#2999, #3019) _Thanks @Gray-lab_
-* Generate: Use a global Random number generator when seed is null to enforce values randomness (#2893) _Thanks @KroMignon_
 
 ## ScottPlot 4.1.68 (in development)
 * Axis: Added `IsReverse` property to let users invert the orientation of an axis (#2958) _Thanks @HandsomeGoldenKnight_
@@ -24,7 +23,7 @@
 * Plot: Added `LastRenderDimensions` for easy access to the latest figure dimensions (#3000, #3002) _Thanks @dhgigisoave_
 * DataLogger and DataStreamer: Added support for custom line styles (#2972, #2972) _Thanks @Gray-lab_
 * Population: Defining `BoxAlphaOverride` and `MarkerAlpha` allows for exact color representation (#2967, #3013) _Thanks @Gray-lab and @Em3a-c_
-* Generate: Use a global Random number generator when seed is null to enforce values randomness (#2893) _Thanks @KroMignon_
+* Generate: Use a global Random number generator for improved randomness and thread safety (#2893) _Thanks @KroMignon_
 
 ## ScottPlot 5.0.9-beta
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2023-10-03_

--- a/src/ScottPlot4/ScottPlot/Generate.cs
+++ b/src/ScottPlot4/ScottPlot/Generate.cs
@@ -151,9 +151,9 @@ public static class Generate
     /// <summary>
     /// Return a series of values starting with <paramref name="offset"/> and
     /// each randomly deviating from the previous by at most <paramref name="mult"/>.
-    /// Random values are deterministic based on the value of <paramref name="seed"/>.
+    /// Random values can be deterministic if the value of <paramref name="seed"/> is not null.
     /// </summary>
-    public static double[] RandomWalk(int count, double mult = 1, double offset = 0, int seed = 0)
+    public static double[] RandomWalk(int count, double mult = 1, double offset = 0, int? seed = null)
     {
         RandomDataGenerator gen = new(seed);
         return gen.RandomWalk(count, mult, offset);
@@ -161,18 +161,23 @@ public static class Generate
 
     /// <summary>
     /// Return an array of <paramref name="count"/> random values 
-    /// from <paramref name="min"/> to <paramref name="max"/>
-    /// according to the random seed defined by <paramref name="seed"/>
+    /// from <paramref name="min"/> to <paramref name="max"/>.
+    /// Random values can be deterministic if the value of <paramref name="seed"/> is not null.
     /// </summary>
-    public static double[] Random(int count, double min = 0, double max = 1, int seed = 0)
+    public static double[] Random(int count, double min = 0, double max = 1, int? seed = null)
     {
         RandomDataGenerator gen = new(seed);
         return Enumerable.Range(0, count)
             .Select(_ => gen.RandomNumberInRange(min, max))
             .ToArray();
     }
-
-    public static double[] RandomNormal(int count, double mean = 0, double stdDev = 1, int seed = 0)
+    /// <summary>
+    /// Return an array of <paramref name="count"/> random number normally
+    /// distributed around the given <paramref name="mean"/> according to 
+    /// the <paramref name="stdDev"/> standard deviation.
+    /// Random values can be deterministic if the value of <paramref name="seed"/> is not null.
+    /// </summary>
+    public static double[] RandomNormal(int count, double mean = 0, double stdDev = 1, int? seed = null)
     {
         RandomDataGenerator gen = new(seed);
         return Enumerable.Range(0, count)

--- a/src/ScottPlot4/ScottPlot/RandomDataGenerator.cs
+++ b/src/ScottPlot4/ScottPlot/RandomDataGenerator.cs
@@ -11,15 +11,17 @@ public class RandomDataGenerator
     /// Global random number generator, to ensure each generator will returns different data.
     /// Using ThreadLocal, because Random is not thread safe.
     /// </summary>
-    private static readonly ThreadLocal<Random> _tlRng = new ThreadLocal<Random>(() => new Random());
+    private static readonly ThreadLocal<Random> GlobalRandomThread = new(() => new Random());
+
     /// <summary>
     /// Local random number generator to be able to return the same data.
     /// </summary>
-    private Random? _localRand = null;
+    private readonly Random? SeededRandom = null;
+
     /// <summary>
     /// To select right random number generator
     /// </summary>
-    private Random Rand => _localRand ?? _tlRng.Value;
+    private Random Rand => SeededRandom ?? GlobalRandomThread.Value!;
 
     /// <summary>
     /// Create a random number generator.
@@ -28,7 +30,7 @@ public class RandomDataGenerator
     public RandomDataGenerator(int? seed = null)
     {
         if (seed.HasValue)
-            _localRand = new(seed.Value);
+            SeededRandom = new(seed.Value);
     }
 
     #region Methods that return single numbers

--- a/src/ScottPlot5/ScottPlot5/RandomDataGenerator.cs
+++ b/src/ScottPlot5/ScottPlot5/RandomDataGenerator.cs
@@ -1,40 +1,30 @@
-﻿using System.Security.Cryptography;
-
-namespace ScottPlot;
+﻿namespace ScottPlot;
 
 #nullable enable
 
 public class RandomDataGenerator
 {
-    private Random Rand;
-    private readonly RandomNumberGenerator RNG;
+    private readonly Random Rand;
+
+    /// <summary>
+    /// Create a random number generator.
+    /// The seed is random by deafult, but could be fixed to the defined value
+    /// </summary>
+    public RandomDataGenerator(int? seed = null)
+    {
+        Rand = seed.HasValue
+            ? new Random(seed.Value)
+            : new Random(GetCryptoRandomInt());
+    }
+
     public static RandomDataGenerator Generate { get; private set; } = new(0);
 
-    /// <summary>
-    /// Use a random seed so each generator returns different data.
-    /// </summary>
-    public RandomDataGenerator()
+    private static int GetCryptoRandomInt()
     {
-        RNG = RandomNumberGenerator.Create();
+        var RNG = System.Security.Cryptography.RandomNumberGenerator.Create();
         byte[] data = new byte[sizeof(int)];
         RNG.GetBytes(data);
-        int randomValue = BitConverter.ToInt32(data, 0) & (int.MaxValue - 1);
-        Rand = new Random(randomValue);
-    }
-
-    /// <summary>
-    /// Use a fixed seed so each generator returns the same data.
-    /// </summary>
-    public RandomDataGenerator(int seed = 0)
-    {
-        Rand = new(seed);
-        RNG = RandomNumberGenerator.Create();
-    }
-
-    public void RandomizeSeed()
-    {
-        Rand = new();
-        Generate = new();
+        return BitConverter.ToInt32(data, 0) & (int.MaxValue - 1);
     }
 
     #region Methods that return single numbers


### PR DESCRIPTION
Use a global Random number generator when `seed` is null to enforce values randomness. Should fix #2893

