### PR TITLE
SP5: Radial gauge plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _Not yet on NuGet..._
 * Fonts: Improve behavior of cached typefaces (#3334, #3335) _Thanks @Milkitic_
 * Legend: Added support for horizontal orientation (#3341, #3302, #3280) _Thanks @KroMignon_
 * Controls: Created `AddSeparator()` to facilitate creation of custom context menus (#3342) _Thanks @MCF_
+* Live Data: Improved indexing of the `Wipe` view to prevent race conditions when displaying live data (#3352) _Thanks @drolevar_
 
 ## ScottPlot 5.0.21
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-28_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _Not yet on NuGet..._
 * Legend: Added support for horizontal orientation (#3341, #3302, #3280) _Thanks @KroMignon_
 * Controls: Created `AddSeparator()` to facilitate creation of custom context menus (#3342) _Thanks @MCF_
 * Live Data: Improved indexing of the `Wipe` view to prevent race conditions when displaying live data (#3352) _Thanks @drolevar_
+* Radial Gauge Plot: Added a new plot type for displaying categorical data as circular gauges (#3358) _Thanks @arthurits_
 
 ## ScottPlot 5.0.21
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-28_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/RadialGauge.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/RadialGauge.cs
@@ -1,0 +1,21 @@
+﻿namespace ScottPlotCookbook.Recipes.PlotTypes;
+
+public class RadialGauge : ICategory
+{
+    public string Chapter => "Plot Types";
+    public string CategoryName => "Radial gauge";
+    public string CategoryDescription => "A radial gauge chart displays scalar data as circular gauges.";
+
+    public class RadialGaugeQuickstart : RecipeBase
+    {
+        public override string Name => "Radial gauge from values";
+        public override string Description => "A radial gauge chart can be created from a few values.";
+
+        [Test]
+        public override void Execute()
+        {
+            double[] values = { 100, 80, 65, 45, 20 };
+            var radialGauglePlot = myPlot.Add.RadialGaugePlot(values);
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/RadialGauge.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/RadialGauge.cs
@@ -129,23 +129,25 @@ public class RadialGauge : ICategory
         }
     }
 
-    public class RadialGaugeCaps : RecipeBase
-    {
-        public override string Name => "Gauge Caps";
-        public override string Description =>
-            "Caps can be customized for the starting and end of the gauges. ";
+    // This does not apply unless we create our own caps drawing
 
-        public override void Execute()
-        {
-            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
-            double[] values = { 100, 80, 65, 45, 20 };
+    //public class RadialGaugeCaps : RecipeBase
+    //{
+    //    public override string Name => "Gauge Caps";
+    //    public override string Description =>
+    //        "Caps can be customized for the starting and end of the gauges. ";
 
-            var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
-            radialGaugePlot.CircularBackground = false;
-            radialGaugePlot.StartCap = SKStrokeCap.Round;
-            radialGaugePlot.EndCap = SKStrokeCap.Round;
-        }
-    }
+    //    public override void Execute()
+    //    {
+    //        myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+    //        double[] values = { 100, 80, 65, 45, 20 };
+
+    //        var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
+    //        radialGaugePlot.CircularBackground = false;
+    //        radialGaugePlot.StartCap = SKStrokeCap.Round;
+    //        radialGaugePlot.EndCap = SKStrokeCap.Round;
+    //    }
+    //}
 
     public class RadialGaugeStart : RecipeBase
     {
@@ -211,7 +213,7 @@ public class RadialGauge : ICategory
             double[] values = { 100, 80, 65, 45, 20 };
 
             var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
-            radialGaugePlot.LabelPositionFraction = 0;
+            radialGaugePlot.LabelPositionFraction = 0.5;
         }
     }
 
@@ -243,7 +245,7 @@ public class RadialGauge : ICategory
             double[] values = { 100, 80, 65, 45, 20 };
 
             var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
-            //radialGaugePlot.Font.Typeface.Color = Color.Black;
+            radialGaugePlot.Font.Color= Colors.Black;
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/RadialGauge.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/RadialGauge.cs
@@ -1,4 +1,6 @@
-﻿namespace ScottPlotCookbook.Recipes.PlotTypes;
+﻿using SkiaSharp;
+
+namespace ScottPlotCookbook.Recipes.PlotTypes;
 
 public class RadialGauge : ICategory
 {
@@ -15,7 +17,286 @@ public class RadialGauge : ICategory
         public override void Execute()
         {
             double[] values = { 100, 80, 65, 45, 20 };
-            var radialGauglePlot = myPlot.Add.RadialGaugePlot(values);
+            myPlot.Add.RadialGaugePlot(values);
+        }
+    }
+
+    public class RadialGaugeColormap : RecipeBase
+    {
+        public override string Name => "Gauge Colors";
+        public override string Description => "Gauge colors can be customized by changing the default palette.";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, 65, 45, 20 };
+            myPlot.Add.RadialGaugePlot(values);
+        }
+    }
+
+    public class RadialGaugeNegative : RecipeBase
+    {
+        public override string Name => "Negative Values";
+        public override string Description => "Radial gauge plots support positive and negative values.";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, -65, 45, -20 };
+            myPlot.Add.RadialGaugePlot(values);
+        }
+    }
+
+    public class RadialGaugeSequential : RecipeBase
+    {
+        public override string Name => "Sequential Gauge Mode";
+        public override string Description =>
+            "Sequential gauge mode indicates that the base of each gauge starts " +
+            "at the tip of the previous gauge.";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, 65, 45, 50 };
+            var radialGaugePlot= myPlot.Add.RadialGaugePlot(values);
+            radialGaugePlot.GaugeMode = ScottPlot.RadialGaugeMode.Sequential;
+        }
+    }
+
+    public class RadialGaugeReverse : RecipeBase
+    {
+        public override string Name => "Reverse Order";
+        public override string Description =>
+            "Gauges are displayed from the center outward by default but the order can be customized.";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, 65, 45, 50 };
+            var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
+            radialGaugePlot.GaugeMode = ScottPlot.RadialGaugeMode.Sequential;
+            radialGaugePlot.OrderInsideOut = false;
+        }
+    }
+
+    public class RadialGaugeModeSingle : RecipeBase
+    {
+        public override string Name => "Single Gauge Mode";
+        public override string Description =>
+            "The SingleGauge mode draws all gauges stacked together as a single gauge. " +
+            "This is useful for showing a progress gauges composed of many individual smaller gauges.";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, 65, 45 };
+
+            var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
+            radialGaugePlot.GaugeMode = ScottPlot.RadialGaugeMode.SingleGauge;
+            radialGaugePlot.MaximumAngle = 180;
+            radialGaugePlot.StartingAngle = 180;
+        }
+    }
+
+    public class RadialGaugeDirection : RecipeBase
+    {
+        public override string Name => "Gauge Direction";
+        public override string Description =>
+            "The direction of gauges can be customized. Clockwise is used by default.";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, 65, 45, 20 };
+
+            var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
+            radialGaugePlot.Clockwise = false;
+        }
+    }
+
+    public class RadialGaugeSize : RecipeBase
+    {
+        public override string Name => "Gauge Size";
+        public override string Description =>
+            "The empty space between gauges can be adjusted as a fraction of their width. ";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, 65, 45, 20 };
+            var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
+            radialGaugePlot.SpaceFraction = .05;
+        }
+    }
+
+    public class RadialGaugeCaps : RecipeBase
+    {
+        public override string Name => "Gauge Caps";
+        public override string Description =>
+            "Caps can be customized for the starting and end of the gauges. ";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, 65, 45, 20 };
+
+            var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
+            radialGaugePlot.CircularBackground = false;
+            radialGaugePlot.StartCap = SKStrokeCap.Round;
+            radialGaugePlot.EndCap = SKStrokeCap.Round;
+        }
+    }
+
+    public class RadialGaugeStart : RecipeBase
+    {
+        public override string Name => "Gauge Starting Angle";
+        public override string Description =>
+            "The starting angle for gauges can be customized. " +
+            "270 for North (default value), 0 for East, 90 for South, 180 for West, etc.";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, 65, 45, 20 };
+
+            var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
+            radialGaugePlot.StartingAngle = 180;
+        }
+    }
+
+    public class RadialGaugeRange : RecipeBase
+    {
+        public override string Name => "Gauge Angular Range";
+        public override string Description =>
+            "By default gauges are full circles (360 degrees) but smaller gauges can be created " +
+            "by customizing the gauge size.";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, 65, 45, 20 };
+
+            var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
+            radialGaugePlot.MaximumAngle = 180;
+        }
+    }
+
+    public class RadialGaugeLabels : RecipeBase
+    {
+        public override string Name => "Show Levels";
+        public override string Description =>
+            "The value of each gauge is displayed as text by default but this behavior can be overridden. " +
+            "Note that this is different than the labels fiels which is what appears in the legened.";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, 65, 45, 20 };
+
+            var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
+            radialGaugePlot.ShowLevels = false;
+        }
+    }
+
+    public class RadialGaugeLabelPos : RecipeBase
+    {
+        public override string Name => "Gauge Label Position";
+        public override string Description =>
+            "Gauge level text is positioned at the tip of each gauge by default, " +
+            "but this position can be adjusted by the user.";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, 65, 45, 20 };
+
+            var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
+            radialGaugePlot.LabelPositionFraction = 0;
+        }
+    }
+
+    public class RadialGaugeLabelFontPct : RecipeBase
+    {
+        public override string Name => "Gauge Label Font Percentage";
+        public override string Description =>
+            "Size of the gauge level text as a fraction of the gauge width.";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, 65, 45, 20 };
+
+            var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
+            radialGaugePlot.FontSizeFraction = .4;
+        }
+    }
+
+    public class RadialGaugeLabelColor : RecipeBase
+    {
+        public override string Name => "Gauge Label Color";
+        public override string Description =>
+            "Level text fonts may be customized.";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, 65, 45, 20 };
+
+            var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
+            //radialGaugePlot.Font.Typeface.Color = Color.Black;
+        }
+    }
+
+    public class RadialGaugeLegend : RecipeBase
+    {
+        public override string Name => "Gauge Labels in Legend";
+        public override string Description =>
+            "Radial gauge labels will appear in the legend if they are assigned. ";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, 65, 45, 20 };
+
+            var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
+            radialGaugePlot.Labels = new string[] { "alpha", "beta", "gamma", "delta", "epsilon" };
+            myPlot.ShowLegend();
+        }
+    }
+
+    public class RadialGaugeBackDim : RecipeBase
+    {
+        public override string Name => "Background Gauges Dim";
+        public override string Description =>
+            "By default the full range of each gauge is drawn as a semitransparent ring. " +
+            "The amount of transparency can be adjusted as desired.";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, 65, 45, 20 };
+
+            var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
+            radialGaugePlot.BackgroundTransparencyFraction = .5;
+        }
+    }
+
+    public class RadialGaugeBackNorm : RecipeBase
+    {
+        public override string Name => "Background Gauges Normalization";
+        public override string Description =>
+            "Gauge backgrounds are drawn as full circles by default. " +
+            "This behavior can be disabled to draw partial backgrounds for non-circular gauges.";
+
+        public override void Execute()
+        {
+            myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
+            double[] values = { 100, 80, 65, 45, 20 };
+
+            var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
+            radialGaugePlot.CircularBackground = false;
+            radialGaugePlot.MaximumAngle = 180;
+            radialGaugePlot.StartingAngle = 180;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/RadialGauge.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/RadialGauge.cs
@@ -58,7 +58,7 @@ public class RadialGauge : ICategory
         {
             myPlot.Add.Palette = new ScottPlot.Palettes.Nord();
             double[] values = { 100, 80, 65, 45, 50 };
-            var radialGaugePlot= myPlot.Add.RadialGaugePlot(values);
+            var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
             radialGaugePlot.GaugeMode = ScottPlot.RadialGaugeMode.Sequential;
         }
     }
@@ -245,7 +245,7 @@ public class RadialGauge : ICategory
             double[] values = { 100, 80, 65, 45, 20 };
 
             var radialGaugePlot = myPlot.Add.RadialGaugePlot(values);
-            radialGaugePlot.Font.Color= Colors.Black;
+            radialGaugePlot.Font.Color = Colors.Black;
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -1,6 +1,7 @@
 ﻿using ScottPlot.Panels;
 using ScottPlot.Plottables;
 using ScottPlot.DataSources;
+using ScottPlot.Plottable;
 
 namespace ScottPlot;
 
@@ -471,6 +472,14 @@ public class PlottableAdder(Plot plot)
     {
         Plot.PlottableList.Add(plottable);
         return plottable;
+    }
+
+    public RadialGaugePlot RadialGaugePlot(IEnumerable<double> values)
+    {
+        Color[] colors = Enumerable.Range(0, values.Count()).Select(x => Palette.GetColor(x)).ToArray();
+        RadialGaugePlot radialGaugePlot = new(values.ToArray(), colors);
+        Plot.PlottableList.Add(radialGaugePlot);
+        return radialGaugePlot;
     }
 
     public Rectangle Rectangle(CoordinateRect rect)

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -479,6 +479,8 @@ public class PlottableAdder(Plot plot)
         Color[] colors = Enumerable.Range(0, values.Count()).Select(x => Palette.GetColor(x)).ToArray();
         RadialGaugePlot radialGaugePlot = new(values.ToArray(), colors);
         Plot.PlottableList.Add(radialGaugePlot);
+        Plot.HideGrid();
+        Plot.Layout.Frameless();
         return radialGaugePlot;
     }
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/RadialGauge.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/RadialGauge.cs
@@ -182,7 +182,7 @@ internal class RadialGauge
         double textAngle = DEG_PER_RAD * textBounds.Width / radius;
 
         // We compute the angular location where the label has to be drawn.
-        double angle = ReduceAngle(StartAngle + SweepAngle * LabelPositionFraction - textAngle/2);
+        double angle = ReduceAngle(StartAngle + SweepAngle * LabelPositionFraction - textAngle / 2);
         bool isBelow = angle <= 180 && angle > 0;
 
         // This is a very dirty trick to avoid label clipping at the gauge's very end.

--- a/src/ScottPlot5/ScottPlot5/Plottables/RadialGauge.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/RadialGauge.cs
@@ -1,0 +1,290 @@
+﻿//using ScottPlot.Drawing;
+using System;
+using System.Drawing;
+using System.Linq;
+
+namespace ScottPlot.Plottable;
+
+/// <summary>
+/// This class represents a single radial gauge.
+/// It has level and styling options and can be rendered onto an existing bitmap using any radius.
+/// </summary>
+internal class RadialGauge
+{
+    /// <summary>
+    /// Location of the base of the gauge (degrees)
+    /// </summary>
+    public double StartAngle { get; set; }
+
+    /// <summary>
+    /// Current level of this gauge (degrees)
+    /// </summary>
+    public double SweepAngle { get; set; }
+
+    /// <summary>
+    /// Maximum angular size of the gauge (swept degrees)
+    /// </summary>
+    public double MaximumSizeAngle { get; set; }
+
+    /// <summary>
+    /// Angle where the background starts (degrees)
+    /// </summary>
+    public double BackStartAngle { get; set; }
+
+    /// <summary>
+    /// If true angles end clockwise relative to their base
+    /// </summary>
+    public bool Clockwise { get; set; }
+
+    /// <summary>
+    /// Used internally to get the angle swept by the gauge background. It's equal to 360 degrees if CircularBackground is set to true. Also, returns a positive value is the gauge is drawn clockwise and a negative one otherwise
+    /// </summary>
+    internal double BackAngleSweep
+    {
+        get
+        {
+            double maxBackAngle = CircularBackground ? 360 : MaximumSizeAngle;
+            if (!Clockwise) maxBackAngle = -maxBackAngle;
+            return maxBackAngle;
+        }
+        private set { BackAngleSweep = value; } // Added for the sweepAngle check in DrawArc due to System.Drawing throwing an OutOfMemoryException.
+    }
+
+    /// <summary>
+    /// If true the background will always be drawn as a complete circle regardless of MaximumSizeAngle
+    /// </summary>
+    public bool CircularBackground { get; set; } = true;
+
+    /// <summary>
+    /// Font used to render values at the tip of the gauge
+    /// </summary>
+    public SKFont Font { get; set; }
+
+    /// <summary>
+    /// Size of the font relative to the line thickness
+    /// </summary>
+    public double FontSizeFraction { get; set; }
+
+    /// <summary>
+    /// Text to display on top of the label
+    /// </summary>
+    public string Label { get; set; }
+
+    /// <summary>
+    /// Location of the label text along the length of the gauge.
+    /// Low values place the label near the base and high values place the label at its tip.
+    /// </summary>
+    public double LabelPositionFraction { get; set; }
+
+    /// <summary>
+    /// Size of the gauge (pixels)
+    /// </summary>
+    public double Width { get; set; }
+
+    /// <summary>
+    /// Color of the gauge foreground
+    /// </summary>
+    public Color Color { get; set; }
+
+    /// <summary>
+    /// Color of the gauge background
+    /// </summary>
+    public Color BackgroundColor { get; set; }
+
+    /// <summary>
+    /// Style of the base of the gauge
+    /// </summary>
+    public SkiaSharp.SKStrokeCap StartCap { get; set; } = SKStrokeCap.Round;
+
+    /// <summary>
+    /// Style of the tip of the gauge
+    /// </summary>
+    public SkiaSharp.SKStrokeCap EndCap { get; set; } = SKStrokeCap.Round;
+
+    /// <summary>
+    /// Defines the location of each gauge relative to the start angle and distance from the center
+    /// </summary>
+    public RadialGaugeMode Mode { get; set; }
+
+    /// <summary>
+    /// Indicates whether or not labels will be rendered as text
+    /// </summary>
+    public bool ShowLabels { get; set; }
+
+    /// <summary>
+    /// Render the gauge onto an existing Bitmap
+    /// </summary>
+    /// <param name="gfx">active graphics object</param>
+    public void Render(RenderPack rp, float radius)
+    {
+        RenderBackground(rp, radius);
+        RenderGaugeForeground(rp, radius);
+        //RenderGaugeLabels(rp, radius);
+    }
+
+    private void RenderBackground(RenderPack rp, float radius)
+    {
+        if (Mode == RadialGaugeMode.SingleGauge)
+            return;
+
+        //using Pen backgroundPen = GDI.Pen(BackgroundColor);
+        //backgroundPen.Width = (float)Width;
+        //backgroundPen.StartCap = System.Drawing.Drawing2D.LineCap.Round;
+        //backgroundPen.EndCap = System.Drawing.Drawing2D.LineCap.Round;
+
+        // This check is specific to System.Drawing since DrawArc throws an OutOfMemoryException when the sweepAngle is very small.
+        if (Math.Abs(BackAngleSweep) <= 0.01)
+            BackAngleSweep = 0;
+
+        // See some examples here: https://learn.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/graphics/skiasharp/curves/arcs
+        using SKPaint paint = new()
+        {
+            IsAntialias = true,
+            Style = SKPaintStyle.Stroke,
+            StrokeWidth = (float)Width,
+            StrokeCap = StartCap,
+            Color = new(BackgroundColor.ARGB)
+        };
+
+        rp.Canvas.DrawArc(new(rp.FigureRect.BottomCenter.X - radius, rp.FigureRect.LeftCenter.Y - radius, rp.FigureRect.BottomCenter.X + radius, rp.FigureRect.LeftCenter.Y + radius),
+            (float)BackStartAngle,
+            (float)BackAngleSweep,
+            true,
+            paint);
+
+
+        //gfx.DrawArc(backgroundPen,
+        //            (rp.FigureRect.BottomCenter.X - radius),
+        //            (rp.FigureRect.LeftCenter.Y - radius),
+        //            (radius * 2),
+        //            (radius * 2),
+        //            (float)BackStartAngle,
+        //            (float)BackAngleSweep);
+    }
+
+    public void RenderGaugeForeground(RenderPack rp, float radius)
+    {
+        //using Pen pen = GDI.Pen(Color);
+        //pen.Width = (float)Width;
+        //pen.StartCap = StartCap;
+        //pen.EndCap = EndCap;
+
+        // This check is specific to System.Drawing since DrawArc throws an OutOfMemoryException when the sweepAngle is very small.
+        if (Math.Abs(SweepAngle) <= 0.01)
+            SweepAngle = 0;
+
+        using SKPaint paint = new()
+        {
+            IsAntialias = true,
+            Style = SKPaintStyle.Stroke,
+            StrokeWidth = (float)Width,
+            StrokeCap = StartCap,
+            Color = new(Color.ARGB)
+        };
+
+        rp.Canvas.DrawArc(new(rp.FigureRect.BottomCenter.X - radius, rp.FigureRect.LeftCenter.Y - radius, rp.FigureRect.BottomCenter.X + radius, rp.FigureRect.LeftCenter.Y + radius),
+            (float)BackStartAngle,
+            (float)BackAngleSweep,
+            true,
+            paint);
+
+        //gfx.DrawArc(
+        //    pen,
+        //    (center.X - radius),
+        //    (center.Y - radius),
+        //    (radius * 2),
+        //    (radius * 2),
+        //    (float)StartAngle,
+        //    (float)SweepAngle);
+    }
+
+    private const double DEG_PER_RAD = 180.0 / Math.PI;
+
+    //private void RenderGaugeLabels(Graphics gfx, PlotDimensions dims, PointF center, float radius)
+    //{
+    //    if (!ShowLabels)
+    //        return;
+
+    //    // TODO: use this so font size is in pixels not pt
+    //    //Font.Size = lineWidth * (float)FontSizeFraction;
+    //    //using System.Drawing.Font fontGauge = GDI.Font(Font);
+
+    //    using Brush brush = GDI.Brush(Font.Color);
+    //    using System.Drawing.Font font = new(Font.Name, (float)Width * (float)FontSizeFraction, FontStyle.Bold);
+
+    //    using StringFormat sf = GDI.StringFormat(HorizontalAlignment.Center, VerticalAlignment.Middle);
+
+    //    RectangleF[] letterRectangles = MeasureCharacters(gfx, font, Label);
+    //    double totalLetterWidths = letterRectangles.Select(rect => rect.Width).Sum();
+    //    double textWidthFrac = totalLetterWidths / radius;
+
+    //    double angle = ReduceAngle(StartAngle + SweepAngle * LabelPositionFraction);
+    //    double angle2 = (1 - 2 * LabelPositionFraction) * DEG_PER_RAD * textWidthFrac / 2;
+    //    bool isPositive = (SweepAngle > 0);
+    //    angle += isPositive ? angle2 : -angle2;
+
+    //    bool isBelow = angle < 180 && angle > 0;
+    //    int sign = isBelow ? 1 : -1;
+    //    double theta = angle * Math.PI / 180;
+    //    theta += textWidthFrac / 2 * sign;
+
+    //    for (int i = 0; i < Label.Length; i++)
+    //    {
+    //        theta -= letterRectangles[i].Width / 2 / radius * sign;
+    //        double rotation = (theta - Math.PI / 2 * sign) * DEG_PER_RAD;
+    //        float x = center.X + radius * (float)Math.Cos(theta);
+    //        float y = center.Y + radius * (float)Math.Sin(theta);
+
+    //        gfx.RotateTransform((float)rotation);
+    //        gfx.TranslateTransform(x, y, System.Drawing.Drawing2D.MatrixOrder.Append);
+    //        gfx.DrawString(Label[i].ToString(), font, brush, 0, 0, sf);
+    //        GDI.ResetTransformPreservingScale(gfx, dims);
+
+    //        theta -= letterRectangles[i].Width / 2 / radius * sign;
+    //    }
+    //}
+
+    ///// <summary>
+    ///// Return an array indicating the size of each character in a string.
+    ///// Specifiy the maximum expected size to avoid issues associated with text wrapping.
+    ///// </summary>
+    //private static RectangleF[] MeasureCharacters(Graphics gfx, System.Drawing.Font font, string text, int maxWidth = 800, int maxHeight = 100)
+    //{
+    //    using StringFormat stringFormat = new()
+    //    {
+    //        Alignment = StringAlignment.Center,
+    //        LineAlignment = StringAlignment.Center,
+    //        Trimming = StringTrimming.None,
+    //        FormatFlags = StringFormatFlags.MeasureTrailingSpaces,
+    //    };
+
+    //    CharacterRange[] charRanges = Enumerable.Range(0, text.Length)
+    //        .Select(x => new CharacterRange(x, 1))
+    //        .ToArray();
+
+    //    stringFormat.SetMeasurableCharacterRanges(charRanges);
+
+    //    RectangleF imageRectangle = new(0, 0, maxWidth, maxHeight);
+    //    Region[] characterRegions = gfx.MeasureCharacterRanges(text, font, imageRectangle, stringFormat);
+    //    RectangleF[] characterRectangles = characterRegions.Select(x => x.GetBounds(gfx)).ToArray();
+
+    //    return characterRectangles;
+    //}
+
+    /// <summary>
+    /// Reduces an angle into the range [0°-360°].
+    /// Angles greater than 360 will roll-over (370º becomes 10º).
+    /// Angles less than 0 will roll-under (-10º becomes 350º).
+    /// </summary>
+    /// <param name="angle">Angle value</param>
+    /// <returns>Angle whithin [0°-360°]</returns>
+    public static double ReduceAngle(double angle)
+    {
+        angle %= 360;
+
+        if (angle < 0)
+            angle += 360;
+
+        return angle;
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/RadialGauge.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/RadialGauge.cs
@@ -124,15 +124,6 @@ internal class RadialGauge
         if (Mode == RadialGaugeMode.SingleGauge)
             return;
 
-        //using Pen backgroundPen = GDI.Pen(BackgroundColor);
-        //backgroundPen.Width = (float)Width;
-        //backgroundPen.StartCap = System.Drawing.Drawing2D.LineCap.Round;
-        //backgroundPen.EndCap = System.Drawing.Drawing2D.LineCap.Round;
-
-        // This check is specific to System.Drawing since DrawArc throws an OutOfMemoryException when the sweepAngle is very small.
-        if (Math.Abs(BackAngleSweep) <= 0.01)
-            BackAngleSweep = 0;
-
         // See some examples here: https://learn.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/graphics/skiasharp/curves/arcs
         using SKPaint skPaint = new()
         {
@@ -228,80 +219,7 @@ internal class RadialGauge
         };
 
         rp.Canvas.DrawTextOnPath(Label, skPath, skPoint, skPaint);
-
-        // https://stackoverflow.com/questions/59892490/how-to-rotate-text-drawn-using-canvas-drawtextonpath
     }
-
-    //private void RenderGaugeLabels(Graphics gfx, PlotDimensions dims, PointF center, float radius)
-    //{
-    //    if (!ShowLabels)
-    //        return;
-
-    //    // TODO: use this so font size is in pixels not pt
-    //    //Font.Size = lineWidth * (float)FontSizeFraction;
-    //    //using System.Drawing.Font fontGauge = GDI.Font(Font);
-
-    //    using Brush brush = GDI.Brush(Font.Color);
-    //    using System.Drawing.Font font = new(Font.Name, (float)Width * (float)FontSizeFraction, FontStyle.Bold);
-
-    //    using StringFormat sf = GDI.StringFormat(HorizontalAlignment.Center, VerticalAlignment.Middle);
-
-    //    RectangleF[] letterRectangles = MeasureCharacters(gfx, font, Label);
-    //    double totalLetterWidths = letterRectangles.Select(rect => rect.Width).Sum();
-    //    double textWidthFrac = totalLetterWidths / radius;
-
-    //    double angle = ReduceAngle(StartAngle + SweepAngle * LabelPositionFraction);
-    //    double angle2 = (1 - 2 * LabelPositionFraction) * DEG_PER_RAD * textWidthFrac / 2;
-    //    bool isPositive = (SweepAngle > 0);
-    //    angle += isPositive ? angle2 : -angle2;
-
-    //    bool isBelow = angle < 180 && angle > 0;
-    //    int sign = isBelow ? 1 : -1;
-    //    double theta = angle * Math.PI / 180;
-    //    theta += textWidthFrac / 2 * sign;
-
-    //    for (int i = 0; i < Label.Length; i++)
-    //    {
-    //        theta -= letterRectangles[i].Width / 2 / radius * sign;
-    //        double rotation = (theta - Math.PI / 2 * sign) * DEG_PER_RAD;
-    //        float x = center.X + radius * (float)Math.Cos(theta);
-    //        float y = center.Y + radius * (float)Math.Sin(theta);
-
-    //        gfx.RotateTransform((float)rotation);
-    //        gfx.TranslateTransform(x, y, System.Drawing.Drawing2D.MatrixOrder.Append);
-    //        gfx.DrawString(Label[i].ToString(), font, brush, 0, 0, sf);
-    //        GDI.ResetTransformPreservingScale(gfx, dims);
-
-    //        theta -= letterRectangles[i].Width / 2 / radius * sign;
-    //    }
-    //}
-
-    ///// <summary>
-    ///// Return an array indicating the size of each character in a string.
-    ///// Specifiy the maximum expected size to avoid issues associated with text wrapping.
-    ///// </summary>
-    //private static RectangleF[] MeasureCharacters(Graphics gfx, System.Drawing.Font font, string text, int maxWidth = 800, int maxHeight = 100)
-    //{
-    //    using StringFormat stringFormat = new()
-    //    {
-    //        Alignment = StringAlignment.Center,
-    //        LineAlignment = StringAlignment.Center,
-    //        Trimming = StringTrimming.None,
-    //        FormatFlags = StringFormatFlags.MeasureTrailingSpaces,
-    //    };
-
-    //    CharacterRange[] charRanges = Enumerable.Range(0, text.Length)
-    //        .Select(x => new CharacterRange(x, 1))
-    //        .ToArray();
-
-    //    stringFormat.SetMeasurableCharacterRanges(charRanges);
-
-    //    RectangleF imageRectangle = new(0, 0, maxWidth, maxHeight);
-    //    Region[] characterRegions = gfx.MeasureCharacterRanges(text, font, imageRectangle, stringFormat);
-    //    RectangleF[] characterRectangles = characterRegions.Select(x => x.GetBounds(gfx)).ToArray();
-
-    //    return characterRectangles;
-    //}
 
     /// <summary>
     /// Reduces an angle into the range [0°-360°].

--- a/src/ScottPlot5/ScottPlot5/Plottables/RadialGaugePlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/RadialGaugePlot.cs
@@ -1,0 +1,384 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+//using ScottPlot.Drawing;
+
+// This plot type was inspired by MicroCharts:
+// https://github.com/dotnet-ad/Microcharts/blob/main/Sources/Microcharts/Charts/RadialGaugeChart.cs
+
+namespace ScottPlot.Plottable;
+
+/// <summary>
+/// A radial gauge chart is a graphical method of displaying scalar data in the form of 
+/// a chart made of circular gauges so that each scalar is represented by each gauge.
+/// </summary>
+public class RadialGaugePlot : IPlottable
+{
+    public IAxes Axes { get; set; } = new Axes();
+    //public IEnumerable<LegendItem> LegendItems => LegendItem.None;
+
+    /// <summary>
+    /// This array holds the original levels passed-in by the user. 
+    /// These levels are used to calculate radial gauge positions on every render.
+    /// </summary>
+    public double[] Levels { get; private set; }
+
+    /// <summary>
+    /// Number of gauges.
+    /// </summary>
+    public int GaugeCount => Levels.Length;
+
+    /// <summary>
+    /// Maximum size (degrees) for the gauge.
+    /// 180 is a semicircle and 360 is a full circle.
+    /// </summary>
+    public double MaximumAngle { get; set; } = 360;
+
+    /// <summary>
+    /// Controls whether the backgrounds of the gauges are full circles or stop at the maximum angle.
+    /// </summary>
+    public bool CircularBackground { get; set; } = true;
+
+    /// <summary>
+    /// Labels that appear in the legend for each gauge.
+    /// Number of labels must equal number of gauges.
+    /// May be null if gauges are not to appear in the legend.
+    /// </summary>
+    public string[] Labels { get; set; }
+
+    /// <summary>
+    /// Colors for each gauge.
+    /// Number of colors must equal number of gauges.
+    /// </summary>
+    public Color[] Colors { get; set; }
+
+    /// <summary>
+    /// Describes how transparent the unfilled background of each gauge is (0 to 1).
+    /// The larger the number the darker the background becomes.
+    /// </summary>
+    public double BackgroundTransparencyFraction { get; set; } = .15;
+
+    /// <summary>
+    /// Indicates whether gauges fill clockwise as levels increase.
+    /// If false, gauges will fill counter-clockwise (anti-clockwise).
+    /// </summary>
+    public bool Clockwise { get; set; } = true;
+
+    /// <summary>
+    /// Determines whether the gauges are drawn stacked (dafault value), sequentially, or as a single gauge (ressembling a pie plot).
+    /// </summary>
+    public RadialGaugeMode GaugeMode { get; set; } = RadialGaugeMode.Stacked;
+
+    /// <summary>
+    /// Controls whether gauges will be dwan inside-out (true) or outside-in (false)
+    /// </summary>
+    public bool OrderInsideOut { get; set; } = true;
+
+    /// <summary>
+    /// Defines where the gauge label is written on the gage as a fraction of its length.
+    /// Low values place the label near the base and high values place the label at its tip.
+    /// </summary>
+    public double LabelPositionFraction { get; set; } = 1;
+
+    /// <summary>
+    /// Angle (degrees) at which the gauges start.
+    /// 270° for North (default value), 0° for East, 90° for South, 180° for West, etc.
+    /// Expected values in the range [0°-360°], otherwise unexpected side-effects might happen.
+    /// </summary>
+    public float StartingAngle { get; set; } = 270;
+
+    /// <summary>
+    /// The empty space between gauges as a fraction of the gauge width.
+    /// </summary>
+    public double SpaceFraction { get; set; } = .5f;
+
+    /// <summary>
+    /// Size of the gague label text as a fraction of the gauge width.
+    /// </summary>
+    public double FontSizeFraction { get; set; } = .75;
+
+    /// <summary>
+    /// Describes labels drawn on each gauge.
+    /// </summary>
+    public readonly SKFont Font = new();
+
+    /// <summary>
+    /// Controls if value labels are shown inside the gauges.
+    /// </summary>
+    public bool ShowLevels { get; set; } = true;
+
+    /// <summary>
+    /// String formatter to use for converting gauge levels to text
+    /// </summary>
+    public string LevelTextFormat { get; set; } = "0.##";
+
+    /// <summary>
+    /// Style of the tip of the gauge
+    /// </summary>
+    public SkiaSharp.SKStrokeCap EndCap { get; set; } = SKStrokeCap.Round;
+
+    /// <summary>
+    /// Style of the base of the gauge
+    /// </summary>
+    public SkiaSharp.SKStrokeCap StartCap { get; set; } = SKStrokeCap.Round;
+
+    public bool IsVisible { get; set; } = true;
+    public int XAxisIndex { get; set; } = 0;
+    public int YAxisIndex { get; set; } = 0;
+
+    public RadialGaugePlot(double[] levels, Color[] colors)
+    {
+        Update(levels, colors);
+    }
+
+    public override string ToString() => $"RadialGaugePlot with {GaugeCount} gauges.";
+
+    /// <summary>
+    /// Replace gauge levels with new ones.
+    /// </summary>
+    public void Update(double[] levels, Color[] colors = null)
+    {
+        if (levels is null || levels.Length == 0)
+            throw new ArgumentException("values must not be null or empty");
+
+        bool numberOfGroupsChanged = (Levels is null) || (levels.Length != Levels.Length);
+        if (numberOfGroupsChanged)
+        {
+            if (colors is null || colors.Length != levels.Length)
+                throw new ArgumentException("when changing the number of values a new colors array must be provided");
+
+            Colors = new Color[colors.Length];
+            Array.Copy(colors, 0, Colors, 0, colors.Length);
+        }
+
+        Levels = levels;
+    }
+
+    /// <summary>
+    /// Calculate the rotational angles for each gauge from the original data values
+    /// </summary>
+    private static (double[] startAngles, double[] sweepAngles, double backStartAngle) GetGaugeAngles(
+        double[] values,
+        double angleStart,
+        double angleRange,
+        bool clockwise,
+        RadialGaugeMode mode)
+    {
+        double scaleMin = Math.Min(0, values.Min());
+        double scaleMax = values.Max(x => Math.Abs(x));
+
+        if (mode == RadialGaugeMode.Sequential || mode == RadialGaugeMode.SingleGauge)
+        {
+            scaleMax = values.Sum(x => Math.Abs(x));
+            scaleMin = 0;
+        }
+
+        double scaleRange = scaleMax - scaleMin;
+
+        int gaugeCount = values.Length;
+        double[] startAngles = new double[gaugeCount];
+        double[] sweepAngles = new double[gaugeCount];
+
+        angleStart = RadialGauge.ReduceAngle(angleStart);
+        double angleSum = angleStart;
+        for (int i = 0; i < gaugeCount; i++)
+        {
+            double angleSwept = 0;
+            if (scaleRange > 0)
+                angleSwept = angleRange * values[i] / scaleRange;
+
+            if (!clockwise)
+                angleSwept *= -1;
+
+            double initialAngle = (mode == RadialGaugeMode.Stacked) ? angleStart : angleSum;
+            angleSum += angleSwept;
+
+            startAngles[i] = initialAngle;
+            sweepAngles[i] = angleSwept;
+        }
+
+        double backOffset = angleRange * scaleMin / scaleRange;
+        if (!clockwise)
+            backOffset *= -1;
+
+        double backStartAngle = angleStart + backOffset;
+
+        return (startAngles, sweepAngles, backStartAngle);
+    }
+
+    public void ValidateData(bool deep = false)
+    {
+        if (Colors.Length != GaugeCount)
+            throw new InvalidOperationException($"{nameof(Colors)} must be an array with length equal to number of values");
+
+        if (Labels != null && Labels.Length != GaugeCount)
+            throw new InvalidOperationException($"If {nameof(Labels)} is not null, it must be the same length as the number of values");
+
+        if (MaximumAngle < 0 || MaximumAngle > 360)
+            throw new InvalidOperationException($"{nameof(MaximumAngle)} must be [0-360]");
+
+        if (LabelPositionFraction < 0 || LabelPositionFraction > 1)
+            throw new InvalidOperationException($"{nameof(LabelPositionFraction)} must be a value from 0 to 1");
+
+        if (SpaceFraction < 0 || SpaceFraction > 1)
+            throw new InvalidOperationException($"{nameof(SpaceFraction)} must be from 0 to 1");
+    }
+
+    public IEnumerable<LegendItem> LegendItems
+    {
+        get
+        {
+            if (Labels is null)
+                return LegendItem.None;
+
+            List<LegendItem> legendItems = [];
+            for (int i = 0; i < Labels.Length; i++)
+            {
+                var item = new LegendItem()
+                {
+                    Label = Labels[i],
+                    LineColor = Colors[i],
+                    LineWidth = 10,
+                    Marker = MarkerStyle.None
+                };
+                legendItems.Add(item);
+            }
+
+            return legendItems;
+        }
+    }
+    
+
+    public AxisLimits GetAxisLimits()
+    {
+        double radius = 1 + 0.5d / GaugeCount - SpaceFraction / GaugeCount / 4;
+        return new AxisLimits(-radius, radius, -radius, radius);
+    }
+
+    //public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
+    //{
+    //    ValidateData();
+
+    //    (double[] startAngles, double[] sweepAngles, double StartingAngleBackGauges) = GetGaugeAngles(
+    //        values: Levels,
+    //        angleStart: StartingAngle,
+    //        angleRange: MaximumAngle,
+    //        clockwise: Clockwise,
+    //        mode: GaugeMode);
+
+    //    PointF centerPixel = new(dims.GetPixelX(0), dims.GetPixelY(0));
+    //    using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
+
+    //    float pxPerUnit = (float)Math.Min(dims.PxPerUnitX, dims.PxPerUnitY);
+
+    //    float gaugeWidthPx = pxPerUnit / (GaugeCount * ((float)SpaceFraction + 1));
+    //    float radiusPixels = gaugeWidthPx * ((float)SpaceFraction + 1);
+
+    //    int backgroundAlpha = (int)(255 * BackgroundTransparencyFraction);
+    //    backgroundAlpha = Math.Max(0, backgroundAlpha);
+    //    backgroundAlpha = Math.Min(255, backgroundAlpha);
+
+    //    int index;
+    //    int position;
+    //    for (int i = 0; i < GaugeCount; i++)
+    //    {
+    //        if (GaugeMode == RadialGaugeMode.SingleGauge)
+    //        {
+    //            index = GaugeCount - i - 1;
+    //            position = GaugeCount;
+    //        }
+    //        else
+    //        {
+    //            index = i;
+    //            position = OrderInsideOut ? i + 1 : (GaugeCount - i);
+    //        }
+
+    //        RadialGauge gauge = new()
+    //        {
+    //            MaximumSizeAngle = MaximumAngle,
+    //            StartAngle = startAngles[index],
+    //            SweepAngle = sweepAngles[index],
+    //            Color = Colors[index],
+    //            BackgroundColor = Color.FromArgb(backgroundAlpha, Colors[index]),
+    //            Width = gaugeWidthPx,
+    //            CircularBackground = CircularBackground,
+    //            Clockwise = Clockwise,
+    //            BackStartAngle = StartingAngleBackGauges,
+    //            StartCap = StartCap,
+    //            EndCap = EndCap,
+    //            Mode = GaugeMode,
+    //            Font = Font,
+    //            FontSizeFraction = FontSizeFraction,
+    //            Label = Levels[index].ToString(LevelTextFormat),
+    //            LabelPositionFraction = LabelPositionFraction,
+    //            ShowLabels = ShowLevels,
+    //        };
+
+    //        float radiusPx = position * radiusPixels;
+    //        gauge.Render(gfx, dims, centerPixel, radiusPx);
+    //    }
+    //}
+
+    public void Render(RenderPack rp)
+    {
+        ValidateData();
+
+        (double[] startAngles, double[] sweepAngles, double StartingAngleBackGauges) = GetGaugeAngles(
+            values: Levels,
+            angleStart: StartingAngle,
+            angleRange: MaximumAngle,
+            clockwise: Clockwise,
+            mode: GaugeMode);
+
+        float pxPerUnit = 72; // float pxPerUnit = (float)Math.Min(dims.PxPerUnitX, dims.PxPerUnitY);
+
+        float gaugeWidthPx = pxPerUnit / (GaugeCount * ((float)SpaceFraction + 1));
+        float radiusPixels = gaugeWidthPx * ((float)SpaceFraction + 1);
+
+        int backgroundAlpha = (int)(255 * BackgroundTransparencyFraction);
+        backgroundAlpha = Math.Max(0, backgroundAlpha);
+        backgroundAlpha = Math.Min(255, backgroundAlpha);
+
+        int index;
+        int position;
+        for (int i = 0; i < GaugeCount; i++)
+        {
+            if (GaugeMode == RadialGaugeMode.SingleGauge)
+            {
+                index = GaugeCount - i - 1;
+                position = GaugeCount;
+            }
+            else
+            {
+                index = i;
+                position = OrderInsideOut ? i + 1 : (GaugeCount - i);
+            }
+
+            RadialGauge gauge = new()
+            {
+                MaximumSizeAngle = MaximumAngle,
+                StartAngle = startAngles[index],
+                SweepAngle = sweepAngles[index],
+                Color = Colors[index],
+                BackgroundColor = new (Colors[index].R, Colors[index].G, Colors[index].B, backgroundAlpha),
+                Width = gaugeWidthPx,
+                CircularBackground = CircularBackground,
+                Clockwise = Clockwise,
+                BackStartAngle = StartingAngleBackGauges,
+                StartCap = StartCap,
+                EndCap = EndCap,
+                Mode = GaugeMode,
+                Font = Font,
+                FontSizeFraction = FontSizeFraction,
+                Label = Levels[index].ToString(LevelTextFormat),
+                LabelPositionFraction = LabelPositionFraction,
+                ShowLabels = ShowLevels,
+            };
+
+            float radiusPx = position * radiusPixels;
+            gauge.Render(rp, radiusPx);
+        }
+    }
+
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/RadialGaugePlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/RadialGaugePlot.cs
@@ -331,14 +331,17 @@ public class RadialGaugePlot : IPlottable
             clockwise: Clockwise,
             mode: GaugeMode);
 
-        float pxPerUnit = 72; // float pxPerUnit = (float)Math.Min(dims.PxPerUnitX, dims.PxPerUnitY);
+        // Copied from Pie plottable to get the maximum radius centered on the plot area
+        Pixel origin = Axes.GetPixel(Coordinates.Origin);
+        float minX = Math.Abs(Axes.GetPixelX(1) - origin.X);
+        float minY = Math.Abs(Axes.GetPixelY(1) - origin.Y);
+        float radius = Math.Min(minX, minY) / GaugeCount;
 
-        float gaugeWidthPx = pxPerUnit / (GaugeCount * ((float)SpaceFraction + 1));
-        float radiusPixels = gaugeWidthPx * ((float)SpaceFraction + 1);
+        float gaugeWidthPx = radius / ((float)SpaceFraction + 1);
 
-        int backgroundAlpha = (int)(255 * BackgroundTransparencyFraction);
-        backgroundAlpha = Math.Max(0, backgroundAlpha);
-        backgroundAlpha = Math.Min(255, backgroundAlpha);
+        byte backgroundAlpha = (byte)(255 * BackgroundTransparencyFraction);
+        backgroundAlpha = Math.Max((byte)0, backgroundAlpha);
+        backgroundAlpha = Math.Min((byte)255, backgroundAlpha);
 
         int index;
         int position;
@@ -376,7 +379,7 @@ public class RadialGaugePlot : IPlottable
                 ShowLabels = ShowLevels,
             };
 
-            float radiusPx = position * radiusPixels;
+            float radiusPx = position * radius;
             gauge.Render(rp, radiusPx);
         }
     }

--- a/src/ScottPlot5/ScottPlot5/Plottables/RadialGaugePlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/RadialGaugePlot.cs
@@ -135,13 +135,13 @@ public class RadialGaugePlot : IPlottable
     public void Update(double[] levels, Color[]? colors = null)
     {
         if (levels is null || levels.Length == 0)
-            throw new ArgumentException("values must not be null or empty");
+            throw new ArgumentException("Values must not be null or empty");
 
         bool numberOfGroupsChanged = (Levels is null) || (levels.Length != Levels.Length);
         if (numberOfGroupsChanged)
         {
             if (colors is null || colors.Length != levels.Length)
-                throw new ArgumentException("when changing the number of values a new colors array must be provided");
+                throw new ArgumentException("When changing the number of values a new colors array must be provided");
 
             Colors = new Color[colors.Length];
             Array.Copy(colors, 0, Colors, 0, colors.Length);
@@ -251,70 +251,6 @@ public class RadialGaugePlot : IPlottable
         return new AxisLimits(-radius, radius, -radius, radius);
     }
 
-    //public void Render(PlotDimensions dims, Bitmap bmp, bool lowQuality = false)
-    //{
-    //    ValidateData();
-
-    //    (double[] startAngles, double[] sweepAngles, double StartingAngleBackGauges) = GetGaugeAngles(
-    //        values: Levels,
-    //        angleStart: StartingAngle,
-    //        angleRange: MaximumAngle,
-    //        clockwise: Clockwise,
-    //        mode: GaugeMode);
-
-    //    PointF centerPixel = new(dims.GetPixelX(0), dims.GetPixelY(0));
-    //    using Graphics gfx = GDI.Graphics(bmp, dims, lowQuality);
-
-    //    float pxPerUnit = (float)Math.Min(dims.PxPerUnitX, dims.PxPerUnitY);
-
-    //    float gaugeWidthPx = pxPerUnit / (GaugeCount * ((float)SpaceFraction + 1));
-    //    float radiusPixels = gaugeWidthPx * ((float)SpaceFraction + 1);
-
-    //    int backgroundAlpha = (int)(255 * BackgroundTransparencyFraction);
-    //    backgroundAlpha = Math.Max(0, backgroundAlpha);
-    //    backgroundAlpha = Math.Min(255, backgroundAlpha);
-
-    //    int index;
-    //    int position;
-    //    for (int i = 0; i < GaugeCount; i++)
-    //    {
-    //        if (GaugeMode == RadialGaugeMode.SingleGauge)
-    //        {
-    //            index = GaugeCount - i - 1;
-    //            position = GaugeCount;
-    //        }
-    //        else
-    //        {
-    //            index = i;
-    //            position = OrderInsideOut ? i + 1 : (GaugeCount - i);
-    //        }
-
-    //        RadialGauge gauge = new()
-    //        {
-    //            MaximumSizeAngle = MaximumAngle,
-    //            StartAngle = startAngles[index],
-    //            SweepAngle = sweepAngles[index],
-    //            Color = Colors[index],
-    //            BackgroundColor = Color.FromArgb(backgroundAlpha, Colors[index]),
-    //            Width = gaugeWidthPx,
-    //            CircularBackground = CircularBackground,
-    //            Clockwise = Clockwise,
-    //            BackStartAngle = StartingAngleBackGauges,
-    //            StartCap = StartCap,
-    //            EndCap = EndCap,
-    //            Mode = GaugeMode,
-    //            Font = Font,
-    //            FontSizeFraction = FontSizeFraction,
-    //            Label = Levels[index].ToString(LevelTextFormat),
-    //            LabelPositionFraction = LabelPositionFraction,
-    //            ShowLabels = ShowLevels,
-    //        };
-
-    //        float radiusPx = position * radiusPixels;
-    //        gauge.Render(gfx, dims, centerPixel, radiusPx);
-    //    }
-    //}
-
     public void Render(RenderPack rp)
     {
         ValidateData();
@@ -335,8 +271,6 @@ public class RadialGaugePlot : IPlottable
         float gaugeWidth = radius / ((float)SpaceFraction + 1);
 
         byte backgroundAlpha = (byte)(255 * BackgroundTransparencyFraction);
-        //backgroundAlpha = Math.Max((byte)0, backgroundAlpha);
-        //backgroundAlpha = Math.Min((byte)255, backgroundAlpha);
 
         int index;
         int position;

--- a/src/ScottPlot5/ScottPlot5/Plottables/RadialGaugePlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/RadialGaugePlot.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-//using ScottPlot.Drawing;
-
-// This plot type was inspired by MicroCharts:
+﻿// This plot type was inspired by MicroCharts:
 // https://github.com/dotnet-ad/Microcharts/blob/main/Sources/Microcharts/Charts/RadialGaugeChart.cs
 
 namespace ScottPlot.Plottable;
@@ -16,13 +10,12 @@ namespace ScottPlot.Plottable;
 public class RadialGaugePlot : IPlottable
 {
     public IAxes Axes { get; set; } = new Axes();
-    //public IEnumerable<LegendItem> LegendItems => LegendItem.None;
 
     /// <summary>
     /// This array holds the original levels passed-in by the user. 
     /// These levels are used to calculate radial gauge positions on every render.
     /// </summary>
-    public double[] Levels { get; private set; }
+    public double[] Levels { get; private set; } = [];
 
     /// <summary>
     /// Number of gauges.
@@ -51,7 +44,7 @@ public class RadialGaugePlot : IPlottable
     /// Colors for each gauge.
     /// Number of colors must equal number of gauges.
     /// </summary>
-    public Color[] Colors { get; set; }
+    public Color[] Colors { get; set; } = [];
 
     /// <summary>
     /// Describes how transparent the unfilled background of each gauge is (0 to 1).
@@ -101,7 +94,7 @@ public class RadialGaugePlot : IPlottable
     /// <summary>
     /// Describes labels drawn on each gauge.
     /// </summary>
-    public readonly SKFont Font = new();
+    public readonly FontStyle Font = new();
 
     /// <summary>
     /// Controls if value labels are shown inside the gauges.
@@ -129,6 +122,8 @@ public class RadialGaugePlot : IPlottable
 
     public RadialGaugePlot(double[] levels, Color[] colors)
     {
+        Font.Color = ScottPlot.Colors.White;
+        Font.Bold = true;
         Update(levels, colors);
     }
 
@@ -137,7 +132,7 @@ public class RadialGaugePlot : IPlottable
     /// <summary>
     /// Replace gauge levels with new ones.
     /// </summary>
-    public void Update(double[] levels, Color[] colors = null)
+    public void Update(double[] levels, Color[]? colors = null)
     {
         if (levels is null || levels.Length == 0)
             throw new ArgumentException("values must not be null or empty");
@@ -337,11 +332,11 @@ public class RadialGaugePlot : IPlottable
         float minY = Math.Abs(Axes.GetPixelY(1) - origin.Y);
         float radius = Math.Min(minX, minY) / GaugeCount;
 
-        float gaugeWidthPx = radius / ((float)SpaceFraction + 1);
+        float gaugeWidth = radius / ((float)SpaceFraction + 1);
 
         byte backgroundAlpha = (byte)(255 * BackgroundTransparencyFraction);
-        backgroundAlpha = Math.Max((byte)0, backgroundAlpha);
-        backgroundAlpha = Math.Min((byte)255, backgroundAlpha);
+        //backgroundAlpha = Math.Max((byte)0, backgroundAlpha);
+        //backgroundAlpha = Math.Min((byte)255, backgroundAlpha);
 
         int index;
         int position;
@@ -365,7 +360,7 @@ public class RadialGaugePlot : IPlottable
                 SweepAngle = sweepAngles[index],
                 Color = Colors[index],
                 BackgroundColor = new (Colors[index].R, Colors[index].G, Colors[index].B, backgroundAlpha),
-                Width = gaugeWidthPx,
+                Width = gaugeWidth,
                 CircularBackground = CircularBackground,
                 Clockwise = Clockwise,
                 BackStartAngle = StartingAngleBackGauges,

--- a/src/ScottPlot5/ScottPlot5/Plottables/RadialGaugePlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/RadialGaugePlot.cs
@@ -243,7 +243,7 @@ public class RadialGaugePlot : IPlottable
             return legendItems;
         }
     }
-    
+
 
     public AxisLimits GetAxisLimits()
     {
@@ -293,7 +293,7 @@ public class RadialGaugePlot : IPlottable
                 StartAngle = startAngles[index],
                 SweepAngle = sweepAngles[index],
                 Color = Colors[index],
-                BackgroundColor = new (Colors[index].R, Colors[index].G, Colors[index].B, backgroundAlpha),
+                BackgroundColor = new(Colors[index].R, Colors[index].G, Colors[index].B, backgroundAlpha),
                 Width = gaugeWidth,
                 CircularBackground = CircularBackground,
                 Clockwise = Clockwise,

--- a/src/ScottPlot5/ScottPlot5/Primitives/RadialGaugeMode.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/RadialGaugeMode.cs
@@ -1,0 +1,20 @@
+﻿namespace ScottPlot
+{
+    public enum RadialGaugeMode
+    {
+        /// <summary>
+        /// Successive gauges start outward from the center but start at the same angle
+        /// </summary>
+        Stacked,
+
+        /// <summary>
+        /// Successive gauges start outward from the center and start at sequential angles
+        /// </summary>
+        Sequential,
+
+        /// <summary>
+        /// Gauges are all the same distance from the center but start at sequential angles
+        /// </summary>
+        SingleGauge
+    }
+}


### PR DESCRIPTION
Creates the radial gauge plottable, based on the v4 version.
Adds the cookbook recipes demonstrating the main features.
![image](https://github.com/ScottPlot/ScottPlot/assets/63915486/bc1f90d9-8a18-46c6-a2b1-e1af6eb5d052)

There's one caveat. The line caps (`StartCap` and `EndCap` properties) functionality is severely reduced, since Skia doesn't include the `System.Drawing.Drawing2D.LineCap` options. This is commented in the submitted code in case it is owner-implemented in the future. The only functional property is `StartCap`, which only admits one of the values of the `SKStrokeCap` enum, while the `EndCap` property is ignored throughout the code.
