### PR TITLE
SP5: Fix typeface caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 _Not yet on NuGet..._
 * Rendering: Added additional options for gradient fills (#3324) _Thanks @KroMignon_
 * Plot: Improve `GetPixel()` behavior when a custom `ScaleFactor` is in use (#3327) _Thanks @MCF_
+* Fonts: Improve behavior of cached typefaces (#3334, #3335) _Thanks @Milkitic_
 
 ## ScottPlot 5.0.21
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-28_

--- a/src/ScottPlot5/ScottPlot5/Primitives/FontStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/FontStyle.cs
@@ -15,7 +15,7 @@ public class FontStyle
 
     private SKTypeface? CachedTypeface = null;
 
-    public SKTypeface Typeface => CachedTypeface ?? CreateTypeface(Name, Bold, Italic);
+    public SKTypeface Typeface => CachedTypeface ??= CreateTypeface(Name, Bold, Italic);
 
     private string _name = Fonts.Default;
     public string Name

--- a/src/ScottPlot5/ScottPlot5/Primitives/FontStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/FontStyle.cs
@@ -15,6 +15,7 @@ public class FontStyle
 
     private SKTypeface? CachedTypeface = null;
 
+    // TODO: use a class for cached typeface management
     public SKTypeface Typeface => CachedTypeface ??= CreateTypeface(Name, Bold, Italic);
 
     private string _name = Fonts.Default;

--- a/src/ScottPlot5/ScottPlot5/Primitives/Label.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Label.cs
@@ -24,9 +24,15 @@ public class Label
 
     public bool UseCachedTypefaces = true;
     private SKTypeface? CachedTypeface = null;
-    private SKTypeface Typeface => (UseCachedTypefaces && CachedTypeface is not null)
-        ? CachedTypeface
-        : FontStyle.CreateTypeface(FontName, Bold, Italic);
+    private SKTypeface Typeface
+    {
+        get
+        {
+            if (UseCachedTypefaces)
+                return CachedTypeface ??= FontStyle.CreateTypeface(FontName, Bold, Italic);
+            return FontStyle.CreateTypeface(FontName, Bold, Italic);
+        }
+    }
 
     private string _FontName = Fonts.Default;
     public string FontName


### PR DESCRIPTION
Fixes: https://github.com/ScottPlot/ScottPlot/issues/3335

Checked https://github.com/ScottPlot/ScottPlot/pull/2848 and https://github.com/ScottPlot/ScottPlot/issues/2419, but it seems that the issue is not actually fixed in the latest branch.
It causes critical performance issues in Linux systems.
In KUbuntu 23.10 with Avalonia 11.0.7 , the problem still exists as below:

![Screenshot_20240202_105303](https://github.com/ScottPlot/ScottPlot/assets/24785749/f1ea6e30-a358-4e4a-908e-4d6b1e69ae98)

After fixing:

![Screenshot_20240202_140558](https://github.com/ScottPlot/ScottPlot/assets/24785749/f2ccee85-e184-44e2-90ac-e6e2b2fd5197)

Just simply modifed the code to reach the caching goals:

```cs
// public SKTypeface Typeface => CachedTypeface ?? CreateTypeface(Name, Bold, Italic); // broken
public SKTypeface Typeface => CachedTypeface ??= CreateTypeface(Name, Bold, Italic); // works
```