### PR TITLE
Interaction.PlotActions improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Plot: Added `Plot.Remove()` overloads for removing plottables matching specific criteria (#3296, #3297) _Thanks @KroMignon_
 * Plot: Added `Plot.GetPlottables()` overloads to facilitate iterating over plottables of a specific type
 * Rendering: Added support for gradient fills (#3298, #3157) _Thanks @KroMignon and @faguetan_
+* Controls: Disabling interactions then re-enabling them restores original interactions (#3305, #3304) _Thanks @Nils-Berghs_
 
 ## ScottPlot 5.0.20
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-21_

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/CustomMouseActions.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/CustomMouseActions.cs
@@ -23,6 +23,7 @@ public partial class CustomMouseActions : Form, IDemoWindow
         ScottPlot.Control.Interaction interaction = new(formsPlot1)
         {
             Inputs = ScottPlot.Control.InputBindings.Standard(),
+            Actions = ScottPlot.Control.PlotActions.Standard(),
         };
 
         formsPlot1.Interaction = interaction;
@@ -37,6 +38,7 @@ public partial class CustomMouseActions : Form, IDemoWindow
         ScottPlot.Control.Interaction interaction = new(formsPlot1)
         {
             Inputs = customInputBindings,
+            Actions = ScottPlot.Control.PlotActions.NonInteractive(),
         };
 
         formsPlot1.Interaction = interaction;

--- a/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
@@ -20,7 +20,7 @@ public class Interaction : IPlotInteraction
     /// A field to store the plotActions during a 'Disabled' period
     /// </summary>
     private PlotActions EnabledPlotActions;
-    
+
     /// <summary>
     /// Delegates in this object can be overwritten with custom functions that manipulate the plot.
     /// (e.g., changing the sensitivity of click-drag-zooming)

--- a/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
@@ -17,9 +17,9 @@ public class Interaction : IPlotInteraction
     public InputBindings Inputs = InputBindings.Standard();
 
     /// <summary>
-    /// A field to store the plotActions during a 'Disabled' period
+    /// Stores the <see cref="Actions"/> that were preseent when <see cref="Disable"/> was called.
     /// </summary>
-    private PlotActions EnabledPlotActions;
+    private PlotActions ActionsWhenDisabled = PlotActions.Standard();
 
     /// <summary>
     /// Delegates in this object can be overwritten with custom functions that manipulate the plot.
@@ -45,8 +45,7 @@ public class Interaction : IPlotInteraction
     /// </summary>
     public void Disable()
     {
-        //back up the enabled plot actions
-        EnabledPlotActions = Actions;
+        ActionsWhenDisabled = Actions;
         Actions = PlotActions.NonInteractive();
     }
 
@@ -55,7 +54,7 @@ public class Interaction : IPlotInteraction
     /// </summary>
     public void Enable()
     {
-        Actions = EnabledPlotActions;
+        Actions = ActionsWhenDisabled;
     }
 
     /// <summary>

--- a/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
@@ -17,6 +17,11 @@ public class Interaction : IPlotInteraction
     public InputBindings Inputs = InputBindings.Standard();
 
     /// <summary>
+    /// A field to store the plotActions during a 'Disabled' period
+    /// </summary>
+    private PlotActions EnabledPlotActions;
+    
+    /// <summary>
     /// Delegates in this object can be overwritten with custom functions that manipulate the plot.
     /// (e.g., changing the sensitivity of click-drag-zooming)
     /// </summary>
@@ -40,6 +45,8 @@ public class Interaction : IPlotInteraction
     /// </summary>
     public void Disable()
     {
+        //back up the enabled plot actions
+        EnabledPlotActions = Actions;
         Actions = PlotActions.NonInteractive();
     }
 
@@ -48,7 +55,7 @@ public class Interaction : IPlotInteraction
     /// </summary>
     public void Enable()
     {
-        Actions = PlotActions.Standard();
+        Actions = EnabledPlotActions;
     }
 
     /// <summary>


### PR DESCRIPTION
A fix for #3304 

This fix stores the plot actions assigned to the Interaction in seperate field during disabled periods (e.g, when dragging axis lines).
It restores the actions on Enable

```.cs
/// <summary>
/// Disable all mouse interactivity
/// </summary>
public void Disable()
{
    //back up the enabled plot actions
    EnabledPlotActions = Actions;
    Actions = PlotActions.NonInteractive();
}

/// <summary>
/// Enable mouse interactivity using the default mouse actions
/// </summary>
public void Enable()
{
    Actions = EnabledPlotActions;
}
```