### PR TITLE
SP5 control interaction: prevent unnecessary call to ZoomRectangleClear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _Not yet on NuGet..._
 * Axes: Restrict pan, zoom, and autoscale to a single dimension if the cursor is over an axis panel (#3410) @drolevar
 * Controls: Improved behavior of middle-click-drag zoom rectangle actions when CTRL or SHIFT is pressed
 * DataLogger and DataStreamer: Improve support for multi-axis plots (#3411) @drolevar
+* Controls: Prevent premature clearing of zoom rectangle (#3412) @drolevar
 
 ## ScottPlot 4.1.72
 _Not yet on NuGet..._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ _Not yet on NuGet..._
 * Axes: Restrict pan, zoom, and autoscale to a single dimension if the cursor is over an axis panel (#3410) @drolevar
 * Controls: Improved behavior of middle-click-drag zoom rectangle actions when CTRL or SHIFT is pressed
 * DataLogger and DataStreamer: Improve support for multi-axis plots (#3411) @drolevar
-* Controls: Prevent premature clearing of zoom rectangle (#3412) @drolevar
+* Controls: Prevent unnecessary zoom rectangle clearing (#3412) @drolevar
 
 ## ScottPlot 4.1.72
 _Not yet on NuGet..._

--- a/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
@@ -149,7 +149,7 @@ public class Interaction : IPlotInteraction
             Actions.AutoScale(PlotControl, position);
         }
 
-        if (button == Inputs.DragZoomRectangleButton)
+        if (IsZoomingRectangle && button == Inputs.DragZoomRectangleButton)
         {
             Actions.ZoomRectangleClear(PlotControl);
             IsZoomingRectangle = false;


### PR DESCRIPTION
Avoid extra ZoomRectangleClear when we don't have a zoom rectangle.