### PR TITLE
SP5 Plot: Fix GetPixel bug when ScaleFactor is not 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * https://scottplot.net/versions/ describes the major versions of ScottPlot
 * https://scottplot.net/changelog/ is a formatted version of this document
 
+## ScottPlot 5.0.22 (Not yet on NuGet)
+* Plot: Fix GetPixel bug when ScaleFactor was not 1.0 (#3327) _Thanks @MCF_
+
 ## ScottPlot 5.0.21
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-28_
 * RenderManager: Exposed `EnableRendering` to facilitate render locking in async environments (#3264, #3213, #3095) _Thanks @kagerouttepaso_

--- a/src/ScottPlot5/ScottPlot5 Tests/UnitTests/PlotCoordinateConversion.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/UnitTests/PlotCoordinateConversion.cs
@@ -1,0 +1,35 @@
+﻿namespace ScottPlotTests.UnitTests;
+
+internal class PlotCoordinateConversion
+{
+    [Test]
+    public void Test_Plot_Pixel_To_Coords_And_Back()
+    {
+        Plot plt = new();
+        plt.Axes.SetLimits(-5, 25, 10, 30);
+        plt.SaveTestImage();
+
+        Pixel initialPx = new(55.0F, 333.0F);
+        Coordinates coordinates = plt.GetCoordinates(initialPx);
+        Pixel convertedPx = plt.GetPixel(coordinates);
+
+        convertedPx.X.Should().Be(initialPx.X);
+        convertedPx.Y.Should().Be(initialPx.Y);
+    }
+
+    [Test]
+    public void Test_Plot_Pixel_To_Coords_And_Back_Scaled()
+    {
+        Plot plt = new();
+        plt.Axes.SetLimits(1, 2, -15, -5);
+        plt.ScaleFactor = 2.5F;     // Change from default of 1.0F
+        plt.SaveTestImage();
+
+        Pixel initialPx = new(329.0F, 200.0F);
+        Coordinates coordinates = plt.GetCoordinates(initialPx);
+        Pixel convertedPx = plt.GetPixel(coordinates);
+
+        convertedPx.X.Should().Be(initialPx.X);
+        convertedPx.Y.Should().Be(initialPx.Y);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -126,13 +126,15 @@ public class Plot : IDisposable
     /// </summary>
     public Pixel GetPixel(Coordinates coordinates, IXAxis xAxis, IYAxis yAxis)
     {
-        if (ScaleFactor != 1)
-        {
-            coordinates = new(coordinates.X * ScaleFactor, coordinates.Y * ScaleFactor);
-        }
-
         float xPixel = xAxis.GetPixel(coordinates.X, RenderManager.LastRender.DataRect);
         float yPixel = yAxis.GetPixel(coordinates.Y, RenderManager.LastRender.DataRect);
+
+        if (ScaleFactor != 1)
+        {
+            xPixel *= ScaleFactor;
+            yPixel *= ScaleFactor;
+        }
+
         return new Pixel(xPixel, yPixel);
     }
 


### PR DESCRIPTION
Fixes #3327 

A per title, fixes the GetPixel bug.  Includes 2 new unit tests for the fix.

I've taken the liberty of updating the CHANGELOG.  Apologies if this makes the merge more complicated.