### PR TITLE
Statistics for 2D arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Box: Refactored box plot API to favor simplicity and user customization (#3072)
 * Rendering: Added `RenderManager.RenderStarting` event to allow modification of plottable properties (#3077) _Thanks GooBad_
 * Rendering: Added `RenderManager.PreRenderLock` event so developers of multi-threaded applications can ensure plottables are stable at render time (#3095) _Thanks @bclehmann_
+* Statistics: Added descriptive statistics methods and improved support for 2D arrays (#3113, #3121) _Thanks @arthurits_
 
 ## ScottPlot 4.1.70 (in development)
 * Population Plot: Improved performance for populations with curves that run off the screen (#3054) _Thanks @Em3a-c and @cornford_

--- a/src/ScottPlot5/ScottPlot5 Tests/Statistics/ArrayTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Statistics/ArrayTests.cs
@@ -1,0 +1,92 @@
+﻿using FluentAssertions;
+
+namespace ScottPlotTests.Statistics;
+
+internal class ArrayTests
+{
+    readonly double[] Sample1D = { 2, 3, 5, 7 };
+
+    readonly double[] Sample1DWithNan = { 2, 3, double.NaN, 7 };
+
+    readonly double[,] Sample2D =
+    {
+        { 2, 3, 5, 7},
+        { 11, 13, 17, 19},
+        { 23, 29, 31, 37}
+    };
+
+    readonly double[,] Sample2DWithNaN =
+    {
+        { 2, 3, double.NaN, 7},
+        { 11, double.NaN, double.NaN, double.NaN},
+        { 23, double.NaN, double.NaN, 37}
+    };
+
+    [Test]
+    public void Test_ArrayStats1D_NanMean()
+    {
+        // known values calculated with https://goodcalculators.com/standard-error-calculator/
+
+        // real of all values are real
+        ScottPlot.Statistics.Descriptive.Mean(Sample1D).Should().Be(4.25);
+
+        // NaN if any values are nan
+        double.IsNaN(ScottPlot.Statistics.Descriptive.Mean(Sample1DWithNan)).Should().BeTrue();
+
+        // Nan methods ignore NaN values
+        ScottPlot.Statistics.Descriptive.NanMean(Sample1DWithNan).Should().Be(4);
+    }
+
+    [Test]
+    public void Test_ArrayStats1D_NanStdev()
+    {
+        // known values calculated with https://goodcalculators.com/standard-error-calculator/
+
+        // real of all values are real
+        ScottPlot.Statistics.Descriptive.StandardDeviation(Sample1D).Should().BeApproximately(2.217356, 1e-5);
+        ScottPlot.Statistics.Descriptive.StandardError(Sample1D).Should().BeApproximately(1.1086778913, 1e-5);
+
+        // NaN if any values are nan
+        double.IsNaN(ScottPlot.Statistics.Descriptive.StandardDeviation(Sample1DWithNan)).Should().BeTrue();
+        double.IsNaN(ScottPlot.Statistics.Descriptive.StandardError(Sample1DWithNan)).Should().BeTrue();
+
+        // Nan methods ignore NaN values
+        ScottPlot.Statistics.Descriptive.NanStandardDeviation(Sample1DWithNan).Should().BeApproximately(2.645751, 1e-5);
+        ScottPlot.Statistics.Descriptive.NanStandardError(Sample1DWithNan).Should().BeApproximately(1.5275252317, 1e-5);
+    }
+
+    [Test]
+    public void Test_ArrayStats2D_AllReal()
+    {
+        // known values calculated with https://goodcalculators.com/standard-error-calculator/
+
+        double[] expectedMeans = { 12, 15, 17.66666, 21 };
+        double[] expectedStandardError = { 6.0827625303, 7.5718777944, 7.5129517797, 8.7177978871 };
+
+        double[] vMeans = ScottPlot.Statistics.Descriptive.VerticalMean(Sample2D);
+        double[] vStdErrs = ScottPlot.Statistics.Descriptive.VerticalStandardError(Sample2D);
+
+        vMeans.Length.Should().Be(4);
+        vStdErrs.Length.Should().Be(4);
+
+        for (int i = 0; i < 4; i++)
+        {
+            vMeans[i].Should().BeApproximately(expectedMeans[i], 1e-5);
+            vStdErrs[i].Should().BeApproximately(expectedStandardError[i], 1e-5);
+        }
+    }
+
+    [Test]
+    public void Test_ArrayStats2D_WithNan()
+    {
+        // known values calculated with https://goodcalculators.com/standard-error-calculator/
+
+        double[] expectedMeans = { 12, 3, double.NaN, 22 };
+        ScottPlot.Statistics.Descriptive.VerticalNanMean(Sample2DWithNaN)
+            .Should().BeEquivalentTo(expectedMeans);
+
+        double[] expectedStandardError = { 6.082762530298219, 0, double.NaN, 15 };
+        ScottPlot.Statistics.Descriptive.VerticalNanStandardError(Sample2DWithNaN)
+            .Should().BeEquivalentTo(expectedStandardError);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Statistics/Descriptive.cs
+++ b/src/ScottPlot5/ScottPlot5/Statistics/Descriptive.cs
@@ -253,7 +253,7 @@ public static class Descriptive
     /// <summary>
     /// Transpose a multidimensional (not jagged) array
     /// </summary>
-    public static double[,] Rotate90(double[,] matrix)
+    public static double[,] ArrayTranspose(double[,] matrix)
     {
         int rows = matrix.GetLength(0);
         int cols = matrix.GetLength(1);
@@ -274,7 +274,7 @@ public static class Descriptive
     public static double[] ArrayToVector(double[,] values, uint? row = 0, uint? column = null)
     {
         if (values.GetLength(0) == 0)
-            throw new ArgumentException($"{nameof(values)} cannot be empty");
+            throw new ArgumentException($"Array {nameof(values)} cannot be empty");
 
         double[] vector = Array.Empty<double>();
         if (row is not null)
@@ -284,7 +284,7 @@ public static class Descriptive
         }
         else if (column is not null)
         {
-            vector = ArrayToVector(Rotate90(values), column);
+            vector = ArrayToVector(ArrayTranspose(values), column);
         }
 
         return vector;

--- a/src/ScottPlot5/ScottPlot5/Statistics/Descriptive.cs
+++ b/src/ScottPlot5/ScottPlot5/Statistics/Descriptive.cs
@@ -65,8 +65,11 @@ public static class Descriptive
     /// </summary>
     public static double Variance(double[] values)
     {
-        if (values.Length < 2)
-            throw new ArgumentException($"{nameof(values)} must have at least 2 values");
+        if (values.Length == 0)
+            throw new ArgumentException($"{nameof(values)} must not be empty");
+
+        if (values.Length == 1)
+            return 0;
 
         // TODO: benchmark and see if this can be optimized by not using LINQ
         double mean = Mean(values);
@@ -94,8 +97,11 @@ public static class Descriptive
     /// </summary>
     public static double VarianceP(double[] values)
     {
-        if (values.Length < 1)
-            throw new ArgumentException($"{nameof(values)} must have at least 1 value");
+        if (values.Length == 0)
+            throw new ArgumentException($"{nameof(values)} must not be empty");
+
+        if (values.Length == 1)
+            return 0;
 
         // TODO: benchmark and see if this can be optimized by not using LINQ
         double mean = Mean(values);
@@ -195,10 +201,16 @@ public static class Descriptive
 
     /// <summary>
     /// Return the sample mean. NaN values are ignored.
+    /// Returns NaN if all values are NaN.
     /// </summary>
-    public static double NaNMean<T>(IReadOnlyList<T> values)
+    public static double NanMean<T>(IReadOnlyList<T> values)
     {
-        return Mean(RemoveNaN(values));
+        IReadOnlyList<double> real = RemoveNaN(values);
+
+        if (real.Any() == false)
+            return double.NaN;
+
+        return Mean(real);
     }
 
     /// <summary>
@@ -207,9 +219,14 @@ public static class Descriptive
     /// Use this function when your data is a sample from a population.
     /// To calculate the variance from the entire population use <see cref="VarianceP(double[])"/>.
     /// </summary>
-    public static double NaNVariance<T>(IReadOnlyList<T> values)
+    public static double NanVariance<T>(IReadOnlyList<T> values)
     {
-        return Variance(RemoveNaN(values));
+        IReadOnlyList<double> real = RemoveNaN(values);
+
+        if (real.Count() < 2)
+            return double.NaN;
+
+        return Variance(real);
     }
 
     /// <summary>
@@ -218,36 +235,56 @@ public static class Descriptive
     /// Use this function when your data is a sample from a population.
     /// To calculate the variance from the entire population use <see cref="VarianceP(double[])"/>.
     /// </summary>
-    public static double NaNVarianceP<T>(IReadOnlyList<T> values)
+    public static double NanVarianceP<T>(IReadOnlyList<T> values)
     {
-        return VarianceP(RemoveNaN(values));
+        IReadOnlyList<double> real = RemoveNaN(values);
+
+        if (real.Count() < 2)
+            return double.NaN;
+
+        return VarianceP(real);
     }
 
     /// <summary>
     /// Return the sample standard deviation (the square root of the sample variance).
     /// NaN values are ignored.
     /// </summary>
-    public static double NaNStandardDeviation<T>(IReadOnlyList<T> values)
+    public static double NanStandardDeviation<T>(IReadOnlyList<T> values)
     {
-        return StandardDeviation(RemoveNaN(values));
+        IReadOnlyList<double> real = RemoveNaN(values);
+
+        if (real.Count() < 2)
+            return double.NaN;
+
+        return StandardDeviation(real);
     }
 
     /// <summary>
     /// Return the population standard deviation (the square root of the sample variance).
     /// NaN values are ignored.
     /// </summary>
-    public static double NaNStandardDeviationP<T>(IReadOnlyList<T> values)
+    public static double NanStandardDeviationP<T>(IReadOnlyList<T> values)
     {
-        return StandardDeviationP(RemoveNaN(values));
+        IReadOnlyList<double> real = RemoveNaN(values);
+
+        if (real.Count() < 2)
+            return double.NaN;
+
+        return StandardDeviationP(real);
     }
 
     /// <summary>
     /// Standard error of the mean.
     /// NaN values are ignored.
     /// </summary>
-    public static double NaNStandardError<T>(IReadOnlyList<T> values)
+    public static double NanStandardError<T>(IReadOnlyList<T> values)
     {
-        return StandardError(RemoveNaN(values));
+        IReadOnlyList<double> real = RemoveNaN(values);
+
+        if (!real.Any())
+            return double.NaN;
+
+        return StandardError(real);
     }
 
     /// <summary>
@@ -290,39 +327,105 @@ public static class Descriptive
         return vector;
     }
 
-    public static double NaNMean(double[,] values, uint row = 0, uint? column = null)
+    public static double NanMean(double[,] values, uint row = 0, uint? column = null)
     {
         double[] vector = ArrayToVector(values, row, column);
-        return NaNMean(vector);
+        return NanMean(vector);
     }
 
-    public static double NaNVariance<T>(double[,] values, uint row = 0, uint? column = null)
+    public static double NanVariance<T>(double[,] values, uint row = 0, uint? column = null)
     {
         double[] vector = ArrayToVector(values, row, column);
         return Variance(RemoveNaN(vector));
     }
 
-    public static double NaNVarianceP<T>(double[,] values, uint row = 0, uint? column = null)
+    public static double NanVarianceP<T>(double[,] values, uint row = 0, uint? column = null)
     {
         double[] vector = ArrayToVector(values, row, column);
         return VarianceP(RemoveNaN(vector));
     }
 
-    public static double NaNStandardDeviation<T>(double[,] values, uint row = 0, uint? column = null)
+    public static double NanStandardDeviation<T>(double[,] values, uint row = 0, uint? column = null)
     {
         double[] vector = ArrayToVector(values, row, column);
         return StandardDeviation(RemoveNaN(vector));
     }
 
-    public static double NaNStandardDeviationP<T>(double[,] values, uint row = 0, uint? column = null)
+    public static double NanStandardDeviationP<T>(double[,] values, uint row = 0, uint? column = null)
     {
         double[] vector = ArrayToVector(values, row, column);
         return StandardDeviationP(RemoveNaN(vector));
     }
 
-    public static double NaNStandardError<T>(double[,] values, uint row = 0, uint? column = null)
+    public static double NanStandardError<T>(double[,] values, uint row = 0, uint? column = null)
     {
         double[] vector = ArrayToVector(values, row, column);
-        return NaNStandardError(RemoveNaN(vector));
+        return NanStandardError(RemoveNaN(vector));
+    }
+
+    public static double[] VerticalSlice(double[,] values, int columnIndex)
+    {
+        double[] slice = new double[values.GetLength(0)];
+
+        for (int y = 0; y < slice.Length; y++)
+        {
+            slice[y] = values[y, columnIndex];
+        }
+
+        return slice;
+    }
+
+    public static double[] VerticalMean(double[,] values)
+    {
+        return Enumerable
+            .Range(0, values.GetLength(1))
+            .Select(x => VerticalSlice(values, x))
+            .Select(Mean)
+            .ToArray();
+    }
+
+    public static double[] VerticalNanMean(double[,] values)
+    {
+        return Enumerable
+            .Range(0, values.GetLength(1))
+            .Select(x => VerticalSlice(values, x))
+            .Select(NanMean)
+            .ToArray();
+    }
+
+    public static double[] VerticalStandardDeviation(double[,] values)
+    {
+        return Enumerable
+            .Range(0, values.GetLength(1))
+            .Select(x => VerticalSlice(values, x))
+            .Select(StandardDeviation)
+            .ToArray();
+    }
+
+    public static double[] VerticalNanStandardDeviation(double[,] values)
+    {
+        return Enumerable
+            .Range(0, values.GetLength(1))
+            .Select(x => VerticalSlice(values, x))
+            .Select(NanStandardDeviation)
+            .ToArray();
+    }
+
+    public static double[] VerticalStandardError(double[,] values)
+    {
+        return Enumerable
+            .Range(0, values.GetLength(1))
+            .Select(x => VerticalSlice(values, x))
+            .Select(StandardError)
+            .ToArray();
+    }
+
+    public static double[] VerticalNanStandardError(double[,] values)
+    {
+        return Enumerable
+            .Range(0, values.GetLength(1))
+            .Select(x => VerticalSlice(values, x))
+            .Select(NanStandardError)
+            .ToArray();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Statistics/Descriptive.cs
+++ b/src/ScottPlot5/ScottPlot5/Statistics/Descriptive.cs
@@ -164,4 +164,165 @@ public static class Descriptive
     {
         return StandardDeviation(values) / Math.Sqrt(values.Count);
     }
+
+
+    public static IReadOnlyList<double> RemoveNaN<T>(IReadOnlyList<T> values)
+    {
+        double[] values2 = NumericConversion.GenericToDoubleArray(values);
+        List<double> values3 = new();
+
+        foreach (double value in values2)
+        {
+            if (!double.IsNaN(value))
+                values3.Add(value);
+        }
+
+        return values3;
+    }
+
+    public static double[] RemoveNaN(double[] values)
+    {
+        List<double> values2 = new();
+
+        foreach (double value in values)
+        {
+            if (!double.IsNaN(value))
+                values2.Add(value);
+        }
+
+        return values2.ToArray();
+    }
+
+    /// <summary>
+    /// Return the sample mean. NaN values are ignored.
+    /// </summary>
+    public static double NaNMean<T> (IReadOnlyList<T> values)
+    {
+        return Mean(RemoveNaN(values));
+    }
+
+    /// <summary>
+    /// Return the sample variance (second moment about the mean) of data.
+    /// Input must contain at least two values. NaN values are ignored.
+    /// Use this function when your data is a sample from a population.
+    /// To calculate the variance from the entire population use <see cref="VarianceP(double[])"/>.
+    /// </summary>
+    public static double NaNVariance<T>(IReadOnlyList<T> values)
+    {
+        return Variance(RemoveNaN(values));
+    }
+
+    /// <summary>
+    /// Return the sample variance (second moment about the mean) of data.
+    /// Input must contain at least two values. NaN values are ignored.
+    /// Use this function when your data is a sample from a population.
+    /// To calculate the variance from the entire population use <see cref="VarianceP(double[])"/>.
+    /// </summary>
+    public static double NaNVarianceP<T>(IReadOnlyList<T> values)
+    {
+        return VarianceP(RemoveNaN(values));
+    }
+
+    /// <summary>
+    /// Return the sample standard deviation (the square root of the sample variance).
+    /// NaN values are ignored.
+    /// </summary>
+    public static double NaNStandardDeviation<T>(IReadOnlyList<T> values)
+    {
+        return StandardDeviation(RemoveNaN(values));
+    }
+
+    /// <summary>
+    /// Return the population standard deviation (the square root of the sample variance).
+    /// NaN values are ignored.
+    /// </summary>
+    public static double NaNStandardDeviationP<T>(IReadOnlyList<T> values)
+    {
+        return StandardDeviationP(RemoveNaN(values));
+    }
+
+    /// <summary>
+    /// Standard error of the mean.
+    /// NaN values are ignored.
+    /// </summary>
+    public static double NaNStandardError<T>(IReadOnlyList<T> values)
+    {
+        return StandardError(RemoveNaN(values));
+    }
+
+    /// <summary>
+    /// Transpose a multidimensional (not jagged) array
+    /// </summary>
+    public static double[,] Rotate90(double[,] matrix)
+    {
+        int rows = matrix.GetLength(0);
+        int cols = matrix.GetLength(1);
+        double[,] result = new double[cols, rows];
+
+        for (int i = 0; i < rows; i++)
+        {
+            for (int j = 0; j < cols; j++)
+                result[j, i] = matrix[i, j];
+
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Extracts a row or column from a 2D array
+    /// </summary>
+    public static double[] ArrayToVector(double[,] values, uint? row = 0, uint? column = null)
+    {
+        if (values.GetLength(0) == 0)
+            throw new ArgumentException($"{nameof(values)} cannot be empty");
+
+        double[] vector = Array.Empty<double>();
+        if (row is not null)
+        {
+            vector = new double[values.GetLength(1)];
+            Array.Copy(values, (int)row * values.GetLength(1), vector, 0, values.GetLength(1));
+        }
+        else if (column is not null)
+        {
+            vector = ArrayToVector(Rotate90(values), column);
+        }
+
+        return vector;
+    }
+
+    public static double NaNMean(double[,] values, uint row = 0, uint? column = null)
+    {
+        double[] vector = ArrayToVector(values, row, column);
+        return NaNMean(vector);
+    }
+
+    public static double NaNVariance<T>(double[,] values, uint row = 0, uint? column = null)
+    {
+        double[] vector = ArrayToVector(values, row, column);
+        return Variance(RemoveNaN(vector));
+    }
+
+    public static double NaNVarianceP<T>(double[,] values, uint row = 0, uint? column = null)
+    {
+        double[] vector = ArrayToVector(values, row, column);
+        return VarianceP(RemoveNaN(vector));
+    }
+
+    public static double NaNStandardDeviation<T>(double[,] values, uint row = 0, uint? column = null)
+    {
+        double[] vector = ArrayToVector(values, row, column);
+        return StandardDeviation(RemoveNaN(vector));
+    }
+
+    public static double NaNStandardDeviationP<T>(double[,] values, uint row = 0, uint? column = null)
+    {
+        double[] vector = ArrayToVector(values, row, column);
+        return StandardDeviationP(RemoveNaN(vector));
+    }
+
+    public static double NaNStandardError<T>(double[,] values, uint row = 0, uint? column = null)
+    {
+        double[] vector = ArrayToVector(values, row, column);
+        return NaNStandardError(RemoveNaN(vector));
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Statistics/Descriptive.cs
+++ b/src/ScottPlot5/ScottPlot5/Statistics/Descriptive.cs
@@ -196,7 +196,7 @@ public static class Descriptive
     /// <summary>
     /// Return the sample mean. NaN values are ignored.
     /// </summary>
-    public static double NaNMean<T> (IReadOnlyList<T> values)
+    public static double NaNMean<T>(IReadOnlyList<T> values)
     {
         return Mean(RemoveNaN(values));
     }


### PR DESCRIPTION
**Purpose:**
* Proposes initial solution for #3113 
* Adds new overloaded methods: `NaNMean<T>`, `NaNVariance<T>`, `NaNVarianceP<T>`, `NaNStandardDeviation<T>`, `NaNStandardDeviationP<T>`, and `NaNStandardError<T>`, for both `IReadOnlyList` and 2D (not jagged) arrays.
* Auxiliary functions: `RemoveNaN<T>`, `RemoveNaN`, `ArrayTraspose`, and `ArrayToVector`, are defined as `public` but they are only used internally. Consider making them `private`.
* Auxiliary functions: `RemoveNaN<T>`, `RemoveNaN`, `ArrayTraspose`, and `ArrayToVector` do not really belong to `Descriptive.cs`. Should they be relocated to `NumericConversion.cs`?
