### PR TITLE
SignalXY: Fix final segment is not being rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ _Not yet on NuGet..._
 * Style: `Plot.Style.AxisFrame()` has moved to `Plot.Axes.Frame()`
 * Style: `Plot.Style.SetBestFonts()` has moved to `Plot.Font.Automatic()`
 * Grid: Added `Plot.Grid` with axis-specific styling options as seen in the cookbook (#3291, #3293) @bjschwarz, @PaxITIS
+* SignalXY: Fixed a bug where the final line segment was not drawn (#3495, #3423) @MareMare @mjazd
+* SignalXY: Improved support for inverted vertical axes (#3495) @MareMare
 
 ## ScottPlot 5.0.22
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-16_

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
@@ -281,7 +281,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     {
         var (lastPointPosition, lastPointIndex) = SearchIndex(axes.YAxis.Range.Span > 0 ? axes.YAxis.Max : axes.YAxis.Min); // if axis is reversed last index will on the bottom limit of the plot
 
-        if (lastPointIndex <= MaximumIndex)
+        if (lastPointPosition <= MaximumIndex)
         {
             float afterX = axes.GetPixelX(Ys[lastPointIndex] + XOffset);
             float afterY = axes.GetPixelY(Xs[lastPointIndex] + YOffset);


### PR DESCRIPTION
This will fix issue #3423 

<details><summary>test code:</summary>

```cs
using ScottPlot;

namespace Sandbox5;

public partial class Form1 : Form
{
    public Form1()
    {
        InitializeComponent();
        Size = new Size(800, 450);
        Text = "ScottPlot5-WinForms for Issue 3423";

        var line = formsPlot1.Plot.Add.Line(0, 0, 1, 0);
        line.Label = "SP5:Line";
        line.LineWidth = 5;

        var signal = formsPlot1.Plot.Add.Signal(new double[] { 1, 1 });
        signal.Label = "SP5:Signal";
        signal.LineWidth = 5;

        // SignalXYSourceDoubleArray
        double[] xs1 = Generate.Consecutive(3);
        double[] ys1 = Generate.Repeating(3, 2);
        var signalXY1 = formsPlot1.Plot.Add.SignalXY(xs1, ys1);
        signalXY1.Label = "SP5:SignalXY";
        signalXY1.LineWidth = 5;

        // SignalXYSourceGenericArray
        float[] xs2 = Generate.Consecutive(3).Select(value => (float)value).ToArray();
        int[] ys2 = Generate.Repeating(3, 3).Select(value => (int)value).ToArray();
        var signalXY2 = formsPlot1.Plot.Add.SignalXY(xs2, ys2);
        signalXY2.Label = "SP5:SignalXY Generic";
        signalXY2.LineWidth = 5;

        formsPlot1.Plot.ShowLegend();
        formsPlot1.Plot.HideGrid();
        formsPlot1.Refresh();
    }
}
```

</details>

![image](https://github.com/ScottPlot/ScottPlot/assets/807378/5a732469-cfdd-49d5-9811-236b36d73093)

Changes were made to mimic the way conditions were determined in SP4.
Also, the `GetIndex` method is now public in SP5, so we left it as is.
