### PR TITLE
SP5: Simplify legend system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Plot: Benchmark is now a user-customizable plottable and `Plot.ShowBenchmark` is now `Plot.Benchmark.IsVisible` (#2961)
 * Grid: Improve support for custom line styles (#2904) _Thanks @minjjKang_
 * Pie: Improve appearance of slice labels in the legend (#2894, #2852) _Thanks @zy1075984_
+* Legend: Replaced `List<ILegend>` with a simple `Legend` object with an `IsVisible` property (#2792)
 
 ## ScottPlot 4.1.68 (in development)
 * Axis: Added `IsReverse` property to let users invert the orientation of an axis (#2958) _Thanks @HandsomeGoldenKnight_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Legend.cs
@@ -24,18 +24,14 @@ internal class Legend : RecipePageBase
             var sig2 = myPlot.Add.Signal(Generate.Cos(51));
             sig2.Label = "Cos";
 
-            // enable the legend
-            myPlot.Legend();
-
-            // get the legend so it can be further customized
-            var legend = myPlot.GetLegend();
-            legend.OutlineStyle.Color = Colors.Navy;
-            legend.OutlineStyle.Width = 2;
-            legend.BackgroundFill.Color = Colors.LightBlue;
-            legend.ShadowFill.Color = Colors.Blue.WithOpacity(.5);
-            legend.Font.Size = 16;
-            legend.Font.Name = Fonts.Serif;
-            legend.Alignment = Alignment.UpperCenter;
+            myPlot.Legend.IsVisible = true;
+            myPlot.Legend.OutlineStyle.Color = Colors.Navy;
+            myPlot.Legend.OutlineStyle.Width = 2;
+            myPlot.Legend.BackgroundFill.Color = Colors.LightBlue;
+            myPlot.Legend.ShadowFill.Color = Colors.Blue.WithOpacity(.5);
+            myPlot.Legend.Font.Size = 16;
+            myPlot.Legend.Font.Name = Fonts.Serif;
+            myPlot.Legend.Alignment = Alignment.UpperCenter;
         }
     }
 
@@ -61,11 +57,10 @@ internal class Legend : RecipePageBase
             item2.Label = "Beta";
 
             // enable the legend
-            myPlot.Legend();
+            myPlot.Legend.IsVisible = true;
 
-            // get the legend so it can be further customized
-            var legend = myPlot.GetLegend();
-            legend.ManualLegendItems = new[] { item1, item2 };
+            // configure the legend to use the custom items
+            myPlot.Legend.ManualLegendItems = new[] { item1, item2 };
         }
     }
 
@@ -85,11 +80,10 @@ internal class Legend : RecipePageBase
             sig2.Label = "Cos";
 
             // enable the legend
-            myPlot.Legend();
+            myPlot.Legend.IsVisible = true;
 
-            // get the legend so it can be further customized
-            var legend = myPlot.GetLegend();
-            legend.ManualLegendItems = sig1.LegendItems;
+            // configure the legend to use the custom items
+            myPlot.Legend.ManualLegendItems = sig1.LegendItems;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Quickstart.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Quickstart.cs
@@ -104,7 +104,7 @@ internal class Quickstart : RecipePageBase
             var sig2 = myPlot.Add.Signal(Generate.Cos(51));
             sig2.Label = "Cos";
 
-            myPlot.Legend();
+            myPlot.Legend.IsVisible = true;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
@@ -159,7 +159,7 @@ internal class Styling : RecipePageBase
                     color: scatter.LineStyle.Color);
             }
 
-            myPlot.Legend();
+            myPlot.Legend.IsVisible = true;
         }
     }
 
@@ -189,7 +189,7 @@ internal class Styling : RecipePageBase
                 scatter.MarkerStyle = MarkerStyle.None;
             }
 
-            myPlot.Legend();
+            myPlot.Legend.IsVisible = true;
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
@@ -81,7 +81,7 @@ internal class Bar : RecipePageBase
 
             myPlot.Add.Bar(seriesList);
 
-            myPlot.Legend();
+            myPlot.Legend.IsVisible = true;
 
             myPlot.AutoScale();
             myPlot.SetAxisLimits(bottom: 0);

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/FillY.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/FillY.cs
@@ -108,7 +108,8 @@ internal class FillY : RecipePageBase
             xyy.LineStyle.Pattern = LinePattern.Dot;
             xyy.LineStyle.Width = 2;
             xyy.Label = "xyy";
-            myPlot.Legend(true);
+
+            myPlot.Legend.IsVisible = true;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Signal.cs
@@ -27,7 +27,7 @@ internal class Signal : RecipePageBase
             sig2.Data.YOffset = .25;
             sig2.Label = "Offset";
 
-            myPlot.Legend();
+            myPlot.Legend.IsVisible = true;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Tests/RenderTests/LegendTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/RenderTests/LegendTests.cs
@@ -14,10 +14,28 @@ internal class LegendTests
 
         plt.SaveTestImage(300, 200, "legend-default");
 
-        plt.Legend(true);
+        plt.Legend.IsVisible = true;
         plt.SaveTestImage(300, 200, "legend-enabled");
 
-        plt.Legend(false);
+        plt.Legend.IsVisible = false;
         plt.SaveTestImage(300, 200, "legend-disabled");
+    }
+
+    [Test]
+    public void Test_Legend_FontStyle()
+    {
+        Plot plt = new();
+
+        var sig1 = plt.Add.Signal(Generate.Sin());
+        var sig2 = plt.Add.Signal(Generate.Cos());
+
+        sig1.Label = "Sine";
+        sig2.Label = "Cosine";
+
+        plt.Legend.IsVisible = true;
+        plt.Legend.Font.Size = 26;
+        plt.Legend.Font.Color = Colors.Magenta;
+
+        plt.SaveTestImage();
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/PieTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/PieTests.cs
@@ -41,7 +41,7 @@ internal class PieTests
         var pie = plt.Add.Pie(slices);
         pie.LineStyle.Color = ScottPlot.Colors.Transparent;
 
-        plt.Legend();
+        plt.Legend.IsVisible = true;
         plt.SaveTestImage();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Interfaces/ILegend.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/ILegend.cs
@@ -1,7 +1,0 @@
-﻿namespace ScottPlot;
-
-public interface ILegend
-{
-    bool IsVisible { get; set; }
-    void Render(RenderPack rp);
-}

--- a/src/ScottPlot5/ScottPlot5/Legends/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/Legend.cs
@@ -1,6 +1,6 @@
 ﻿namespace ScottPlot.Legends;
 
-public class StandardLegend
+public class Legend
 {
     public bool IsVisible { get; set; } = false;
     public Alignment Alignment { get; set; } = Alignment.LowerRight;

--- a/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/StandardLegend.cs
@@ -1,8 +1,6 @@
-﻿using ScottPlot;
+﻿namespace ScottPlot.Legends;
 
-namespace ScottPlot.Legends;
-
-public class StandardLegend : ILegend
+public class StandardLegend
 {
     public bool IsVisible { get; set; } = false;
     public Alignment Alignment { get; set; } = Alignment.LowerRight;

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -28,7 +28,7 @@ public class Plot : IDisposable
     public Panels.TitlePanel TitlePanel { get; } = new();
 
     public List<IGrid> Grids { get; } = new();
-    public List<ILegend> Legends { get; } = new();
+    public StandardLegend Legend { get; } = new();
     public List<IPlottable> PlottableList { get; } = new();
     public PlottableAdder Add { get; }
     public IPalette Palette { get => Add.Palette; set => Add.Palette = value; }
@@ -102,10 +102,6 @@ public class Plot : IDisposable
         // add a default grid using the primary axes
         IGrid grid = new Grids.DefaultGrid(xAxisPrimary, yAxisPrimary);
         Grids.Add(grid);
-
-        // add a standard legend
-        ILegend legend = new StandardLegend();
-        Legends.Add(legend);
 
         // setup classes which must be aware of the plot
         Add = new(this);
@@ -669,27 +665,6 @@ public class Plot : IDisposable
             return defaultGrids.First();
         else
             throw new InvalidOperationException("The plot has no default grids");
-    }
-
-    /// <summary>
-    /// Return the first default legend in use.
-    /// Throws an exception if no default legends exist.
-    /// </summary>
-    public Legends.StandardLegend GetLegend()
-    {
-        IEnumerable<Legends.StandardLegend> standardLegends = Legends.OfType<Legends.StandardLegend>();
-        if (standardLegends.Any())
-            return standardLegends.First();
-        else
-            throw new InvalidOperationException("The plot has no standard legends");
-    }
-
-    /// <summary>
-    /// Set visibility of all legends.
-    /// </summary>
-    public void Legend(bool enable = true)
-    {
-        Legends.ForEach(x => x.IsVisible = enable);
     }
 
     /// <summary>

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -28,7 +28,7 @@ public class Plot : IDisposable
     public Panels.TitlePanel TitlePanel { get; } = new();
 
     public List<IGrid> Grids { get; } = new();
-    public StandardLegend Legend { get; } = new();
+    public Legend Legend { get; } = new();
     public List<IPlottable> PlottableList { get; } = new();
     public PlottableAdder Add { get; }
     public IPalette Palette { get => Add.Palette; set => Add.Palette = value; }

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/RenderLegends.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/RenderLegends.cs
@@ -4,11 +4,6 @@ public class RenderLegends : IRenderAction
 {
     public void Render(RenderPack rp)
     {
-        LegendItem[] items = rp.Plot.PlottableList.SelectMany(x => x.LegendItems).ToArray();
-
-        foreach (ILegend legend in rp.Plot.Legends)
-        {
-            legend.Render(rp);
-        }
+        rp.Plot.Legend.Render(rp);
     }
 }


### PR DESCRIPTION
This PR refactors the legend system to replace `List<ILegend>` with a single `Legend` object. This makes it easier to customize the legend appearance and behavior. 

However, the way of enabling legends has changed:
```cs
// this is how to enable the legend now
Plot.Legend.IsVisible = true;
```

```cs
// this old strategy no longer works
Plot.Legend(true);
```

resolves #2792