### PR TITLE
SP5: fix making colors brighter or darker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _Not yet on NuGet..._
 * Avalonia: Redraw plots using a non-blocking background thread to improve multi-axis behavior (#3373, #3359) @oktrue, @BendRocks, and @ykarpeev
 * Bar plot: Added a `Label` property to allow a collection of bars to be displayed as a single item in the legend (#3375) @fhannan-ti
 * WPF: Redraw plots using a non-blocking background background thread to improve multi-axis behavior (#3373, #3359, #3381) @drolevar
+* Ellipse: Added `LineWidth`, `LineColor`, and `FillColor` shortcut properties
 
 ## ScottPlot 5.0.21
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-28_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ _Not yet on NuGet..._
 * Bar plot: Added a `Label` property to allow a collection of bars to be displayed as a single item in the legend (#3375) @fhannan-ti
 * WPF: Redraw plots using a non-blocking background background thread to improve multi-axis behavior (#3373, #3359, #3381) @drolevar
 * Ellipse: Added `LineWidth`, `LineColor`, and `FillColor` shortcut properties
+* Color: Added `Lighten()` and `Darken()` properties (#3387, #3390) @KroMignon
+* Color: Modified `ToHSL()` to return improved Hue, Saturation and Luminosity values (#3390) @KroMignon
 
 ## ScottPlot 5.0.21
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-28_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Shapes.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Shapes.cs
@@ -43,7 +43,21 @@ public class Shapes : ICategory
         [Test]
         public override void Execute()
         {
-            // TODO: need a circle plot type
+            var c1 = myPlot.Add.Circle(1, 0, .5);
+            var c2 = myPlot.Add.Circle(2, 0, .5);
+            var c3 = myPlot.Add.Circle(3, 0, .5);
+
+            c1.FillStyle.Color = Colors.Blue;
+            c2.FillStyle.Color = Colors.Blue.Darken(.75);
+            c3.FillStyle.Color = Colors.Blue.Lighten(.75);
+
+            c1.LineWidth = 0;
+            c2.LineWidth = 0;
+            c3.LineWidth = 0;
+
+            // force circles to remain circles
+            ScottPlot.AxisRules.SquareZoomOut squareRule = new(myPlot.Axes.Bottom, myPlot.Axes.Left);
+            myPlot.Axes.Rules.Add(squareRule);
         }
     }
 
@@ -56,7 +70,16 @@ public class Shapes : ICategory
         [Test]
         public override void Execute()
         {
-            // TODO: need ellipse plot type
+            for (int i = 0; i < 10; i++)
+            {
+                var el = myPlot.Add.Ellipse(0, 0, 1, 10, rotation: i * 10);
+                double fraction = i / 10.0;
+                el.LineColor = Colors.Blue.WithAlpha(fraction);
+            }
+
+            // force circles to remain circles
+            ScottPlot.AxisRules.SquareZoomOut squareRule = new(myPlot.Axes.Bottom, myPlot.Axes.Left);
+            myPlot.Axes.Rules.Add(squareRule);
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
@@ -1,4 +1,5 @@
 ﻿using ScottPlot;
+using System.Diagnostics;
 
 namespace Sandbox.WinForms;
 
@@ -8,7 +9,32 @@ public partial class Form1 : Form
     {
         InitializeComponent();
 
-        var ohlcs = Generate.RandomOHLCs(12_000);
-        formsPlot1.Plot.Add.Candlestick(ohlcs);
+        var c1 = formsPlot1.Plot.Add.Circle(5, 5, 9);
+        var c2 = formsPlot1.Plot.Add.Circle(10, 0, 9);
+        var c3 = formsPlot1.Plot.Add.Circle(15, 10, 9);
+        c1.FillStyle.Color = Colors.Red;
+        c2.FillStyle.Color = c1.FillStyle.Color.Darken(.5f);
+        c3.FillStyle.Color = c1.FillStyle.Color.Lighten(.5f);
+
+        var c = Colors.Red;
+        var rgb = c.ToStringRGB();
+        (float h, float s, float l) = c.ToHSL();
+        Debug.WriteLine($"RGB: {rgb} Hue: {h}, Saturation: {s}, Liminance: {l}");
+
+        var cc = ScottPlot.Color.FromHSL(h, s, l);
+        rgb = cc.ToStringRGB();
+        (h, s, l) = cc.ToHSL();
+        Debug.WriteLine($"RGB: {rgb} Hue: {h}, Saturation: {s}, Liminance: {l}");
+
+        rgb = c1.FillStyle.Color.ToStringRGB();
+        (h, s, l) = c1.FillStyle.Color.ToHSL();
+        Debug.WriteLine($"RGB: {rgb} Hue: {h}, Saturation: {s}, Liminance: {l}");
+        rgb = c2.FillStyle.Color.ToStringRGB();
+        (h, s, l) = c2.FillStyle.Color.ToHSL();
+        Debug.WriteLine($"RGB: {rgb} Hue: {h}, Saturation: {s}, Liminance: {l}");
+        rgb = c3.FillStyle.Color.ToStringRGB();
+        (h, s, l) = c3.FillStyle.Color.ToHSL();
+        Debug.WriteLine($"RGB: {rgb} Hue: {h}, Saturation: {s}, Liminance: {l}");
+        formsPlot1.Plot.SavePng("DarkenLighten.png", 240, 240);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using ScottPlot.Extensions;
+using System.Runtime.InteropServices;
 
 namespace ScottPlot;
 
@@ -248,6 +249,21 @@ public static class Drawing
         };
 
         canvas.DrawCircle(center.ToSKPoint(), radius, paint);
+    }
+
+    public static void DrawOval(SKCanvas canvas, SKPaint paint, LineStyle lineStyle, PixelRect rect)
+    {
+        if (lineStyle.Width == 0 || lineStyle.Color == Colors.Transparent)
+            return;
+
+        lineStyle.ApplyToPaint(paint);
+        canvas.DrawOval(rect.ToSKRect(), paint);
+    }
+
+    public static void FillOval(SKCanvas canvas, SKPaint paint, FillStyle fillStyle, PixelRect rect)
+    {
+        fillStyle.ApplyToPaint(paint, rect);
+        canvas.DrawOval(rect.ToSKRect(), paint);
     }
 
     public static void DrawMarker(SKCanvas canvas, SKPaint paint, Pixel pixel, MarkerStyle style)

--- a/src/ScottPlot5/ScottPlot5/Plottables/Ellipse.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Ellipse.cs
@@ -9,7 +9,11 @@ public class Ellipse : IPlottable
     public IEnumerable<LegendItem> LegendItems => LegendItem.Single(Label, LineStyle);
 
     public LineStyle LineStyle { get; set; } = new() { Color = Colors.Black, Width = 2 };
+    public float LineWidth { get => LineStyle.Width; set => LineStyle.Width = value; }
+    public Color LineColor { get => LineStyle.Color; set => LineStyle.Color = value; }
+
     public FillStyle FillStyle { get; set; } = new() { Color = Colors.Transparent };
+    public Color FillColor { get => FillStyle.Color; set => FillStyle.Color = value; }
 
     /// <summary>
     /// Label to appear in the legend
@@ -86,14 +90,9 @@ public class Ellipse : IPlottable
         float rx = Axes.GetPixelX(RadiusX) - Axes.GetPixelX(0);
         float ry = Axes.GetPixelY(RadiusY) - Axes.GetPixelY(0);
 
-        if (FillStyle.Color.A > 0)
-        {
-            FillStyle.ApplyToPaint(paint, Axes.GetPixelRect(new CoordinateRect(0, 0, RadiusX, RadiusY)));
-            rp.Canvas.DrawOval(0, 0, rx, ry, paint);
-        }
-
-        LineStyle.ApplyToPaint(paint);
-        rp.Canvas.DrawOval(0, 0, rx, ry, paint);
+        PixelRect rect = new(-rx, rx, ry, -ry);
+        Drawing.FillOval(rp.Canvas, paint, FillStyle, rect);
+        Drawing.DrawOval(rp.Canvas, paint, LineStyle, rect);
 
         rp.Canvas.Restore();
     }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
@@ -1,5 +1,19 @@
 ﻿namespace ScottPlot;
 
+internal static class ByteExtension
+{
+    static public byte Lighten(this byte color, float fraction)
+    {
+        var fColor = color + (255 - color) * fraction;
+        return (byte)Math.Min(Math.Max(fColor, 0), 255);
+    }
+    static public byte Darken(this byte color, float fraction)
+    {
+        var fColor = color * fraction;
+        return (byte)Math.Min(Math.Max(fColor, 0), 255);
+    }
+}
+
 public readonly struct Color
 {
     public readonly byte Red;
@@ -223,17 +237,22 @@ public readonly struct Color
     public Color WithLightness(float lightness = .5f)
     {
         (float h, float s, float _) = ToHSL();
-        return FromHSL(h, s, lightness);
+        return FromHSL(h, s, Math.Min(Math.Max(lightness, 0f), 1f));
     }
 
     public Color Lighten(float fraction = .5f)
     {
-        return new Color((byte)(R + (255 - R) * fraction), (byte)(G + (255 - G) * fraction), (byte)(B + (255 - B) * fraction), Alpha);
+        if (fraction < 0)
+            return Darken(-fraction);
+        fraction = Math.Min(1f, fraction);
+        return new Color(R.Lighten(fraction), G.Lighten(fraction), B.Lighten(fraction), Alpha);
     }
 
     public Color Darken(float fraction = .5f)
     {
-        fraction = 1 - fraction;
-        return new Color((byte)(R * fraction), (byte)(G * fraction), (byte)(B * fraction), Alpha);
+        if (fraction < 0)
+            return Lighten(-fraction);
+        fraction = Math.Max(0f, 1f - fraction);
+        return new Color(R.Darken(fraction), G.Darken(fraction), B.Darken(fraction), Alpha);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
@@ -231,19 +231,18 @@ public readonly struct Color
 
     public Color WithLightness(float lightness = .5f)
     {
-        (float h, float s, float l) = ToHSL();
+        (float h, float s, float _) = ToHSL();
         return FromHSL(h, s, lightness);
     }
 
     public Color Lighten(float fraction = .5f)
     {
-        (float h, float s, float l) = ToHSL();
-        return FromHSL(h, s, l + (1 - l) * fraction);
+        return new Color((byte)(R + (255 - R) * fraction), (byte)(G + (255 - G) * fraction), (byte)(B + (255 - B) * fraction), Alpha);
     }
 
     public Color Darken(float fraction = .5f)
     {
-        (float h, float s, float l) = ToHSL();
-        return FromHSL(h, s, l * fraction);
+        fraction = 1 - fraction;
+        return new Color((byte)(R * fraction), (byte)(G * fraction), (byte)(B * fraction), Alpha);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
@@ -1,13 +1,14 @@
 ﻿namespace ScottPlot;
 
-internal static class ByteExtension
+internal static class ColorByteExtensions
 {
-    static public byte Lighten(this byte color, float fraction)
+    static public byte Lighten(this byte color, double fraction)
     {
         var fColor = color + (255 - color) * fraction;
         return (byte)Math.Min(Math.Max(fColor, 0), 255);
     }
-    static public byte Darken(this byte color, float fraction)
+
+    static public byte Darken(this byte color, double fraction)
     {
         var fColor = color * fraction;
         return (byte)Math.Min(Math.Max(fColor, 0), 255);
@@ -240,7 +241,11 @@ public readonly struct Color
         return FromHSL(h, s, Math.Min(Math.Max(lightness, 0f), 1f));
     }
 
-    public Color Lighten(float fraction = .5f)
+    /// <summary>
+    /// Amount to lighten the color (from 0-1).
+    /// Larger numbers produce lighter results.
+    /// </summary>
+    public Color Lighten(double fraction = .5f)
     {
         if (fraction < 0)
             return Darken(-fraction);
@@ -248,7 +253,11 @@ public readonly struct Color
         return new Color(R.Lighten(fraction), G.Lighten(fraction), B.Lighten(fraction), Alpha);
     }
 
-    public Color Darken(float fraction = .5f)
+    /// <summary>
+    /// Amount to darken the color (from 0-1).
+    /// Larger numbers produce darker results.
+    /// </summary>
+    public Color Darken(double fraction = .5f)
     {
         if (fraction < 0)
             return Lighten(-fraction);

--- a/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
@@ -146,49 +146,40 @@ public readonly struct Color
 
     public (float h, float s, float l) ToHSL()
     {
-        // adapted from Microsoft.Maui.Graphics/Color.cs (MIT license)
+        // Converter adapted from http://en.wikipedia.org/wiki/HSL_color_space
+        float r = Red / 255f;
+        float g = Green / 255f;
+        float b = Blue / 255f;
 
-        float v = Math.Max(Red, Green);
-        v = Math.Max(v, Blue);
-
-        float m = Math.Min(Red, Green);
-        m = Math.Min(m, Blue);
+        float max = Math.Max(Math.Max(r, g), b);
+        float min = Math.Min(Math.Min(r, g), b);
 
         float h, s, l;
-        l = (m + v) / 2.0f;
+        l = (min + max) / 2.0f;
         if (l <= 0.0)
         {
             return (0, 0, 0);
         }
 
-        float vm = v - m;
-        s = vm;
+        float delta = max - min;
+        s = delta;
         if (s <= 0.0)
         {
             return (0, 0, l);
         }
 
-        s /= l <= 0.5f ? v + m : 2.0f - v - m;
+        s = (l > 0.5f) ? delta / (2.0f - delta) : delta / (max + min);
 
-        float r2 = (v - Red) / vm;
-        float g2 = (v - Green) / vm;
-        float b2 = (v - Blue) / vm;
+        if (r > g && r > b)
+            h = (g - b) / delta + (g < b ? 6.0f : 0.0f);
 
-        if (Red == v)
-        {
-            h = Green == m ? 5.0f + b2 : 1.0f - g2;
-        }
-        else if (Green == v)
-        {
-            h = Blue == m ? 1.0f + r2 : 3.0f - b2;
-        }
+        else if (g > b)
+            h = (b - r) / delta + 2.0f;
+
         else
-        {
-            h = Red == m ? 3.0f + g2 : 5.0f - r2;
-        }
+            h = (r - g) / delta + 4.0f;
 
         h /= 6.0f;
-
         return (h, s, l);
     }
 


### PR DESCRIPTION
Work with R, G and B color component to handle `Color.Darken` and `Color.Lighten`  and avoid color mixing.
This should fix issue #3387.

```cs
ScottPlot.Plot myPlot = new();

var c1 = myPlot.Add.Circle(5, 5, 9);
var c2 = myPlot.Add.Circle(10, 0, 9);
var c3 = myPlot.Add.Circle(15, 10, 9);
c1.FillStyle.Color = Colors.Red;
c2.FillStyle.Color = c1.FillStyle.Color.Darken(.5f);
c3.FillStyle.Color = c1.FillStyle.Color.Lighten(.5f);

myPlot.SavePng("DarkenLighten.png", 240, 240);
```
![DarkenLighten](https://github.com/ScottPlot/ScottPlot/assets/3978902/113a8fe7-6637-4be3-bd41-7cb0afdd0da9)
