### PR TITLE
SP5: Implement SignalConst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## ScottPlot 5.0.15-beta (not yet on NuGet)
 * Ticks: Added additional styling options for axis tick labels (#3185) _Thanks @barnettben_
 * Finance: Added `Sequential` property to display OHLC data without gaps (#2611, #3187) _Thanks @robbyls, @mjpz, and @segeyros_
+* SignalConst: A high performance plot type for evenly-spaced unchanging data (#70, #3188) _Thanks @StendProg_
 
 ## ScottPlot 5.0.14-beta
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-10_

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml
@@ -7,6 +7,22 @@
         xmlns:local="clr-namespace:Sandbox.WPF"
         mc:Ignorable="d"
         WindowStartupLocation="CenterScreen"
-        Title="ScottPlot 5 - WPF Sandbox" Height="300" Width="500">
-    <ScottPlot:WpfPlot x:Name="WpfPlot1"/>
+        Title="ScottPlot 5 - WPF Sandbox" Height="800" Width="800">
+
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="2*"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="2*"/>
+            <RowDefinition Height="2*"/>
+        </Grid.RowDefinitions>
+
+        <ScrollViewer Grid.Column="0" Grid.Row="0" Grid.RowSpan="2">
+            <StackPanel x:Name="charts">
+
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
 </Window>

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml
@@ -7,22 +7,7 @@
         xmlns:local="clr-namespace:Sandbox.WPF"
         mc:Ignorable="d"
         WindowStartupLocation="CenterScreen"
-        Title="ScottPlot 5 - WPF Sandbox" Height="800" Width="800">
-
-    <Grid>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="2*"/>
-            <ColumnDefinition Width="2*"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="2*"/>
-            <RowDefinition Height="2*"/>
-        </Grid.RowDefinitions>
-
-        <ScrollViewer Grid.Column="0" Grid.Row="0" Grid.RowSpan="2">
-            <StackPanel x:Name="charts">
-
-            </StackPanel>
-        </ScrollViewer>
-    </Grid>
+        Title="ScottPlot 5 - WPF Sandbox" 
+        Height="600" Width="800">
+    <ScottPlot:WpfPlot Name="WpfPlot1" />
 </Window>

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml.cs
@@ -1,5 +1,8 @@
-﻿using System.Windows;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
 using ScottPlot;
+using ScottPlot.WPF;
 
 namespace Sandbox.WPF;
 
@@ -8,9 +11,56 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+        ShowCharts();
+    }
 
-        WpfPlot1.Plot.Add.Signal(Generate.Sin());
-        WpfPlot1.Plot.Add.Signal(Generate.Cos());
-        WpfPlot1.Refresh();
+    private void ShowCharts()
+    {
+        List<WpfPlot> wpfPlotList = new();
+
+        for (int i = 0; i < 11; i++)
+        {
+            double[] doubles = Generate.RandomWalk(7_016_960);
+            float[] floats = doubles.Select(x => (float)x).ToArray();
+
+            var plot = new WpfPlot();
+            plot.Plot.Add.Signal(doubles, 256);
+            wpfPlotList.Add(plot);
+        }
+
+        for (int sourceIndex = 0; sourceIndex < wpfPlotList.Count; sourceIndex++)
+        {
+            var sourceChart = wpfPlotList[sourceIndex];
+            sourceChart.Height = 200;
+
+            for (int targetIndex = 0; targetIndex < wpfPlotList.Count; targetIndex++)
+            {
+                if (sourceIndex == targetIndex)
+                    continue;
+                var targetChart = wpfPlotList[targetIndex];
+                sourceChart.MouseUp += (s, e) =>
+                {
+                    ApplyLayoutToOtherPlot(sourceChart, targetChart);
+                };
+            }
+
+            var rule = new ScottPlot.AxisRules.LockedVertical(sourceChart.Plot.Axes.Left);
+            sourceChart.Plot.Axes.Rules.Clear();
+            sourceChart.Plot.Axes.Rules.Add(rule);
+            sourceChart.Refresh();
+
+            charts.Children.Add(sourceChart);
+        }
+    }
+
+    private void ApplyLayoutToOtherPlot(IPlotControl source, IPlotControl target)
+    {
+        AxisLimits axesBefore = target.Plot.Axes.GetLimits();
+        target.Plot.Axes.SetLimitsX(source.Plot.Axes.GetLimits());
+        AxisLimits axesAfter = target.Plot.Axes.GetLimits();
+        if (axesBefore != axesAfter)
+        {
+            target.Refresh();
+        }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml.cs
@@ -1,8 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Windows;
+﻿using System.Windows;
 using ScottPlot;
-using ScottPlot.WPF;
 
 namespace Sandbox.WPF;
 
@@ -11,56 +8,8 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
-        ShowCharts();
-    }
-
-    private void ShowCharts()
-    {
-        List<WpfPlot> wpfPlotList = new();
-
-        for (int i = 0; i < 11; i++)
-        {
-            double[] doubles = Generate.RandomWalk(7_016_960);
-            float[] floats = doubles.Select(x => (float)x).ToArray();
-
-            var plot = new WpfPlot();
-            plot.Plot.Add.Signal(doubles, 256);
-            wpfPlotList.Add(plot);
-        }
-
-        for (int sourceIndex = 0; sourceIndex < wpfPlotList.Count; sourceIndex++)
-        {
-            var sourceChart = wpfPlotList[sourceIndex];
-            sourceChart.Height = 200;
-
-            for (int targetIndex = 0; targetIndex < wpfPlotList.Count; targetIndex++)
-            {
-                if (sourceIndex == targetIndex)
-                    continue;
-                var targetChart = wpfPlotList[targetIndex];
-                sourceChart.MouseUp += (s, e) =>
-                {
-                    ApplyLayoutToOtherPlot(sourceChart, targetChart);
-                };
-            }
-
-            var rule = new ScottPlot.AxisRules.LockedVertical(sourceChart.Plot.Axes.Left);
-            sourceChart.Plot.Axes.Rules.Clear();
-            sourceChart.Plot.Axes.Rules.Add(rule);
-            sourceChart.Refresh();
-
-            charts.Children.Add(sourceChart);
-        }
-    }
-
-    private void ApplyLayoutToOtherPlot(IPlotControl source, IPlotControl target)
-    {
-        AxisLimits axesBefore = target.Plot.Axes.GetLimits();
-        target.Plot.Axes.SetLimitsX(source.Plot.Axes.GetLimits());
-        AxisLimits axesAfter = target.Plot.Axes.GetLimits();
-        if (axesBefore != axesAfter)
-        {
-            target.Refresh();
-        }
+        double[] values = Generate.RandomWalk(10_000_000);
+        WpfPlot1.Plot.Add.SignalConst(values);
+        WpfPlot1.Plot.Title($"{values.Length:N0} Points");
     }
 }

--- a/src/ScottPlot5/ScottPlot5/DataSources/SegmentedTree.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SegmentedTree.cs
@@ -1,0 +1,309 @@
+﻿using System.Threading.Tasks;
+
+namespace ScottPlot.DataSources;
+
+public class SegmentedTree<T> where T : struct, IComparable
+{
+    private T[] sourceArray;
+
+    private T[] TreeMin;
+    private T[] TreeMax;
+    private int n = 0; // size of each Tree
+    public bool TreesReady = false;
+
+    // precompiled lambda expressions for fast math on generic
+    private static Func<T, T, T> MinExp;
+    private static Func<T, T, T> MaxExp;
+    private static Func<T, T, bool> EqualExp;
+    private static Func<T> MaxValue;
+    private static Func<T> MinValue;
+    private static Func<T, T, bool> LessThanExp;
+    private static Func<T, T, bool> GreaterThanExp;
+
+    public T[] SourceArray
+    {
+        get => sourceArray;
+        set
+        {
+            sourceArray = value ?? throw new Exception("Source Array cannot be null");
+            UpdateTrees();
+        }
+    }
+
+    public SegmentedTree()
+    {
+        try // runtime check
+        {
+            var v = new T();
+            NumericConversion.GenericToDouble(ref v);
+        }
+        catch
+        {
+            throw new ArgumentOutOfRangeException("Unsupported data type, provide convertable to double data types");
+        }
+        InitExp();
+    }
+
+    public async Task SetSourceAsync(T[] data)
+    {
+        sourceArray = data ?? throw new ArgumentNullException("Data cannot be null");
+        await Task.Run(() => UpdateTrees());
+    }
+
+    private void InitExp()
+    {
+        ParameterExpression paramA = Expression.Parameter(typeof(T), "a");
+        ParameterExpression paramB = Expression.Parameter(typeof(T), "b");
+        // add the parameters together
+        ConditionalExpression bodyMin = Expression.Condition(Expression.LessThanOrEqual(paramA, paramB), paramA, paramB);
+        ConditionalExpression bodyMax = Expression.Condition(Expression.GreaterThanOrEqual(paramA, paramB), paramA, paramB);
+        BinaryExpression bodyEqual = Expression.Equal(paramA, paramB);
+        MemberExpression bodyMaxValue = Expression.MakeMemberAccess(null, typeof(T).GetField("MaxValue"));
+        MemberExpression bodyMinValue = Expression.MakeMemberAccess(null, typeof(T).GetField("MinValue"));
+        BinaryExpression bodyLessThan = Expression.LessThan(paramA, paramB);
+        BinaryExpression bodyGreaterThan = Expression.GreaterThan(paramA, paramB);
+        // compile it
+        MinExp = Expression.Lambda<Func<T, T, T>>(bodyMin, paramA, paramB).Compile();
+        MaxExp = Expression.Lambda<Func<T, T, T>>(bodyMax, paramA, paramB).Compile();
+        EqualExp = Expression.Lambda<Func<T, T, bool>>(bodyEqual, paramA, paramB).Compile();
+        MaxValue = Expression.Lambda<Func<T>>(bodyMaxValue).Compile();
+        MinValue = Expression.Lambda<Func<T>>(bodyMinValue).Compile();
+        LessThanExp = Expression.Lambda<Func<T, T, bool>>(bodyLessThan, paramA, paramB).Compile();
+        GreaterThanExp = Expression.Lambda<Func<T, T, bool>>(bodyGreaterThan, paramA, paramB).Compile();
+    }
+
+    public void updateElement(int index, T newValue)
+    {
+        sourceArray[index] = newValue;
+        // Update Tree, can be optimized            
+        if (index == sourceArray.Length - 1) // last elem haven't pair
+        {
+            TreeMin[n / 2 + index / 2] = sourceArray[index];
+            TreeMax[n / 2 + index / 2] = sourceArray[index];
+        }
+        else if (index % 2 == 0) // even elem have right pair
+        {
+            TreeMin[n / 2 + index / 2] = MinExp(sourceArray[index], sourceArray[index + 1]);
+            TreeMax[n / 2 + index / 2] = MaxExp(sourceArray[index], sourceArray[index + 1]);
+        }
+        else // odd elem have left pair
+        {
+            TreeMin[n / 2 + index / 2] = MinExp(sourceArray[index], sourceArray[index - 1]);
+            TreeMax[n / 2 + index / 2] = MaxExp(sourceArray[index], sourceArray[index - 1]);
+        }
+
+        T candidate;
+        for (int i = (n / 2 + index / 2) / 2; i > 0; i /= 2)
+        {
+            candidate = MinExp(TreeMin[i * 2], TreeMin[i * 2 + 1]);
+            if (EqualExp(TreeMin[i], candidate)) // if node same then new value don't need to recalc all upper
+                break;
+            TreeMin[i] = candidate;
+        }
+        for (int i = (n / 2 + index / 2) / 2; i > 0; i /= 2)
+        {
+            candidate = MaxExp(TreeMax[i * 2], TreeMax[i * 2 + 1]);
+            if (EqualExp(TreeMax[i], candidate)) // if node same then new value don't need to recalc all upper
+                break;
+            TreeMax[i] = candidate;
+        }
+    }
+
+    public void updateRange(int from, int to, T[] newData, int fromData = 0) // RangeUpdate
+    {
+        //update source signal
+        for (int i = from; i < to; i++)
+        {
+            sourceArray[i] = newData[i - from + fromData];
+        }
+
+        for (int i = n / 2 + from / 2; i < n / 2 + to / 2; i++)
+        {
+            TreeMin[i] = MinExp(sourceArray[i * 2 - n], sourceArray[i * 2 + 1 - n]);
+            TreeMax[i] = MaxExp(sourceArray[i * 2 - n], sourceArray[i * 2 + 1 - n]);
+        }
+        if (to == sourceArray.Length) // last elem haven't pair
+        {
+            TreeMin[n / 2 + to / 2] = sourceArray[to - 1];
+            TreeMax[n / 2 + to / 2] = sourceArray[to - 1];
+        }
+        else if (to % 2 == 1) //last elem even(to-1) and not last
+        {
+            TreeMin[n / 2 + to / 2] = MinExp(sourceArray[to - 1], sourceArray[to]);
+            TreeMax[n / 2 + to / 2] = MaxExp(sourceArray[to - 1], sourceArray[to]);
+        }
+
+        from = (n / 2 + from / 2) / 2;
+        to = (n / 2 + to / 2) / 2;
+
+        T candidate;
+        while (from != 0) // up to root elem, that is [1], [0] - is free elem
+        {
+            if (from != to)
+            {
+                for (int i = from; i <= to; i++) // Recalc all level nodes in range 
+                {
+                    TreeMin[i] = MinExp(TreeMin[i * 2], TreeMin[i * 2 + 1]);
+                    TreeMax[i] = MaxExp(TreeMax[i * 2], TreeMax[i * 2 + 1]);
+                }
+            }
+            else
+            {
+                // left == rigth, so no need more from to loop
+                for (int i = from; i > 0; i /= 2) // up to root node
+                {
+                    candidate = MinExp(TreeMin[i * 2], TreeMin[i * 2 + 1]);
+                    if (EqualExp(TreeMin[i], candidate)) // if node same then new value don't need to recalc all upper
+                        break;
+                    TreeMin[i] = candidate;
+                }
+
+                for (int i = from; i > 0; i /= 2) // up to root node
+                {
+                    candidate = MaxExp(TreeMax[i * 2], TreeMax[i * 2 + 1]);
+                    if (EqualExp(TreeMax[i], candidate)) // if node same then new value don't need to recalc all upper
+                        break;
+                    TreeMax[i] = candidate;
+                }
+                // all work done exit while loop
+                break;
+            }
+            // level up
+            from = from / 2;
+            to = to / 2;
+        }
+    }
+
+    public void updateData(int from, T[] newData)
+    {
+        updateRange(from, newData.Length, newData);
+    }
+
+    public void updateData(T[] newData)
+    {
+        updateRange(0, newData.Length, newData);
+    }
+
+    public void UpdateTreesInBackground()
+    {
+        Task.Run(() => { UpdateTrees(); });
+    }
+
+    public void UpdateTrees()
+    {
+        // O(n) to build trees
+        TreesReady = false;
+        try
+        {
+            if (sourceArray.Length == 0)
+                throw new ArgumentOutOfRangeException($"Array cant't be empty");
+            // Size up to pow2
+            if (sourceArray.Length > 0x40_00_00_00) // pow 2 must be more then int.MaxValue
+                throw new ArgumentOutOfRangeException($"Array higher than {0x40_00_00_00} not supported by SignalConst");
+            int pow2 = 1;
+            while (pow2 < 0x40_00_00_00 && pow2 < sourceArray.Length)
+                pow2 <<= 1;
+            n = pow2;
+            TreeMin = new T[n];
+            TreeMax = new T[n];
+            T maxValue = MaxValue();
+            T minValue = MinValue();
+
+            // fill bottom layer of tree
+            for (int i = 0; i < sourceArray.Length / 2; i++) // with source array pairs min/max
+            {
+                TreeMin[n / 2 + i] = MinExp(sourceArray[i * 2], sourceArray[i * 2 + 1]);
+                TreeMax[n / 2 + i] = MaxExp(sourceArray[i * 2], sourceArray[i * 2 + 1]);
+            }
+            if (sourceArray.Length % 2 == 1) // if array size odd, last element haven't pair to compare
+            {
+                TreeMin[n / 2 + sourceArray.Length / 2] = sourceArray[sourceArray.Length - 1];
+                TreeMax[n / 2 + sourceArray.Length / 2] = sourceArray[sourceArray.Length - 1];
+            }
+            for (int i = n / 2 + (sourceArray.Length + 1) / 2; i < n; i++) // min/max for pairs of nonexistent elements
+            {
+                TreeMin[i] = minValue;
+                TreeMax[i] = maxValue;
+            }
+            // fill other layers
+            for (int i = n / 2 - 1; i > 0; i--)
+            {
+                TreeMin[i] = MinExp(TreeMin[2 * i], TreeMin[2 * i + 1]);
+                TreeMax[i] = MaxExp(TreeMax[2 * i], TreeMax[2 * i + 1]);
+            }
+            TreesReady = true;
+        }
+        catch (OutOfMemoryException)
+        {
+            TreeMin = null;
+            TreeMax = null;
+            TreesReady = false;
+            return;
+        }
+    }
+
+    //  O(log(n)) for each range min/max query
+    public void MinMaxRangeQuery(int l, int r, out double lowestValue, out double highestValue)
+    {
+        T lowestValueT;
+        T highestValueT;
+        // if the tree calculation isn't finished or if it crashed
+        if (!TreesReady)
+        {
+            // use the original (slower) min/max calculated method
+            lowestValueT = sourceArray[l];
+            highestValueT = sourceArray[l];
+            for (int i = l; i < r; i++)
+            {
+                if (LessThanExp(sourceArray[i], lowestValueT))
+                    lowestValueT = sourceArray[i];
+                if (GreaterThanExp(sourceArray[i], highestValueT))
+                    highestValueT = sourceArray[i];
+            }
+            lowestValue = NumericConversion.GenericToDouble(ref lowestValueT);
+            highestValue = NumericConversion.GenericToDouble(ref highestValueT);
+            return;
+        }
+
+        lowestValueT = MaxValue();
+        highestValueT = MinValue();
+        if (l == r)
+        {
+            lowestValue = highestValue = NumericConversion.GenericToDouble(ref sourceArray[l]);
+            return;
+        }
+        // first iteration on source array that virtualy bottom of tree
+        if ((l & 1) == 1) // l is right child
+        {
+            lowestValueT = MinExp(lowestValueT, sourceArray[l]);
+            highestValueT = MaxExp(highestValueT, sourceArray[l]);
+        }
+        if ((r & 1) != 1) // r is left child
+        {
+            lowestValueT = MinExp(lowestValueT, sourceArray[r]);
+            highestValueT = MaxExp(highestValueT, sourceArray[r]);
+        }
+        // go up from array to bottom of Tree
+        l = (l + n + 1) / 2;
+        r = (r + n - 1) / 2;
+        // next iterations on tree
+        while (l <= r)
+        {
+            if ((l & 1) == 1) // l is right child
+            {
+                lowestValueT = MinExp(lowestValueT, TreeMin[l]);
+                highestValueT = MaxExp(highestValueT, TreeMax[l]);
+            }
+            if ((r & 1) != 1) // r is left child
+            {
+                lowestValueT = MinExp(lowestValueT, TreeMin[r]);
+                highestValueT = MaxExp(highestValueT, TreeMax[r]);
+            }
+            // go up one level
+            l = (l + 1) / 2;
+            r = (r - 1) / 2;
+        }
+        lowestValue = NumericConversion.GenericToDouble(ref lowestValueT);
+        highestValue = NumericConversion.GenericToDouble(ref highestValueT);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalConstSource.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalConstSource.cs
@@ -1,0 +1,5 @@
+﻿namespace ScottPlot.DataSources;
+
+public class SignalConstSource
+{
+}

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalConstSource.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalConstSource.cs
@@ -1,5 +1,0 @@
-﻿namespace ScottPlot.DataSources;
-
-public class SignalConstSource
-{
-}

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalConstSourceArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalConstSourceArray.cs
@@ -1,0 +1,91 @@
+﻿namespace ScottPlot.DataSources;
+
+public class SignalConstSourceArray<T>
+    where T : struct, IComparable
+{
+    public readonly SegmentedTree<T> SegmentedTree = new();
+
+    public readonly T[] Ys;
+    public readonly double Period;
+
+    public double XOffset = 0;
+    public double YOffset = 0;
+    public int MinRenderIndex = 0;
+    public int MaxRenderIndex = int.MaxValue;
+
+    public SignalConstSourceArray(T[] ys, double period)
+    {
+        Ys = ys;
+        Period = period;
+        SegmentedTree.SourceArray = ys;
+        MaxRenderIndex = ys.Length - 1;
+    }
+    public AxisLimits GetAxisLimits()
+    {
+        SegmentedTree.MinMaxRangeQuery(0, Ys.Length - 1, out double low, out double high);
+        return new AxisLimits(0, Ys.Length * Period, low, high);
+    }
+
+    public int GetIndex(double x, bool visibleDataOnly)
+    {
+        int i = (int)((x - XOffset) / Period);
+
+        if (visibleDataOnly)
+        {
+            i = Math.Max(i, MinRenderIndex);
+            i = Math.Min(i, MaxRenderIndex);
+        }
+
+        return i;
+    }
+
+    public bool RangeContainsSignal(double xMin, double xMax)
+    {
+        int xMinIndex = GetIndex(xMin, false);
+        int xMaxIndex = GetIndex(xMax, false);
+        return xMaxIndex >= MinRenderIndex && xMinIndex <= MaxRenderIndex;
+    }
+
+    public SignalRangeY GetLimitsY(int firstIndex, int lastIndex)
+    {
+        double min = double.PositiveInfinity;
+        double max = double.NegativeInfinity;
+
+        for (int i = firstIndex; i <= lastIndex; i++)
+        {
+            double value = NumericConversion.GenericToDouble(Ys, i);
+            min = Math.Min(min, value);
+            max = Math.Max(max, value);
+        }
+
+        return new SignalRangeY(min, max);
+    }
+
+    public PixelColumn GetPixelColumn(IAxes axes, int xPixelIndex)
+    {
+        float xPixel = axes.DataRect.Left + xPixelIndex;
+        double xRangeMin = axes.GetCoordinateX(xPixel);
+        float xUnitsPerPixel = (float)(axes.XAxis.Width / axes.DataRect.Width);
+        double xRangeMax = xRangeMin + xUnitsPerPixel;
+
+        if (RangeContainsSignal(xRangeMin, xRangeMax) == false)
+            return PixelColumn.WithoutData(xPixel);
+
+        // determine column limits horizontally
+        int i1 = GetIndex(xRangeMin, true);
+        int i2 = GetIndex(xRangeMax, true);
+
+        // first and last Y vales for this column
+        double y1 = NumericConversion.GenericToDouble(Ys, i1);
+        double y2 = NumericConversion.GenericToDouble(Ys, i2);
+        float yEnter = axes.GetPixelY(y1 + YOffset);
+        float yExit = axes.GetPixelY(y2 + YOffset);
+
+        // column min and max
+        SignalRangeY rangeY = GetLimitsY(i1, i2);
+        float yBottom = axes.GetPixelY(rangeY.Min + YOffset);
+        float yTop = axes.GetPixelY(rangeY.Max + YOffset);
+
+        return new PixelColumn(xPixel, yEnter, yExit, yBottom, yTop);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceBase.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceBase.cs
@@ -26,6 +26,7 @@ public abstract class SignalSourceBase
 
         return i;
     }
+
     public bool RangeContainsSignal(double xMin, double xMax)
     {
         int xMinIndex = GetIndex(xMin, false);

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -423,6 +423,18 @@ public class PlottableAdder
         return sig;
     }
 
+    public SignalConst SignalConst(double[] ys, double period = 1, Color? color = null)
+    {
+        SignalConst sig = new(ys, period)
+        {
+            Color = color ?? GetNextColor()
+        };
+
+        Plot.PlottableList.Add(sig);
+
+        return sig;
+    }
+
     public SignalXY SignalXY(double[] xs, double[] ys, Color? color = null)
     {
         SignalXYSourceDoubleArray dataSource = new(xs, ys);

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -423,9 +423,10 @@ public class PlottableAdder
         return sig;
     }
 
-    public SignalConst SignalConst(double[] ys, double period = 1, Color? color = null)
+    public SignalConst<T> SignalConst<T>(T[] ys, double period = 1, Color? color = null)
+        where T : struct, IComparable
     {
-        SignalConst sig = new(ys, period)
+        SignalConst<T> sig = new(ys, period)
         {
             Color = color ?? GetNextColor()
         };

--- a/src/ScottPlot5/ScottPlot5/Plottables/SignalConst.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/SignalConst.cs
@@ -2,20 +2,14 @@
 
 namespace ScottPlot.Plottables;
 
-public class SignalConst : IPlottable
+public class SignalConst<T>(T[] ys, double period) : IPlottable
+    where T : struct, IComparable
 {
-    readonly SegmentedTree<double> SegmentedTree = new();
-    readonly double[] Ys;
-    readonly double Period;
-
+    readonly SignalConstSourceArray<T> DataSource = new(ys, period);
     public readonly MarkerStyle Marker = new();
     public readonly LineStyle LineStyle = new();
 
     public string? Label { get; set; }
-    public double XOffset = 0;
-    public double YOffset = 0;
-    public int MinRenderIndex = 0;
-    public int MaxRenderIndex = int.MaxValue;
 
     public Color Color
     {
@@ -28,84 +22,12 @@ public class SignalConst : IPlottable
         }
     }
 
-    public SignalConst(double[] ys, double period = 1)
-    {
-        Ys = ys;
-        Period = period;
-        SegmentedTree.SourceArray = ys;
-        MaxRenderIndex = ys.Length - 1;
-    }
-
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = ScottPlot.Axes.Default;
 
     public IEnumerable<LegendItem> LegendItems => LegendItem.None;
 
-    public AxisLimits GetAxisLimits()
-    {
-        SegmentedTree.MinMaxRangeQuery(0, Ys.Length - 1, out double low, out double high);
-        return new AxisLimits(0, Ys.Length * Period, low, high);
-    }
-
-    public int GetIndex(double x, bool visibleDataOnly)
-    {
-        int i = (int)((x - XOffset) / Period);
-
-        if (visibleDataOnly)
-        {
-            i = Math.Max(i, MinRenderIndex);
-            i = Math.Min(i, MaxRenderIndex);
-        }
-
-        return i;
-    }
-
-    public bool RangeContainsSignal(double xMin, double xMax)
-    {
-        int xMinIndex = GetIndex(xMin, false);
-        int xMaxIndex = GetIndex(xMax, false);
-        return xMaxIndex >= MinRenderIndex && xMinIndex <= MaxRenderIndex;
-    }
-
-    public SignalRangeY GetLimitsY(int firstIndex, int lastIndex)
-    {
-        double min = double.PositiveInfinity;
-        double max = double.NegativeInfinity;
-
-        for (int i = firstIndex; i <= lastIndex; i++)
-        {
-            min = Math.Min(min, Ys[i]);
-            max = Math.Max(max, Ys[i]);
-        }
-
-        return new SignalRangeY(min, max);
-    }
-
-    public PixelColumn GetPixelColumn(IAxes axes, int xPixelIndex)
-    {
-        float xPixel = axes.DataRect.Left + xPixelIndex;
-        double xRangeMin = axes.GetCoordinateX(xPixel);
-        float xUnitsPerPixel = (float)(axes.XAxis.Width / axes.DataRect.Width);
-        double xRangeMax = xRangeMin + xUnitsPerPixel;
-
-        if (RangeContainsSignal(xRangeMin, xRangeMax) == false)
-            return PixelColumn.WithoutData(xPixel);
-
-        // determine column limits horizontally
-        int i1 = GetIndex(xRangeMin, true);
-        int i2 = GetIndex(xRangeMax, true);
-
-        // first and last Y vales for this column
-        float yEnter = axes.GetPixelY(Ys[i1] + YOffset);
-        float yExit = axes.GetPixelY(Ys[i2] + YOffset);
-
-        // column min and max
-        SignalRangeY rangeY = GetLimitsY(i1, i2);
-        float yBottom = axes.GetPixelY(rangeY.Min + YOffset);
-        float yTop = axes.GetPixelY(rangeY.Max + YOffset);
-
-        return new PixelColumn(xPixel, yEnter, yExit, yBottom, yTop);
-    }
+    public AxisLimits GetAxisLimits() => DataSource.GetAxisLimits();
 
     public void Render(RenderPack rp)
     {
@@ -113,7 +35,7 @@ public class SignalConst : IPlottable
         LineStyle.ApplyToPaint(paint);
 
         IEnumerable<PixelColumn> cols = Enumerable.Range(0, (int)Axes.DataRect.Width)
-            .Select(x => GetPixelColumn(Axes, x))
+            .Select(x => DataSource.GetPixelColumn(Axes, x))
             .Where(x => x.HasData);
 
         if (!cols.Any())

--- a/src/ScottPlot5/ScottPlot5/Plottables/SignalConst.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/SignalConst.cs
@@ -1,0 +1,135 @@
+﻿using ScottPlot.DataSources;
+
+namespace ScottPlot.Plottables;
+
+public class SignalConst : IPlottable
+{
+    readonly SegmentedTree<double> SegmentedTree = new();
+    readonly double[] Ys;
+    readonly double Period;
+
+    public readonly MarkerStyle Marker = new();
+    public readonly LineStyle LineStyle = new();
+
+    public string? Label { get; set; }
+    public double XOffset = 0;
+    public double YOffset = 0;
+    public int MinRenderIndex = 0;
+    public int MaxRenderIndex = int.MaxValue;
+
+    public Color Color
+    {
+        get => LineStyle.Color;
+        set
+        {
+            LineStyle.Color = value;
+            Marker.Fill.Color = value;
+            Marker.Outline.Color = value;
+        }
+    }
+
+    public SignalConst(double[] ys, double period = 1)
+    {
+        Ys = ys;
+        Period = period;
+        SegmentedTree.SourceArray = ys;
+        MaxRenderIndex = ys.Length - 1;
+    }
+
+    public bool IsVisible { get; set; } = true;
+    public IAxes Axes { get; set; } = ScottPlot.Axes.Default;
+
+    public IEnumerable<LegendItem> LegendItems => LegendItem.None;
+
+    public AxisLimits GetAxisLimits()
+    {
+        SegmentedTree.MinMaxRangeQuery(0, Ys.Length - 1, out double low, out double high);
+        return new AxisLimits(0, Ys.Length * Period, low, high);
+    }
+
+    public int GetIndex(double x, bool visibleDataOnly)
+    {
+        int i = (int)((x - XOffset) / Period);
+
+        if (visibleDataOnly)
+        {
+            i = Math.Max(i, MinRenderIndex);
+            i = Math.Min(i, MaxRenderIndex);
+        }
+
+        return i;
+    }
+
+    public bool RangeContainsSignal(double xMin, double xMax)
+    {
+        int xMinIndex = GetIndex(xMin, false);
+        int xMaxIndex = GetIndex(xMax, false);
+        return xMaxIndex >= MinRenderIndex && xMinIndex <= MaxRenderIndex;
+    }
+
+    public SignalRangeY GetLimitsY(int firstIndex, int lastIndex)
+    {
+        double min = double.PositiveInfinity;
+        double max = double.NegativeInfinity;
+
+        for (int i = firstIndex; i <= lastIndex; i++)
+        {
+            min = Math.Min(min, Ys[i]);
+            max = Math.Max(max, Ys[i]);
+        }
+
+        return new SignalRangeY(min, max);
+    }
+
+    public PixelColumn GetPixelColumn(IAxes axes, int xPixelIndex)
+    {
+        float xPixel = axes.DataRect.Left + xPixelIndex;
+        double xRangeMin = axes.GetCoordinateX(xPixel);
+        float xUnitsPerPixel = (float)(axes.XAxis.Width / axes.DataRect.Width);
+        double xRangeMax = xRangeMin + xUnitsPerPixel;
+
+        if (RangeContainsSignal(xRangeMin, xRangeMax) == false)
+            return PixelColumn.WithoutData(xPixel);
+
+        // determine column limits horizontally
+        int i1 = GetIndex(xRangeMin, true);
+        int i2 = GetIndex(xRangeMax, true);
+
+        // first and last Y vales for this column
+        float yEnter = axes.GetPixelY(Ys[i1] + YOffset);
+        float yExit = axes.GetPixelY(Ys[i2] + YOffset);
+
+        // column min and max
+        SignalRangeY rangeY = GetLimitsY(i1, i2);
+        float yBottom = axes.GetPixelY(rangeY.Min + YOffset);
+        float yTop = axes.GetPixelY(rangeY.Max + YOffset);
+
+        return new PixelColumn(xPixel, yEnter, yExit, yBottom, yTop);
+    }
+
+    public void Render(RenderPack rp)
+    {
+        using SKPaint paint = new();
+        LineStyle.ApplyToPaint(paint);
+
+        IEnumerable<PixelColumn> cols = Enumerable.Range(0, (int)Axes.DataRect.Width)
+            .Select(x => GetPixelColumn(Axes, x))
+            .Where(x => x.HasData);
+
+        if (!cols.Any())
+            return;
+
+        using SKPath path = new();
+        path.MoveTo(cols.First().X, cols.First().Enter);
+
+        foreach (PixelColumn col in cols)
+        {
+            path.LineTo(col.X, col.Enter);
+            path.MoveTo(col.X, col.Bottom);
+            path.LineTo(col.X, col.Top);
+            path.MoveTo(col.X, col.Exit);
+        }
+
+        rp.Canvas.DrawPath(path, paint);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Primitives/Axes.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Axes.cs
@@ -10,6 +10,8 @@ public class Axes : IAxes
     public IYAxis YAxis { get; set; } = null!;
     public PixelRect DataRect { get; set; }
 
+    public static Axes Default => new();
+
     public Axes()
     {
     }


### PR DESCRIPTION
SignalConst is a high performance plot type for generic numeric data that uses segmented trees to improve range search performance at the expense of storing ranges in memory. Originally discussed in #70. Resolves #3188