### PR TITLE
#3396 SignalXY with Inverted YAxis

### DIFF
--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
@@ -100,7 +100,10 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
         double min = Ys[index1];
         double max = Ys[index1];
 
-        for (int i = index1; i <= index2; i++)
+        var minindex = Math.Min(index1, index2);
+        var maxindex = Math.Max(index1, index2);
+
+        for (int i = minindex; i <= maxindex; i++)
         {
             min = Math.Min(Ys[i], min);
             max = Math.Max(Ys[i], max);

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
@@ -54,14 +54,21 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
             .Select(pxColumn => GetColumnPixelsX(pxColumn, visibileRange, rp, axes))
             .SelectMany(x => x);
 
+        Pixel[] leftOutsidePoint = PointBefore, rightOutsidePoint = PointAfter;
+        if (axes.XAxis.Range.Span < 0)
+        {
+            leftOutsidePoint = PointAfter;
+            rightOutsidePoint = PointBefore;
+        }
+
         // combine with one extra point before and after
-        Pixel[] points = [.. PointBefore, .. VisiblePoints, .. PointAfter];
+            Pixel[] points = [.. leftOutsidePoint, .. VisiblePoints, .. rightOutsidePoint];
 
         // use interpolation at the edges to prevent points from going way off the screen
-        if (PointBefore.Length > 0)
+        if (leftOutsidePoint.Length > 0)
             SignalInterpolation.InterpolateBeforeX(rp, points);
 
-        if (PointAfter.Length > 0)
+        if (rightOutsidePoint.Length > 0)
             SignalInterpolation.InterpolateAfterX(rp, points);
 
         return points;
@@ -79,14 +86,21 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
             .Select(pxRow => GetColumnPixelsY(pxRow, visibleRange, rp, axes))
             .SelectMany(x => x);
 
+        Pixel[] bottomOutsidePoint = PointBefore, topOutsidePoint = PointAfter;
+        if (axes.YAxis.Range.Span < 0)
+        {
+            bottomOutsidePoint = PointAfter;
+            topOutsidePoint = PointBefore;
+        }
+
         // combine with one extra point before and after
-        Pixel[] points = [.. PointBefore, .. VisiblePoints, .. PointAfter];
+        Pixel[] points = [.. bottomOutsidePoint, .. VisiblePoints, .. topOutsidePoint];
 
         // use interpolation at the edges to prevent points from going way off the screen
-        if (PointBefore.Length > 0)
+        if (bottomOutsidePoint.Length > 0)
             SignalInterpolation.InterpolateBeforeY(rp, points);
 
-        if (PointAfter.Length > 0)
+        if (topOutsidePoint.Length > 0)
             SignalInterpolation.InterpolateAfterY(rp, points);
 
         return points;

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
@@ -29,7 +29,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
         double xMax = Xs[MaximumIndex] + XOffset;
 
         CoordinateRange xRange = new(xMin, xMax);
-        CoordinateRange yRange = GetRange(MinimumIndex, MaximumIndex);
+        CoordinateRange yRange = GetRangeY(MinimumIndex, MaximumIndex);
         return Rotated
             ? new AxisLimits(yRange, xRange)
             : new AxisLimits(xRange, yRange);
@@ -95,7 +95,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     /// <summary>
     /// Return the vertical range covered by data between the given indices (inclusive)
     /// </summary>
-    public CoordinateRange GetRange(int index1, int index2)
+    public CoordinateRange GetRangeY(int index1, int index2)
     {
         double min = Ys[index1];
         double max = Ys[index1];
@@ -159,6 +159,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
         if (pointsInRange > 1)
         {
             CoordinateRange yRange = GetRange(startIndex, endIndex - 1);
+            CoordinateRange yRange = GetRangeY(startIndex, lastIndex); //YOffset is added in GetRangeY
             yield return new Pixel(xPixel, axes.GetPixelY(yRange.Min)); // min
             yield return new Pixel(xPixel, axes.GetPixelY(yRange.Max)); // max
             yield return new Pixel(xPixel, axes.GetPixelY(Ys[endIndex - 1] + YOffset)); // exit
@@ -191,6 +192,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
         if (pointsInRange > 1)
         {
             CoordinateRange yRange = GetRange(startIndex, endIndex - 1);
+            CoordinateRange yRange = GetRangeY(startIndex, lastIndex);
             yield return new Pixel(axes.GetPixelX(yRange.Min), yPixel); // min
             yield return new Pixel(axes.GetPixelX(yRange.Max), yPixel); // max
             yield return new Pixel(axes.GetPixelX(Ys[endIndex - 1] + XOffset), yPixel); // exit

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
@@ -128,9 +128,12 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     {
         int index = Array.BinarySearch(Xs, indexRange.Min, indexRange.Length, x - XOffset);
 
+        // If x is not exactly matched to any value in Xs, BinarySearch returns a negative number. We can bitwise negation to obtain the position where x would be inserted (i.e., the next highest index).
+        // If x is below the min Xs, BinarySearch returns -1. Here, bitwise negation returns 0 (i.e., x would be inserted at the first index of the array).
+        // If x is above the max Xs, BinarySearch returns -maxIndex. Bitwise negation of this value returns maxIndex + 1 (i.e., the position after the last index). However, this index is beyond the array bounds, so we return the final index instead.
         if (index < 0)
         {
-            index = ~index; // read BinarySearch() docs
+            index = index < -indexRange.Max ? indexRange.Max : ~index; // read BinarySearch() docs
         }
 
         return index;

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
@@ -153,7 +153,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
         double end = start + unitsPerPixelX;
         int startIndex = GetIndex(start, rng);
         int endIndex = GetIndex(end, rng);
-        int pointsInRange = endIndex - startIndex;
+        int pointsInRange = Math.Abs(endIndex - startIndex);
 
         if (pointsInRange == 0)
         {
@@ -164,11 +164,11 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
 
         if (pointsInRange > 1)
         {
-            CoordinateRange yRange = GetRange(startIndex, endIndex - 1);
+            int lastIndex = startIndex < endIndex ? endIndex -1 : endIndex + 1;
             CoordinateRange yRange = GetRangeY(startIndex, lastIndex); //YOffset is added in GetRangeY
             yield return new Pixel(xPixel, axes.GetPixelY(yRange.Min)); // min
             yield return new Pixel(xPixel, axes.GetPixelY(yRange.Max)); // max
-            yield return new Pixel(xPixel, axes.GetPixelY(Ys[endIndex - 1] + YOffset)); // exit
+            yield return new Pixel(xPixel, axes.GetPixelY(Ys[lastIndex] + YOffset)); // exit
         }
     }
 
@@ -186,7 +186,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
         double end = start + unitsPerPixelY;
         int startIndex = GetIndex(start, rng);
         int endIndex = GetIndex(end, rng);
-        int pointsInRange = endIndex - startIndex;
+        int pointsInRange = Math.Abs(endIndex - startIndex);
 
         if (pointsInRange == 0)
         {
@@ -197,11 +197,11 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
 
         if (pointsInRange > 1)
         {
-            CoordinateRange yRange = GetRange(startIndex, endIndex - 1);
+            int lastIndex = startIndex < endIndex ? endIndex - 1 : endIndex + 1;
             CoordinateRange yRange = GetRangeY(startIndex, lastIndex);
             yield return new Pixel(axes.GetPixelX(yRange.Min), yPixel); // min
             yield return new Pixel(axes.GetPixelX(yRange.Max), yPixel); // max
-            yield return new Pixel(axes.GetPixelX(Ys[endIndex - 1] + XOffset), yPixel); // exit
+            yield return new Pixel(axes.GetPixelX(Ys[lastIndex] + XOffset), yPixel); // exit
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
@@ -211,14 +211,14 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     /// </summary>
     private (Pixel[] pointsBefore, int firstIndex) GetFirstPointX(IAxes axes)
     {
-        int pointBeforeIndex = GetIndex(axes.XAxis.Min);
+        int firstPointIndex = GetIndex(axes.XAxis.Range.Span > 0 ? axes.XAxis.Min : axes.XAxis.Max); // if axis is reversed first index will on the right limit of the plot
 
-        if (pointBeforeIndex > MinimumIndex)
+        if (firstPointIndex > MinimumIndex)
         {
-            float beforeX = axes.GetPixelX(Xs[pointBeforeIndex - 1] + XOffset);
-            float beforeY = axes.GetPixelY(Ys[pointBeforeIndex - 1] + YOffset);
+            float beforeX = axes.GetPixelX(Xs[firstPointIndex - 1] + XOffset);
+            float beforeY = axes.GetPixelY(Ys[firstPointIndex - 1] + YOffset);
             Pixel beforePoint = new(beforeX, beforeY);
-            return ([beforePoint], pointBeforeIndex);
+            return ([beforePoint], firstPointIndex);
         }
         else
         {
@@ -232,14 +232,14 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     /// </summary>
     private (Pixel[] pointsBefore, int firstIndex) GetFirstPointY(IAxes axes)
     {
-        int pointBeforeIndex = GetIndex(axes.YAxis.Min);
+        int firstPointIndex = GetIndex(axes.YAxis.Range.Span > 0? axes.YAxis.Min: axes.YAxis.Max); // if axis is reversed first index will on the top limit of the plot
 
-        if (pointBeforeIndex > MinimumIndex)
+        if (firstPointIndex > MinimumIndex)
         {
-            float beforeX = axes.GetPixelX(Ys[pointBeforeIndex - 1] + XOffset);
-            float beforeY = axes.GetPixelY(Xs[pointBeforeIndex - 1] + YOffset);
+            float beforeX = axes.GetPixelX(Ys[firstPointIndex - 1] + XOffset);
+            float beforeY = axes.GetPixelY(Xs[firstPointIndex - 1] + YOffset);
             Pixel beforePoint = new(beforeX, beforeY);
-            return ([beforePoint], pointBeforeIndex);
+            return ([beforePoint], firstPointIndex);
         }
         else
         {
@@ -253,14 +253,14 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     /// </summary>
     private (Pixel[] pointsBefore, int lastIndex) GetLastPointX(IAxes axes)
     {
-        int pointAfterIndex = GetIndex(axes.XAxis.Max);
+        int lastPointIndex = GetIndex(axes.XAxis.Range.Span > 0 ? axes.XAxis.Max : axes.XAxis.Min); // if axis is reversed last index will on the left limit of the plot
 
-        if (pointAfterIndex <= MaximumIndex)
+        if (lastPointIndex < MaximumIndex)
         {
-            float afterX = axes.GetPixelX(Xs[pointAfterIndex] + XOffset);
-            float afterY = axes.GetPixelY(Ys[pointAfterIndex] + YOffset);
+            float afterX = axes.GetPixelX(Xs[lastPointIndex+1] + XOffset);
+            float afterY = axes.GetPixelY(Ys[lastPointIndex+1] + YOffset);
             Pixel afterPoint = new(afterX, afterY);
-            return ([afterPoint], pointAfterIndex);
+            return ([afterPoint], lastPointIndex);
         }
         else
         {
@@ -274,14 +274,14 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     /// </summary>
     private (Pixel[] pointsBefore, int lastIndex) GetLastPointY(IAxes axes)
     {
-        int pointAfterIndex = GetIndex(axes.YAxis.Max);
+        int lastPointIndex = GetIndex(axes.YAxis.Range.Span > 0 ? axes.YAxis.Max : axes.YAxis.Min); // if axis is reversed last index will on the bottom limit of the plot
 
-        if (pointAfterIndex <= MaximumIndex)
+        if (lastPointIndex < MaximumIndex)
         {
-            float afterX = axes.GetPixelX(Ys[pointAfterIndex] + XOffset);
-            float afterY = axes.GetPixelY(Xs[pointAfterIndex] + YOffset);
+            float afterX = axes.GetPixelX(Ys[lastPointIndex+1] + XOffset);
+            float afterY = axes.GetPixelY(Xs[lastPointIndex+1] + YOffset);
             Pixel afterPoint = new(afterX, afterY);
-            return ([afterPoint], pointAfterIndex);
+            return ([afterPoint], lastPointIndex);
         }
         else
         {

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
@@ -150,16 +150,16 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
     /// </summary>
     private (Pixel[] pointsBefore, int firstIndex) GetFirstPoint(IAxes axes)
     {
-        int pointBeforeIndex = GetIndexX(axes.XAxis.Min);
+        int firstPointIndex = GetIndexX(axes.XAxis.Range.Span > 0 ? axes.XAxis.Min : axes.XAxis.Max); // if axis is reversed first index will on the right limit of the plot
 
-        if (pointBeforeIndex > MinimumIndex)
+        if (firstPointIndex > MinimumIndex)
         {
-            double x = NumericConversion.GenericToDouble(Xs, pointBeforeIndex - 1) + XOffset;
-            double y = NumericConversion.GenericToDouble(Ys, pointBeforeIndex - 1) + YOffset;
+            double x = NumericConversion.GenericToDouble(Xs, firstPointIndex - 1) + XOffset;
+            double y = NumericConversion.GenericToDouble(Ys, firstPointIndex - 1) + YOffset;
             float beforeX = axes.GetPixelX(x);
             float beforeY = axes.GetPixelY(y);
             Pixel beforePoint = new(beforeX, beforeY);
-            return ([beforePoint], pointBeforeIndex);
+            return ([beforePoint], firstPointIndex);
         }
         else
         {
@@ -173,16 +173,16 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
     /// </summary>
     private (Pixel[] pointsBefore, int lastIndex) GetLastPoint(IAxes axes)
     {
-        int pointAfterIndex = GetIndexX(axes.XAxis.Max);
+        int lastPointIndex = GetIndexX(axes.XAxis.Range.Span > 0 ? axes.XAxis.Max : axes.XAxis.Min); // if axis is reversed last index will on the left limit of the plot
 
-        if (pointAfterIndex <= MaximumIndex)
+        if (lastPointIndex < MaximumIndex)
         {
-            double x = NumericConversion.GenericToDouble(Xs, pointAfterIndex) + XOffset;
-            double y = NumericConversion.GenericToDouble(Ys, pointAfterIndex) + YOffset;
+            double x = NumericConversion.GenericToDouble(Xs, lastPointIndex) + XOffset;
+            double y = NumericConversion.GenericToDouble(Ys, lastPointIndex) + YOffset;
             float afterX = axes.GetPixelX(x);
             float afterY = axes.GetPixelY(y);
             Pixel afterPoint = new(afterX, afterY);
-            return ([afterPoint], pointAfterIndex);
+            return ([afterPoint], lastPointIndex);
         }
         else
         {

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
@@ -19,7 +19,7 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
     {
         if (xs.Length != ys.Length)
         {
-            throw new InvalidOperationException($"{nameof(xs)} and {nameof(ys)} must have equal length");
+            throw new ArgumentException($"{nameof(xs)} and {nameof(ys)} must have equal length");
         }
 
         Xs = xs;

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
@@ -99,9 +99,12 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
         NumericConversion.DoubleToGeneric(x - XOffset, out TX x2);
         int index = Array.BinarySearch(Xs, indexRange.Min, indexRange.Length, x2);
 
+        // If x is not exactly matched to any value in Xs, BinarySearch returns a negative number. We can bitwise negation to obtain the position where x would be inserted (i.e., the next highest index).
+        // If x is below the min Xs, BinarySearch returns -1. Here, bitwise negation returns 0 (i.e., x would be inserted at the first index of the array).
+        // If x is above the max Xs, BinarySearch returns -maxIndex. Bitwise negation of this value returns maxIndex + 1 (i.e., the position after the last index). However, this index is beyond the array bounds, so we return the final index instead.
         if (index < 0)
         {
-            index = ~index; // read BinarySearch() docs
+            index = index < -indexRange.Max ? indexRange.Max : ~index; // read BinarySearch() docs
         }
 
         return index;

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
@@ -33,7 +33,9 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
         double xMax = NumericConversion.GenericToDouble(Xs, MaximumIndex) + XOffset;
         CoordinateRange xRange = new(xMin, xMax);
         CoordinateRange yRange = GetRangeY(MinimumIndex, MaximumIndex);
-        return new AxisLimits(xRange, yRange);
+        return Rotated
+            ? new AxisLimits(yRange, xRange)
+            : new AxisLimits(xRange, yRange);
     }
 
     public Pixel[] GetPixelsToDraw(RenderPack rp, IAxes axes)

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
@@ -69,7 +69,10 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
         double min = NumericConversion.GenericToDouble(Ys, index1);
         double max = NumericConversion.GenericToDouble(Ys, index1);
 
-        for (int i = index1; i <= index2; i++)
+        var minindex = Math.Min(index1, index2);
+        var maxindex = Math.Max(index1, index2);
+
+        for (int i = minindex; i <= maxindex; i++)
         {
             double value = NumericConversion.GenericToDouble(Ys, i);
             min = Math.Min(value, min);

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
@@ -48,14 +48,21 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
             .Select(pixelColumnIndex => GetColumnPixels(pixelColumnIndex, columnIndexRange, rp, axes))
             .SelectMany(x => x);
 
+        Pixel[] leftOutsidePoint = PointBefore, rightOutsidePoint = PointAfter;
+        if (axes.XAxis.Range.Span < 0)
+        {
+            leftOutsidePoint = PointAfter;
+            rightOutsidePoint = PointBefore;
+        }
+
         // combine with one extra point before and after
-        Pixel[] points = [.. PointBefore, .. VisiblePoints, .. PointAfter];
+        Pixel[] points = [.. leftOutsidePoint, .. VisiblePoints, .. rightOutsidePoint];
 
         // use interpolation at the edges to prevent points from going way off the screen
-        if (PointBefore.Length > 0)
+        if (leftOutsidePoint.Length > 0)
             SignalInterpolation.InterpolateBeforeX(rp, points);
 
-        if (PointAfter.Length > 0)
+        if (rightOutsidePoint.Length > 0)
             SignalInterpolation.InterpolateAfterX(rp, points);
 
         return points;

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
@@ -124,7 +124,7 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
         double end = start + unitsPerPixelX;
         int startIndex = GetIndex(start, rng);
         int endIndex = GetIndex(end, rng);
-        int pointsInRange = endIndex - startIndex;
+        int pointsInRange = Math.Abs(endIndex - startIndex);
 
         if (pointsInRange == 0)
         {
@@ -136,8 +136,9 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
 
         if (pointsInRange > 1)
         {
-            double yEnd = NumericConversion.GenericToDouble(Ys, endIndex - 1);
-            CoordinateRange yRange = GetRangeY(startIndex, endIndex - 1);
+            int lastIndex = startIndex < endIndex ? endIndex - 1 : endIndex + 1;
+            double yEnd = NumericConversion.GenericToDouble(Ys, lastIndex);
+            CoordinateRange yRange = GetRangeY(startIndex, lastIndex); //YOffset is added in GetRangeY
             yield return new Pixel(xPixel, axes.GetPixelY(yRange.Min)); // min
             yield return new Pixel(xPixel, axes.GetPixelY(yRange.Max)); // max
             yield return new Pixel(xPixel, axes.GetPixelY(yEnd) + YOffset); // exit

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
@@ -7,7 +7,7 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
     public bool Rotated
     {
         get => false;
-        set => throw new NotImplementedException("rotation is not yet supported for generic SignalXY plots");
+        set => throw new NotImplementedException("rotation is not yet supported for generic SignalXY plots (try using doubles)");
     }
 
     public double XOffset { get; set; } = 0;


### PR DESCRIPTION
This resolves issue #3396, allowing reversed X axes on SignalXY plots, and reversed Y axes on rotated SignalXY plots.

Code below was used in WPF sample project to verify various scenarios.
Note that inverted axis is currently missing axis labels according to #3397 

```cs
using System;
using System.Linq;
using System.Windows;
using ScottPlot;

namespace Sandbox.WPF;

public partial class MainWindow : Window
{
    public MainWindow()
    {
        InitializeComponent();
        double[] Xs = Enumerable.Range(1, 5000).Select(i => (double)i).ToArray();
        var signal = WpfPlot1.Plot.Add.SignalXY(Xs, Generate.Sin(count: 5000, oscillations: 4));
        //Test with normal X axis
        //WpfPlot1.Plot.Axes.SetLimitsX(left: 100.1, right: 5100);
        
        //Test with reversed X axis
        //WpfPlot1.Plot.Axes.SetLimitsX(left: 5100, right: 100.1);

        //Test with rotated SignalXY plot on normal Y axis
        //signal.Data.Rotated = true;
        //WpfPlot1.Plot.Axes.SetLimitsY(bottom: 100.1, top: 5100);

        //Test with rotated SignalXY plot on reversed Y axis
        signal.Data.Rotated = true;
        WpfPlot1.Plot.Axes.SetLimitsY(bottom: 5100, top: 100.1);

        //test with generic data type (not double) on normal X axis
        //int[] Xs = Enumerable.Range(1, 5000).Select(i => (int)i).ToArray();
        //int[] Ys = Enumerable.Range(1, 5000).Select(i => (int)i).ToArray();
        //var signal = WpfPlot1.Plot.Add.SignalXY(Xs,Ys);
        //WpfPlot1.Plot.Axes.SetLimitsX(left: 100.1, right: 5100);

        //test with generic data type (not double) on reversed X axis
        //int[] Xs = Enumerable.Range(1, 5000).Select(i => (int)i).ToArray();
        //int[] Ys = Enumerable.Range(1, 5000).Select(i => (int)i).ToArray();
        //var signal = WpfPlot1.Plot.Add.SignalXY(Xs,Ys);
        //WpfPlot1.Plot.Axes.SetLimitsX(left: 5100, right: 100.1);

    }
}

```