### PR TITLE
SP5 Plot: allow optional axes as arguments to GetPixel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Plot: Added `Plot.GetPlottables()` overloads to facilitate iterating over plottables of a specific type
 * Rendering: Added support for gradient fills (#3298, #3157) _Thanks @KroMignon and @faguetan_
 * Controls: Disabling interactions then re-enabling them restores original interactions (#3305, #3304) _Thanks @Nils-Berghs_
+* Plot: Added `Plot.GetPixel()` overload for improved support on multi-axis plots (#3306) _Thanks @MCF_
 
 ## ScottPlot 5.0.20
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-21_

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -117,12 +117,12 @@ public class Plot : IDisposable
     /// <summary>
     /// Return the pixel for a specific coordinate using measurements from the most recent render.
     /// </summary>
-    public Pixel GetPixel(Coordinates coordinates)
+    public Pixel GetPixel(Coordinates coordinates, IXAxis? xAxis = null, IYAxis? yAxis = null)
     {
         Coordinates scaledCoordinates = new(coordinates.X * ScaleFactor, coordinates.Y * ScaleFactor);
         PixelRect dataRect = RenderManager.LastRender.DataRect;
-        float x = Axes.Bottom.GetPixel(scaledCoordinates.X, dataRect);
-        float y = Axes.Left.GetPixel(scaledCoordinates.Y, dataRect);
+        float x = (xAxis ?? Axes.Bottom).GetPixel(scaledCoordinates.X, dataRect);
+        float y = (yAxis ?? Axes.Left).GetPixel(scaledCoordinates.Y, dataRect);
         return new Pixel(x, y);
     }
 

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -115,15 +115,25 @@ public class Plot : IDisposable
     }
 
     /// <summary>
-    /// Return the pixel for a specific coordinate using measurements from the most recent render.
+    /// Return the location on the screen (pixel) for a location on the plot (coordinates) on the default axes.
+    /// The figure size and layout referenced will be the one from the last render.
     /// </summary>
-    public Pixel GetPixel(Coordinates coordinates, IXAxis? xAxis = null, IYAxis? yAxis = null)
+    public Pixel GetPixel(Coordinates coordinates) => GetPixel(coordinates, Axes.Bottom, Axes.Left);
+
+    /// <summary>
+    /// Return the location on the screen (pixel) for a location on the plot (coordinates) on the given axes.
+    /// The figure size and layout referenced will be the one from the last render.
+    /// </summary>
+    public Pixel GetPixel(Coordinates coordinates, IXAxis xAxis, IYAxis yAxis)
     {
-        Coordinates scaledCoordinates = new(coordinates.X * ScaleFactor, coordinates.Y * ScaleFactor);
-        PixelRect dataRect = RenderManager.LastRender.DataRect;
-        float x = (xAxis ?? Axes.Bottom).GetPixel(scaledCoordinates.X, dataRect);
-        float y = (yAxis ?? Axes.Left).GetPixel(scaledCoordinates.Y, dataRect);
-        return new Pixel(x, y);
+        if (ScaleFactor != 1)
+        {
+            coordinates = new(coordinates.X * ScaleFactor, coordinates.Y * ScaleFactor);
+        }
+
+        float xPixel = xAxis.GetPixel(coordinates.X, RenderManager.LastRender.DataRect);
+        float yPixel = yAxis.GetPixel(coordinates.Y, RenderManager.LastRender.DataRect);
+        return new Pixel(xPixel, yPixel);
     }
 
     /// <summary>


### PR DESCRIPTION
Now matches the inverse GetCoordinates functions

This is helpful when working with mouse events on multi-axes plots and determining nearest data point under the cursor.