### PR TITLE
SP4: Improve Bitmap disposal as controls are unloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * DataLogger and DataStreamer: Added support for custom line styles (#2972, #2972) _Thanks @Gray-lab_
 * Population: Defining `BoxAlphaOverride` and `MarkerAlpha` allows for exact color representation (#2967, #3013) _Thanks @Gray-lab and @Em3a-c_
 * Generate: Use a global Random number generator for improved randomness and thread safety (#2893) _Thanks @KroMignon_
+* Controls: Improve `Bitmap` disposal as controls are unloaded (#3023, #2902) _Thanks @KroMignon and @mocakturk_
 
 ## ScottPlot 5.0.9-beta
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2023-10-03_

--- a/src/ScottPlot4/ScottPlot.Avalonia/AvaPlot.axaml.cs
+++ b/src/ScottPlot4/ScottPlot.Avalonia/AvaPlot.axaml.cs
@@ -127,6 +127,11 @@ namespace ScottPlot.Avalonia
             Backend.StartProcessingEvents();
         }
 
+        protected override void OnUnloaded(RoutedEventArgs e)
+        {
+            Backend?.Dispose();
+            base.OnUnloaded(e);
+        }
         public (double x, double y) GetMouseCoordinates(int xAxisIndex = 0, int yAxisIndex = 0) => Backend.GetMouseCoordinates(xAxisIndex, yAxisIndex);
 
         public (float x, float y) GetMousePixel() => Backend.GetMousePixel();

--- a/src/ScottPlot4/ScottPlot.Eto/PlotView.cs
+++ b/src/ScottPlot4/ScottPlot.Eto/PlotView.cs
@@ -96,6 +96,12 @@ namespace ScottPlot.Eto
             Backend.StartProcessingEvents();
         }
 
+        protected override void OnUnLoad(EventArgs e)
+        {
+            Backend?.Dispose();
+            base.OnUnLoad(e);
+        }
+
         /// <summary>
         /// Return the mouse position on the plot (in coordinate space) for the latest X and Y coordinates
         /// </summary>

--- a/src/ScottPlot4/ScottPlot.WPF/WpfPlot.cs
+++ b/src/ScottPlot4/ScottPlot.WPF/WpfPlot.cs
@@ -226,11 +226,11 @@ namespace ScottPlot
 
         protected override void OnVisualParentChanged(DependencyObject oldParent)
         {
-            if(Parent is null)
+            if (Parent is null)
                 Backend?.Dispose();
             base.OnVisualParentChanged(oldParent);
         }
-        
+
         protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
         {
             base.OnRenderSizeChanged(sizeInfo);

--- a/src/ScottPlot4/ScottPlot.WPF/WpfPlot.cs
+++ b/src/ScottPlot4/ScottPlot.WPF/WpfPlot.cs
@@ -224,6 +224,13 @@ namespace ScottPlot
             base.OnApplyTemplate();
         }
 
+        protected override void OnVisualParentChanged(DependencyObject oldParent)
+        {
+            if(Parent is null)
+                Backend?.Dispose();
+            base.OnVisualParentChanged(oldParent);
+        }
+        
         protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
         {
             base.OnRenderSizeChanged(sizeInfo);

--- a/src/ScottPlot4/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot4/ScottPlot.WinForms/FormsPlot.cs
@@ -138,6 +138,11 @@ namespace ScottPlot
 
             Backend.StartProcessingEvents();
         }
+        protected override void OnHandleDestroyed(EventArgs e)
+        {
+            Backend?.Dispose();
+            base.OnHandleDestroyed(e);
+        }
 
         /// <summary>
         /// Return the mouse position on the plot (in coordinate space) for the latest X and Y coordinates

--- a/src/ScottPlot4/ScottPlot/Control/Backend.cs
+++ b/src/ScottPlot4/ScottPlot/Control/Backend.cs
@@ -54,8 +54,12 @@ namespace ScottPlot.Control
     /// User controls can instantiate this object, pass mouse and resize event information in, and have
     /// renders triggered using events.
     /// </summary>
-    public class ControlBackEnd
+    public class ControlBackEnd : IDisposable
     {
+        /// <summary>
+        /// Track whether Dispose has been called.
+        /// </summary>
+        private bool disposedValue;
         /// <summary>
         /// This event is invoked when an existing Bitmap is redrawn.
         /// e.g., after rendering following a click-drag-pan mouse event.
@@ -789,6 +793,36 @@ namespace ScottPlot.Control
 
                 linkedPlotControl.PlotControl.Configuration.EmitLinkedControlUpdateSignals = true;
             }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects)
+                }
+
+                while (OldBitmaps.Count > 0)
+                    OldBitmaps.Dequeue()?.Dispose();
+                Bmp?.Dispose();
+                Bmp = null;
+                disposedValue = true;
+            }
+        }
+
+        ~ControlBackEnd()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: false);
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
ControlBackEnd implements now `IDisposable`.

When disposing (or on destruction), all bitmaps in `OldBitmaps` queue and `Bmp` are disposed to avoid memory overflow.

This should fix issue #2902