### PR TITLE
ScottPlot 5: Function Plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Legend: Added `ManualItems` to allow building custom legend content
 * Render: Prevent the pre-render auto-scaler from resetting manually defined axis limits (#3058)
 * Cookbook: Rewrote reflection and source file parsing for simplified querying (#3081, #3080, #3079, #2962, #2755)
+* Function: Added a new line plot type where Y position is a user defined function (#3094) _@bclehmann_
 
 ## ScottPlot 4.1.70 (in development)
 * Population Plot: Improved performance for populations with curves that run off the screen (#3054) _Thanks @Em3a-c and @cornford_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Function.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Function.cs
@@ -1,0 +1,32 @@
+﻿namespace ScottPlotCookbook.Recipes.PlotTypes;
+
+public class Function : ICategory
+{
+    public string Chapter => "Plot Types";
+    public string CategoryName => "Function";
+    public string CategoryDescription => "Function plots are a type of line plot where Y positions " +
+        "are defined by a function that depends on X rather than a collection of discrete data points.";
+
+    public class FunctionQuickstart : RecipeBase
+    {
+        public override string Name => "Function Quickstart";
+        public override string Description => "Create a function plot from a formula.";
+
+        [Test]
+        public override void Execute()
+        {
+            // Functions are defined as delegates with an input and output
+            var func1 = new Func<double, double>((x) => Math.Sin(x) * Math.Sin(x / 2));
+            var func2 = new Func<double, double>((x) => Math.Sin(x) * Math.Sin(x / 3));
+            var func3 = new Func<double, double>((x) => Math.Cos(x) * Math.Sin(x / 5));
+
+            // Add functions to the plot
+            myPlot.Add.Function(func1);
+            myPlot.Add.Function(func2);
+            myPlot.Add.Function(func3);
+
+            // Manually set axis limits because functions do not have discrete data points
+            myPlot.SetAxisLimits(-10, 10, -1.5, 1.5);
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/DataSources/FunctionSource.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/FunctionSource.cs
@@ -10,7 +10,7 @@ namespace ScottPlot.DataSources
     {
         public CoordinateRange RangeX { get; set; } = new(double.NegativeInfinity, double.PositiveInfinity);
         public Func<double, double> EvaluateFunc { get; set; }
-        public Func<CoordinateRange, CoordinateRange> GetYRangeFunc { get; set; } = null;
+        public Func<CoordinateRange, CoordinateRange> GetRangeYFunc { get; set; } = null;
 
         public FunctionSource(Func<double, double> evaluateFunc)
         {
@@ -18,9 +18,9 @@ namespace ScottPlot.DataSources
         }
 
         public double Get(double x) => EvaluateFunc(x);
-        public CoordinateRange GetYRange(CoordinateRange xs) =>
-            GetYRangeFunc is not null
-            ? GetYRangeFunc(xs)
+        public CoordinateRange GetRangeY(CoordinateRange xs) =>
+            GetRangeYFunc is not null
+            ? GetRangeYFunc(xs)
             : new CoordinateRange(double.NaN, double.NaN);
 
     }

--- a/src/ScottPlot5/ScottPlot5/DataSources/FunctionSource.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/FunctionSource.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.DataSources
+{
+    public class FunctionSource : IFunctionSource
+    {
+        public CoordinateRange RangeX { get; set; } = new(double.NegativeInfinity, double.PositiveInfinity);
+        public Func<double, double> EvaluateFunc { get; set; }
+        public Func<CoordinateRange, CoordinateRange> GetYRangeFunc { get; set; } = null;
+
+        public FunctionSource(Func<double, double> evaluateFunc)
+        {
+            EvaluateFunc = evaluateFunc;
+        }
+
+        public double Get(double x) => EvaluateFunc(x);
+        public CoordinateRange GetYRange(CoordinateRange xs) =>
+            GetYRangeFunc is not null
+            ? GetYRangeFunc(xs)
+            : new CoordinateRange(double.NaN, double.NaN);
+
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/DataSources/IFunctionSource.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/IFunctionSource.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.DataSources
+{
+    public interface IFunctionSource
+    {
+        CoordinateRange RangeX { get; }
+        CoordinateRange GetYRange(CoordinateRange rangeX);
+        double Get(double x);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/DataSources/IFunctionSource.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/IFunctionSource.cs
@@ -9,7 +9,7 @@ namespace ScottPlot.DataSources
     public interface IFunctionSource
     {
         CoordinateRange RangeX { get; }
-        CoordinateRange GetYRange(CoordinateRange rangeX);
+        CoordinateRange GetRangeY(CoordinateRange rangeX);
         double Get(double x);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Extensions/NumericExtensions.cs
+++ b/src/ScottPlot5/ScottPlot5/Extensions/NumericExtensions.cs
@@ -37,4 +37,12 @@ public static class NumericExtensions
     {
         return (float)(degrees / 180.0 * Math.PI);
     }
+
+    public static double FiniteCoallesce(this double value, double fallback)
+    {
+        if (double.IsInfinity(value) || double.IsNaN(value))
+            return fallback;
+        else
+            return value;
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -197,6 +197,21 @@ public class PlottableAdder
         return rangePlot;
     }
 
+    public FunctionPlot Function(IFunctionSource functionSource)
+    {
+        FunctionPlot functionPlot = new(functionSource);
+        functionPlot.LineStyle.Color = GetNextColor();
+
+        Plot.PlottableList.Add(functionPlot);
+        return functionPlot;
+    }
+
+    public FunctionPlot Function(Func<double, double> func)
+    {
+        var functionSource = new FunctionSource(func);
+        return Function(functionSource);
+    }
+
     public Heatmap Heatmap(double[,] intensities)
     {
         Heatmap heatmap = new(intensities);

--- a/src/ScottPlot5/ScottPlot5/Plottables/FunctionPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/FunctionPlot.cs
@@ -1,0 +1,82 @@
+﻿using ScottPlot.DataSources;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Plottables
+{
+    public class FunctionPlot : IPlottable
+    {
+        public bool IsVisible { get; set; } = true;
+        public IAxes Axes { get; set; } = new Axes();
+
+        public string? Label { get; set; }
+        public LineStyle LineStyle { get; } = new();
+        IFunctionSource Source { get; set; }
+        public FunctionPlot(IFunctionSource source)
+        {
+            Source = source;
+        }
+
+        private double MinX => Math.Min(Source.RangeX.Min.FiniteCoallesce(Axes.XAxis.Min), Axes.XAxis.Min);
+        private double MaxX => Math.Max(Source.RangeX.Max.FiniteCoallesce(Axes.XAxis.Max), Axes.XAxis.Max);
+
+        public IEnumerable<LegendItem> LegendItems => EnumerableExtensions.One(
+            new LegendItem
+            {
+                Label = Label,
+                Marker = MarkerStyle.None,
+                Line = LineStyle,
+            });
+
+        public AxisLimits GetAxisLimits()
+        {
+            var xMin = Source.RangeX.Min.FiniteCoallesce(double.NaN);
+            var xMax = Source.RangeX.Max.FiniteCoallesce(double.NaN);
+
+            if (!double.IsNaN(xMin) && !double.IsNaN(xMax))
+            {
+                var yRange = Source.GetYRange(new(xMin, xMax));
+                return new AxisLimits(xMin, xMax, yRange.Min, yRange.Max);
+            }
+
+            return new AxisLimits(xMin, xMax, double.NaN, double.NaN);
+        }
+
+        public void Render(RenderPack rp)
+        {
+            var unitsPerPixel = Axes.XAxis.GetCoordinateDistance(1, rp.DataRect);
+
+            using SKPath path = new();
+            bool penIsDown = false;
+            for (double x = MinX; x <= MaxX; x += unitsPerPixel)
+            {
+                double y = Source.Get(x);
+                if (y.IsInfiniteOrNaN())
+                {
+                    penIsDown = false; // Picking up pen allows us to skip over regions where the function is undefined
+                    continue;
+                }
+
+                var px = Axes.GetPixel(new(x, y));
+
+                if (penIsDown)
+                {
+                    path.LineTo(px.ToSKPoint());
+                }
+                else
+                {
+                    path.MoveTo(px.ToSKPoint());
+                    penIsDown = true;
+                }
+            }
+
+            using SKPaint paint = new();
+            LineStyle.ApplyToPaint(paint);
+
+            rp.Canvas.DrawPath(path, paint);
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/FunctionPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/FunctionPlot.cs
@@ -38,7 +38,7 @@ namespace ScottPlot.Plottables
 
             if (!double.IsNaN(xMin) && !double.IsNaN(xMax))
             {
-                var yRange = Source.GetYRange(new(xMin, xMax));
+                var yRange = Source.GetRangeY(new(xMin, xMax));
                 return new AxisLimits(xMin, xMax, yRange.Min, yRange.Max);
             }
 


### PR DESCRIPTION
**Purpose:**
Adds a function plot, like exists in ScottPlot 4.

One can specify an `IFunctionSource` for more depth:
```cs
var funcSource = new FunctionSource(x => Math.Sin(x) / x);
funcSource.RangeX = new(-10, 10);
funcSource.GetRangeYFunc = (CoordinateRange xs) =>
{
    if (Math.Sign(xs.Min) != Math.Sign(xs.Max)) // Crosses 0
        return new(-1, 1);

    double distanceFromZero = Math.Min(Math.Abs(xs.Min), Math.Abs(xs.Max));

    double magnitude = 1 / distanceFromZero;
    return new CoordinateRange(-magnitude, magnitude);
};

var fn1 = WpfPlot1.Plot.Add.Function(funcSource);
fn1.Label = "sin(x) / x";
```

Or one can just pass in a lambda:
```
var fn2 = WpfPlot1.Plot.Add.Function(x => 1 / Math.Round(x));
fn2.Label = "1 / round(x)";
```

The result: 
![image](https://github.com/ScottPlot/ScottPlot/assets/8635304/deec3943-bc92-4ccf-b7e3-2df7ae4dc651)

**Note**, if one does not specify `RangeX` and `GetRangeY` then the plottable will not know its own bounds (it will have limits of (NaN, NaN, NaN, NaN)). If it is the lone plottable in the plot then the plot must be given explicit axis limits, nothing will be drawn if `AutoScale()` is used. If it is not the only plottable then it will simply use the axis limits of the other plottables.