### PR TITLE
Add missing horizontal line marker shape to enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Performance: Improved performance of Bar and Finance plots by not drawing shapes outside the data area (#3053, #3078) _Thanks @AndreyPalyutin_
 * Colormap: Added a `Reversed()` method for creating colormaps with reversed color order (#3100) _Thanks @bukkideme_
 * Version: Added `ShouldBe()` method to assert the version of ScottPlot matches the expected one (#3093)
+* Marker: Added support for `Marker.horizontalBar` to compliment `verticalBar` (#3101) _Thanks @SerhiiMahera_
 
 ## ScottPlot 5.0.10-beta
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2023-12-03_

--- a/src/ScottPlot4/ScottPlot/Marker/Marker.cs
+++ b/src/ScottPlot4/ScottPlot/Marker/Marker.cs
@@ -51,6 +51,7 @@ namespace ScottPlot
                 MarkerShape.filledTriangleDown => new MarkerShapes.FilledTriangleDown(),
                 MarkerShape.openTriangleUp => new MarkerShapes.OpenTriangleUp(),
                 MarkerShape.openTriangleDown => new MarkerShapes.OpenTriangleDown(),
+                MarkerShape.horizontalBar => new MarkerShapes.HorizontalBar(),
                 _ => throw new NotImplementedException($"unsupported {shape.GetType()}: {shape}"),
             };
         }

--- a/src/ScottPlot4/ScottPlot/Marker/MarkerShape.cs
+++ b/src/ScottPlot4/ScottPlot/Marker/MarkerShape.cs
@@ -20,5 +20,6 @@
         filledTriangleDown,
         openTriangleUp,
         openTriangleDown,
+        horizontalBar
     }
 }


### PR DESCRIPTION
**Purpose: Add missing horizontal line marker shape to enum**
* During development I find out that HorizontalBar.cs is available in MarkerShapes folder. But MarkerShape.horizontalBar was missing. I tried to solve my issue with MarkerShape.cross and it looks not so nice. So, would be great to have it here.
![image](https://github.com/ScottPlot/ScottPlot/assets/144694413/2e8ceaaa-c236-4fc7-9643-e5c57f28be01)

```cs
 plt.AddMarker(1, 210, MarkerShape.horizontalBar, color: Color.Black, size: 5);
```