### PR TITLE
Fix race condition in ScottPlot.DataViews.Wipe

### DIFF
--- a/src/ScottPlot5/ScottPlot5/DataViews/Wipe.cs
+++ b/src/ScottPlot5/ScottPlot5/DataViews/Wipe.cs
@@ -36,9 +36,9 @@ public class Wipe : IDataStreamerView
 
         for (int i = 0; i < oldest.Length; i++)
         {
-            double xPos = (i + Streamer.Data.NextIndex) * Streamer.Data.SamplePeriod + Streamer.Data.OffsetX;
+            double xPos = (i + newestCount) * Streamer.Data.SamplePeriod + Streamer.Data.OffsetX;
             float x = Streamer.Axes.GetPixelX(WipeRight ? xPos : xMax - xPos);
-            float y = Streamer.Axes.GetPixelY(Streamer.Data.Data[i + Streamer.Data.NextIndex] + Streamer.Data.OffsetY);
+            float y = Streamer.Axes.GetPixelY(Streamer.Data.Data[i + newestCount] + Streamer.Data.OffsetY);
             oldest[i] = new(x, y);
         }
 


### PR DESCRIPTION
Streamer.Data.NextIndex might get updated after it's assigned to newestCount, but before it's used when populating oldest[i], which sometimes leads to array index getting out of bounds.