### PR TITLE
Fix up a performance issue, that can occur when the population plot draws its' distribution curve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## ScottPlot 5.0.11-beta (in development)
 
 ## ScottPlot 4.1.70 (in development)
+* Population Plot: Improved performance for populations with curves that run off the screen (#3054) _Thanks @Em3a-c and @cornford_
 
 ## ScottPlot 5.0.10-beta
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2023-12-03_

--- a/src/ScottPlot4/ScottPlot/Plottable/PopulationPlot.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/PopulationPlot.cs
@@ -286,7 +286,8 @@ namespace ScottPlot.Plottable
             popLeft += popWidth * edgePaddingFrac;
             popWidth -= (popWidth * edgePaddingFrac) * 2;
 
-            double[] ys = DataGen.Range(pop.minus3stDev, pop.plus3stDev, dims.UnitsPerPxY);
+            // draw the distribution curve for the visible part of the plot, to avoid performance issues
+            double[] ys = DataGen.Range(Math.Max(pop.minus3stDev, dims.YMin), Math.Min(pop.plus3stDev, dims.YMax), dims.UnitsPerPxY);
             if (ys.Length == 0)
                 return;
             double[] ysFrac = pop.GetDistribution(ys, normalize: false);


### PR DESCRIPTION
For the PopulationPlot, only draw the distribution curve for the visible part of the plot, to avoid performance issues.

This fix was implemented by myself and @cornford 

I have provided an example below, to reproduce the issue. 

Operating System: Windows
Application Type: WPF

```cs
public void CreatePopulationMultiSeries(WpfPlot plot)
{
    // Show the legend (not necessary for the issue)
    plot.Plot.Legend();  
   
    // 1 group
    var groupNames = new[] { "Group A" };
    plot.Plot.XTicks(groupNames);

    // 1 series
    var seriesColours = new System.Drawing.Color[] { System.Drawing.Color.Blue };

    var seriesData = new[]
    {
        new [] // Group 1
        {
            new double[]{ 1.0, 600000.0 }
         }
    };

    // when setting these axis limits, the performance will suffer, when the distribution curve is rendered
    plot.Plot.SetAxisLimits(yMin: 0, yMax: 2.0);

    // Create the population plot
    var populations = seriesData.Select(series => series.Select(seriesData => new Population(seriesData)).ToArray()).ToArray();
    var populationSeries = populations.Select((p, i) => new PopulationSeries(p, seriesLabel: $"Series {i + 1}")).ToArray();
    var populationMultiSeries = new PopulationMultiSeries(populationSeries.ToArray());
    var populationPlot = plot.Plot.AddPopulations(populationMultiSeries);
    
    // Set the series colour
    for (var i = 0; i < populationPlot.MultiSeries.seriesCount; i++)
    {
        populationPlot.MultiSeries.multiSeries[i].color = seriesColours[i];
    }

    // Configure the DataFormat, (not necessary for the issue)
    populationPlot.DataFormat = ScottPlot.Plottable.PopulationPlot.DisplayItems.ScatterOnly;

    plot.Refresh();
}
```

```
<WpfPlot x:Name="PlotName"  />
```