### PR TITLE
Adding hand drawn line styles to (most) plots

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml
@@ -9,5 +9,14 @@
         WindowStartupLocation="CenterScreen"
         Title="ScottPlot 5 - WPF Sandbox" 
         Height="600" Width="800">
-    <ScottPlot:WpfPlot Name="WpfPlot1" />
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="1*"/>
+            <RowDefinition Height="10*" />
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Grid.Row="0">
+            <ComboBox x:Name="plotsCombo" SelectionChanged="plotsCombo_SelectionChanged" MinWidth="150" Height="30"/>
+        </StackPanel>
+        <ScottPlot:WpfPlot Name="WpfPlot1" Grid.Row="1"/>
+    </Grid>
 </Window>

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml.cs
@@ -1,14 +1,180 @@
-﻿using System.Windows;
+﻿using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Media.Media3D;
 using ScottPlot;
+using ScottPlot.Grids;
+using ScottPlot.Plottables;
 
 namespace Sandbox.WPF;
 
 public partial class MainWindow : Window
 {
+    readonly Plot _Plot;
+
+    enum TestPlots
+    {
+        Lines, Scatter, Bar, Pie, Box, OHLC
+    }
+
     public MainWindow()
     {
         InitializeComponent();
-        WpfPlot1.Plot.Add.Signal(Generate.Sin());
-        WpfPlot1.Plot.Add.Signal(Generate.Cos());
+        _Plot = WpfPlot1.Plot;
+
+        AvailablePlots = Enum.GetNames<TestPlots>();
+
+        plotsCombo.ItemsSource = AvailablePlots;
+        plotsCombo.SelectedIndex = 0;
+    }
+
+    public string[] AvailablePlots { get; set; }
+
+    void ShowLinePlot()
+    {
+        _Plot.Clear();
+
+        Signal sinSignal = _Plot.Add.Signal(Generate.Sin());
+        sinSignal.LineStyle.Width = 2;
+        sinSignal.Color = Colors.Black;
+
+        Signal cosSignal = _Plot.Add.Signal(Generate.Cos());
+        cosSignal.LineStyle.Width = 2;
+        cosSignal.Color = Colors.Gray;
+
+        _Plot.Style.SetFont(Fonts.Monospace);
+        _Plot.Style.SetLineStylePatterns(LinePattern.HandDrawn);
+
+        WpfPlot1.Refresh();
+    }
+
+    void ShowScatterPlot()
+    {
+        _Plot.Clear();
+
+        double[] dataX = { 1, 2, 3, 4, 5 };
+        double[] dataY = { 1, 4, 9, 16, 25 };
+        var scatterPlot = _Plot.Add.Scatter(dataX, dataY);
+
+        _Plot.Style.SetLineStylePatterns(LinePattern.HandDrawn);
+
+        _Plot.Axes.Margins();
+
+        WpfPlot1.Refresh();
+    }
+
+    void ShowBarPlot()
+    {
+        _Plot.Clear();
+
+        // add bars
+        double[] values = { 5, 10, 7, 13 };
+        var barPlot = _Plot.Add.Bars(values);
+        
+        _Plot.Style.SetLineStylePatterns(LinePattern.HandDrawn);
+
+        // tell the plot to autoscale with no padding beneath the bars
+        _Plot.Axes.Margins(bottom: 0);
+        
+        WpfPlot1.Refresh();
+    }
+
+    void ShowPiePlot()
+    {
+        _Plot.Clear();
+
+        double[] values = { 5, 2, 8, 4, 8 };
+        var pie = _Plot.Add.Pie(values);
+        pie.ExplodeFraction = .1;
+
+        _Plot.Style.SetLineStylePatterns(LinePattern.HandDrawn);
+
+        _Plot.Axes.Margins();
+
+        WpfPlot1.Refresh();
+    }
+
+    private void plotsCombo_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+    {
+        string? selected = plotsCombo.SelectedItem as string;
+        if (selected != null)
+        {
+            if (Enum.TryParse<TestPlots>(selected, out TestPlots plotSelected))
+            {
+                switch (plotSelected)
+                {
+                    case TestPlots.Lines:
+                        ShowLinePlot();
+                        break;
+                    case TestPlots.Scatter:
+                        ShowScatterPlot();
+                        break;
+                    case TestPlots.Bar:
+                        ShowBarPlot();
+                        break;
+                    case TestPlots.Pie:
+                        ShowPiePlot();
+                        break;
+                    case TestPlots.Box:
+                        ShowBoxPlot();
+                        break;
+                    case TestPlots.OHLC:
+                        ShowOHLCPlot();
+                        break;
+                    default:
+                        break;
+                }
+            }
+ 
+        }
+    }
+
+    private void ShowOHLCPlot()
+    {
+        _Plot.Clear();
+
+        var prices = Generate.RandomOHLCs(30);
+        _Plot.Add.OHLC(prices);
+        _Plot.Axes.DateTimeTicksBottom();
+
+        _Plot.Style.SetFont(Fonts.Monospace);
+        _Plot.Style.SetLineStylePatterns(LinePattern.HandDrawn);
+
+        _Plot.Axes.AutoScale();
+        WpfPlot1.Refresh();
+    }
+
+    private void ShowBoxPlot()
+    {
+        _Plot.Clear();
+
+        List<Box> boxes1 = new()
+        {
+            Generate.RandomBox(1),
+            Generate.RandomBox(2),
+            Generate.RandomBox(3),
+        };
+
+        List<Box> boxes2 = new() 
+        {
+            Generate.RandomBox(5),
+            Generate.RandomBox(6),
+            Generate.RandomBox(7),
+        };
+
+        var bp1 = _Plot.Add.Boxes(boxes1);
+        bp1.Label = "Group 1";
+
+        var bp2 = _Plot.Add.Boxes(boxes2);
+        bp2.Label = "Group 2";
+
+        _Plot.ShowLegend(Alignment.UpperRight);
+
+        _Plot.Axes.AutoScale();
+
+        _Plot.Style.SetFont(Fonts.Monospace);
+        _Plot.Style.SetLineStylePatterns(LinePattern.HandDrawn);
+
+        WpfPlot1.Refresh();
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Tests/UnitTests/StylingTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/UnitTests/StylingTests.cs
@@ -1,0 +1,140 @@
+﻿using ScottPlot.Grids;
+using ScottPlot.Interfaces;
+using ScottPlot.Plottables;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlotTests.UnitTests
+{
+    [TestFixture]
+    internal class StylingTests
+    {
+        public void TestHandDrawnStyleAppliesToAxes()
+        {
+            Plot myPlot = new();
+
+            myPlot.Add.Signal(Generate.Sin());
+
+            myPlot.Style.SetLineStylePatterns(LinePattern.HandDrawn);
+
+            int styleableCount = 0;
+            foreach (var axis in myPlot.Axes.GetAxes())
+            {
+                Assert.That(axis.FrameLineStyle.Pattern, Is.EqualTo(LinePattern.HandDrawn));
+                styleableCount++;
+            }
+            Assert.That(styleableCount, Is.GreaterThan(0));
+        }
+
+        public void TestHandDrawnStyleAppliesToGrid()
+        {
+            Plot myPlot = new();
+
+            myPlot.Add.Signal(Generate.Sin());
+
+            myPlot.Style.SetLineStylePatterns(LinePattern.HandDrawn);
+
+            int styleableCount = 0;
+            foreach (var grid in myPlot.Axes.Grids.OfType<DefaultGrid>())
+            {
+                Assert.That(grid.MajorLineStyle.Pattern, Is.EqualTo(LinePattern.HandDrawn));
+            }
+            Assert.That(styleableCount, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void TestHandDrawnStyleAppliesToOHLC()
+        {
+            Plot myPlot = new();
+
+            var prices = Generate.RandomOHLCs(30);
+            myPlot.Add.OHLC(prices);
+
+            AssertPlottableHasHandDrawnStyle(myPlot);
+        }
+
+        [Test]
+        public void TestHandDrawnStyleAppliesToBar()
+        {
+            Plot myPlot = new();
+
+            // add bars
+            double[] values = { 5, 10, 7, 13 };
+            BarPlot bar = myPlot.Add.Bars(values);
+
+            // TODO: create unit test that validates bar plot has hand drawn style -
+            // bar and box do not implement IHoldLineStyle
+        }
+
+        [Test]
+        public void TestHandDrawnStyleAppliesToPie()
+        {
+            Plot myPlot = new();
+
+            double[] values = { 5, 2, 8, 4, 8 };
+            var pie = myPlot.Add.Pie(values);
+
+            AssertPlottableHasHandDrawnStyle(myPlot);
+        }
+
+        [Test]
+        public void TestHandDrawnStyleAppliesToBox()
+        {
+            Plot myPlot = new();
+
+            List<Box> boxes1 = new()
+            {
+                Generate.RandomBox(1),
+                Generate.RandomBox(2),
+                Generate.RandomBox(3),
+            };
+
+            var bp1 = myPlot.Add.Boxes(boxes1);
+            bp1.Label = "Group 1";
+
+            AssertPlottableHasHandDrawnStyle(myPlot);
+        }
+
+        [Test]
+        public void TestHandDrawnStyleAppliesToLine()
+        {
+            Plot myPlot = new();
+
+            myPlot.Add.Signal(Generate.Sin());
+
+            AssertPlottableHasHandDrawnStyle(myPlot);
+        }
+
+        [Test]
+        public void TestHandDrawnStyleAppliesToScatter()
+        {
+            Plot myPlot = new();
+
+            double[] dataX = { 1, 2, 3, 4, 5 };
+            double[] dataY = { 1, 4, 9, 16, 25 };
+            var scatterPlot = myPlot.Add.Scatter(dataX, dataY);
+
+            AssertPlottableHasHandDrawnStyle(myPlot);
+        }
+
+        void AssertPlottableHasHandDrawnStyle(Plot myPlot)
+        {
+            myPlot.Style.SetLineStylePatterns(LinePattern.HandDrawn);
+            int styleableCount = 0;
+
+            foreach (var plottable in myPlot.GetPlottables())
+            {
+                if (plottable is IHoldLineStyle)
+                {
+                    Assert.That(((IHoldLineStyle)plottable).LineStyle.Pattern, Is.EqualTo(LinePattern.HandDrawn));
+                    styleableCount++;
+                }
+            }
+
+            Assert.That(styleableCount, Is.GreaterThan(0));
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -204,7 +204,7 @@ public static class Drawing
         canvas.DrawRect(rect.ToSKRect(), paint);
     }
 
-    public static void DrawRectangle(SKCanvas canvas, PixelRect rect, Color color, float lineWidth = 1)
+    public static void DrawRectangle(SKCanvas canvas, PixelRect rect, Color color, float lineWidth = 1, LinePattern pattern = LinePattern.Solid)
     {
         using SKPaint paint = new()
         {
@@ -212,6 +212,7 @@ public static class Drawing
             IsStroke = true,
             StrokeWidth = lineWidth,
             IsAntialias = true,
+            PathEffect = pattern.GetPathEffect()
         };
 
         DrawRectangle(canvas, rect, paint);

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IHoldLineStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IHoldLineStyle.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Interfaces
+{
+    public interface IHoldLineStyle
+    {
+        LineStyle LineStyle { get; }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/Arrow.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Arrow.cs
@@ -1,6 +1,8 @@
-﻿namespace ScottPlot.Plottables;
+﻿using ScottPlot.Interfaces;
 
-public class Arrow : IPlottable
+namespace ScottPlot.Plottables;
+
+public class Arrow : IPlottable, IHoldLineStyle
 {
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = new Axes();
@@ -24,7 +26,7 @@ public class Arrow : IPlottable
     /// <summary>
     /// Advanced styling options
     /// </summary>
-    public readonly LineStyle LineStyle = new() { Color = Colors.Gray, Width = 2 };
+    public LineStyle LineStyle { get; } = new() { Color = Colors.Gray, Width = 2 };
 
     /// <summary>
     /// Color of the arrow line and arrowhead

--- a/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
@@ -1,6 +1,8 @@
-﻿namespace ScottPlot.Plottables;
+﻿using ScottPlot.Interfaces;
 
-public abstract class AxisLine : IPlottable, IRenderLast
+namespace ScottPlot.Plottables;
+
+public abstract class AxisLine : IPlottable, IRenderLast, IHoldLineStyle
 {
     public bool IsVisible { get; set; } = true;
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/AxisSpan.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/AxisSpan.cs
@@ -1,6 +1,8 @@
-﻿namespace ScottPlot.Plottables;
+﻿using ScottPlot.Interfaces;
 
-public abstract class AxisSpan : IPlottable
+namespace ScottPlot.Plottables;
+
+public abstract class AxisSpan : IPlottable, IHoldLineStyle
 {
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = new Axes();

--- a/src/ScottPlot5/ScottPlot5/Plottables/BarPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/BarPlot.cs
@@ -1,4 +1,6 @@
-﻿namespace ScottPlot.Plottables;
+﻿using ScottPlot.Interfaces;
+
+namespace ScottPlot.Plottables;
 
 /// <summary>
 /// Holds a collection of individually styled bars

--- a/src/ScottPlot5/ScottPlot5/Plottables/BoxPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/BoxPlot.cs
@@ -1,9 +1,11 @@
-﻿namespace ScottPlot.Plottables;
+﻿using ScottPlot.Interfaces;
+
+namespace ScottPlot.Plottables;
 
 /// <summary>
 /// Displays 1 or more boxes all styled the same
 /// </summary>
-public class BoxPlot : IPlottable
+public class BoxPlot : IPlottable, IHoldLineStyle
 {
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = new Axes();
@@ -16,6 +18,7 @@ public class BoxPlot : IPlottable
     public Color FillColor { set => Boxes.ForEach(x => x.Fill.Color = value); }
     public Color StrokeColor { set => Boxes.ForEach(x => x.Stroke.Color = value); }
     public float StrokeWidth { set => Boxes.ForEach(x => x.Stroke.Width = value); }
+    public LineStyle LineStyle { get; } = new();
 
     public AxisLimits GetAxisLimits()
     {
@@ -35,6 +38,8 @@ public class BoxPlot : IPlottable
 
         foreach (Box box in Boxes)
         {
+            // style the box.  This would be better located outside the render loop...
+            box.LineStyle.Pattern = LineStyle.Pattern;
             box.Render(rp, paint, Axes);
         }
     }

--- a/src/ScottPlot5/ScottPlot5/Plottables/CandlestickPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/CandlestickPlot.cs
@@ -1,10 +1,17 @@
-﻿namespace ScottPlot.Plottables;
+﻿using ScottPlot.Interfaces;
 
-public class CandlestickPlot(IOHLCSource data) : IPlottable
+namespace ScottPlot.Plottables;
+
+public class CandlestickPlot(IOHLCSource data) : IPlottable, IHoldLineStyle
 {
     public bool IsVisible { get; set; } = true;
 
     public IAxes Axes { get; set; } = new Axes();
+
+    /// <summary>
+    /// Only used for setting pattern of lines.  Other line styles derive from OHLC plot.
+    /// </summary>
+    public LineStyle LineStyle { get; } = new();
 
     private readonly IOHLCSource Data = data;
 
@@ -66,6 +73,9 @@ public class CandlestickPlot(IOHLCSource data) : IPlottable
             bool isRising = ohlc.Close >= ohlc.Open;
             LineStyle lineStyle = isRising ? RisingLineStyle : FallingLineStyle;
             FillStyle fillStlye = isRising ? RisingFillStyle : FallingFillStyle;
+
+            // Apply pattern from class property for styling the path
+            lineStyle.Pattern = LineStyle.Pattern;
 
             float top = Axes.GetPixelY(ohlc.High);
             float bottom = Axes.GetPixelY(ohlc.Low);

--- a/src/ScottPlot5/ScottPlot5/Plottables/Crosshair.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Crosshair.cs
@@ -1,6 +1,8 @@
-﻿namespace ScottPlot.Plottables;
+﻿using ScottPlot.Interfaces;
 
-public class Crosshair : IPlottable
+namespace ScottPlot.Plottables;
+
+public class Crosshair : IPlottable, IHoldLineStyle
 {
     public bool IsVisible { get; set; } = true;
 
@@ -17,7 +19,7 @@ public class Crosshair : IPlottable
     public bool VerticalLineIsVisible { get; set; } = true;
 
     public bool HorizontalLineIsVisible { get; set; } = true;
-    public readonly LineStyle LineStyle = new();
+    public LineStyle LineStyle { get; } = new();
 
     public void Render(RenderPack rp)
     {

--- a/src/ScottPlot5/ScottPlot5/Plottables/DataLogger.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/DataLogger.cs
@@ -1,10 +1,11 @@
 ﻿
 using ScottPlot.AxisLimitCalculators;
 using ScottPlot.DataSources;
+using ScottPlot.Interfaces;
 
 namespace ScottPlot.Plottables;
 
-public class DataLogger : IPlottable, IManagesAxisLimits
+public class DataLogger : IPlottable, IManagesAxisLimits, IHoldLineStyle
 {
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = ScottPlot.Axes.Default;
@@ -15,7 +16,7 @@ public class DataLogger : IPlottable, IManagesAxisLimits
     public IAxisLimitManager AxisManager { get; set; } = new Full();
 
     public AxisLimits GetAxisLimits() => Data.GetAxisLimits();
-    public LineStyle LineStyle = new();
+    public LineStyle LineStyle { get; } = new();
     public Color Color { get => LineStyle.Color; set => LineStyle.Color = value; }
 
     /// <summary>

--- a/src/ScottPlot5/ScottPlot5/Plottables/DataStreamer.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/DataStreamer.cs
@@ -1,15 +1,16 @@
 ﻿using ScottPlot.AxisLimitCalculators;
 using ScottPlot.DataSources;
+using ScottPlot.Interfaces;
 
 namespace ScottPlot.Plottables;
 
-public class DataStreamer : IPlottable, IManagesAxisLimits
+public class DataStreamer : IPlottable, IManagesAxisLimits, IHoldLineStyle
 {
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = ScottPlot.Axes.Default;
     public IEnumerable<LegendItem> LegendItems => LegendItem.None;
 
-    public readonly LineStyle LineStyle = new();
+    public LineStyle LineStyle { get; } = new();
     public Color Color { get => LineStyle.Color; set => LineStyle.Color = value; }
 
     public DataStreamerSource Data { get; set; }

--- a/src/ScottPlot5/ScottPlot5/Plottables/Ellipse.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Ellipse.cs
@@ -1,8 +1,9 @@
 ﻿using ScottPlot.Extensions;
+using ScottPlot.Interfaces;
 
 namespace ScottPlot.Plottables;
 
-public class Ellipse : IPlottable
+public class Ellipse : IPlottable, IHoldLineStyle
 {
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = new Axes();

--- a/src/ScottPlot5/ScottPlot5/Plottables/ErrorBar.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/ErrorBar.cs
@@ -1,6 +1,8 @@
-﻿namespace ScottPlot.Plottables
+﻿using ScottPlot.Interfaces;
+
+namespace ScottPlot.Plottables
 {
-    public class ErrorBar : IPlottable
+    public class ErrorBar : IPlottable, IHoldLineStyle
     {
         // TODO: use an errorbar source instead of so many lists
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/FillY.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/FillY.cs
@@ -1,6 +1,8 @@
-﻿namespace ScottPlot.Plottables;
+﻿using ScottPlot.Interfaces;
 
-public class FillY : IPlottable
+namespace ScottPlot.Plottables;
+
+public class FillY : IPlottable, IHoldLineStyle
 {
     public string? Label { get; set; }
     public bool IsVisible { get; set; } = true;

--- a/src/ScottPlot5/ScottPlot5/Plottables/FunctionPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/FunctionPlot.cs
@@ -1,6 +1,8 @@
-﻿namespace ScottPlot.Plottables;
+﻿using ScottPlot.Interfaces;
 
-public class FunctionPlot : IPlottable
+namespace ScottPlot.Plottables;
+
+public class FunctionPlot : IPlottable, IHoldLineStyle
 {
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = new Axes();

--- a/src/ScottPlot5/ScottPlot5/Plottables/LinePlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/LinePlot.cs
@@ -1,6 +1,8 @@
-﻿namespace ScottPlot.Plottables;
+﻿using ScottPlot.Interfaces;
 
-public class LinePlot : IPlottable
+namespace ScottPlot.Plottables;
+
+public class LinePlot : IPlottable, IHoldLineStyle
 {
     public Coordinates Start { get; set; }
     public Coordinates End { get; set; }

--- a/src/ScottPlot5/ScottPlot5/Plottables/OHLCPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/OHLCPlot.cs
@@ -1,6 +1,8 @@
-﻿namespace ScottPlot.Plottables;
+﻿using ScottPlot.Interfaces;
 
-public class OhlcPlot(IOHLCSource data) : IPlottable
+namespace ScottPlot.Plottables;
+
+public class OhlcPlot(IOHLCSource data) : IPlottable, IHoldLineStyle
 {
     public bool IsVisible { get; set; } = true;
 
@@ -27,6 +29,11 @@ public class OhlcPlot(IOHLCSource data) : IPlottable
 
     public IEnumerable<LegendItem> LegendItems => Enumerable.Empty<LegendItem>();
 
+    /// <summary>
+    /// Used for applying styling to both rising and falling candles
+    /// </summary>
+    public LineStyle LineStyle { get; } = new();
+
     public AxisLimits GetAxisLimits() => Data.GetLimits();
 
     public void Render(RenderPack rp)
@@ -34,6 +41,10 @@ public class OhlcPlot(IOHLCSource data) : IPlottable
         using SKPaint paint = new();
         using SKPath risingPath = new();
         using SKPath fallingPath = new();
+
+        // style the OHLCs
+        RisingStyle.Pattern = LineStyle.Pattern;
+        FallingStyle.Pattern = LineStyle.Pattern;
 
         foreach (OHLC ohlc in Data.GetOHLCs())
         {

--- a/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
@@ -1,6 +1,8 @@
-﻿namespace ScottPlot.Plottables;
+﻿using ScottPlot.Interfaces;
 
-public class Pie : IPlottable
+namespace ScottPlot.Plottables;
+
+public class Pie : IPlottable, IHoldLineStyle
 {
     public IList<PieSlice> Slices { get; set; }
     public LineStyle LineStyle { get; set; } = new() { Width = 0 };

--- a/src/ScottPlot5/ScottPlot5/Plottables/Polygon.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Polygon.cs
@@ -1,10 +1,12 @@
-﻿namespace ScottPlot.Plottables;
+﻿using ScottPlot.Interfaces;
+
+namespace ScottPlot.Plottables;
 
 /// <summary>
 /// A polygon is a collection of X/Y points that are all connected to form a closed shape.
 /// Polygons can be optionally filled with a color or a gradient.
 /// </summary>
-public class Polygon : IPlottable
+public class Polygon : IPlottable, IHoldLineStyle
 {
     public static Polygon Empty => new();
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/Rectangle.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Rectangle.cs
@@ -1,7 +1,9 @@
 ﻿
+using ScottPlot.Interfaces;
+
 namespace ScottPlot.Plottables;
 
-public class Rectangle : IPlottable
+public class Rectangle : IPlottable, IHoldLineStyle
 {
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = new Axes();

--- a/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
@@ -1,6 +1,8 @@
-﻿namespace ScottPlot.Plottables;
+﻿using ScottPlot.Interfaces;
 
-public class Scatter(IScatterSource data) : IPlottable
+namespace ScottPlot.Plottables;
+
+public class Scatter(IScatterSource data) : IPlottable, IHoldLineStyle
 {
     public string Label { get; set; } = string.Empty;
     public bool IsVisible { get; set; } = true;

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -2,9 +2,11 @@
  * !! Avoid temptation to use generics or generic math at this early stage of development
  */
 
+using ScottPlot.Interfaces;
+
 namespace ScottPlot.Plottables;
 
-public class Signal : IPlottable
+public class Signal : IPlottable, IHoldLineStyle
 {
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = new Axes();
@@ -15,7 +17,7 @@ public class Signal : IPlottable
 
     public readonly MarkerStyle Marker;
 
-    public readonly LineStyle LineStyle;
+    public LineStyle LineStyle { get; private set; }
 
     /// <summary>
     /// Maximum size of the marker (in pixels) to display

--- a/src/ScottPlot5/ScottPlot5/Plottables/SignalConst.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/SignalConst.cs
@@ -1,13 +1,14 @@
 ﻿using ScottPlot.DataSources;
+using ScottPlot.Interfaces;
 
 namespace ScottPlot.Plottables;
 
-public class SignalConst<T>(T[] ys, double period) : IPlottable
+public class SignalConst<T>(T[] ys, double period) : IPlottable, IHoldLineStyle
     where T : struct, IComparable
 {
     readonly SignalConstSourceDoubleArray<T> Data = new(ys, period);
     public readonly MarkerStyle Marker = new();
-    public readonly LineStyle LineStyle = new();
+    public LineStyle LineStyle { get; } = new();
 
     public string? Label { get; set; }
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/SignalXY.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/SignalXY.cs
@@ -1,6 +1,8 @@
-﻿namespace ScottPlot.Plottables;
+﻿using ScottPlot.Interfaces;
 
-public class SignalXY : IPlottable
+namespace ScottPlot.Plottables;
+
+public class SignalXY : IPlottable, IHoldLineStyle
 {
     public ISignalXYSource Data { get; set; }
 

--- a/src/ScottPlot5/ScottPlot5/Primitives/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Bar.cs
@@ -19,6 +19,8 @@ public class Bar
     public float BorderLineWidth = 1;
     public float ErrorLineWidth = 0;
 
+    public LinePattern BarLinePattern { get; set; } = LinePattern.Solid;
+
     // TODO: something like ErrorInDirectionOfValue?
     // Maybe ErrorPosition should be an enum containing: None, Upward, Downward, Both, or Extend
     public bool ErrorPositive = true;
@@ -88,7 +90,7 @@ public class Bar
     {
         PixelRect rect = axes.GetPixelRect(Rect);
         Drawing.Fillectangle(rp.Canvas, rect, FillColor);
-        Drawing.DrawRectangle(rp.Canvas, rect, BorderColor, BorderLineWidth);
+        Drawing.DrawRectangle(rp.Canvas, rect, BorderColor, BorderLineWidth, BarLinePattern);
 
         if (Error == 0)
             return;
@@ -97,7 +99,7 @@ public class Bar
         {
             Pixel pt1 = axes.GetPixel(line.Start);
             Pixel pt2 = axes.GetPixel(line.End);
-            Drawing.DrawLine(rp.Canvas, paint, pt1, pt2, BorderColor, BorderLineWidth);
+            Drawing.DrawLine(rp.Canvas, paint, pt1, pt2, BorderColor, BorderLineWidth, true, BarLinePattern);
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Box.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Box.cs
@@ -20,6 +20,8 @@ public class Box
     public double CapSize { get; set; } = 0.3;
     public FillStyle Fill { get; set; } = new();
     public LineStyle Stroke { get; set; } = new();
+    public LineStyle LineStyle { get; } = new();
+
     public Orientation Orientation { get; set; } = Orientation.Vertical;
 
     public AxisLimits GetAxisLimits()
@@ -45,35 +47,35 @@ public class Box
 
         // body stroke
         Stroke.ApplyToPaint(paint);
-        Drawing.DrawRectangle(rp.Canvas, bodyRectPx, paint);
+        Drawing.DrawRectangle(rp.Canvas, bodyRectPx, paint, LineStyle);
 
         if (BoxMiddle.HasValue)
         {
             CoordinateLine lineMid = new(bodyRect.Left, BoxMiddle.Value, bodyRect.Right, BoxMiddle.Value);
             PixelLine lineMidPx = axes.GetPixelLine(lineMid);
-            Drawing.DrawLine(rp.Canvas, paint, lineMidPx);
+            Drawing.DrawLine(rp.Canvas, paint, lineMidPx, LineStyle);
         }
 
         if (WhiskerMax.HasValue)
         {
             CoordinateLine lineMax = new(Position, BoxMax, Position, WhiskerMax.Value);
             PixelLine lineMaxPx = axes.GetPixelLine(lineMax);
-            Drawing.DrawLine(rp.Canvas, paint, lineMaxPx);
+            Drawing.DrawLine(rp.Canvas, paint, lineMaxPx, LineStyle);
 
             CoordinateLine lineMaxAcross = new(Position - CapSize / 2, WhiskerMax.Value, Position + CapSize / 2, WhiskerMax.Value);
             PixelLine lineMaxAcrossPx = axes.GetPixelLine(lineMaxAcross);
-            Drawing.DrawLine(rp.Canvas, paint, lineMaxAcrossPx);
+            Drawing.DrawLine(rp.Canvas, paint, lineMaxAcrossPx, LineStyle);
         }
 
         if (WhiskerMin.HasValue)
         {
             CoordinateLine lineMin = new(Position, BoxMin, Position, WhiskerMin.Value);
             PixelLine lineMinPx = axes.GetPixelLine(lineMin);
-            Drawing.DrawLine(rp.Canvas, paint, lineMinPx);
+            Drawing.DrawLine(rp.Canvas, paint, lineMinPx, LineStyle);
 
             CoordinateLine lineMinAcross = new(Position - CapSize / 2, WhiskerMin.Value, Position + CapSize / 2, WhiskerMin.Value);
             PixelLine lineMinAcrossPx = axes.GetPixelLine(lineMinAcross);
-            Drawing.DrawLine(rp.Canvas, paint, lineMinAcrossPx);
+            Drawing.DrawLine(rp.Canvas, paint, lineMinAcrossPx, LineStyle);
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/LinePattern.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LinePattern.cs
@@ -11,6 +11,7 @@ public enum LinePattern
     Dashed,
     DenselyDashed,
     Dotted,
+    HandDrawn
 }
 
 public static class LinePatternExtensions
@@ -23,6 +24,7 @@ public static class LinePatternExtensions
             LinePattern.Dashed => SKPathEffect.CreateDash(new float[] { 10, 10 }, 0),
             LinePattern.DenselyDashed => SKPathEffect.CreateDash(new float[] { 6, 6 }, 0),
             LinePattern.Dotted => SKPathEffect.CreateDash(new float[] { 3, 5 }, 0),
+            LinePattern.HandDrawn => SKPathEffect.CreateDiscrete(8, 1),
             _ => throw new NotImplementedException($"Line pattern '{pattern}' has no matching path effect"),
         };
     }

--- a/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
+++ b/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
@@ -1,5 +1,6 @@
 ﻿using ScottPlot.AxisPanels;
 using ScottPlot.Grids;
+using ScottPlot.Interfaces;
 using ScottPlot.Legends;
 using System.ComponentModel;
 
@@ -147,5 +148,26 @@ public class PlotStyler
             background: Color.FromHex("#404040"),
             foreground: Color.FromHex("#d7d7d7"),
             border: Color.FromHex("#d7d7d7"));
+    }
+
+    public void SetLineStylePatterns(LinePattern pattern)
+    {
+        foreach (IPlottable plottable in Plot.GetPlottables())
+        {
+            if (plottable is IHoldLineStyle)
+            {
+                ((IHoldLineStyle)plottable).LineStyle.Pattern = pattern;
+            }
+        }
+
+        foreach (IAxis axis in Plot.Axes.GetAxes())
+        {
+            axis.FrameLineStyle.Pattern = pattern;
+        }
+
+        foreach (DefaultGrid grid in Plot.Axes.Grids.OfType<DefaultGrid>())
+        {
+            grid.MajorLineStyle.Pattern = pattern;
+        }
     }
 }


### PR DESCRIPTION
I added a handdrawn line style pattern.  This creates a discrete path effect:

```cs
SKPathEffect.CreateDiscrete(8, 1)
```
Added interface to query if the object has the LineStyle property. I usually like interfaces to be methods instead of holding a property, but this was an easy way to retrofit existing plottable classes. Added SetLineStylePatterns method to the Styler class. Added some unit tests to validate the line style pattern is being set properly.

I could not understand how to style the radial gauge.  Legends and other annotation need some attention as well.

Example of use:
```cs
        Signal sinSignal = _Plot.Add.Signal(Generate.Sin());
        sinSignal.LineStyle.Width = 2;
        sinSignal.Color = Colors.Black;

        Signal cosSignal = _Plot.Add.Signal(Generate.Cos());
        cosSignal.LineStyle.Width = 2;
        cosSignal.Color = Colors.Gray;

        _Plot.Style.SetFont(Fonts.Monospace);
        _Plot.Style.SetLineStylePatterns(LinePattern.HandDrawn);
```

![image](https://github.com/ScottPlot/ScottPlot/assets/40821256/35f7ee60-eb1c-4024-bbc5-d105f31cd395)
