### PR TITLE
SP5: Fix right aligned axis label position

### DIFF
--- a/.github/workflows/ScottPlot5-CI.yaml
+++ b/.github/workflows/ScottPlot5-CI.yaml
@@ -77,6 +77,8 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+      - name: 🚚 Install Additional Workloads
+        run: dotnet workload install maui-android maui-ios maccatalyst
       - name: 🚚 Workload Restore
         run: dotnet workload restore ${{ env.SLN_SP5_FULL }}
       - name: 🚚 Restore ScottPlot5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Render: Prevent the pre-render auto-scaler from resetting manually defined axis limits (#3058)
 * Cookbook: Rewrote reflection and source file parsing for simplified querying (#3081, #3080, #3079, #2962, #2755)
 * Function: Added a new line plot type where Y position is a user defined function (#3094) _Thanks @bclehmann_
-* Axes: Improved axis label alignment for secondary axes (#3030) _Thanks @bclehmann_
+* Axes: Improved axis label alignment for secondary axes (#3030) _Thanks @albyoo_
 
 ## ScottPlot 4.1.70 (in development)
 * Population Plot: Improved performance for populations with curves that run off the screen (#3054) _Thanks @Em3a-c and @cornford_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 * Legend: Added `ManualItems` to allow building custom legend content
 * Render: Prevent the pre-render auto-scaler from resetting manually defined axis limits (#3058)
 * Cookbook: Rewrote reflection and source file parsing for simplified querying (#3081, #3080, #3079, #2962, #2755)
-* Function: Added a new line plot type where Y position is a user defined function (#3094) _@bclehmann_
+* Function: Added a new line plot type where Y position is a user defined function (#3094) _Thanks @bclehmann_
+* Axes: Improved axis label alignment for secondary axes (#3030) _Thanks @bclehmann_
 
 ## ScottPlot 4.1.70 (in development)
 * Population Plot: Improved performance for populations with curves that run off the screen (#3054) _Thanks @Em3a-c and @cornford_

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
@@ -80,14 +80,15 @@ public abstract class YAxisBase : AxisBase, IAxis
         PixelRect panelRect = GetPanelRect(rp.DataRect, size, offset);
 
         float textDistanceFromEdge = 10;
-        Pixel labelPoint = new(panelRect.Left + textDistanceFromEdge, rp.DataRect.VerticalCenter);
+        float labelX = Edge == Edge.Left ? panelRect.Left + textDistanceFromEdge : panelRect.Right - textDistanceFromEdge;
+        Pixel labelPoint = new(labelX, rp.DataRect.VerticalCenter);
 
         if (ShowDebugInformation)
         {
             Drawing.DrawDebugRectangle(rp.Canvas, panelRect, labelPoint, Label.Font.Color);
         }
 
-        Label.Alignment = Edge == Edge.Left ? Alignment.UpperCenter : Alignment.LowerCenter;
+        Label.Alignment = Alignment.UpperCenter;
         Label.Rotation = Edge == Edge.Left ? -90 : 90;
         Label.Draw(rp.Canvas, labelPoint);
 


### PR DESCRIPTION
**Purpose:**
* Fixes: #3030 

![image](https://github.com/ScottPlot/ScottPlot/assets/139430929/e91df3c8-6412-421b-a8a8-556f98563a28)
