### PR TITLE
SP5: Remove duplicated render manager initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-17_
 * SignalXY: Added `MinimumIndex` and `MaximumIndex` for partial array rendering (#3227)
 * SignalXY: Added `OffsetX` and `OffsetY` for for applying a fixed offset in coordinate space (#3227)
 * SignalConst: Improved display when signals are zoomed in enough to see individual points (#3228) _Thanks @Marvenix_
+* Plot: Improved render manager initialization (#3233) _Thanks @VoteForPedro_
 
 ## ScottPlot 5.0.17
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-16_

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -34,7 +34,6 @@ public class Plot : IDisposable
         Style = new(this);
         RenderManager = new(this);
         Legend = new(this);
-        RenderManager = new(this);
         Layout = new(this);
     }
 


### PR DESCRIPTION
Tiny PR aimed to remove duplicated render manager initialization.