### PR TITLE
SP5: Updated LegendItems in BarPlot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _Not yet on NuGet..._
 * Radial Gauge Plot: Added a new plot type for displaying categorical data as circular gauges (#3358) _Thanks @arthurits_
 * Generate: Improved `RandomNormalSample()` behavior by fixing an off-by-one indexing error _Thanks @DominicBeer_
 * Avalonia: Redraw plots using a non-blocking background thread to improve multi-axis behavior (#3373, #3359) _Thanks @oktrue, @BendRocks, and @ykarpeev_
+* Bar plot: Added a `Label` property to allow a collection of bars to be displayed as a single item in the legend (#3375) _Thanks @fhannan-ti_
 
 ## ScottPlot 5.0.21
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-28_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
@@ -190,13 +190,9 @@ public class Bar : ICategory
             // build the legend manually
             myPlot.Legend.IsVisible = true;
             myPlot.Legend.Location = Alignment.UpperLeft;
-
-            LegendItem[] legendItems =
-            {
-                new() { Label = "Monday", FillColor = palette.GetColor(0) },
-                new() { Label = "Tuesday", FillColor = palette.GetColor(1) },
-                new() { Label = "Wednesday", FillColor = palette.GetColor(2) }
-            };
+            myPlot.Legend.ManualItems.Add(new() { Label = "Monday", FillColor = palette.GetColor(0) });
+            myPlot.Legend.ManualItems.Add(new() { Label = "Tuesday", FillColor = palette.GetColor(1) });
+            myPlot.Legend.ManualItems.Add(new() { Label = "Wednesday", FillColor = palette.GetColor(2) });
 
             // show group labels on the bottom axis
             Tick[] ticks =

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
@@ -23,6 +23,28 @@ public class Bar : ICategory
         }
     }
 
+    public class BarLegend : RecipeBase
+    {
+        public override string Name => "Bar Plot Legend";
+        public override string Description => "A collection of bars can appear in the legend as a single item.";
+
+        [Test]
+        public override void Execute()
+        {
+            double[] xs1 = { 1, 2, 3, 4 };
+            double[] ys1 = { 5, 10, 7, 13 };
+            var bars1 = myPlot.Add.Bars(xs1, ys1);
+            bars1.Label = "Alpha";
+
+            double[] xs2 = { 6, 7, 8, 9 };
+            double[] ys2 = { 7, 12, 9, 15 };
+            var bars2 = myPlot.Add.Bars(xs2, ys2);
+            bars2.Label = "Beta";
+
+            myPlot.ShowLegend(Alignment.UpperLeft);
+        }
+    }
+
     public class BarPosition : RecipeBase
     {
         public override string Name => "Bar Positioning";

--- a/src/ScottPlot5/ScottPlot5/Plottables/BarPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/BarPlot.cs
@@ -8,8 +8,6 @@ public class BarPlot : IPlottable
     public string Label { get; set; } = string.Empty;
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = new Axes();
-    public LineStyle LineStyle { get; set; } = new();
-    public MarkerStyle MarkerStyle { get; set; } = MarkerStyle.Default;
 
     public IEnumerable<Bar> Bars { get; set; } // TODO: bars data source
 
@@ -53,7 +51,24 @@ public class BarPlot : IPlottable
         Bars = bars;
     }
 
-    public IEnumerable<LegendItem> LegendItems => LegendItem.Single(Label, MarkerStyle, LineStyle);
+    public IEnumerable<LegendItem> LegendItems
+    {
+        get
+        {
+            if (!Bars.Any())
+            {
+                return LegendItem.None;
+            }
+
+            LegendItem item = new()
+            {
+                Label = Label,
+                FillColor = Bars.First().FillColor,
+            };
+
+            return LegendItem.Single(item);
+        }
+    }
 
     public AxisLimits GetAxisLimits()
     {

--- a/src/ScottPlot5/ScottPlot5/Plottables/BarPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/BarPlot.cs
@@ -5,9 +5,12 @@
 /// </summary>
 public class BarPlot : IPlottable
 {
+    public string Label { get; set; } = string.Empty;
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = new Axes();
-    public string? Label { get; set; }
+    public LineStyle LineStyle { get; set; } = new();
+    public MarkerStyle MarkerStyle { get; set; } = MarkerStyle.Default;
+
     public IEnumerable<Bar> Bars { get; set; } // TODO: bars data source
 
     /// <summary>
@@ -50,7 +53,7 @@ public class BarPlot : IPlottable
         Bars = bars;
     }
 
-    public IEnumerable<LegendItem> LegendItems => LegendItem.None;
+    public IEnumerable<LegendItem> LegendItems => LegendItem.Single(Label, MarkerStyle, LineStyle);
 
     public AxisLimits GetAxisLimits()
     {


### PR DESCRIPTION
As of 5.0.21, `BarPlot` does not show a legend even after calling `Plot.ShowLegend()` or setting `Plot.Legend.IsVisible = true`. This change is to add that functionality, using the `Scatter` implementation as a reference.