### PR TITLE
SP5: refactor tick measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Axis Lines: Label background color may be distinct from line color (#3309) _Thanks @PhoenixChenLu_
 * Axis Spans: New `Plot.Add.HorizontalSpan()` and `Plot.Add.VerticalSpan()` methods for shading axis ranges (#3307) _Thanks @erikjl_
 * Interactivity: Added methods to simplify dragging axis lines and spans. See the demo application for details. (#3307) _Thanks @erikjl_
+* Ticks: Improved tick density calculation to prevent overlapping tick labels for very large numbers (#3203)
 
 ## ScottPlot 5.0.20
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-21_

--- a/src/ScottPlot5/ScottPlot5 Tests/UnitTests/TickGenerators/DecimalTickSpacingCalculatorTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/UnitTests/TickGenerators/DecimalTickSpacingCalculatorTests.cs
@@ -1,0 +1,21 @@
+﻿namespace ScottPlotTests.UnitTests.TickGenerators;
+
+internal class DecimalTickSpacingCalculatorTests
+{
+    [Test]
+    public void Test_CalculatorLabels_ShouldAlwaysFitInGivenSpace()
+    {
+        ScottPlot.TickGenerators.DecimalTickSpacingCalculator calc = new();
+        CoordinateRange range = new(-500_000_000, 500_000_000);
+        PixelLength axisLength = new(500);
+
+        for (int i = 10; i < 100; i += 10)
+        {
+            PixelLength maxLabelLength = new(i);
+            double[] positions = calc.GenerateTickPositions(range, axisLength, maxLabelLength);
+            double spacePerLabel = axisLength.Length / positions.Length;
+            Console.WriteLine($"when labels are {maxLabelLength}, each {spacePerLabel} px of space");
+            spacePerLabel.Should().BeGreaterThan(maxLabelLength.Length);
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/XAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/XAxisBase.cs
@@ -108,4 +108,11 @@ public abstract class XAxisBase : AxisBase, IAxis
     {
         return distance / (dataArea.Width / Width);
     }
+
+    public void RegenerateTicks(PixelLength size)
+    {
+        using SKPaint paint = new();
+        TickLabelStyle.ApplyToPaint(paint);
+        TickGenerator.Regenerate(Range.ToCoordinateRange, Edge, size, paint);
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
@@ -104,4 +104,11 @@ public abstract class YAxisBase : AxisBase, IAxis
     {
         return distance / (dataArea.Height / Height);
     }
+
+    public void RegenerateTicks(PixelLength size)
+    {
+        using SKPaint paint = new();
+        TickLabelStyle.ApplyToPaint(paint);
+        TickGenerator.Regenerate(Range.ToCoordinateRange, Edge, size, paint);
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -30,19 +30,40 @@ public static class Drawing
         return new PixelSize(width, height);
     }
 
-    public static PixelSize MeasureLargestString(string[] strings, SKPaint paint)
+    public static (string text, PixelLength width) MeasureWidestString(string[] strings, SKPaint paint)
     {
         float maxWidth = 0;
-        float maxHeight = 0;
+        string maxText = string.Empty;
 
         for (int i = 0; i < strings.Length; i++)
         {
-            PixelSize tickSize = MeasureString(strings[i], paint);
-            maxWidth = Math.Max(maxWidth, tickSize.Width);
-            maxHeight = Math.Max(maxHeight, tickSize.Height);
+            PixelSize size = MeasureString(strings[i], paint);
+            if (size.Width > maxWidth)
+            {
+                maxWidth = size.Width;
+                maxText = strings[i];
+            }
         }
 
-        return new PixelSize(maxWidth, maxHeight);
+        return (maxText, maxWidth);
+    }
+
+    public static (string text, PixelLength width) MeasureHighestString(string[] strings, SKPaint paint)
+    {
+        float maxHeight = 0;
+        string maxText = string.Empty;
+
+        for (int i = 0; i < strings.Length; i++)
+        {
+            PixelSize size = MeasureString(strings[i], paint);
+            if (size.Height > maxHeight)
+            {
+                maxHeight = size.Height;
+                maxText = strings[i];
+            }
+        }
+
+        return (maxText, maxHeight);
     }
 
     public static void DrawLine(SKCanvas canvas, SKPaint paint, PixelLine pixelLine)

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IAxis.cs
@@ -45,7 +45,12 @@ public interface IAxis : IPanel
     /// <summary>
     /// Logic for determining tick positions and formatting tick labels
     /// </summary>
-    ITickGenerator TickGenerator { get; set; }
+    ITickGenerator TickGenerator { get; set; } // TODO: never call TickGenerator.Generate() externally
+
+    /// <summary>
+    /// Use the <see cref="TickLabelStyle"/> to generate ticks with ideal spacing.
+    /// </summary>
+    public void RegenerateTicks(PixelLength size);
 
     /// <summary>
     /// The label is the text displayed distal to the ticks

--- a/src/ScottPlot5/ScottPlot5/Interfaces/ITickGenerator.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/ITickGenerator.cs
@@ -16,5 +16,5 @@ public interface ITickGenerator
     /// Logic for generating ticks automatically.
     /// Generated ticks are stored in <see cref="Ticks"/>.
     /// </summary>
-    void Regenerate(CoordinateRange range, Edge edge, PixelLength size);
+    void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint);
 }

--- a/src/ScottPlot5/ScottPlot5/LayoutEngines/Automatic.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutEngines/Automatic.cs
@@ -19,15 +19,9 @@ public class Automatic : LayoutEngineBase, ILayoutEngine
          * 
          */
 
-        PixelSize figureSize = figureRect.Size;
-
-        panels.OfType<IXAxis>()
-            .ToList()
-            .ForEach(xAxis => xAxis.TickGenerator.Regenerate(xAxis.Range.ToCoordinateRange, xAxis.Edge, figureSize.Width));
-
-        panels.OfType<IYAxis>()
-            .ToList()
-            .ForEach(yAxis => yAxis.TickGenerator.Regenerate(yAxis.Range.ToCoordinateRange, yAxis.Edge, figureSize.Height));
+        // NOTE: the actual ticks will be regenerated later, after the layout is determined
+        panels.OfType<IXAxis>().ToList().ForEach(x => x.RegenerateTicks(figureRect.Width));
+        panels.OfType<IYAxis>().ToList().ForEach(x => x.RegenerateTicks(figureRect.Height));
 
         Dictionary<IPanel, float> panelSizes = LayoutEngineBase.MeasurePanels(panels);
         Dictionary<IPanel, float> panelOffsets = GetPanelOffsets(panels, panelSizes);
@@ -40,8 +34,8 @@ public class Automatic : LayoutEngineBase, ILayoutEngine
 
         PixelRect dataRect = new(
             left: paddingNeededForPanels.Left,
-            right: figureSize.Width - paddingNeededForPanels.Right,
-            bottom: figureSize.Height - paddingNeededForPanels.Bottom,
+            right: figureRect.Width - paddingNeededForPanels.Right,
+            bottom: figureRect.Height - paddingNeededForPanels.Bottom,
             top: paddingNeededForPanels.Top);
 
         dataRect = dataRect.WithPan(figureRect.Left, figureRect.Top);

--- a/src/ScottPlot5/ScottPlot5/LayoutEngines/FixedPadding.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutEngines/FixedPadding.cs
@@ -16,13 +16,9 @@ public class FixedPadding : LayoutEngineBase, ILayoutEngine
     {
         // must recalculate ticks before measuring panels
 
-        panels.OfType<IXAxis>()
-            .ToList()
-            .ForEach(xAxis => xAxis.TickGenerator.Regenerate(xAxis.Range.ToCoordinateRange, xAxis.Edge, figureRect.Width));
-
-        panels.OfType<IYAxis>()
-            .ToList()
-            .ForEach(yAxis => yAxis.TickGenerator.Regenerate(yAxis.Range.ToCoordinateRange, yAxis.Edge, figureRect.Height));
+        // NOTE: the actual ticks will be regenerated later, after the layout is determined
+        panels.OfType<IXAxis>().ToList().ForEach(x => x.RegenerateTicks(figureRect.Width));
+        panels.OfType<IYAxis>().ToList().ForEach(x => x.RegenerateTicks(figureRect.Height));
 
         Dictionary<IPanel, float> panelSizes = LayoutEngineBase.MeasurePanels(panels);
         Dictionary<IPanel, float> panelOffsets = GetPanelOffsets(panels, panelSizes);

--- a/src/ScottPlot5/ScottPlot5/Panels/ColorBar.cs
+++ b/src/ScottPlot5/ScottPlot5/Panels/ColorBar.cs
@@ -97,7 +97,7 @@ public class ColorBar : IPanel
         axis.Min = range.Min;
         axis.Max = range.Max;
 
-        axis.TickGenerator.Regenerate(axis.Range.ToCoordinateRange, axis.Edge, length);
+        axis.RegenerateTicks(length);
 
         return axis;
     }

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/RegenerateTicks.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/RegenerateTicks.cs
@@ -4,14 +4,8 @@ public class RegenerateTicks : IRenderAction
 {
     public void Render(RenderPack rp)
     {
-        rp.Plot.Axes.Bottom.TickGenerator.Regenerate(
-            range: rp.Plot.Axes.Bottom.Range.ToRectifiedCoordinateRange,
-            edge: rp.Plot.Axes.Bottom.Edge,
-            size: rp.DataRect.Width);
-
-        rp.Plot.Axes.Left.TickGenerator.Regenerate(
-            range: rp.Plot.Axes.Left.Range.ToRectifiedCoordinateRange,
-            edge: rp.Plot.Axes.Left.Edge,
-            size: rp.DataRect.Height);
+        // TODO: shouldn't all axis ticks be regenerated???
+        rp.Plot.Axes.Bottom.RegenerateTicks(rp.DataRect.Width);
+        rp.Plot.Axes.Left.RegenerateTicks(rp.DataRect.Height);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/DateTimeAutomatic.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/DateTimeAutomatic.cs
@@ -56,7 +56,7 @@ public class DateTimeAutomatic : IDateTimeTickGenerator
         return null;
     }
 
-    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size)
+    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint)
     {
         if (range.Span >= TimeSpan.MaxValue.Days || double.IsNaN(range.Span))
         {
@@ -89,7 +89,7 @@ public class DateTimeAutomatic : IDateTimeTickGenerator
             }
 
             // attempt to generate the ticks given these conditions
-            (List<Tick>? ticks, PixelSize? largestTickLabelSize) = GenerateTicks(range, timeUnit, niceIncrement.Value, tickLabelBounds);
+            (List<Tick>? ticks, PixelSize? largestTickLabelSize) = GenerateTicks(range, timeUnit, niceIncrement.Value, tickLabelBounds, paint);
 
             // if ticks were returned, use them
             if (ticks is not null)
@@ -116,7 +116,7 @@ public class DateTimeAutomatic : IDateTimeTickGenerator
     /// If all labels fit within the bounds, the list of ticks is returned.
     /// If a label doesn't fit in the bounds, the list is null and the size of the large tick label is returned.
     /// </summary>
-    private (List<Tick>? Positions, PixelSize? PixelSize) GenerateTicks(CoordinateRange range, ITimeUnit unit, int increment, PixelSize tickLabelBounds)
+    private (List<Tick>? Positions, PixelSize? PixelSize) GenerateTicks(CoordinateRange range, ITimeUnit unit, int increment, PixelSize tickLabelBounds, SKPaint paint)
     {
         DateTime rangeMin = range.Min.ToDateTime();
         DateTime rangeMax = range.Max.ToDateTime();
@@ -129,7 +129,6 @@ public class DateTimeAutomatic : IDateTimeTickGenerator
         DateTime end = unit.Next(rangeMax, increment);
         string dtFormat = unit.GetDateTimeFormatString();
 
-        using SKPaint paint = new();
         List<Tick> ticks = new();
 
         const int maxTickCount = 1000;

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/DateTimeFixedInterval.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/DateTimeFixedInterval.cs
@@ -21,7 +21,7 @@
             return dates.Select(dt => dt.ToNumber());
         }
 
-        public void Regenerate(CoordinateRange range, Edge edge, PixelLength size)
+        public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint)
         {
             List<Tick> ticks = new();
 

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/DecimalTickSpacingCalculator.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/DecimalTickSpacingCalculator.cs
@@ -3,8 +3,34 @@
 public class DecimalTickSpacingCalculator
 {
     public double TickDensity { get; set; } = 1.0;
+    public int MaximumTickCount { get; set; } = 1000;
 
-    public double GetIdealTickSpacing(CoordinateRange range, PixelLength axisLength, PixelLength maxLabelLength, int bailAfter)
+    public double[] GenerateTickPositions(CoordinateRange range, PixelLength axisLength, PixelLength maxLabelLength)
+    {
+        double tickSpacing = GetIdealTickSpacing(range, axisLength, maxLabelLength);
+
+        double firstTickOffset = range.Min % tickSpacing;
+        int tickCount = (int)(range.Span / tickSpacing) + 2;
+        tickCount = Math.Min(1000, tickCount);
+        tickCount = Math.Max(1, tickCount);
+
+        double[] majorTickPositions = Enumerable.Range(0, tickCount)
+            .Select(x => range.Min - firstTickOffset + tickSpacing * x)
+            .Where(range.Contains)
+            .ToArray();
+
+        if (majorTickPositions.Length < 2)
+        {
+            double tickBelow = range.Min - firstTickOffset;
+            double firstTick = majorTickPositions.Length > 0 ? majorTickPositions[0] : tickBelow;
+            double nextTick = tickBelow + tickSpacing;
+            majorTickPositions = [firstTick, nextTick];
+        }
+
+        return majorTickPositions;
+    }
+
+    private double GetIdealTickSpacing(CoordinateRange range, PixelLength axisLength, PixelLength maxLabelLength)
     {
         double unitsPerPx = range.Span / axisLength.Length;
 
@@ -27,7 +53,7 @@ public class DecimalTickSpacingCalculator
         // https://github.com/ScottPlot/ScottPlot/issues/3203
         int divisions = 0;
         int tickCount = 0;
-        while (tickCount < targetTickCount && tickSpacings.Count < bailAfter)
+        while (tickCount < targetTickCount && tickSpacings.Count < MaximumTickCount)
         {
             tickSpacings.Add(tickSpacings.Last() / divBy[divisions++ % divBy.Length]);
             tickCount = (int)(range.Span / tickSpacings.Last());

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/DecimalTickSpacingCalculator.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/DecimalTickSpacingCalculator.cs
@@ -1,0 +1,38 @@
+﻿namespace ScottPlot.TickGenerators;
+
+public class DecimalTickSpacingCalculator
+{
+    public double TickDensity { get; set; } = 1.0;
+
+    public double GetIdealTickSpacing(CoordinateRange range, PixelLength axisLength, PixelLength maxLabelLength, int bailAfter)
+    {
+        double unitsPerPx = range.Span / axisLength.Length;
+
+        int targetTickCount = (int)(axisLength.Length / maxLabelLength.Length * TickDensity);
+
+        int radix = 10;
+        int exponent = (int)Math.Log(range.Span, radix);
+        double initialSpace = Math.Pow(radix, exponent);
+        List<double> tickSpacings = [initialSpace, initialSpace, initialSpace];
+
+        double[] divBy;
+        if (radix == 10)
+            divBy = [2, 2, 2.5]; // 10, 5, 2.5, 1
+        else if (radix == 16)
+            divBy = [2, 2, 2, 2]; // 16, 8, 4, 2, 1
+        else
+            throw new ArgumentException($"radix {radix} is not supported");
+
+        // TODO: this needs to be better at determining ideal density
+        // https://github.com/ScottPlot/ScottPlot/issues/3203
+        int divisions = 0;
+        int tickCount = 0;
+        while (tickCount < targetTickCount && tickSpacings.Count < bailAfter)
+        {
+            tickSpacings.Add(tickSpacings.Last() / divBy[divisions++ % divBy.Length]);
+            tickCount = (int)(range.Span / tickSpacings.Last());
+        }
+
+        return tickSpacings[tickSpacings.Count - 3];
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/EmptyTickGenerator.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/EmptyTickGenerator.cs
@@ -10,7 +10,7 @@ public class EmptyTickGenerator : ITickGenerator
     {
     }
 
-    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size)
+    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint)
     {
     }
 }

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/NumericAutomatic.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/NumericAutomatic.cs
@@ -54,10 +54,8 @@ public class NumericAutomatic : ITickGenerator
         // determine if the actual tick labels are larger than predicted,
         // suggesting density is too high and overlapping may occur.
         (string largestText, PixelLength actualMaxLength) = edge.IsVertical()
-            ? Drawing.MeasureWidestString(majorTickLabels, paint)
+            ? Drawing.MeasureHighestString(majorTickLabels, paint)
             : Drawing.MeasureWidestString(majorTickLabels, paint);
-
-        Debug.WriteLineIf(edge == Edge.Bottom, $"[{depth}] Largest: {actualMaxLength} '{largestText}'");
 
         // recursively recalculate tick density if necessary
         return actualMaxLength.Length > maxLabelLength.Length

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/NumericAutomatic.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/NumericAutomatic.cs
@@ -4,7 +4,11 @@ public class NumericAutomatic : ITickGenerator
 {
     public Tick[] Ticks { get; set; } = [];
 
-    public int MaxTickCount { get; set; } = 10_000;
+    public int MaxTickCount
+    {
+        get => TickSpacingCalculator.MaximumTickCount;
+        set => TickSpacingCalculator.MaximumTickCount = value;
+    }
 
     public bool IntegerTicksOnly { get; set; } = false;
 
@@ -44,8 +48,7 @@ public class NumericAutomatic : ITickGenerator
             Debug.WriteLine($"Warning: Tick recusion depth = {depth}");
 
         // generate ticks and labels based on predicted maximum label size
-        double tickSpacing = TickSpacingCalculator.GetIdealTickSpacing(range, axisLength, maxLabelLength.Length, MaxTickCount);
-        double[] majorTickPositions = GenerateTickPositions(range, tickSpacing);
+        double[] majorTickPositions = TickSpacingCalculator.GenerateTickPositions(range, axisLength, maxLabelLength.Length);
         string[] majorTickLabels = majorTickPositions.Select(x => LabelFormatter(x)).ToArray();
 
         // determine if the actual tick labels are larger than predicted,
@@ -60,29 +63,6 @@ public class NumericAutomatic : ITickGenerator
         return actualMaxLength.Length > maxLabelLength.Length
             ? GenerateTicks(range, edge, axisLength, actualMaxLength, paint, depth + 1)
             : GenerateFinalTicks(majorTickPositions, majorTickLabels, range);
-    }
-
-    private double[] GenerateTickPositions(CoordinateRange range, double tickSpacing)
-    {
-        double firstTickOffset = range.Min % tickSpacing;
-        int tickCount = (int)(range.Span / tickSpacing) + 2;
-        tickCount = Math.Min(1000, tickCount);
-        tickCount = Math.Max(1, tickCount);
-
-        double[] majorTickPositions = Enumerable.Range(0, tickCount)
-            .Select(x => range.Min - firstTickOffset + tickSpacing * x)
-            .Where(range.Contains)
-            .ToArray();
-
-        if (majorTickPositions.Length < 2)
-        {
-            double tickBelow = range.Min - firstTickOffset;
-            double firstTick = majorTickPositions.Length > 0 ? majorTickPositions[0] : tickBelow;
-            double nextTick = tickBelow + tickSpacing;
-            majorTickPositions = [firstTick, nextTick];
-        }
-
-        return majorTickPositions;
     }
 
     private Tick[] GenerateFinalTicks(double[] positions, string[] labels, CoordinateRange visibleRange)

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
@@ -13,7 +13,7 @@ public class NumericFixedInterval : ITickGenerator
         Interval = interval;
     }
 
-    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size)
+    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint)
     {
         List<Tick> ticks = new();
 

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/NumericManual.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/NumericManual.cs
@@ -32,7 +32,7 @@ public class NumericManual : ITickGenerator
         }
     }
 
-    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size) { }
+    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint) { }
 
     public void Add(Tick tick)
     {


### PR DESCRIPTION
A SKPaint is now passed throughout the measurement system and tick font size is respected during measurements. The logic for determining tick density is now broken into its own class so it can be more easily customized and tested. #3203