### PR TITLE
SP4 RadarPlot: Added customization settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * ScatterPlotDraggable: Fixed bug affecting `IsUnderMouse()` after `Update()` is called (#2870, #2969, #3025) _Thanks @KroMignon, @SasKayDE, and @onur-akaydin_
 * Bar: New `AddBar()` overload for creating a single highly customized bar graph bar (#3024, #3033) _Thanks @melhashash_
 * FormsPlot: Fix bug affecting mouse interaction on plots with all items hidden (#2895) _Thanks @LapinFou_
+* RadarPlot: Added customization options for axis label string formatting, manual tick positions, and transparency (#3041) _Thanks @JbmOnGitHub_
 
 ## ScottPlot 5.0.9-beta
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2023-10-03_

--- a/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Radar.cs
+++ b/src/ScottPlot4/ScottPlot.Cookbook/Recipes/Plottable/Radar.cs
@@ -322,17 +322,30 @@ namespace ScottPlot.Cookbook.Recipes.Plottable
         public string ID => "radar_customization";
         public string Title => "Customization";
         public string Description =>
-            "Radar charts support customization of the line color and width.";
+            "Radar charts support extensive customization options.";
 
         public void ExecuteRecipe(Plot plt)
         {
-            double[,] values = {
-                { 78,  83, 84, 76, 43 },
-                { 100, 50, 70, 60, 90 }
-            };
+            double[,] values = { { 2, 4, 3 }, { 3, 3, 4 } };
+            double[] maxValues = { 5, 5, 5 };
 
-            var radar = plt.AddRadar(values);
-            radar.WebColor = System.Drawing.Color.Red;
+            var radar = plt.AddRadar(
+                values: values,
+                independentAxes: false,
+                maxValues: maxValues,
+                alphafill: 20);
+
+            static string CustomLabelFormatter(double position)
+            {
+                return position.ToString("f1");
+            }
+
+            radar.CategoryLabels = new string[] { "Speed", "Velocity", "Strength" };
+            radar.GroupLabels = new[] { "First try", "Second try" };
+            radar.Font.Size = 10;
+            radar.TickValues = new double[] { 1, 2, 3, 4, 5 };
+            radar.AxisLabelStringFormatter = CustomLabelFormatter;
+            radar.WebColor = System.Drawing.Color.WhiteSmoke;
             radar.LineWidth = 3;
         }
     }

--- a/src/ScottPlot4/ScottPlot/Plot/Plot.Add.cs
+++ b/src/ScottPlot4/ScottPlot/Plot/Plot.Add.cs
@@ -1069,15 +1069,16 @@ namespace ScottPlot
         /// <param name="independentAxes">if true, axis (category) values are scaled independently</param>
         /// <param name="maxValues">if provided, each category (column) is normalized to these values</param>
         /// <param name="disableFrameAndGrid">also make the plot frameless and disable its grid</param>
+        /// <param name="alphafill">if provided, this value overrides the intermediate transparency (alpha) applied by default to the area fill color</param>
         /// <returns>the radar plot that was just created and added to the plot</returns>
-        public RadarPlot AddRadar(double[,] values, bool independentAxes = false, double[] maxValues = null, bool disableFrameAndGrid = true)
+        public RadarPlot AddRadar(double[,] values, bool independentAxes = false, double[] maxValues = null, bool disableFrameAndGrid = true, int alphafill = 50)
         {
 
             Color[] colors = Enumerable.Range(0, values.Length)
                                        .Select(i => settings.PlottablePalette.GetColor(i))
                                        .ToArray();
 
-            Color[] fills = colors.Select(x => Color.FromArgb(50, x)).ToArray();
+            Color[] fills = colors.Select(x => Color.FromArgb(alphafill, x)).ToArray();
 
             RadarPlot plottable = new(values, colors, fills, independentAxes, maxValues);
             Add(plottable);

--- a/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
@@ -100,7 +100,7 @@ namespace ScottPlot.Plottable
         /// <summary>
         /// Format used to generate values ​​on the axis
         /// </summary>
-        public string AxisLabelStringFormat { get; set; } = "f1";
+        public Func<double, string> AxisLabelStringFormatter { get; set; } = new Func<double, string>((x) => x.ToString("f1"));
 
         /// <summary>
         /// The tick Locations expressed as ratios. { 0.25, 0.5, 1 } by default
@@ -108,7 +108,8 @@ namespace ScottPlot.Plottable
         public double[] TickLocations { get; private set; } = { 0.25, 0.5, 1 };
 
         /// <summary>
-        /// When IndependentAxes is false, TickValues ​​is able to display ticks based on concrete values ​​on the axis instead of ticks expressed as a ratio by default
+        /// When <see cref="IndependentAxes"/> is false, TickValues ​​is able to display circular ticks 
+        /// based on these concrete values instead of the ratios defined by <see cref="TickLocations"/>
         /// </summary>
         public double[] TickValues { get; set; } = null;
 
@@ -342,7 +343,7 @@ namespace ScottPlot.Plottable
                 Graphics = gfx,
                 ImagePlacement = ImagePlacement.Outside,
                 Font = Font,
-                AxisLabelStringFormat = AxisLabelStringFormat,
+                AxisLabelStringFormatter = AxisLabelStringFormatter,
             };
 
             axis.Render(dims, bmp, lowQuality);

--- a/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
@@ -85,7 +85,7 @@ namespace ScottPlot.Plottable
         /// <summary>
         /// Font used for labeling values on the plot
         /// </summary>
-        public readonly Drawing.Font Font = new();
+        public Drawing.Font Font { get; set; } = new();
 
         /// <summary>
         /// If true, each value will be written in text on the plot.
@@ -96,6 +96,21 @@ namespace ScottPlot.Plottable
         /// If true, each category name will be written in text at every corner of the radar
         /// </summary>
         public bool ShowCategoryLabels { get; set; } = true;
+
+        /// <summary>
+        /// Format used to generate values ​​on the axis
+        /// </summary>
+        public string AxisLabelStringFormat { get; set; } = "f1";
+
+        /// <summary>
+        /// The tick Locations expressed as ratios. { 0.25, 0.5, 1 } by default
+        /// </summary>
+        public double[] TickLocations { get; private set; } = { 0.25, 0.5, 1 };
+
+        /// <summary>
+        /// When IndependentAxes is false, TickValues ​​is able to display ticks based on concrete values ​​on the axis instead of ticks expressed as a ratio by default
+        /// </summary>
+        public double[] TickValues { get; set; } = null;
 
         /// <summary>
         /// Controls rendering style of the concentric circles (ticks) of the web
@@ -305,8 +320,12 @@ namespace ScottPlot.Plottable
 
         private void RenderAxis(Graphics gfx, PlotDimensions dims, Bitmap bmp, bool lowQuality)
         {
-            double[] tickLocations = new[] { 0.25, 0.5, 1 };
-            StarAxisTick[] ticks = tickLocations.Select(x => GetTick(x)).ToArray();
+            if (!IndependentAxes && TickValues != null)
+            {
+                TickLocations = TickValues.Select(x => x / NormMax).ToArray();
+            }
+
+            StarAxisTick[] ticks = TickLocations.Select(x => GetTick(x)).ToArray();
 
             StarAxis axis = new()
             {
@@ -321,9 +340,11 @@ namespace ScottPlot.Plottable
                 LabelEachSpoke = IndependentAxes,
                 ShowAxisValues = ShowAxisValues,
                 Graphics = gfx,
-                ImagePlacement = ImagePlacement.Outside
+                ImagePlacement = ImagePlacement.Outside,
+                Font = Font,
+                AxisLabelStringFormat = AxisLabelStringFormat,
             };
-
+            
             axis.Render(dims, bmp, lowQuality);
         }
     }

--- a/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/RadarPlot.cs
@@ -344,7 +344,7 @@ namespace ScottPlot.Plottable
                 Font = Font,
                 AxisLabelStringFormat = AxisLabelStringFormat,
             };
-            
+
             axis.Render(dims, bmp, lowQuality);
         }
     }

--- a/src/ScottPlot4/ScottPlot/StarAxis.cs
+++ b/src/ScottPlot4/ScottPlot/StarAxis.cs
@@ -90,7 +90,7 @@ namespace ScottPlot
         /// <summary>
         /// Format used to generate values ​​on the axis
         /// </summary>
-        public string AxisLabelStringFormat { get; set; } = "f1";
+        public Func<double, string> AxisLabelStringFormatter { get; set; } = new Func<double, string>((x) => x.ToString("f1"));
 
         /// <summary>
         /// Determines the width of each spoke and the axis lines.
@@ -179,12 +179,12 @@ namespace ScottPlot
                             sf.LineAlignment = y < origin.Y ? StringAlignment.Far : StringAlignment.Near;
 
                             double val = Ticks[j].Labels[i];
-                            Graphics.DrawString(val.ToString(AxisLabelStringFormat), font, fontBrush, x, y, sf);
+                            Graphics.DrawString(AxisLabelStringFormatter.Invoke(val), font, fontBrush, x, y, sf);
                         }
                         else if (i == 0)
                         {
                             double val = Ticks[j].Labels[0];
-                            Graphics.DrawString(val.ToString(AxisLabelStringFormat), font, fontBrush, origin.X, (float)(-tickDistancePx + origin.Y), sf);
+                            Graphics.DrawString(AxisLabelStringFormatter.Invoke(val), font, fontBrush, origin.X, (float)(-tickDistancePx + origin.Y), sf);
                         }
                     }
                 }

--- a/src/ScottPlot4/ScottPlot/StarAxis.cs
+++ b/src/ScottPlot4/ScottPlot/StarAxis.cs
@@ -88,6 +88,11 @@ namespace ScottPlot
         public Drawing.Font Font = new();
 
         /// <summary>
+        /// Format used to generate values ​​on the axis
+        /// </summary>
+        public string AxisLabelStringFormat { get; set; } = "f1";
+
+        /// <summary>
         /// Determines the width of each spoke and the axis lines.
         /// </summary>
         public int LineWidth { get; set; } = 1;
@@ -174,12 +179,12 @@ namespace ScottPlot
                             sf.LineAlignment = y < origin.Y ? StringAlignment.Far : StringAlignment.Near;
 
                             double val = Ticks[j].Labels[i];
-                            Graphics.DrawString($"{val:f1}", font, fontBrush, x, y, sf);
+                            Graphics.DrawString(val.ToString(AxisLabelStringFormat), font, fontBrush, x, y, sf);
                         }
                         else if (i == 0)
                         {
                             double val = Ticks[j].Labels[0];
-                            Graphics.DrawString($"{val:f1}", font, fontBrush, origin.X, (float)(-tickDistancePx + origin.Y), sf);
+                            Graphics.DrawString(val.ToString(AxisLabelStringFormat), font, fontBrush, origin.X, (float)(-tickDistancePx + origin.Y), sf);
                         }
                     }
                 }


### PR DESCRIPTION
**Purpose**

Hi, I wanted to modify the appearance of the radar chart to approximate the rendering shown below.

For this, it would be useful if some parameters were accessible.

Here are some suggestions although I haven't yet mastered all the concepts of this very nice library!

- StarAxis.AxisLabelStringFormat : Format used to generate values ​​on axis ; ex : "0.#" to eliminate unnecessary decimals
- RadarPlot.Font: Public access to the Font used for labeling values on the plot
- RadarPlot.AlphaFill: this value overrides the intermediate transparency (alpha) applied by default to the area fill color
- RadarPlot.TickValues: When IndependentAxes is false, TickValues ​​is able to display ticks based on concrete values ​​on the axis instead of ticks expressed as a ratio by default ; ex : { 1, 3, 5 }

```cs
// code to produce the 'after customization' image below

var myPlot = new ScottPlot.Plot();
            
  double[,] values = { { 2, 4, 3 }, { 3, 3, 4 } };
  double[] maxValues = { 5, 5, 5 };

  var radar = myPlot.AddRadar(
      values: values,
      independentAxes: false,
      maxValues: maxValues,
      alphafill: 20); // new custom argument

  radar.CategoryLabels = new string[] { "Speed", "Velocity", "Strength" };
  radar.GroupLabels = new[] { "First try", "Second try" };

  ScottPlot.Drawing.Font font = new ScottPlot.Drawing.Font
  {
      Size = 14
  };
  radar.Font = font; // new custom argument
  radar.TickValues = new double[] { 1, 2, 3, 4, 5}; // new custom argument
  radar.AxisLabelStringFormat = "0.#"; // new custom argument
```

**before customization**
![image](https://github.com/ScottPlot/ScottPlot/assets/3384411/5b639580-ee34-469f-b222-93d09a55ee12)

**after customization**
![image](https://github.com/ScottPlot/ScottPlot/assets/3384411/0ecb1cd7-feb4-4a08-909e-2b98f887c369)
