### PR TITLE
SP5: Add support for polycolor gradients with custom color positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 * https://scottplot.net/versions/ describes the major versions of ScottPlot
 * https://scottplot.net/changelog/ is a formatted version of this document
 
+## ScottPlot 5.0.22
+_Not yet on NuGet..._
+* Rendering: Added additional options for gradient fills (#3324) _Thanks @KroMignon_
+
 ## ScottPlot 5.0.21
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-28_
 * RenderManager: Exposed `EnableRendering` to facilitate render locking in async environments (#3264, #3213, #3095) _Thanks @kagerouttepaso_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Shapes.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Shapes.cs
@@ -106,7 +106,7 @@ public class Shapes : ICategory
                 HatchColor = Colors.Blue,
                 Hatch = new Gradient()
                 {
-                    GradiantType = GradiantType.Linear,
+                    GradientType = GradientType.Linear,
                     AlignmentStart = Alignment.UpperRight,
                     AlignmentEnd = Alignment.LowerLeft,
                 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Gradient.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Gradient.cs
@@ -1,11 +1,11 @@
 ﻿namespace ScottPlot;
 
-public class Gradient(GradiantType gradientType = GradiantType.Linear) : IHatch
+public class Gradient(GradientType gradientType = GradientType.Linear) : IHatch
 {
     /// <summary>
     /// Describes the geometry of a color gradient used to fill an area
     /// </summary>
-    public GradiantType GradiantType { get; set; } = gradientType;
+    public GradientType GradientType { get; set; } = gradientType;
 
     /// <summary>
     /// Get or set the start angle in degrees for sweep gradient
@@ -49,9 +49,9 @@ public class Gradient(GradiantType gradientType = GradiantType.Linear) : IHatch
             ? Colors.Select(x => x.ToSKColor()).ToArray()
             : [backgroundColor.ToSKColor(), hatchColor.ToSKColor()];
 
-        return GradiantType switch
+        return GradientType switch
         {
-            GradiantType.Radial => SKShader.CreateRadialGradient(
+            GradientType.Radial => SKShader.CreateRadialGradient(
                 center: new SKPoint(rect.HorizontalCenter, rect.VerticalCenter),
                 radius: Math.Max(rect.Width, rect.Height) / 2.0f,
                 colors: colors,
@@ -59,7 +59,7 @@ public class Gradient(GradiantType gradientType = GradiantType.Linear) : IHatch
                 mode: TileMode
                 ),
 
-            GradiantType.Sweep => SKShader.CreateSweepGradient(
+            GradientType.Sweep => SKShader.CreateSweepGradient(
                 center: new SKPoint(rect.HorizontalCenter, rect.VerticalCenter),
                 colors: colors,
                 colorPos: ColorPositions,
@@ -68,7 +68,7 @@ public class Gradient(GradiantType gradientType = GradiantType.Linear) : IHatch
                 endAngle: EndAngle
                 ),
 
-            GradiantType.TwoPointConical => SKShader.CreateTwoPointConicalGradient(
+            GradientType.TwoPointConical => SKShader.CreateTwoPointConicalGradient(
                 start: rect.TopLeft.ToSKPoint(),
                 startRadius: Math.Min(rect.Width, rect.Height),
                 end: rect.BottomRight.ToSKPoint(),

--- a/src/ScottPlot5/ScottPlot5/Primitives/Gradient.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Gradient.cs
@@ -45,7 +45,7 @@ public class Gradient(GradiantType gradientType = GradiantType.Linear) : IHatch
 
     public SKShader GetShader(Color backgroundColor, Color hatchColor, PixelRect rect)
     {
-        SKColor[] colors = Colors?.Length > 2
+        SKColor[] colors = Colors?.Length > 1
             ? Colors.Select(x => x.ToSKColor()).ToArray()
             : [backgroundColor.ToSKColor(), hatchColor.ToSKColor()];
 

--- a/src/ScottPlot5/ScottPlot5/Primitives/Gradient.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Gradient.cs
@@ -32,21 +32,37 @@ public class Gradient(GradiantType gradientType = GradiantType.Linear) : IHatch
     /// </summary>
     public Alignment AlignmentEnd { get; set; } = Alignment.LowerRight;
 
+    /// <summary>
+    /// Colors used for the gradient, or null to use the Hatch colors.
+    /// </summary>
+    public Color[] Colors { get; set; } = null!;
+
+    /// <summary>
+    /// Get or set the positions (in the range of 0..1) of each corresponding color, 
+    /// or null to evenly distribute the colors.
+    /// </summary>
+    public float[] ColorPositions { get; set; } = null!;
+
     public SKShader GetShader(Color backgroundColor, Color hatchColor, PixelRect rect)
     {
+        SKColor[] colors = Colors?.Length > 2 
+            ? Colors.Select(x => x.ToSKColor()).ToArray()
+            : [backgroundColor.ToSKColor(), hatchColor.ToSKColor()];
+
         return GradiantType switch
         {
             GradiantType.Radial => SKShader.CreateRadialGradient(
                 center: new SKPoint(rect.HorizontalCenter, rect.VerticalCenter),
                 radius: Math.Max(rect.Width, rect.Height) / 2.0f,
-                colors: [backgroundColor.ToSKColor(), hatchColor.ToSKColor()],
+                colors: colors,
+                colorPos: ColorPositions,
                 mode: TileMode
                 ),
 
             GradiantType.Sweep => SKShader.CreateSweepGradient(
                 center: new SKPoint(rect.HorizontalCenter, rect.VerticalCenter),
-                colors: [backgroundColor.ToSKColor(), hatchColor.ToSKColor()],
-                colorPos: null,
+                colors: colors,
+                colorPos: ColorPositions,
                 tileMode: TileMode,
                 startAngle: StartAngle,
                 endAngle: EndAngle
@@ -57,15 +73,16 @@ public class Gradient(GradiantType gradientType = GradiantType.Linear) : IHatch
                 startRadius: Math.Min(rect.Width, rect.Height),
                 end: rect.BottomRight.ToSKPoint(),
                 endRadius: Math.Min(rect.Width, rect.Height),
-                colors: [backgroundColor.ToSKColor(), hatchColor.ToSKColor()],
-                colorPos: null,
+                colors: colors,
+                colorPos: ColorPositions,
                 mode: TileMode
                 ),
 
             _ => SKShader.CreateLinearGradient(
                 start: rect.GetAlignedPixel(AlignmentStart).ToSKPoint(),
                 end: rect.GetAlignedPixel(AlignmentEnd).ToSKPoint(),
-                colors: [backgroundColor.ToSKColor(), hatchColor.ToSKColor()],
+                colors: colors,
+                colorPos: ColorPositions,
                 mode: TileMode
                 ),
         };

--- a/src/ScottPlot5/ScottPlot5/Primitives/Gradient.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Gradient.cs
@@ -45,7 +45,7 @@ public class Gradient(GradiantType gradientType = GradiantType.Linear) : IHatch
 
     public SKShader GetShader(Color backgroundColor, Color hatchColor, PixelRect rect)
     {
-        SKColor[] colors = Colors?.Length > 2 
+        SKColor[] colors = Colors?.Length > 2
             ? Colors.Select(x => x.ToSKColor()).ToArray()
             : [backgroundColor.ToSKColor(), hatchColor.ToSKColor()];
 

--- a/src/ScottPlot5/ScottPlot5/Primitives/GradientType.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/GradientType.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Describes the geometry of a color gradient used to fill an area
 /// </summary>
-public enum GradiantType
+public enum GradientType
 {
     Linear,
     Radial,


### PR DESCRIPTION
Allow to create gradient fill with more than 2 colors.

This PR also fix a typo in enum name `GradiantType` ==> `GradientType`.

Example 
```cs
ScottPlot.Plot myPlot = new();

Coordinates[] points =
{
    new (0, 0.25),
    new (0.3, 0.75),
    new (1, 1),
    new (0.7, 0.5),
    new (1, 0)
};

var poly = myPlot.Add.Polygon(points);

poly.FillStyle = new FillStyle
{
    Color = Colors.Green,
    HatchColor = Colors.Blue,
    Hatch = new Gradient()
    {
        GradientType = GradientType.Radial,
        Colors = new Color[] { Colors.Yellow, Colors.DarkBlue, Colors.GreenYellow, Colors.Purple },
        ColorPositions = new float[] { 0.4f, 0.6f, 0.75f, 1 }
    }
};

poly.LineStyle = new LineStyle
{
    AntiAlias = true,
    Color = Colors.Black,
    Pattern = LinePattern.Dashed,
    Width = 2
};

poly.MarkerStyle = new MarkerStyle(MarkerShape.OpenCircle, 8);
poly.MarkerStyle.Fill.Color = Colors.Gold;
poly.MarkerStyle.Outline.Color = Colors.Brown;

myPlot.SavePng("polycolor.png", 150, 150);
```
![PolyColor](https://github.com/ScottPlot/ScottPlot/assets/3978902/ddcf7722-12ec-4289-b858-1f49a0fa22d5)
