### PR TITLE
WPF: Redraw plots using a non-blocking background thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _Not yet on NuGet..._
 * Generate: Improved `RandomNormalSample()` behavior by fixing an off-by-one indexing error @DominicBeer
 * Avalonia: Redraw plots using a non-blocking background thread to improve multi-axis behavior (#3373, #3359) @oktrue, @BendRocks, and @ykarpeev
 * Bar plot: Added a `Label` property to allow a collection of bars to be displayed as a single item in the legend (#3375) @fhannan-ti
+* WPF: Redraw plots using a non-blocking background background thread to improve multi-axis behavior (#3373, #3359, #3381) @drolevar
 
 ## ScottPlot 5.0.21
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-28_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlot.cs
@@ -46,6 +46,12 @@ namespace ScottPlot.WPF
 
         public override void Refresh()
         {
+            if (!CheckAccess())
+            {
+                Dispatcher.BeginInvoke(Refresh);
+                return;
+            }
+
             SKElement?.InvalidateVisual();
         }
     }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotGL.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotGL.cs
@@ -47,6 +47,12 @@ public class WpfPlotGL : WpfPlotBase
 
     public override void Refresh()
     {
+        if (!CheckAccess())
+        {
+            Dispatcher.BeginInvoke(Refresh);
+            return;
+        }
+
         SKElement?.InvalidateVisual();
     }
 


### PR DESCRIPTION
This is almost exactly the same as #3373 but for WPF. Checks whether Refresh is called on a UI thread, and if not, calls asynchronous Dispatcher.BeginInvoke(Refresh).