### PR TITLE
SP5: Plot.Remove() generic overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 * Ticks: Created `IMinorTickGenerator` to allow users to inject their own logic for placing minor ticks
 * Axes: Added support for log-scale tick labels and grid lines (#3143)
 * Plot: Users can now `Add.Ellipse()` and `Add.Circle()` to place closed curves on plots (#3277, #3287) _Thanks @hockerschwan_
-* Plot: Added a `Plot.Remove()` overload for removing all plottables of the given type (#3296) _Thanks @DerekGooding_
+* Plot: Added a `Plot.Remove()` overloads for removing all plottables of the given type (#3296, #3296) _Thanks @DerekGooding_
+* Plot: Added a `Plot.Remove()` overloads for removing plottables matching specific criteria (#3296, #3297) _Thanks @KroMignon_
 
 ## ScottPlot 5.0.20
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-21_

--- a/src/ScottPlot5/ScottPlot5 Tests/UnitTests/PlottableManagement.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/UnitTests/PlottableManagement.cs
@@ -67,4 +67,69 @@ internal class PlottableManagement
         myPlot.Remove(typeof(ScottPlot.Plottables.Scatter));
         myPlot.PlottableList.Count.Should().Be(0);
     }
+
+    [Test]
+    public void Test_Plot_RemoveTypeGeneric()
+    {
+        double[] xs = Generate.Consecutive();
+        double[] ys = Generate.Sin();
+
+        Plot myPlot = new();
+
+        // add scatter plots
+        var sp1 = myPlot.Add.Scatter(xs, ys);
+        var sp2 = myPlot.Add.Scatter(xs, ys);
+        var sp3 = myPlot.Add.Scatter(xs, ys);
+
+        // add signal plots
+        var sig1 = myPlot.Add.Signal(ys);
+        var sig2 = myPlot.Add.Signal(ys);
+        var sig3 = myPlot.Add.Signal(ys);
+
+        // add duplicates
+        myPlot.Add.Plottable(sp2);
+        myPlot.Add.Plottable(sp2);
+        myPlot.Add.Plottable(sig2);
+        myPlot.Add.Plottable(sig2);
+
+        myPlot.PlottableList.Count.Should().Be(10);
+
+        myPlot.Remove<ScottPlot.Plottables.Signal>();
+        myPlot.PlottableList.Count.Should().Be(5);
+
+        myPlot.Remove<ScottPlot.Plottables.Scatter>();
+        myPlot.PlottableList.Count.Should().Be(0);
+    }
+
+    [Test]
+    public void Test_Plot_RemoveTypePredicate()
+    {
+        double[] xs = Generate.Consecutive();
+        double[] ys = Generate.Sin();
+
+        Plot myPlot = new();
+
+        var sp1 = myPlot.Add.Scatter(xs, ys);
+        sp1.Label = "AAA";
+
+        var sp2 = myPlot.Add.Scatter(xs, ys);
+        sp2.Label = "ABC";
+
+        var sp3 = myPlot.Add.Scatter(xs, ys);
+        sp3.Label = "ABAB";
+
+        var sp4 = myPlot.Add.Scatter(xs, ys);
+        sp4.Label = "LOLOLOLOLOLOL";
+        sp4.Color = Colors.Magenta;
+
+        myPlot.PlottableList.Count.Should().Be(4);
+
+        // match label content
+        myPlot.Remove<ScottPlot.Plottables.Scatter>(x => x.Label!.Contains('B'));
+        myPlot.PlottableList.Count.Should().Be(2);
+
+        // match style options
+        myPlot.Remove<ScottPlot.Plottables.Scatter>(x => x.Color == Colors.Magenta);
+        myPlot.PlottableList.Count.Should().Be(1);
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -3,7 +3,6 @@ using ScottPlot.Control;
 using ScottPlot.Legends;
 using ScottPlot.Rendering;
 using ScottPlot.Stylers;
-using System.Linq;
 
 namespace ScottPlot;
 

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -3,6 +3,7 @@ using ScottPlot.Control;
 using ScottPlot.Legends;
 using ScottPlot.Rendering;
 using ScottPlot.Stylers;
+using System.Linq;
 
 namespace ScottPlot;
 
@@ -319,6 +320,32 @@ public class Plot : IDisposable
     public void Remove(IPlottable plottable)
     {
         PlottableList.Remove(plottable);
+    }
+
+    /// <summary>
+    /// Remove a specific type of IPlottable from the plot.
+    /// This removes the given object from <see cref="PlottableList"/>.
+    /// </summary>
+    /// <typeparam name="T">Type of <see cref="IPlottable"/> to be removed</typeparam>
+    /// <returns>The number of elements removed from<see cref="PlottableList"/>.</returns>
+    public int Remove<T>() where T : IPlottable
+    {
+        return PlottableList.RemoveAll(x => x is T);
+    }
+
+    /// <summary>
+    /// Remove a specific type of IPlottable from the plot.
+    /// This removes the given object from <see cref="PlottableList"/>.
+    /// </summary>
+    /// <param name="predicate">A function to test each element for a condition.</param>
+    /// <typeparam name="T">Type of <see cref="IPlottable"/> to be removed</typeparam>
+    /// <returns>The number of elements removed from<see cref="PlottableList"/>.</returns>
+    public int Remove<T>(Func<T, bool> predicate) where T : IPlottable
+    {
+        var toRemove = PlottableList.OfType<T>().Where(predicate).ToList();
+        foreach(var item in toRemove)
+            PlottableList.Remove(item);
+        return toRemove.Count;
     }
 
     /// <summary>

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -337,29 +337,24 @@ public class Plot : IDisposable
     }
 
     /// <summary>
-    /// Remove a specific type of IPlottable from the plot.
-    /// This removes the given object from <see cref="PlottableList"/>.
+    /// Remove a all instances of a specific type from the <see cref="PlottableList"/>.
     /// </summary>
     /// <typeparam name="T">Type of <see cref="IPlottable"/> to be removed</typeparam>
-    /// <returns>The number of elements removed from<see cref="PlottableList"/>.</returns>
-    public int Remove<T>() where T : IPlottable
+    public void Remove<T>() where T : IPlottable
     {
-        return PlottableList.RemoveAll(x => x is T);
+        PlottableList.RemoveAll(x => x is T);
     }
 
     /// <summary>
-    /// Remove a specific type of IPlottable from the plot.
-    /// This removes the given object from <see cref="PlottableList"/>.
+    /// Remove all instances of a specific type from the <see cref="PlottableList"/> 
+    /// that meet the <paramref name="predicate"/> criteraia.
     /// </summary>
     /// <param name="predicate">A function to test each element for a condition.</param>
     /// <typeparam name="T">Type of <see cref="IPlottable"/> to be removed</typeparam>
-    /// <returns>The number of elements removed from<see cref="PlottableList"/>.</returns>
-    public int Remove<T>(Func<T, bool> predicate) where T : IPlottable
+    public void Remove<T>(Func<T, bool> predicate) where T : IPlottable
     {
-        var toRemove = PlottableList.OfType<T>().Where(predicate).ToList();
-        foreach (var item in toRemove)
-            PlottableList.Remove(item);
-        return toRemove.Count;
+        List<T> toRemove = PlottableList.OfType<T>().Where(predicate).ToList();
+        toRemove.ForEach(x => PlottableList.Remove(x));
     }
 
     /// <summary>

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -342,7 +342,7 @@ public class Plot : IDisposable
     public int Remove<T>(Func<T, bool> predicate) where T : IPlottable
     {
         var toRemove = PlottableList.OfType<T>().Where(predicate).ToList();
-        foreach(var item in toRemove)
+        foreach (var item in toRemove)
             PlottableList.Remove(item);
         return toRemove.Count;
     }


### PR DESCRIPTION
This PR adds overload to `Plot.Remove()` to be able to remove `IPlottable` in generic way.

This should fix issue #3284.

Usage exampes:
```cs
ScottPlot.Plot myPlot = new();

myPlot.Add.Signal(Generate.Sin()).Label = "Toto";
myPlot.Add.Signal(Generate.Cos());

// to remove all Signals
myPlot.Remove<ScottPlot.Plottables.Signal>();

....

// to remove all Signals without Label
myPlot.Remove<ScottPlot.Plottables.Signal>((x) => (x.Label?.Length ?? 0) <= 0);

...

```