### PR TITLE
SP4: Fix ScatterPlotDraggable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Population: Defining `BoxAlphaOverride` and `MarkerAlpha` allows for exact color representation (#2967, #3013) _Thanks @Gray-lab and @Em3a-c_
 * Generate: Use a global Random number generator for improved randomness and thread safety (#2893) _Thanks @KroMignon_
 * Controls: Improve `Bitmap` disposal as controls are unloaded (#3023, #2902) _Thanks @KroMignon and @mocakturk_
+* ScatterPlotDraggable: Fixed bug affecting `IsUnderMouse()` after `Update()` is called (#2870, #2969, #3025) _Thanks @KroMignon, @SasKayDE, and @onur-akaydin_
 
 ## ScottPlot 5.0.9-beta
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2023-10-03_

--- a/src/ScottPlot4/ScottPlot/Plottable/ScatterPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/ScatterPlot.cs
@@ -49,7 +49,7 @@ namespace ScottPlot.Plottable
         /// </summary>
         public double OffsetY { get; set; } = 0;
 
-        public int PointCount => Ys.Length;
+        public int PointCount => Ys?.Length ?? 0;
 
         // customization
         public bool IsVisible { get; set; } = true;

--- a/src/ScottPlot4/ScottPlot/Plottable/ScatterPlotDraggable.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/ScatterPlotDraggable.cs
@@ -9,8 +9,6 @@ namespace ScottPlot.Plottable
     /// </summary>
     public class ScatterPlotDraggable : ScatterPlot, IDraggable
     {
-        public new double[] Xs { get; private set; }
-        public new double[] Ys { get; private set; }
         public int CurrentIndex { get; set; } = 0;
 
         /// <summary>
@@ -71,7 +69,7 @@ namespace ScottPlot.Plottable
         /// <param name="fixedSize">This argument is ignored</param>
         public void DragTo(double coordinateX, double coordinateY, bool fixedSize)
         {
-            if (!DragEnabled)
+            if (!DragEnabled || CurrentIndex >= PointCount)
                 return;
 
             Coordinate original = new(coordinateX, coordinateY);
@@ -115,10 +113,6 @@ namespace ScottPlot.Plottable
 
         public ScatterPlotDraggable(double[] xs, double[] ys, double[] errorX = null, double[] errorY = null) : base(xs, ys, errorX, errorY)
         {
-            this.Xs = xs;
-            this.Ys = ys;
-            this.XError = errorX;
-            this.YError = errorY;
         }
     }
 }


### PR DESCRIPTION
**Purpose:**

This should resolve issues with `ScatteerPlotDraggable` (#2870 and #2969):
- remove duplicated members `Xs` and `Ys`, they are already managed by base class `ScatterPlot`
- ensure a valid point is selected before trying to update its position
- avoid possible exception with `PointCount` when no data is set
