### PR TITLE
#3397 Resovles broken Axes labels and ticks on inverted axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _Not yet on NuGet..._
 * Color: Added `Lighten()` and `Darken()` properties (#3387, #3390) @KroMignon
 * Color: Modified `ToHSL()` to return improved Hue, Saturation and Luminosity values (#3390) @KroMignon
 * SignalXY: Improve support for displaying data on inverted axes (#3396, #3400) @BrianAtZetica
+* Axes: Improved support for ticks and labels on inverted axes (#3401, #3397) @BrianAtZetica
 
 ## ScottPlot 5.0.21
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-01-28_

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -215,7 +215,7 @@ public class AxisManager
     {
         yAxis.Min = bottom;
         yAxis.Max = top;
-        AutoScaler.InvertedY = bottom > top? true : false;
+        AutoScaler.InvertedY = bottom > top ? true : false;
     }
 
     public void SetLimitsX(double left, double right)

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -208,12 +208,14 @@ public class AxisManager
     {
         xAxis.Min = left;
         xAxis.Max = right;
+        AutoScaler.InvertedX = left > right ? true : false;
     }
 
     public void SetLimitsY(double bottom, double top, IYAxis yAxis)
     {
         yAxis.Min = bottom;
         yAxis.Max = top;
+        AutoScaler.InvertedY = bottom > top? true : false;
     }
 
     public void SetLimitsX(double left, double right)

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -208,14 +208,15 @@ public class AxisManager
     {
         xAxis.Min = left;
         xAxis.Max = right;
-        AutoScaler.InvertedX = left > right ? true : false;
+        if (xAxis.Range.HasBeenSet) AutoScaler.InvertedX = left > right ? true : false;
     }
 
     public void SetLimitsY(double bottom, double top, IYAxis yAxis)
     {
         yAxis.Min = bottom;
         yAxis.Max = top;
-        AutoScaler.InvertedY = bottom > top ? true : false;
+
+        if(yAxis.Range.HasBeenSet) AutoScaler.InvertedY = bottom > top ? true : false;
     }
 
     public void SetLimitsX(double left, double right)

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -216,7 +216,7 @@ public class AxisManager
         yAxis.Min = bottom;
         yAxis.Max = top;
 
-        if(yAxis.Range.HasBeenSet) AutoScaler.InvertedY = bottom > top ? true : false;
+        if (yAxis.Range.HasBeenSet) AutoScaler.InvertedY = bottom > top ? true : false;
     }
 
     public void SetLimitsX(double left, double right)

--- a/src/ScottPlot5/ScottPlot5/Grids/DefaultGrid.cs
+++ b/src/ScottPlot5/ScottPlot5/Grids/DefaultGrid.cs
@@ -28,8 +28,13 @@ public class DefaultGrid(IXAxis xAxis, IYAxis yAxis) : IGrid
         if (!IsVisible)
             return;
 
-        var xTicks = XAxis.TickGenerator.Ticks.Where(x => x.Position >= XAxis.Min && x.Position <= XAxis.Max);
-        var yTicks = YAxis.TickGenerator.Ticks.Where(x => x.Position >= YAxis.Min && x.Position <= YAxis.Max);
+        var minX = Math.Min(XAxis.Min, XAxis.Max);
+        var maxX = Math.Max(XAxis.Min, XAxis.Max);
+        var minY = Math.Min(YAxis.Min, YAxis.Max);
+        var maxY = Math.Max(YAxis.Min, YAxis.Max);
+
+        var xTicks = XAxis.TickGenerator.Ticks.Where(x => x.Position >= minX && x.Position <= maxX);
+        var yTicks = YAxis.TickGenerator.Ticks.Where(x => x.Position >= minY && x.Position <= maxY);
 
         if (MinorLineStyle.Width > 0)
         {

--- a/src/ScottPlot5/ScottPlot5/Primitives/CoordinateRange.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/CoordinateRange.cs
@@ -10,9 +10,12 @@ public readonly record struct CoordinateRange(double Min, double Max)
 
     public bool Contains(double value)
     {
-        if (value < Min)
+        var trueMin = Math.Min(Min, Max);
+        var trueMax = Math.Max(Min, Max);
+
+        if (value < trueMin)
             return false;
-        else if (value > Max)
+        else if (value > trueMax)
             return false;
         else
             return true;
@@ -20,16 +23,21 @@ public readonly record struct CoordinateRange(double Min, double Max)
 
     public bool Intersects(CoordinateRange other)
     {
+        var trueMin = Math.Min(Min, Max);
+        var trueMax = Math.Max(Min, Max);
+        var otherTrueMin = Math.Min(other.Min, other.Max);
+        var otherTrueMax = Math.Max(other.Min, other.Max);
+
         // other engulfs this
-        if (other.Min < Min && other.Max > Max)
+        if (otherTrueMin < trueMin && otherTrueMax > trueMax)
             return true;
 
         // this engulfs other
-        if (Min < other.Min && Max > other.Max)
+        if (trueMin < otherTrueMin && trueMax > otherTrueMax)
             return true;
 
         // partial intersection
-        if (Contains(other.Min) || Contains(other.Max))
+        if (Contains(otherTrueMin) || Contains(otherTrueMax))
             return true;
 
         return false;

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/DecimalTickSpacingCalculator.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/DecimalTickSpacingCalculator.cs
@@ -7,7 +7,7 @@ public class DecimalTickSpacingCalculator
     public double[] GenerateTickPositions(CoordinateRange range, PixelLength axisLength, PixelLength maxLabelLength)
     {
         var AbsSpan = Math.Abs(range.Span);
-        var RangeMin = Math.Min(range.Min,range.Max);
+        var RangeMin = Math.Min(range.Min, range.Max);
         double tickSpacing = GetIdealTickSpacing(range, axisLength, maxLabelLength);
 
         double firstTickOffset = RangeMin % tickSpacing;

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/DecimalTickSpacingCalculator.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/DecimalTickSpacingCalculator.cs
@@ -6,21 +6,23 @@ public class DecimalTickSpacingCalculator
 
     public double[] GenerateTickPositions(CoordinateRange range, PixelLength axisLength, PixelLength maxLabelLength)
     {
+        var AbsSpan = Math.Abs(range.Span);
+        var RangeMin = Math.Min(range.Min,range.Max);
         double tickSpacing = GetIdealTickSpacing(range, axisLength, maxLabelLength);
 
-        double firstTickOffset = range.Min % tickSpacing;
-        int tickCount = (int)(range.Span / tickSpacing) + 2;
+        double firstTickOffset = RangeMin % tickSpacing;
+        int tickCount = (int)(AbsSpan / tickSpacing) + 2;
         tickCount = Math.Min(1000, tickCount);
         tickCount = Math.Max(1, tickCount);
 
         double[] majorTickPositions = Enumerable.Range(0, tickCount)
-            .Select(x => range.Min - firstTickOffset + tickSpacing * x)
+            .Select(x => RangeMin - firstTickOffset + tickSpacing * x)
             .Where(range.Contains)
             .ToArray();
 
         if (majorTickPositions.Length < 2)
         {
-            double tickBelow = range.Min - firstTickOffset;
+            double tickBelow = RangeMin - firstTickOffset;
             double firstTick = majorTickPositions.Length > 0 ? majorTickPositions[0] : tickBelow;
             double nextTick = tickBelow + tickSpacing;
             majorTickPositions = [firstTick, nextTick];
@@ -31,12 +33,13 @@ public class DecimalTickSpacingCalculator
 
     private double GetIdealTickSpacing(CoordinateRange range, PixelLength axisLength, PixelLength maxLabelLength)
     {
-        double unitsPerPx = range.Span / axisLength.Length;
+        var AbsSpan = Math.Abs(range.Span);
+        double unitsPerPx = AbsSpan / axisLength.Length;
 
         int targetTickCount = (int)(axisLength.Length / maxLabelLength.Length) + 1;
 
         int radix = 10;
-        int exponent = (int)Math.Log(range.Span, radix) + 1;
+        int exponent = (int)Math.Log(AbsSpan, radix) + 1;
         double initialSpace = Math.Pow(radix, exponent);
         List<double> tickSpacings = [initialSpace];
 
@@ -54,7 +57,7 @@ public class DecimalTickSpacingCalculator
             double divisor = divBy[tickSpacings.Count % divBy.Length];
             double smallerSpacing = tickSpacings.Last() / divisor;
             tickSpacings.Add(smallerSpacing);
-            int tickCount = (int)(range.Span / tickSpacings.Last());
+            int tickCount = (int)(AbsSpan / tickSpacings.Last());
             if (tickCount > targetTickCount)
                 break;
         }
@@ -63,7 +66,7 @@ public class DecimalTickSpacingCalculator
         for (int i = 0; i < tickSpacings.Count; i++)
         {
             double thisTickSpacing = tickSpacings[tickSpacings.Count - 1 - i];
-            double thisTickCount = range.Span / thisTickSpacing;
+            double thisTickCount = AbsSpan / thisTickSpacing;
             double spacePerTick = axisLength.Length / thisTickCount;
             double neededSpcePerTick = maxLabelLength.Length;
 


### PR DESCRIPTION
This pull request resolves issue #3397 
The issue stems from the use of terms Min and Max, which are not numerically minimum and maximum values when axes are inverted. 

The fix was to find where the assumptions were in correct and locally calculate a "trueMin" or "trueMax" value.

I believe the proper fix would be to have IAxes retain Min and Max properties, but make them a true numeric minimum and maximum. This woul dbe augmented by an "Inverted" property.
Meanwhile, IXAxis would inherit Min, Max and Inverted, and could add Left and Right properties for convenience.
Similarly, IYAxis would inherit Min, Max and Inverted properties, but could add Top and Bottom peroperties for convenience.

Unfortunately that change would require extensive changes and careful planning and woud likely introduce breaking code changes for some users. 

I believe my changes are safe for existing code.

Note that this pull request is dependant on pull request #3400 (I needed the inverted axes to be functioning to test all four scenarios (X/Y axes inverted with rotation)

Test code below.

```cs
using System;
using System.Linq;
using System.Windows;
using ScottPlot;

namespace Sandbox.WPF;

public partial class MainWindow : Window
{
    public MainWindow()
    {
        InitializeComponent();
        double[] Xs = Enumerable.Range(1, 5000).Select(i => (double)i).ToArray();
        var signal = WpfPlot1.Plot.Add.SignalXY(Xs, Generate.Sin(count: 5000, oscillations: 4));
        //Test with normal X axis
        //WpfPlot1.Plot.Axes.SetLimitsX(left: 100.1, right: 5100);

        //Test with reversed X axis
        WpfPlot1.Plot.Axes.SetLimitsX(left: 5100, right: 100.1);

        //Test with rotated SignalXY plot on normal Y axis
        //signal.Data.Rotated = true;
        //WpfPlot1.Plot.Axes.SetLimitsY(bottom: 100.1, top: 5100);

        //Test with rotated SignalXY plot on reversed Y axis
        //signal.Data.Rotated = true;
        //WpfPlot1.Plot.Axes.SetLimitsY(bottom: 5100, top: 100.1);

        //test with generic data type (not double) on normal X axis
        //int[] Xs = Enumerable.Range(1, 5000).Select(i => (int)i).ToArray();
        //int[] Ys = Enumerable.Range(1, 5000).Select(i => (int)i).ToArray();
        //var signal = WpfPlot1.Plot.Add.SignalXY(Xs,Ys);
        //WpfPlot1.Plot.Axes.SetLimitsX(left: 100.1, right: 5100);

        //test with generic data type (not double) on reversed X axis
        //int[] Xs = Enumerable.Range(1, 5000).Select(i => (int)i).ToArray();
        //int[] Ys = Enumerable.Range(1, 5000).Select(i => (int)i).ToArray();
        //var signal = WpfPlot1.Plot.Add.SignalXY(Xs,Ys);
        //WpfPlot1.Plot.Axes.SetLimitsX(left: 5100, right: 100.1);

    }
}

```