### PR TITLE
SP4: improve quickstart code in NuGet readmes

### DIFF
--- a/src/ScottPlot4/ScottPlot.Avalonia/README.md
+++ b/src/ScottPlot4/ScottPlot.Avalonia/README.md
@@ -15,6 +15,7 @@ double[] dataX = new double[] { 1, 2, 3, 4, 5 };
 double[] dataY = new double[] { 1, 4, 9, 16, 25 };
 
 AvaPlot1.Plot.AddScatter(dataX, dataY);
+AvaPlot1.Refresh();
 ```
 
 Additional quickstart information can be found at https://scottplot.net/quickstart/avalonia/

--- a/src/ScottPlot4/ScottPlot.Eto/README.md
+++ b/src/ScottPlot4/ScottPlot.Eto/README.md
@@ -8,11 +8,12 @@ double[] ys = new double[] { 1, 4, 9, 16, 25 };
 
 var plotView = new ScottPlot.Eto.PlotView();
 plotView.Plot.AddScatter(xs, ys);
+plotView.Refresh();
 this.Content = plotView;
 ```
 
-WPF | GTK | OSX
----|---|---
-![](https://raw.githubusercontent.com/ScottPlot/ScottPlot/master/dev/graphics/eto-quickstart-wpf.png)|![](https://raw.githubusercontent.com/ScottPlot/ScottPlot/master/dev/graphics/eto-quickstart-gtk.png)|![](https://raw.githubusercontent.com/ScottPlot/ScottPlot/master/dev/graphics/eto-quickstart-osx.png)
+| WPF                                                                                                   | GTK                                                                                                   | OSX                                                                                                   |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| ![](https://raw.githubusercontent.com/ScottPlot/ScottPlot/master/dev/graphics/eto-quickstart-wpf.png) | ![](https://raw.githubusercontent.com/ScottPlot/ScottPlot/master/dev/graphics/eto-quickstart-gtk.png) | ![](https://raw.githubusercontent.com/ScottPlot/ScottPlot/master/dev/graphics/eto-quickstart-osx.png) |
 
 For more details including MacOS and Linux instructions visit the ScottPlot Eto Quickstart web page: https://scottplot.net/quickstart/eto/

--- a/src/ScottPlot4/ScottPlot.WPF/README.md
+++ b/src/ScottPlot4/ScottPlot.WPF/README.md
@@ -14,6 +14,7 @@ Add the following to your start-up sequence:
 double[] dataX = new double[] { 1, 2, 3, 4, 5 };
 double[] dataY = new double[] { 1, 4, 9, 16, 25 };
 WpfPlot1.Plot.AddScatter(dataX, dataY);
+WpfPlot1.Refresh();
 ```
 
 ## ScottPlot Cookbook

--- a/src/ScottPlot4/ScottPlot.WinForms/README.md
+++ b/src/ScottPlot4/ScottPlot.WinForms/README.md
@@ -8,6 +8,7 @@ Drop a `FormsPlot` from the toolbox onto your form and add the following to your
 double[] xs = new double[] {1, 2, 3, 4, 5};
 double[] ys = new double[] {1, 4, 9, 16, 25};
 formsPlot1.Plot.AddScatter(xs, ys);
+formsPlot1.Refresh();
 ```
 
 ![](https://raw.githubusercontent.com/ScottPlot/ScottPlot/master/dev/graphics/winforms-quickstart.png)

--- a/src/ScottPlot4/ScottPlot/README.md
+++ b/src/ScottPlot4/ScottPlot/README.md
@@ -25,6 +25,7 @@ Drop a `FormsPlot` from the toolbox onto your form and add the following to your
 double[] xs = new double[] {1, 2, 3, 4, 5};
 double[] ys = new double[] {1, 4, 9, 16, 25};
 formsPlot1.Plot.AddScatter(xs, ys);
+formsPlot1.Refresh();
 ```
 
 ![](https://raw.githubusercontent.com/ScottPlot/ScottPlot/master/dev/graphics/winforms-quickstart.png)
@@ -52,6 +53,7 @@ The [**ScottPlot Cookbook**](https://scottplot.net/cookbook/4.1/) demonstrates h
 ## Supported Platforms
 
 ### .NET Versions
+
 * .NET Standard 2.0
 * .NET Framework 4.6.2 and newer
 * .NET (Core) 6 and newer ([compatibility notes](https://scottplot.net/faq/dependencies/))


### PR DESCRIPTION
Add missed `Refresh()` statements, this should fix #2948
