### PR TITLE
SP5: Fixed legend in cookbook example for Grouped Bar Plot

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
@@ -166,15 +166,14 @@ public class Bar : ICategory
             myPlot.Add.Bars(bars);
 
             // build the legend manually
-            myPlot.Legend.IsVisible = true;
-            myPlot.Legend.Location = Alignment.UpperLeft;
-
             LegendItem[] legendItems =
             {
                 new() { Label = "Monday", FillColor = palette.GetColor(0) },
                 new() { Label = "Tuesday", FillColor = palette.GetColor(1) },
                 new() { Label = "Wednesday", FillColor = palette.GetColor(2) }
             };
+
+            myPlot.ShowLegend(legendItems, Alignment.UpperLeft);
 
             // show group labels on the bottom axis
             Tick[] ticks =


### PR DESCRIPTION
The current example for Grouped Bar Plot is not showing the legend. This change fixes it by using `Plot.ShowLegend(items, location)`, which is working as of 5.0.21.