### PR TITLE
SP5: Add horizontal orientation to legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _Not yet on NuGet..._
 * Rendering: Added additional options for gradient fills (#3324) _Thanks @KroMignon_
 * Plot: Improve `GetPixel()` behavior when a custom `ScaleFactor` is in use (#3327) _Thanks @MCF_
 * Fonts: Improve behavior of cached typefaces (#3334, #3335) _Thanks @Milkitic_
+* Legend: Added support for horizontal orientation (#3341, #3302, #3280) _Thanks @KroMignon_
 
 ## ScottPlot 5.0.21
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-28_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Legend.cs
@@ -83,4 +83,45 @@ public class Legend : ICategory
             myPlot.Legend.Location = Alignment.UpperCenter;
         }
     }
+
+    public class LegendOrientation : RecipeBase
+    {
+        public override string Name => "Legend Orientation";
+        public override string Description => "Legend items may be arranged horizontally instead of vertically";
+
+        [Test]
+        public override void Execute()
+        {
+            var sig1 = myPlot.Add.Signal(Generate.Sin(51, phase: .2));
+            var sig2 = myPlot.Add.Signal(Generate.Sin(51, phase: .4));
+            var sig3 = myPlot.Add.Signal(Generate.Sin(51, phase: .6));
+
+            sig1.Label = "Signal 1";
+            sig2.Label = "Signal 2";
+            sig3.Label = "Signal 3";
+
+            myPlot.Legend.IsVisible = true;
+            myPlot.Legend.Orientation = Orientation.Horizontal;
+        }
+    }
+
+    public class LegendWrapping : RecipeBase
+    {
+        public override string Name => "Legend Wrapping";
+        public override string Description => "Legend items may wrap to improve display for a large number of items";
+
+        [Test]
+        public override void Execute()
+        {
+            for (int i = 1; i <= 10; i++)
+            {
+                var sig = myPlot.Add.Signal(Generate.Sin(51, phase: .02 * i));
+                sig.Label = $"Signal #{i}";
+            }
+
+            myPlot.Legend.IsVisible = true;
+            myPlot.Legend.Orientation = Orientation.Horizontal;
+            myPlot.Legend.AllowMultiline = true;
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Legends/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/Legend.cs
@@ -28,6 +28,9 @@ public class Legend(Plot plot)
 
     private readonly Plot Plot = plot;
 
+    public void Show() => IsVisible = true;
+    public void Hide() => IsVisible = false;
+
     public void Render(RenderPack rp)
     {
         if (!IsVisible)

--- a/src/ScottPlot5/ScottPlot5/Legends/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/Legend.cs
@@ -47,8 +47,8 @@ public class Legend(Plot plot)
             return;
 
         var legendSize = GetLegendSize(sizedItems,
-            maxWidth: rp.DataRect.Width - ShadowOffset*2 - Margin.Horizontal,
-            maxHeight: rp.DataRect.Height - ShadowOffset*2 - Margin.Vertical,
+            maxWidth: rp.DataRect.Width - ShadowOffset * 2 - Margin.Horizontal,
+            maxHeight: rp.DataRect.Height - ShadowOffset * 2 - Margin.Vertical,
             withOffset: false);
 
         PixelRect legendRect = legendSize.AlignedInside(rp.DataRect, Location, Margin);

--- a/src/ScottPlot5/ScottPlot5/Legends/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Legends/Legend.cs
@@ -11,6 +11,9 @@ public class Legend(Plot plot)
     public PixelPadding Padding { get; set; } = new PixelPadding(3);
     public PixelPadding ItemPadding { get; set; } = new PixelPadding(3);
 
+    public Orientation Orientation { get; set; } = Orientation.Vertical;
+    public bool AllowMultiline { get; set; } = false;
+
     public FontStyle Font { get; set; } = new();
     public LineStyle OutlineStyle { get; set; } = new();
     public FillStyle BackgroundFill { get; set; } = new() { Color = Colors.White };
@@ -43,10 +46,11 @@ public class Legend(Plot plot)
         if (sizedItems?.Any() != true)
             return;
 
-        float maxWidth = sizedItems.Select(x => x.Size.WithChildren.Width).Max();
-        float totalheight = sizedItems.Select(x => x.Size.WithChildren.Height).Sum();
+        var legendSize = GetLegendSize(sizedItems,
+            maxWidth: rp.DataRect.Width - ShadowOffset*2 - Margin.Horizontal,
+            maxHeight: rp.DataRect.Height - ShadowOffset*2 - Margin.Vertical,
+            withOffset: false);
 
-        PixelSize legendSize = new(maxWidth + Padding.Left + Padding.Right, totalheight + Padding.Top + Padding.Bottom);
         PixelRect legendRect = legendSize.AlignedInside(rp.DataRect, Location, Margin);
         PixelRect legendShadowRect = legendRect.WithDelta(ShadowOffset, ShadowOffset, Location);
         Pixel offset = new(legendRect.Left + Padding.Left, legendRect.Top + Padding.Top);
@@ -60,16 +64,50 @@ public class Legend(Plot plot)
         if (svgStream is null)
             throw new NullReferenceException($"invalid Stream");
 
-        var canvas = RenderToObject(plot, svgStream: svgStream, maxWidth: maxWidth, maxHeight: maxHeight) as SKCanvas;
-        canvas?.Dispose();
+        // measure all items to determine dimensions of the legend
+        using SKPaint paint = new();
+        SizedLegendItem[] sizedItems = GetSizedLegendItems(plot, paint);
+
+        if (sizedItems.Any() != true)
+            throw new InvalidOperationException($"empty legend items");
+
+        var legendSize = GetLegendSize(sizedItems, maxWidth: maxWidth, maxHeight: maxHeight, withOffset: true);
+
+        PixelRect legendRect = new(new Pixel(ShadowOffset, ShadowOffset), legendSize.Width - 2 * ShadowOffset, legendSize.Height - 2 * ShadowOffset);
+        PixelRect legendShadowRect = legendRect.WithDelta(ShadowOffset, ShadowOffset, Location);
+        Pixel offset = new(legendRect.Left + Padding.Left + ShadowOffset, legendRect.Top + Padding.Top + ShadowOffset);
+
+        using SKCanvas canvas = SKSvgCanvas.Create(new SKRect(0, 0, legendSize.Width, legendSize.Height), svgStream);
+        RenderLegend(sizedItems, canvas, paint, offset, legendRect, legendShadowRect);
     }
 
     public Image GetImage(Plot plot, int maxWidth = 0, int maxHeight = 0)
     {
-        SKSurface? surface = RenderToObject(plot, maxWidth: maxWidth, maxHeight: maxHeight) as SKSurface
-            ?? throw new NullReferenceException();
+        // measure all items to determine dimensions of the legend
+        using SKPaint paint = new();
+        SizedLegendItem[] sizedItems = GetSizedLegendItems(plot, paint);
+
+        if (sizedItems.Any() != true)
+            throw new InvalidOperationException($"empty legend items");
+
+        var legendSize = GetLegendSize(sizedItems, maxWidth: maxWidth, maxHeight: maxHeight, withOffset: true);
+
+        PixelRect legendRect = new(new Pixel(ShadowOffset, ShadowOffset), legendSize.Width - 2 * ShadowOffset, legendSize.Height - 2 * ShadowOffset);
+        PixelRect legendShadowRect = legendRect.WithDelta(ShadowOffset, ShadowOffset, Location);
+        Pixel offset = new(legendRect.Left + Padding.Left + ShadowOffset, legendRect.Top + Padding.Top + ShadowOffset);
+
+        SKImageInfo info = new(
+            width: (int)Math.Ceiling(legendSize.Width),
+            height: (int)Math.Ceiling(legendSize.Height),
+            colorType: SKColorType.Rgba8888,
+            alphaType: SKAlphaType.Premul);
+
+        using SKSurface surface = SKSurface.Create(info) ?? throw new NullReferenceException($"invalid SKImageInfo");
+
+        RenderLegend(sizedItems, surface.Canvas, paint, offset, legendRect, legendShadowRect);
+
         SKImage skimg = surface.Snapshot();
-        surface.Dispose();
+
         return new Image(skimg);
     }
 
@@ -77,10 +115,11 @@ public class Legend(Plot plot)
     {
         using SKPaint paint = new();
         SizedLegendItem[] sizedItems = GetSizedLegendItems(plot, paint);
-        float maxWidth = sizedItems.Select(x => x.Size.WithChildren.Width).Max() + Padding.Left + Padding.Right + 2 * ShadowOffset;
-        float totalHeight = sizedItems.Select(x => x.Size.WithChildren.Height).Sum() + Padding.Top + Padding.Bottom + 2 * ShadowOffset;
-        int width = (int)Math.Ceiling(maxWidth);
-        int height = (int)Math.Ceiling(totalHeight);
+
+        var legendSize = GetLegendSize(sizedItems, withOffset: true);
+
+        int width = (int)Math.Ceiling(legendSize.Width);
+        int height = (int)Math.Ceiling(legendSize.Height);
 
         PixelRect legendRect = new(0, width, 0, height);
         PixelRect legendShadowRect = legendRect.WithDelta(ShadowOffset, ShadowOffset, Location);
@@ -90,46 +129,6 @@ public class Legend(Plot plot)
         RenderLegend(sizedItems, svg.Canvas, paint, offset, legendRect, legendShadowRect);
         string svgXml = svg.GetXml();
         return svgXml;
-    }
-
-    private SKObject RenderToObject(ScottPlot.Plot plot, Stream? svgStream = null, int maxWidth = 0, int maxHeight = 0)
-    {
-        // measure all items to determine dimensions of the legend
-        using SKPaint paint = new();
-        SizedLegendItem[] sizedItems = GetSizedLegendItems(plot, paint);
-
-        if (sizedItems.Any() != true)
-            throw new InvalidOperationException($"empty legend items");
-
-        float maxItemWidth = sizedItems.Select(x => x.Size.WithChildren.Width).Max() + Padding.Left + Padding.Right + 2 * ShadowOffset;
-        if (maxWidth > 0)
-            maxItemWidth = Math.Min(maxItemWidth, maxWidth);
-        float totalheight = sizedItems.Select(x => x.Size.WithChildren.Height).Sum() + Padding.Top + Padding.Bottom + 2 * ShadowOffset;
-        if (maxHeight > 0)
-            totalheight = Math.Min(totalheight, maxHeight);
-
-        PixelSize legendSize = new(maxItemWidth, totalheight);
-        PixelRect legendRect = new(new Pixel(ShadowOffset, ShadowOffset), legendSize.Width - 2 * ShadowOffset, legendSize.Height - 2 * ShadowOffset);
-        PixelRect legendShadowRect = legendRect.WithDelta(ShadowOffset, ShadowOffset, Location);
-        Pixel offset = new(legendRect.Left + Padding.Left + ShadowOffset, legendRect.Top + Padding.Top + ShadowOffset);
-
-        if (svgStream is null)
-        {
-            SKImageInfo info = new(
-                width: (int)Math.Ceiling(legendSize.Width),
-                height: (int)Math.Ceiling(legendSize.Height),
-                colorType: SKColorType.Rgba8888,
-                alphaType: SKAlphaType.Premul);
-
-            SKSurface surface = SKSurface.Create(info) ?? throw new NullReferenceException($"invalid SKImageInfo");
-
-            RenderLegend(sizedItems, surface.Canvas, paint, offset, legendRect, legendShadowRect);
-            return surface;
-        }
-
-        SKCanvas canvas = SKSvgCanvas.Create(new SKRect(0, 0, legendSize.Width, legendSize.Height), svgStream);
-        RenderLegend(sizedItems, canvas, paint, offset, legendRect, legendShadowRect);
-        return canvas;
     }
 
     public IEnumerable<LegendItem> GetItems()
@@ -180,6 +179,52 @@ public class Legend(Plot plot)
         return sizedItems.ToArray();
     }
 
+    private PixelSize GetLegendSize(SizedLegendItem[] sizedItems, float maxWidth = 0, float maxHeight = 0, bool withOffset = false)
+    {
+        float legendWidth, legendHeight;
+
+        if (Orientation == Orientation.Vertical)
+        {
+            legendWidth = sizedItems.Select(x => x.Size.WithChildren.Width).Max();
+            legendHeight = sizedItems.Select(x => x.Size.WithChildren.Height).Sum();
+        }
+        else if (AllowMultiline && maxWidth > 0)
+        {
+            float lw = 0;
+            float lh = 0;
+            legendWidth = legendHeight = 0;
+            foreach (var item in sizedItems)
+            {
+                if (item.Size.WithChildren.Width + legendWidth > maxWidth)
+                {
+                    lw = Math.Max(lw, legendWidth);
+                    legendWidth = 0;
+                    legendHeight += lh;
+                    lh = 0;
+                }
+                legendWidth += item.Size.WithChildren.Width;
+                lh = Math.Max(lh, item.Size.WithChildren.Height);
+            }
+            legendHeight += lh;
+            legendWidth = Math.Max(lw, legendWidth);
+        }
+        else
+        {
+            legendWidth = sizedItems.Select(x => x.Size.WithChildren.Width).Sum();
+            legendHeight = sizedItems.Select(x => x.Size.WithChildren.Height).Max();
+        }
+
+        legendWidth += Padding.Left + Padding.Right + (withOffset ? 2 * ShadowOffset : 0);
+        legendHeight += Padding.Top + Padding.Bottom + (withOffset ? 2 * ShadowOffset : 0);
+
+        if (maxWidth > 0)
+            legendWidth = Math.Min(legendWidth, maxWidth);
+        if (maxHeight > 0)
+            legendHeight = Math.Min(legendHeight, maxHeight);
+
+        return new(legendWidth, legendHeight);
+    }
+
     private void RenderLegend(SizedLegendItem[] sizedItems, SKCanvas canvas, SKPaint paint, Pixel offset, PixelRect legendRect, PixelRect legendShadowRect)
     {
         // render the legend panel
@@ -188,20 +233,34 @@ public class Legend(Plot plot)
         Drawing.DrawRectangle(canvas, legendRect, OutlineStyle.Color, OutlineStyle.Width);
 
         // render all items inside the legend
+        float xOffset = offset.X;
+        float prevHeight = 0;
         float yOffset = offset.Y;
         foreach (SizedLegendItem item in sizedItems)
         {
+            if (Orientation == Orientation.Horizontal && AllowMultiline && (xOffset + item.Size.WithChildren.Width) > legendRect.Right)
+            {
+                yOffset += prevHeight;
+                xOffset = offset.X;
+                prevHeight = 0;
+            }
             Common.RenderItem(
                 canvas: canvas,
                 paint: paint,
                 sizedItem: item,
-                x: offset.X,
+                x: xOffset,
                 y: yOffset,
                 symbolWidth: SymbolWidth,
                 symbolPadRight: SymbolLabelSeparation,
                 itemPadding: ItemPadding);
 
-            yOffset += item.Size.WithChildren.Height;
+            if (Orientation == Orientation.Horizontal)
+            {
+                xOffset += item.Size.WithChildren.Width;
+                prevHeight = Math.Max(prevHeight, item.Size.WithChildren.Height);
+            }
+            else
+                yOffset += item.Size.WithChildren.Height;
         }
     }
 }


### PR DESCRIPTION
Add missed property `Orientation` to `Legend`.

Add also an additional property `AllowMultiline` to support multi-line horizontal `Legend` when legend contains too many items.

This should fix issues #3302 and #3280