### PR TITLE
Add AddSeparator method to context menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ _Not yet on NuGet..._
 * Plot: Improve `GetPixel()` behavior when a custom `ScaleFactor` is in use (#3327) _Thanks @MCF_
 * Fonts: Improve behavior of cached typefaces (#3334, #3335) _Thanks @Milkitic_
 * Legend: Added support for horizontal orientation (#3341, #3302, #3280) _Thanks @KroMignon_
+* Controls: Created `AddSeparator()` to facilitate creation of custom context menus (#3342) _Thanks @MCF_
 
 ## ScottPlot 5.0.21
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-28_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlotMenu.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlotMenu.cs
@@ -38,10 +38,16 @@ public class AvaPlotMenu : IPlotMenu
 
         foreach (var curr in ContextMenuItems)
         {
-            var menuItem = new MenuItem { Header = curr.Label };
-            menuItem.Click += (s, e) => curr.OnInvoke(ThisControl);
-
-            items.Add(menuItem);
+            if (curr.IsSeparator)
+            {
+                items.Add(new MenuItem { Header = "-" });
+            }
+            else
+            {
+                var menuItem = new MenuItem { Header = curr.Label };
+                menuItem.Click += (s, e) => curr.OnInvoke(ThisControl);
+                items.Add(menuItem);
+            }
         }
 
         return new()
@@ -102,5 +108,10 @@ public class AvaPlotMenu : IPlotMenu
     public void Add(string Label, Action<IPlotControl> action)
     {
         ContextMenuItems.Add(new ContextMenuItem() { Label = Label, OnInvoke = action });
+    }
+
+    public void AddSeparator()
+    {
+        ContextMenuItems.Add(new ContextMenuItem() { IsSeparator = true });
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/BlazorPlotMenu.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/BlazorPlotMenu.cs
@@ -18,4 +18,8 @@ public class BlazorPlotMenu : IPlotMenu
     public void Add(string Label, Action<IPlotControl> action)
     {
     }
+
+    public void AddSeparator()
+    {
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Eto/EtoPlotMenu.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Eto/EtoPlotMenu.cs
@@ -41,10 +41,16 @@ public class EtoPlotMenu : IPlotMenu
         ContextMenu menu = new();
         foreach (var curr in ContextMenuItems)
         {
-            var menuItem = new ButtonMenuItem() { Text = curr.Label };
-            menuItem.Click += (s, e) => curr.OnInvoke(ThisControl);
-
-            menu.Items.Add(menuItem);
+            if (curr.IsSeparator)
+            {
+                menu.Items.AddSeparator();
+            }
+            else
+            {
+                var menuItem = new ButtonMenuItem() { Text = curr.Label };
+                menuItem.Click += (s, e) => curr.OnInvoke(ThisControl);
+                menu.Items.Add(menuItem);
+            }
         }
 
         return menu;
@@ -119,5 +125,10 @@ public class EtoPlotMenu : IPlotMenu
     public void Add(string Label, Action<IPlotControl> action)
     {
         ContextMenuItems.Add(new ContextMenuItem() { Label = Label, OnInvoke = action });
+    }
+
+    public void AddSeparator()
+    {
+        ContextMenuItems.Add(new ContextMenuItem() { IsSeparator = true });
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotMenu.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotMenu.cs
@@ -44,9 +44,16 @@ public class WpfPlotMenu : IPlotMenu
 
         foreach (ContextMenuItem curr in ContextMenuItems)
         {
-            MenuItem menuItem = new() { Header = curr.Label };
-            menuItem.Click += (s, e) => curr.OnInvoke(ThisControl);
-            menu.Items.Add(menuItem);
+            if (curr.IsSeparator)
+            {
+                menu.Items.Add(new Separator());
+            }
+            else
+            {
+                MenuItem menuItem = new() { Header = curr.Label };
+                menuItem.Click += (s, e) => curr.OnInvoke(ThisControl);
+                menu.Items.Add(menuItem);
+            }
         }
 
         return menu;
@@ -131,5 +138,10 @@ public class WpfPlotMenu : IPlotMenu
     public void Add(string Label, Action<IPlotControl> action)
     {
         ContextMenuItems.Add(new ContextMenuItem() { Label = Label, OnInvoke = action });
+    }
+
+    public void AddSeparator()
+    {
+        ContextMenuItems.Add(new ContextMenuItem() { IsSeparator = true });
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotMenu.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotMenu.cs
@@ -52,10 +52,17 @@ public class FormsPlotMenu : IPlotMenu
 
         foreach (ContextMenuItem item in ContextMenuItems)
         {
-            ToolStripMenuItem menuItem = new(item.Label);
-            menuItem.Click += (s, e) => item.OnInvoke(ThisControl);
+            if (item.IsSeparator)
+            {
+                menu.Items.Add(new ToolStripSeparator());
+            }
+            else
+            {
+                ToolStripMenuItem menuItem = new(item.Label);
+                menuItem.Click += (s, e) => item.OnInvoke(ThisControl);
 
-            menu.Items.Add(menuItem);
+                menu.Items.Add(menuItem);
+            }
         }
 
         return menu;
@@ -125,5 +132,10 @@ public class FormsPlotMenu : IPlotMenu
     public void Add(string Label, Action<IPlotControl> action)
     {
         ContextMenuItems.Add(new ContextMenuItem() { Label = Label, OnInvoke = action });
+    }
+
+    public void AddSeparator()
+    {
+        ContextMenuItems.Add(new ContextMenuItem() { IsSeparator = true });
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/WinUIPlotMenu.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/WinUIPlotMenu.cs
@@ -44,10 +44,16 @@ public class WinUIPlotMenu : IPlotMenu
 
         foreach (var curr in ContextMenuItems)
         {
-            var menuItem = new MenuFlyoutItem { Text = curr.Label };
-            menuItem.Click += (s, e) => curr.OnInvoke(plotControl);
-
-            menu.Items.Add(menuItem);
+            if (curr.IsSeparator)
+            {
+                menu.Items.Add(new MenuFlyoutSeparator());
+            }
+            else
+            {
+                var menuItem = new MenuFlyoutItem { Text = curr.Label };
+                menuItem.Click += (s, e) => curr.OnInvoke(plotControl);
+                menu.Items.Add(menuItem);
+            }
         }
 
         return menu;
@@ -117,5 +123,10 @@ public class WinUIPlotMenu : IPlotMenu
     public void Add(string Label, Action<IPlotControl> action)
     {
         ContextMenuItems.Add(new ContextMenuItem() { Label = Label, OnInvoke = action });
+    }
+
+    public void AddSeparator()
+    {
+        ContextMenuItems.Add(new ContextMenuItem() { IsSeparator = true });
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/CustomMenu.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/CustomMenu.cs
@@ -58,6 +58,8 @@ public partial class CustomMenu : Form, IDemoWindow
             formsplot1.Refresh();
         });
 
+        formsPlot1.Menu.AddSeparator();
+
         formsPlot1.Menu.Add("Clear", (formsplot1) =>
         {
             formsplot1.Plot.Clear();

--- a/src/ScottPlot5/ScottPlot5/Control/ContextMenuItem.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/ContextMenuItem.cs
@@ -5,6 +5,7 @@
 /// </summary>
 public struct ContextMenuItem
 {
+    public bool IsSeparator { get; set; }
     public string Label { get; set; }
     public Action<IPlotControl> OnInvoke { get; set; }
 }

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IPlotMenu.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IPlotMenu.cs
@@ -8,5 +8,7 @@ public interface IPlotMenu
 
     public void Add(string Label, Action<IPlotControl> action);
 
+    public void AddSeparator();
+
     void ShowContextMenu(Pixel pixel);
 }


### PR DESCRIPTION
As discussed on Discord this PR adds the AddSeparator function to the IPlotMenu interface and the plot controls that implement it.  Each of those plot controls has been tested individually in a sandbox or demo.  Only the WinForms demo has the test checked in.

Now the following code will give you a menu separator between the _Add Text_ and _Clear_ menu items.

```cs
        ScottPlot.Plot myPlot = new();

        myPlot.Menu.Add("Add Text", (myPlot) =>
        {
            var txt = formsplot1.Plot.Add.Text("Test", Generate.RandomLocation());
            txt.Size = 10 + Generate.RandomInteger(20);
            txt.Color = Generate.RandomColor(128);
            txt.Bold = true;
            formsplot1.Plot.Axes.AutoScale();
            formsplot1.Refresh();
        });
        myPlot.Menu.AddSeparator();
        myPlot.Menu.Add("Clear", (formsplot1) =>
        {
            formsplot1.Plot.Clear();
            formsplot1.Plot.Axes.AutoScale();
            formsplot1.Refresh();
        });
        myPlot.Refresh();
```