### PR TITLE
Legend: Improve international font support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ _Not yet on NuGet..._
 * Plot: `GetCoordinateRect()` now returns dimensions that respect `ScaleFactor` (#3471) @MCF
 * Label: Added `Measure()` overloads to facilitate measuring arbitrary strings without modifying the label text (#3474, #3473) @aespitia
 * Layout: Improved positioning of text for bottom tick labels with large font (#3436) @edwwsw
+* Legend: Improve international font support when `Plot.Style.SetBestFonts()` is used (#3440) @edwwsw
 
 ## ScottPlot 4.1.72
 _Not yet on NuGet..._

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Miscellaneous/Internationalization.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Miscellaneous/Internationalization.cs
@@ -39,9 +39,17 @@ public class Internationalization : ICategory
         [Test]
         public override void Execute()
         {
+            var sig1 = myPlot.Add.Signal(Generate.Sin());
+            var sig2 = myPlot.Add.Signal(Generate.Cos());
+
+            sig1.Label = "测试"; // Chinese
+            sig2.Label = "테스트"; // Korean
+            myPlot.ShowLegend();
+
             myPlot.Title("测试"); // Chinese
             myPlot.YLabel("試験"); // Japanese
             myPlot.XLabel("테스트"); // Korean
+
             myPlot.Style.SetBestFonts();
         }
     }

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -320,12 +320,12 @@ public class Plot : IDisposable
     /// <summary>
     /// Returns the content of the legend as a raster image
     /// </summary>
-    public Image GetLegendImage() => Legend.GetImage(this);
+    public Image GetLegendImage() => Legend.GetImage();
 
     /// <summary>
     /// Returns the content of the legend as SVG (vector) image
     /// </summary>
-    public string GetLegendSvgXml() => Legend.GetSvgXml(this);
+    public string GetLegendSvgXml() => Legend.GetSvgXml();
 
     #endregion
 

--- a/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
@@ -39,6 +39,11 @@ public readonly struct Color
         }
     }
 
+    public override string ToString()
+    {
+        return $"Color R={R}, G={G}, B={B}";
+    }
+
     public Color(byte red, byte green, byte blue, byte alpha = 255)
     {
         Red = red;

--- a/src/ScottPlot5/ScottPlot5/Primitives/FontStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/FontStyle.cs
@@ -66,6 +66,11 @@ public class FontStyle
     public float Size { get; set; } = 12;
     public bool AntiAlias { get; set; } = true;
 
+    public override string ToString()
+    {
+        return $"{Name}, Size {Size}, {Color}";
+    }
+
     private void ClearCachedTypeface()
     {
         CachedTypeface = null;

--- a/src/ScottPlot5/ScottPlot5/Primitives/FontStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/FontStyle.cs
@@ -89,4 +89,16 @@ public class FontStyle
         Name = Fonts.Detect(text);
     }
 
+    public FontStyle Clone()
+    {
+        return new FontStyle()
+        {
+            Name = Name,
+            Bold = Bold,
+            Italic = Italic,
+            Color = Color,
+            Size = Size,
+            AntiAlias = AntiAlias,
+        };
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/FontStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/FontStyle.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-
-namespace ScottPlot;
+﻿namespace ScottPlot;
 
 /// <summary>
 /// This configuration object (reference type) permanently lives inside objects which require styling.
@@ -81,4 +79,14 @@ public class FontStyle
         SKFontStyle skfs = new(weight, width, slant);
         return SKTypeface.FromFamilyName(font, skfs);
     }
+
+    /// <summary>
+    /// Use the characters in <paramref name="text"/> to determine an installed 
+    /// system font most likely to support this character set.
+    /// </summary>
+    public void SetBestFont(string text)
+    {
+        Name = Fonts.Detect(text);
+    }
+
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/LegendItem.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LegendItem.cs
@@ -17,6 +17,7 @@ public class LegendItem
     public IEnumerable<LegendItem> Children { get; set; } = Array.Empty<LegendItem>();
     public bool HasSymbol => Line.Width > 0 || Marker.IsVisible || Fill.HasValue;
     public bool IsVisible => !string.IsNullOrEmpty(Label);
+    internal FontStyle? CustomFontStyle { get; set; } = null;
 
     public static IEnumerable<LegendItem> None => Array.Empty<LegendItem>();
 

--- a/src/ScottPlot5/ScottPlot5/Primitives/LegendItem.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LegendItem.cs
@@ -17,7 +17,6 @@ public class LegendItem
     public IEnumerable<LegendItem> Children { get; set; } = Array.Empty<LegendItem>();
     public bool HasSymbol => Line.Width > 0 || Marker.IsVisible || Fill.HasValue;
     public bool IsVisible => !string.IsNullOrEmpty(Label);
-    public FontStyle? CustomFont = null;
 
     public static IEnumerable<LegendItem> None => Array.Empty<LegendItem>();
 

--- a/src/ScottPlot5/ScottPlot5/Primitives/LegendItem.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LegendItem.cs
@@ -17,6 +17,7 @@ public class LegendItem
     public IEnumerable<LegendItem> Children { get; set; } = Array.Empty<LegendItem>();
     public bool HasSymbol => Line.Width > 0 || Marker.IsVisible || Fill.HasValue;
     public bool IsVisible => !string.IsNullOrEmpty(Label);
+    public FontStyle? CustomFont = null;
 
     public static IEnumerable<LegendItem> None => Array.Empty<LegendItem>();
 

--- a/src/ScottPlot5/ScottPlot5/Primitives/Pixel.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Pixel.cs
@@ -47,6 +47,8 @@ public struct Pixel : IEquatable<Pixel>
     /// </summary>
     public static Pixel NaN => new(float.NaN, float.NaN);
 
+    public static Pixel Zero => new(0, 0);
+
     /// <summary>
     /// Convert the ScottPlot pixel to a SkiaSharp point
     /// </summary>

--- a/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
+++ b/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
@@ -119,10 +119,10 @@ public class PlotStyler(Plot plot)
         foreach (IAxis axis in Plot.Axes.GetAxes())
         {
             axis.Label.SetBestFont();
+            axis.TickLabelStyle.SetBestFont();
         }
 
-        // TODO: also modify tick labels
-        // TODO: also modify plotted text
+        // TODO: also modify plotted text by adding an IHasText interface
     }
 
     /// <summary>

--- a/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
+++ b/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
@@ -122,6 +122,8 @@ public class PlotStyler(Plot plot)
             axis.TickLabelStyle.SetBestFont();
         }
 
+        Plot.Legend.SetBestFontOnEachRender = true;
+
         // TODO: also modify plotted text by adding an IHasText interface
     }
 


### PR DESCRIPTION
This PR refactors legend rendering to allow fonts to be detected at render time. This behavior is inefficient and hidden behind an opt-in flag. Future refactoring may allow plottable objects to have a `LegendItemStyle` so they can store state. Presently `GetLegendItems()` generates new styles on every call (on every render) so there's not a good way to store font information on a per-item basis across renders.

Resolves #3440