### PR TITLE
SP5: `Plot.Remove()` overload that accepts `Type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Ticks: Created `IMinorTickGenerator` to allow users to inject their own logic for placing minor ticks
 * Axes: Added support for log-scale tick labels and grid lines (#3143)
 * Plot: Users can now `Add.Ellipse()` and `Add.Circle()` to place closed curves on plots (#3277, #3287) _Thanks @hockerschwan_
+* Plot: Added a `Plot.Remove()` overload for removing all plottables of the given type (#3296) _Thanks @DerekGooding_
 
 ## ScottPlot 5.0.20
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-21_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Quickstart.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Quickstart.cs
@@ -103,4 +103,33 @@ public class ScottPlotQuickstart : ICategory
             myPlot.ShowLegend();
         }
     }
+
+    public class AddPlottablesManually : RecipeBase
+    {
+        public override string Name => "Add Plottables Manually";
+        public override string Description => "Although the Plot.Add class has many helpful methods " +
+            "for creating plottable objects and adding them to the plot, users can instantiate plottable " +
+            "objects themselves and use Add.Plottable() to place it on the plot. This stategy allows " +
+            "users to create their own plottables (implementing IPlottable) with custom appearance or behavior.";
+
+        [Test]
+        public override void Execute()
+        {
+            // create a plottable and modify it as desired
+            ScottPlot.Plottables.Marker marker = new()
+            {
+                X = 2,
+                Y = 3,
+                Size = 20,
+                Color = Colors.Magenta,
+                Shape = MarkerShape.OpenDiamond,
+                Label = "My Marker",
+            };
+
+            // add the custom plottable to the plot
+            myPlot.Add.Plottable(marker);
+
+            myPlot.ShowLegend();
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SelectPoints.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SelectPoints.cs
@@ -55,11 +55,7 @@ public partial class SelectPoints : Form, IDemoWindow
         RectanglePlot.IsVisible = false;
 
         // clear old markers
-        var oldMarkers = formsPlot1.Plot.PlottableList.OfType<ScottPlot.Plottables.Marker>().ToArray();
-        foreach (var oldMarker in oldMarkers)
-        {
-            formsPlot1.Plot.Remove(oldMarker);
-        }
+        formsPlot1.Plot.Remove(typeof(ScottPlot.Plottables.Marker));
 
         // identify selectedPoints
         var selectedPoints = DataPoints.Where(x => MouseSlectionRect.Contains(x));

--- a/src/ScottPlot5/ScottPlot5 Tests/UnitTests/PlottableManagement.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/UnitTests/PlottableManagement.cs
@@ -1,0 +1,70 @@
+﻿namespace ScottPlotTests.UnitTests;
+
+internal class PlottableManagement
+{
+    [Test]
+    public void Test_Plot_RemoveInstance()
+    {
+        double[] xs = Generate.Consecutive();
+        double[] ys = Generate.Sin();
+
+        Plot myPlot = new();
+
+        // add scatter plots
+        var sp1 = myPlot.Add.Scatter(xs, ys);
+        var sp2 = myPlot.Add.Scatter(xs, ys);
+        var sp3 = myPlot.Add.Scatter(xs, ys);
+
+        // add signal plots
+        var sig1 = myPlot.Add.Signal(ys);
+        var sig2 = myPlot.Add.Signal(ys);
+        var sig3 = myPlot.Add.Signal(ys);
+
+        // add duplicates
+        myPlot.Add.Plottable(sp2);
+        myPlot.Add.Plottable(sp2);
+        myPlot.Add.Plottable(sig2);
+        myPlot.Add.Plottable(sig2);
+
+        myPlot.PlottableList.Count.Should().Be(10);
+
+        myPlot.Remove(sig1); // one instance
+        myPlot.PlottableList.Count.Should().Be(9);
+
+        myPlot.Remove(sp2); // 3 instances
+        myPlot.PlottableList.Count.Should().Be(6);
+    }
+
+    [Test]
+    public void Test_Plot_RemoveType()
+    {
+        double[] xs = Generate.Consecutive();
+        double[] ys = Generate.Sin();
+
+        Plot myPlot = new();
+
+        // add scatter plots
+        var sp1 = myPlot.Add.Scatter(xs, ys);
+        var sp2 = myPlot.Add.Scatter(xs, ys);
+        var sp3 = myPlot.Add.Scatter(xs, ys);
+
+        // add signal plots
+        var sig1 = myPlot.Add.Signal(ys);
+        var sig2 = myPlot.Add.Signal(ys);
+        var sig3 = myPlot.Add.Signal(ys);
+
+        // add duplicates
+        myPlot.Add.Plottable(sp2);
+        myPlot.Add.Plottable(sp2);
+        myPlot.Add.Plottable(sig2);
+        myPlot.Add.Plottable(sig2);
+
+        myPlot.PlottableList.Count.Should().Be(10);
+
+        myPlot.Remove(sig1.GetType());
+        myPlot.PlottableList.Count.Should().Be(5);
+
+        myPlot.Remove(typeof(ScottPlot.Plottables.Scatter));
+        myPlot.PlottableList.Count.Should().Be(0);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -328,7 +328,7 @@ public class Plot : IDisposable
     public bool Remove(Type plotType)
     {
         List<IPlottable> itemsToRemove = PlottableList.Where(x => x.GetType() != plotType).ToList();
-        if(itemsToRemove.Count == 0)
+        if (itemsToRemove.Count == 0)
             return false;
 
         foreach (var item in itemsToRemove)

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -313,30 +313,27 @@ public class Plot : IDisposable
     #region Helper Methods
 
     /// <summary>
-    /// Remove a specific object from the plot.
-    /// This removes the given object from <see cref="PlottableList"/>.
+    /// Remove the given plottable from the <see cref="PlottableList"/>.
     /// </summary>
     public void Remove(IPlottable plottable)
     {
-        PlottableList.Remove(plottable);
+        while (PlottableList.Contains(plottable))
+        {
+            PlottableList.Remove(plottable);
+        }
     }
 
     /// <summary>
-    /// Remove all items of a specific type from the plot. Returns false if no items were found. 
-    /// This removes all items of a specific type from <see cref="PlottableList"/>.
+    /// Remove all items of a specific type from the <see cref="PlottableList"/>.
     /// </summary>
-    public bool Remove(Type plotType)
+    public void Remove(Type plotType)
     {
-        List<IPlottable> itemsToRemove = PlottableList.Where(x => x.GetType() != plotType).ToList();
-        if (itemsToRemove.Count == 0)
-            return false;
+        List<IPlottable> itemsToRemove = PlottableList.Where(x => x.GetType() == plotType).ToList();
 
-        foreach (var item in itemsToRemove)
+        foreach (IPlottable item in itemsToRemove)
         {
             PlottableList.Remove(item);
         }
-
-        return true;
     }
 
     /// <summary>

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -322,6 +322,24 @@ public class Plot : IDisposable
     }
 
     /// <summary>
+    /// Remove all items of a specific type from the plot. Returns false if no items were found. 
+    /// This removes all items of a specific type from <see cref="PlottableList"/>.
+    /// </summary>
+    public bool Remove(Type plotType)
+    {
+        List<IPlottable> itemsToRemove = PlottableList.Where(x => x.GetType() != plotType).ToList();
+        if(itemsToRemove.Count == 0)
+            return false;
+
+        foreach (var item in itemsToRemove)
+        {
+            PlottableList.Remove(item);
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Disable visibility for all grids
     /// </summary>
     public void HideGrid()

--- a/src/ScottPlot5/ScottPlot5/Plottables/Marker.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Marker.cs
@@ -2,10 +2,25 @@
 
 public class Marker : IPlottable
 {
+    public double X { get; set; }
+    public double Y { get; set; }
+    public Coordinates Location
+    {
+        get => new(X, Y);
+        set { X = value.X; Y = value.Y; }
+    }
+
     public string Label { get; set; } = string.Empty;
-    public Coordinates Location { get; set; }
     public bool IsVisible { get; set; } = true;
     public MarkerStyle MarkerStyle { get; set; } = MarkerStyle.Default;
+    public float Size { get => MarkerStyle.Size; set => MarkerStyle.Size = value; }
+    public MarkerShape Shape { get => MarkerStyle.Shape; set => MarkerStyle.Shape = value; }
+    public Color Color
+    {
+        get => MarkerStyle.Fill.Color;
+        set { MarkerStyle.Fill.Color = value; MarkerStyle.Outline.Color = value; }
+    }
+
     public IAxes Axes { get; set; } = new Axes();
     public IEnumerable<LegendItem> LegendItems => LegendItem.Single(Label, MarkerStyle);
     public AxisLimits GetAxisLimits() => new(Location);


### PR DESCRIPTION
Remove by type.
Fix #3284

Returns false if no items matched that type for debugging purposes. 