### PR TITLE
Refactor Grid system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ _Not yet on NuGet..._
 * Plot: Added `ShowLegend()` overload that does not override the current `Orientation` (#3450) @aespitia
 * Grid: The standard grid can be accessed via `Plot.Grid` instead of `GetDefaultGrid()`
 * Grid: Allow axis-specific grid line customization (#3291, #3293) @bjschwarz, @PaxITIS
+* Legend: `Plot.Style.ColorLegend()` is deprecated. Access `Plot.Legend` properties directly as seen in the cookbook.
 
 ## ScottPlot 5.0.22
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-16_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 _Not yet on NuGet..._
 * Plot: Added `ShowLegend()` overload that does not override the current `Orientation` (#3450) @aespitia
 * Grid: The standard grid can be accessed via `Plot.Grid` instead of `GetDefaultGrid()`
-* Grid: Allow axis-specific grid line customization (#3291, #3293) @bjschwarz, @PaxITIS
 * Style: `Plot.Style.ColorLegend()` is deprecated. Access `Plot.Legend` properties directly as seen in the cookbook.
 * Style: `Plot.Style.ColorAxes()` has moved to `Plot.Axes.Color()`
 * Style: `Plot.Style.AxisFrame()` has moved to `Plot.Axes.Frame()`
 * Style: `Plot.Style.SetBestFonts()` has moved to `Plot.Font.Automatic()`
+* Grid: Added `Plot.Grid` with axis-specific styling options as seen in the cookbook (#3291, #3293) @bjschwarz, @PaxITIS
 
 ## ScottPlot 5.0.22
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-16_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## ScottPlot 5.0.23
 _Not yet on NuGet..._
 * Plot: Added `ShowLegend()` overload that does not override the current `Orientation` (#3450) @aespitia
+* Grid: The standard grid can be accessed via `Plot.Grid` instead of `GetDefaultGrid()`
+* Grid: Allow axis-specific grid line customization (#3291, #3293) @bjschwarz, @PaxITIS
 
 ## ScottPlot 5.0.22
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-16_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ _Not yet on NuGet..._
 * Grid: The standard grid can be accessed via `Plot.Grid` instead of `GetDefaultGrid()`
 * Grid: Allow axis-specific grid line customization (#3291, #3293) @bjschwarz, @PaxITIS
 * Style: `Plot.Style.ColorLegend()` is deprecated. Access `Plot.Legend` properties directly as seen in the cookbook.
-* Style: `Plot.Style.ColorAxes()` is deprecated. Call `Plot.Axes.Color()` instead.
-* Style: `Plot.Style.AxisFrame()` is deprecated. Call `Plot.Axes.Frame()` overloads instead.
+* Style: `Plot.Style.ColorAxes()` has moved to `Plot.Axes.Color()`
+* Style: `Plot.Style.AxisFrame()` has moved to `Plot.Axes.Frame()`
+* Style: `Plot.Style.SetBestFonts()` has moved to `Plot.Font.Automatic()`
 
 ## ScottPlot 5.0.22
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-16_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ _Not yet on NuGet..._
 * Plot: Added `ShowLegend()` overload that does not override the current `Orientation` (#3450) @aespitia
 * Grid: The standard grid can be accessed via `Plot.Grid` instead of `GetDefaultGrid()`
 * Grid: Allow axis-specific grid line customization (#3291, #3293) @bjschwarz, @PaxITIS
-* Legend: `Plot.Style.ColorLegend()` is deprecated. Access `Plot.Legend` properties directly as seen in the cookbook.
+* Style: `Plot.Style.ColorLegend()` is deprecated. Access `Plot.Legend` properties directly as seen in the cookbook.
+* Style: `Plot.Style.ColorAxes()` is deprecated. Call `Plot.Axes.Color()` instead.
 
 ## ScottPlot 5.0.22
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-16_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ _Not yet on NuGet..._
 * Grid: Allow axis-specific grid line customization (#3291, #3293) @bjschwarz, @PaxITIS
 * Style: `Plot.Style.ColorLegend()` is deprecated. Access `Plot.Legend` properties directly as seen in the cookbook.
 * Style: `Plot.Style.ColorAxes()` is deprecated. Call `Plot.Axes.Color()` instead.
+* Style: `Plot.Style.AxisFrame()` is deprecated. Call `Plot.Axes.Frame()` overloads instead.
 
 ## ScottPlot 5.0.22
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-16_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/CustomizingGrids.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/CustomizingGrids.cs
@@ -31,12 +31,32 @@ public class CustomizingGrids : ICategory
         [Test]
         public override void Execute()
         {
-            myPlot.Add.Signal(ScottPlot.Generate.Sin(51));
-            myPlot.Add.Signal(ScottPlot.Generate.Cos(51));
+            myPlot.Add.Signal(Generate.Sin(51));
+            myPlot.Add.Signal(Generate.Cos(51));
 
-            myPlot.Grid.MajorLineStyle.Color = Colors.Green.WithOpacity(.5);
-            myPlot.Grid.MinorLineStyle.Color = Colors.Green.WithOpacity(.1);
-            myPlot.Grid.MinorLineStyle.Width = 1;
+            myPlot.Grid.MajorLineColor = Colors.Green.WithOpacity(.5);
+            myPlot.Grid.MinorLineColor = Colors.Green.WithOpacity(.1);
+            myPlot.Grid.MinorLineWidth = 1;
+        }
+    }
+
+    public class GridCustomAxis : RecipeBase
+    {
+        public override string Name => "Axis Specific Grid Customization";
+        public override string Description => "Axis-specific styling properties are available " +
+            "for extensive axis-specific customization of grid line styling.";
+
+        [Test]
+        public override void Execute()
+        {
+            myPlot.Add.Signal(Generate.Sin(51));
+            myPlot.Add.Signal(Generate.Cos(51));
+
+            myPlot.Grid.XAxisStyle.MajorLineStyle.Color = Colors.Magenta.WithAlpha(.1);
+            myPlot.Grid.XAxisStyle.MajorLineStyle.Width = 5;
+
+            myPlot.Grid.YAxisStyle.MajorLineStyle.Color = Colors.Green.WithAlpha(.3);
+            myPlot.Grid.YAxisStyle.MajorLineStyle.Width = 2;
         }
     }
 
@@ -52,8 +72,8 @@ public class CustomizingGrids : ICategory
             var sig = myPlot.Add.Signal(ScottPlot.Generate.Sin());
             sig.LineWidth = 10;
 
-            myPlot.Grid.MajorLineStyle.Width = 3;
-            myPlot.Grid.MajorLineStyle.Color = Colors.WhiteSmoke;
+            myPlot.Grid.MajorLineWidth = 3;
+            myPlot.Grid.MajorLineColor = Colors.WhiteSmoke;
             myPlot.Grid.IsBeneathPlottables = false;
         }
     }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/CustomizingGrids.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/CustomizingGrids.cs
@@ -34,11 +34,9 @@ public class CustomizingGrids : ICategory
             myPlot.Add.Signal(ScottPlot.Generate.Sin(51));
             myPlot.Add.Signal(ScottPlot.Generate.Cos(51));
 
-            ScottPlot.Grids.DefaultGrid grid = myPlot.GetDefaultGrid();
-
-            grid.MajorLineStyle.Color = Colors.Green.WithOpacity(.5);
-            grid.MinorLineStyle.Color = Colors.Green.WithOpacity(.1);
-            grid.MinorLineStyle.Width = 1;
+            myPlot.Grid.MajorLineStyle.Color = Colors.Green.WithOpacity(.5);
+            myPlot.Grid.MinorLineStyle.Color = Colors.Green.WithOpacity(.1);
+            myPlot.Grid.MinorLineStyle.Width = 1;
         }
     }
 
@@ -54,10 +52,9 @@ public class CustomizingGrids : ICategory
             var sig = myPlot.Add.Signal(ScottPlot.Generate.Sin());
             sig.LineWidth = 10;
 
-            ScottPlot.Grids.DefaultGrid grid = myPlot.GetDefaultGrid();
-            grid.MajorLineStyle.Width = 3;
-            grid.MajorLineStyle.Color = Colors.WhiteSmoke;
-            grid.IsBeneathPlottables = false;
+            myPlot.Grid.MajorLineStyle.Width = 3;
+            myPlot.Grid.MajorLineStyle.Color = Colors.WhiteSmoke;
+            myPlot.Grid.IsBeneathPlottables = false;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/CustomizingTicks.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/CustomizingTicks.cs
@@ -168,7 +168,8 @@ public class CustomizingTicks : ICategory
             myPlot.Add.Signal(Generate.Sin());
             myPlot.Add.Signal(Generate.Cos());
 
-            myPlot.Grid.MajorLineStyle.Width = 1; // TODO: demonstrate how to disable just vertical or horizontal grid lines
+            myPlot.Grid.XAxisStyle.IsVisible = true;
+            myPlot.Grid.YAxisStyle.IsVisible = false;
         }
     }
 
@@ -241,9 +242,9 @@ public class CustomizingTicks : ICategory
             myPlot.Axes.Left.TickGenerator = tickGen;
 
             // show grid lines for minor ticks
-            myPlot.Grid.MajorLineStyle.Color = Colors.Black.WithOpacity(.15);
-            myPlot.Grid.MinorLineStyle.Color = Colors.Black.WithOpacity(.05);
-            myPlot.Grid.MinorLineStyle.Width = 1;
+            myPlot.Grid.MajorLineColor = Colors.Black.WithOpacity(.15);
+            myPlot.Grid.MinorLineColor = Colors.Black.WithOpacity(.05);
+            myPlot.Grid.MinorLineWidth = 1;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/CustomizingTicks.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/CustomizingTicks.cs
@@ -168,8 +168,7 @@ public class CustomizingTicks : ICategory
             myPlot.Add.Signal(Generate.Sin());
             myPlot.Add.Signal(Generate.Cos());
 
-            ScottPlot.Grids.DefaultGrid grid = myPlot.GetDefaultGrid();
-            grid.MajorLineStyle.Width = 1; // TODO: demonstrate how to disable just vertical or horizontal grid lines
+            myPlot.Grid.MajorLineStyle.Width = 1; // TODO: demonstrate how to disable just vertical or horizontal grid lines
         }
     }
 
@@ -242,10 +241,9 @@ public class CustomizingTicks : ICategory
             myPlot.Axes.Left.TickGenerator = tickGen;
 
             // show grid lines for minor ticks
-            var grid = myPlot.GetDefaultGrid();
-            grid.MajorLineStyle.Color = Colors.Black.WithOpacity(.15);
-            grid.MinorLineStyle.Color = Colors.Black.WithOpacity(.05);
-            grid.MinorLineStyle.Width = 1;
+            myPlot.Grid.MajorLineStyle.Color = Colors.Black.WithOpacity(.15);
+            myPlot.Grid.MinorLineStyle.Color = Colors.Black.WithOpacity(.05);
+            myPlot.Grid.MinorLineStyle.Width = 1;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
@@ -25,7 +25,7 @@ public class Styling : ICategory
             myPlot.Axes.Title.Label.Text = "Plot Title";
 
             // some items must be styled directly
-            myPlot.Grid.LineColor = Color.FromHex("#0e3d54");
+            myPlot.Grid.MajorLineColor = Color.FromHex("#0e3d54");
             myPlot.FigureBackground.Color = Color.FromHex("#07263b");
             myPlot.DataBackground.Color = Color.FromHex("#0b3049");
 
@@ -223,7 +223,7 @@ public class Styling : ICategory
 
             // change figure colors
             myPlot.Axes.Color(Color.FromHex("#d7d7d7"));
-            myPlot.Grid.LineColor = Color.FromHex("#404040");
+            myPlot.Grid.MajorLineColor = Color.FromHex("#404040");
             myPlot.FigureBackground.Color = Color.FromHex("#181818");
             myPlot.DataBackground.Color = Color.FromHex("#1f1f1f");
             myPlot.Legend.BackgroundFill.Color = Color.FromHex("#404040");

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
@@ -30,7 +30,7 @@ public class Styling : ICategory
             myPlot.DataBackground.Color = Color.FromHex("#0b3049");
 
             // the Style object contains helper methods to style many items at once
-            myPlot.Style.ColorAxes(Color.FromHex("#a0acb5"));
+            myPlot.Axes.Color(Color.FromHex("#a0acb5"));
         }
     }
 
@@ -222,7 +222,7 @@ public class Styling : ICategory
             myPlot.ShowLegend();
 
             // change figure colors
-            myPlot.Style.ColorAxes(Color.FromHex("#d7d7d7"));
+            myPlot.Axes.Color(Color.FromHex("#d7d7d7"));
             myPlot.Grid.LineColor = Color.FromHex("#404040");
             myPlot.FigureBackground.Color = Color.FromHex("#181818");
             myPlot.DataBackground.Color = Color.FromHex("#1f1f1f");

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
@@ -10,8 +10,8 @@ public class Styling : ICategory
     {
         public override string Name => "Style Helper Functions";
         public override string Description => "Plots contain many objects which can be customized individually " +
-            "by assigining to their public properties, but helper methods exist in the Plot's Style object " +
-            "that make it easier to customzie many items at once using a simpler API.";
+            "by assigning to their public properties, but helper methods exist in the Plot's Style object " +
+            "that make it easier to customize many items at once using a simpler API.";
 
         [Test]
         public override void Execute()
@@ -24,10 +24,13 @@ public class Styling : ICategory
             myPlot.Axes.Left.Label.Text = "Vertical Axis";
             myPlot.Axes.Title.Label.Text = "Plot Title";
 
-            // the Style object contains helper methods to easily style many items at once
-            myPlot.Style.Background(figure: Color.FromHex("#07263b"), data: Color.FromHex("#0b3049"));
+            // some items must be styled directly
+            myPlot.Grid.LineColor = Color.FromHex("#0e3d54");
+            myPlot.FigureBackground.Color = Color.FromHex("#07263b");
+            myPlot.DataBackground.Color = Color.FromHex("#0b3049");
+
+            // the Style object contains helper methods to style many items at once
             myPlot.Style.ColorAxes(Color.FromHex("#a0acb5"));
-            myPlot.Style.ColorGrids(Color.FromHex("#0e3d54"));
         }
     }
 
@@ -220,14 +223,12 @@ public class Styling : ICategory
 
             // change figure colors
             myPlot.Style.ColorAxes(Color.FromHex("#d7d7d7"));
-            myPlot.Style.ColorGrids(Color.FromHex("#404040"));
-            myPlot.Style.Background(
-                figure: Color.FromHex("#181818"),
-                data: Color.FromHex("#1f1f1f"));
-            myPlot.Style.ColorLegend(
-                background: Color.FromHex("#404040"),
-                foreground: Color.FromHex("#d7d7d7"),
-                border: Color.FromHex("#d7d7d7"));
+            myPlot.Grid.LineColor = Color.FromHex("#404040");
+            myPlot.FigureBackground.Color = Color.FromHex("#181818");
+            myPlot.DataBackground.Color = Color.FromHex("#1f1f1f");
+            myPlot.Legend.BackgroundFill.Color = Color.FromHex("#404040");
+            myPlot.Legend.Font.Color = Color.FromHex("#d7d7d7");
+            myPlot.Legend.OutlineStyle.Color = Color.FromHex("#d7d7d7");
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Miscellaneous/AdvancedStyling.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Miscellaneous/AdvancedStyling.cs
@@ -49,7 +49,7 @@ public class AdvancedStyling : ICategory
             myPlot.FigureBackground.Image = bgImage;
 
             // Color the axes and data so they stand out against the dark background
-            myPlot.Style.ColorAxes(Colors.White);
+            myPlot.Axes.Color(Colors.White);
             sig1.Color = sig1.Color.Lighten(.2);
             sig2.Color = sig2.Color.Lighten(.2);
             sig1.LineWidth = 3;

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Miscellaneous/Internationalization.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Miscellaneous/Internationalization.cs
@@ -50,7 +50,7 @@ public class Internationalization : ICategory
             myPlot.YLabel("試験"); // Japanese
             myPlot.XLabel("테스트"); // Korean
 
-            myPlot.Style.SetBestFonts();
+            myPlot.Font.Automatic(); // set font for each item based on its content
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/SignalTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/SignalTests.cs
@@ -15,7 +15,7 @@ internal class SignalTests
 
         ScottPlot.Plot plt = new();
         plt.Add.Signal(data);
-        plt.Axes.Grids.Clear();
+        plt.HideGrid();
         plt.SaveTestImage();
     }
 
@@ -31,7 +31,7 @@ internal class SignalTests
 
         ScottPlot.Plot plt = new();
         plt.Add.Signal(data);
-        plt.Axes.Grids.Clear();
+        plt.HideGrid();
         plt.SaveTestImage();
     }
 

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -149,24 +149,6 @@ public class AxisManager
         Grids.Remove(grid);
     }
 
-    [Obsolete("This method is deprecated. Use DateTimeTicksBottom().")]
-    public void DateTimeTicks(Edge edge)
-    {
-        Remove(edge);
-
-        IXAxis dateAxis = edge switch
-        {
-            Edge.Left => throw new NotImplementedException(), // TODO: support vertical DateTime axes
-            Edge.Right => throw new NotImplementedException(),
-            Edge.Bottom => new DateTimeXAxis(),
-            Edge.Top => throw new NotImplementedException(),
-            _ => throw new NotImplementedException(),
-        };
-
-        Plot.Axes.XAxes.Add(dateAxis);
-        Plot.Axes.Grids.ForEach(x => x.Replace(dateAxis));
-    }
-
     /// <summary>
     /// Remove all bottom axes, create a DateTime bottom axis, add it to the plot, and return it.
     /// </summary>
@@ -175,7 +157,7 @@ public class AxisManager
         Plot.Axes.Remove(Edge.Bottom);
         DateTimeXAxis dateAxis = new();
         Plot.Axes.XAxes.Add(dateAxis);
-        Plot.Axes.Grids.ForEach(x => x.Replace(dateAxis));
+        Plot.Axes.Grids.ForEach(x => x.XAxis = dateAxis);
         return dateAxis;
     }
 

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -116,6 +116,19 @@ public class AxisManager
     }
 
     /// <summary>
+    /// Apply a single color to the label, tick labels, tick marks, and frame of all axes
+    /// </summary>
+    public void Color(Color color)
+    {
+        foreach (AxisBase axis in Plot.Axes.GetAxes().OfType<AxisBase>())
+        {
+            axis.Color(color);
+        }
+
+        Plot.Axes.Title.Label.ForeColor = color;
+    }
+
+    /// <summary>
     /// Remove all axes that lie on the given edge.
     /// </summary>
     public void Remove(Edge edge)

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -129,6 +129,39 @@ public class AxisManager
     }
 
     /// <summary>
+    /// Set visibility of the frame on every axis
+    /// </summary>
+    public void Frame(bool enable)
+    {
+        foreach (AxisBase axis in Plot.Axes.GetAxes().OfType<AxisBase>())
+        {
+            axis.FrameLineStyle.IsVisible = enable;
+        }
+    }
+
+    /// <summary>
+    /// Set thickness of the frame on every axis
+    /// </summary>
+    public void FrameWidth(float width)
+    {
+        foreach (AxisBase axis in Plot.Axes.GetAxes().OfType<AxisBase>())
+        {
+            axis.FrameLineStyle.Width = width;
+        }
+    }
+
+    /// <summary>
+    /// Set color of the frame on every axis
+    /// </summary>
+    public void FrameColor(Color color)
+    {
+        foreach (AxisBase axis in Plot.Axes.GetAxes().OfType<AxisBase>())
+        {
+            axis.FrameLineStyle.Color = color;
+        }
+    }
+
+    /// <summary>
     /// Remove all axes that lie on the given edge.
     /// </summary>
     public void Remove(Edge edge)

--- a/src/ScottPlot5/ScottPlot5/Grids/DefaultGrid.cs
+++ b/src/ScottPlot5/ScottPlot5/Grids/DefaultGrid.cs
@@ -13,6 +13,19 @@ public class DefaultGrid(IXAxis xAxis, IYAxis yAxis) : IGrid
     public IXAxis XAxis { get; set; } = xAxis;
     public IYAxis YAxis { get; set; } = yAxis;
 
+    /// <summary>
+    /// Controls color for <see cref="MajorLineStyle"/> and <see cref="MinorLineStyle"/>
+    /// </summary>
+    public Color LineColor
+    {
+        get => MajorLineStyle.Color;
+        set
+        {
+            MajorLineStyle.Color = value;
+            MinorLineStyle.Color = value;
+        }
+    }
+
     public void Render(RenderPack rp)
     {
         if (!IsVisible)

--- a/src/ScottPlot5/ScottPlot5/Grids/DefaultGrid.cs
+++ b/src/ScottPlot5/ScottPlot5/Grids/DefaultGrid.cs
@@ -10,18 +10,8 @@ public class DefaultGrid(IXAxis xAxis, IYAxis yAxis) : IGrid
 
     public bool IsBeneathPlottables { get; set; } = true;
 
-    public IXAxis XAxis { get; private set; } = xAxis;
-    public IYAxis YAxis { get; private set; } = yAxis;
-
-    public void Replace(IXAxis xAxis)
-    {
-        XAxis = xAxis;
-    }
-
-    public void Replace(IYAxis yAxis)
-    {
-        YAxis = yAxis;
-    }
+    public IXAxis XAxis { get; set; } = xAxis;
+    public IYAxis YAxis { get; set; } = yAxis;
 
     public void Render(RenderPack rp)
     {

--- a/src/ScottPlot5/ScottPlot5/Grids/DefaultGrid.cs
+++ b/src/ScottPlot5/ScottPlot5/Grids/DefaultGrid.cs
@@ -3,26 +3,45 @@
 public class DefaultGrid(IXAxis xAxis, IYAxis yAxis) : IGrid
 {
     public bool IsVisible { get; set; } = true;
-    public LineStyle MajorLineStyle = new() { Width = 1, Color = Colors.Black.WithOpacity(.1) };
-    public LineStyle MinorLineStyle = new() { Width = 0, Color = Colors.Black.WithOpacity(.05) };
-
-    public int MaximumNumberOfGridLines = 1000;
-
     public bool IsBeneathPlottables { get; set; } = true;
-
     public IXAxis XAxis { get; set; } = xAxis;
     public IYAxis YAxis { get; set; } = yAxis;
+    public GridStyle XAxisStyle { get; set; } = new();
+    public GridStyle YAxisStyle { get; set; } = new();
 
-    /// <summary>
-    /// Controls color for <see cref="MajorLineStyle"/> and <see cref="MinorLineStyle"/>
-    /// </summary>
-    public Color LineColor
+    public Color MajorLineColor
     {
-        get => MajorLineStyle.Color;
         set
         {
-            MajorLineStyle.Color = value;
-            MinorLineStyle.Color = value;
+            XAxisStyle.MajorLineStyle.Color = value;
+            YAxisStyle.MajorLineStyle.Color = value;
+        }
+    }
+
+    public Color MinorLineColor
+    {
+        set
+        {
+            XAxisStyle.MinorLineStyle.Color = value;
+            YAxisStyle.MinorLineStyle.Color = value;
+        }
+    }
+
+    public float MajorLineWidth
+    {
+        set
+        {
+            XAxisStyle.MinorLineStyle.Width = value;
+            YAxisStyle.MinorLineStyle.Width = value;
+        }
+    }
+
+    public float MinorLineWidth
+    {
+        set
+        {
+            XAxisStyle.MinorLineStyle.Width = value;
+            YAxisStyle.MinorLineStyle.Width = value;
         }
     }
 
@@ -39,35 +58,7 @@ public class DefaultGrid(IXAxis xAxis, IYAxis yAxis) : IGrid
         var xTicks = XAxis.TickGenerator.Ticks.Where(x => x.Position >= minX && x.Position <= maxX);
         var yTicks = YAxis.TickGenerator.Ticks.Where(x => x.Position >= minY && x.Position <= maxY);
 
-        if (MinorLineStyle.Width > 0)
-        {
-            float[] xTicksMinor = xTicks.Where(x => !x.IsMajor).Select(x => XAxis.GetPixel(x.Position, rp.DataRect)).ToArray();
-            float[] yTicksMinor = yTicks.Where(x => !x.IsMajor).Select(x => YAxis.GetPixel(x.Position, rp.DataRect)).ToArray();
-            RenderGridLines(rp, xTicksMinor, XAxis.Edge, MinorLineStyle);
-            RenderGridLines(rp, yTicksMinor, YAxis.Edge, MinorLineStyle);
-        }
-
-        if (MajorLineStyle.Width > 0)
-        {
-            float[] xTicksMajor = xTicks.Where(x => x.IsMajor).Select(x => XAxis.GetPixel(x.Position, rp.DataRect)).ToArray();
-            float[] yTicksMajor = yTicks.Where(x => x.IsMajor).Select(x => YAxis.GetPixel(x.Position, rp.DataRect)).ToArray();
-            RenderGridLines(rp, xTicksMajor, XAxis.Edge, MajorLineStyle);
-            RenderGridLines(rp, yTicksMajor, YAxis.Edge, MajorLineStyle);
-        }
-    }
-
-    private void RenderGridLines(RenderPack rp, float[] positions, Edge edge, LineStyle lineStyle)
-    {
-        Pixel[] starts = new Pixel[positions.Length];
-        Pixel[] ends = new Pixel[positions.Length];
-
-        for (int i = 0; i < positions.Length; i++)
-        {
-            float px = positions[i];
-            starts[i] = edge.IsHorizontal() ? new Pixel(px, rp.DataRect.Bottom) : new Pixel(rp.DataRect.Left, px);
-            ends[i] = edge.IsHorizontal() ? new Pixel(px, rp.DataRect.Top) : new Pixel(rp.DataRect.Right, px);
-        }
-
-        Drawing.DrawLines(rp.Canvas, starts, ends, lineStyle.Color, lineStyle.Width, antiAlias: true, lineStyle.Pattern);
+        XAxisStyle.Render(rp, XAxis, xTicks);
+        YAxisStyle.Render(rp, YAxis, yTicks);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IGrid.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IGrid.cs
@@ -9,5 +9,7 @@ public interface IGrid
     bool IsBeneathPlottables { get; set; }
     IXAxis XAxis { get; set; }
     IYAxis YAxis { get; set; }
+    GridStyle XAxisStyle { get; set; }
+    GridStyle YAxisStyle { get; set; }
     void Render(RenderPack rp);
 }

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IGrid.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IGrid.cs
@@ -7,7 +7,7 @@ public interface IGrid
 {
     bool IsVisible { get; set; }
     bool IsBeneathPlottables { get; set; }
+    IXAxis XAxis { get; set; }
+    IYAxis YAxis { get; set; }
     void Render(RenderPack rp);
-    void Replace(IXAxis xAxis); // TODO: remove this
-    void Replace(IYAxis yAxis); // TODO: remove this
 }

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -1,5 +1,6 @@
 ﻿using ScottPlot.AxisPanels;
 using ScottPlot.Control;
+using ScottPlot.Grids;
 using ScottPlot.Legends;
 using ScottPlot.Primitives;
 using ScottPlot.Rendering;
@@ -28,6 +29,8 @@ public class Plot : IDisposable
 
     public Legend Legend { get; set; }
 
+    public DefaultGrid Grid => Axes.DefaultGrid;
+
     public IPlottable Benchmark { get; set; } = new Plottables.Benchmark();
 
     public Plot()
@@ -45,7 +48,6 @@ public class Plot : IDisposable
         DataBackground?.Dispose();
         FigureBackground?.Dispose();
         PlottableList.Clear();
-        Axes.Clear();
     }
 
     #region Pixel/Coordinate Conversion
@@ -375,14 +377,6 @@ public class Plot : IDisposable
     }
 
     /// <summary>
-    /// Remove the given grid from the <see cref="Axes"/>.
-    /// </summary>
-    public void Remove(IGrid grid)
-    {
-        Axes.Remove(grid);
-    }
-
-    /// <summary>
     /// Remove all items of a specific type from the <see cref="PlottableList"/>.
     /// </summary>
     public void Remove(Type plotType)
@@ -421,7 +415,7 @@ public class Plot : IDisposable
     /// </summary>
     public void HideGrid()
     {
-        Axes.Grids.ForEach(x => x.IsVisible = false);
+        Axes.AllGrids.ForEach(x => x.IsVisible = false);
     }
 
     /// <summary>
@@ -429,7 +423,7 @@ public class Plot : IDisposable
     /// </summary>
     public void ShowGrid()
     {
-        Axes.Grids.ForEach(x => x.IsVisible = true);
+        Axes.AllGrids.ForEach(x => x.IsVisible = true);
     }
 
     /// <summary>
@@ -507,18 +501,8 @@ public class Plot : IDisposable
             Axes.Left.Label.FontSize = size.Value;
     }
 
-    /// <summary>
-    /// Return the first default grid in use.
-    /// Throws an exception if no default grids exist.
-    /// </summary>
-    public Grids.DefaultGrid GetDefaultGrid()
-    {
-        IEnumerable<Grids.DefaultGrid> defaultGrids = Axes.Grids.OfType<Grids.DefaultGrid>();
-        if (defaultGrids.Any())
-            return defaultGrids.First();
-        else
-            throw new InvalidOperationException("The plot has no default grids");
-    }
+    [Obsolete("This method is deprecated. Access Plot.Grid instead.", true)]
+    public static DefaultGrid GetDefaultGrid() => null!;
 
     #endregion
 

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -5,6 +5,7 @@ using ScottPlot.Legends;
 using ScottPlot.Primitives;
 using ScottPlot.Rendering;
 using ScottPlot.Stylers;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace ScottPlot;
 
@@ -26,6 +27,7 @@ public class Plot : IDisposable
     public AxisManager Axes { get; }
 
     public PlotStyler Style { get; }
+    public FontStyler Font { get; }
 
     public Legend Legend { get; set; }
 
@@ -38,6 +40,7 @@ public class Plot : IDisposable
         Axes = new(this);
         Add = new(this);
         Style = new(this);
+        Font = new(this);
         RenderManager = new(this);
         Legend = new(this);
         Layout = new(this);

--- a/src/ScottPlot5/ScottPlot5/Primitives/GridStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/GridStyle.cs
@@ -1,0 +1,59 @@
+﻿namespace ScottPlot;
+
+public class GridStyle
+{
+    public bool IsVisible { get; set; } = true;
+    public LineStyle MajorLineStyle { get; set; } = LineStyle.DefaultMajorStyle;
+    public LineStyle MinorLineStyle { get; set; } = LineStyle.DefaultMinorStyle;
+    public int MaximumNumberOfGridLines { get; set; } = 1_000;
+    public bool IsBeneathPlottables { get; set; } = true;
+
+    public void Render(RenderPack rp, IAxis axis, IEnumerable<Tick> ticks)
+    {
+        if (!IsVisible)
+            return;
+
+        if (MinorLineStyle.IsVisible && MinorLineStyle.Width > 0)
+        {
+            float[] xTicksMinor = ticks
+                .Where(x => !x.IsMajor)
+                .Select(x => axis.GetPixel(x.Position, rp.DataRect))
+                .Take(MaximumNumberOfGridLines)
+                .ToArray();
+
+            RenderGridLines(rp, xTicksMinor, axis.Edge, MinorLineStyle);
+        }
+
+        if (MajorLineStyle.IsVisible && MajorLineStyle.Width > 0)
+        {
+            float[] xTicksMajor = ticks
+                .Where(x => x.IsMajor)
+                .Select(x => axis.GetPixel(x.Position, rp.DataRect))
+                .Take(MaximumNumberOfGridLines)
+                .ToArray();
+
+            RenderGridLines(rp, xTicksMajor, axis.Edge, MajorLineStyle);
+        }
+    }
+
+    private static void RenderGridLines(RenderPack rp, float[] positions, Edge edge, LineStyle lineStyle)
+    {
+        Pixel[] starts = new Pixel[positions.Length];
+        Pixel[] ends = new Pixel[positions.Length];
+
+        for (int i = 0; i < positions.Length; i++)
+        {
+            float px = positions[i];
+
+            starts[i] = edge.IsHorizontal()
+                ? new Pixel(px, rp.DataRect.Bottom)
+                : new Pixel(rp.DataRect.Left, px);
+
+            ends[i] = edge.IsHorizontal()
+                ? new Pixel(px, rp.DataRect.Top)
+                : new Pixel(rp.DataRect.Right, px);
+        }
+
+        Drawing.DrawLines(rp.Canvas, starts, ends, lineStyle.Color, lineStyle.Width, antiAlias: true, lineStyle.Pattern);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Primitives/LineStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LineStyle.cs
@@ -14,6 +14,18 @@ public class LineStyle
     public bool AntiAlias { get; set; } = true;
     public bool CanBeRendered => IsVisible && Width > 0 && Color.Alpha > 0;
 
+    public static LineStyle DefaultMajorStyle => new()
+    {
+        Width = 1,
+        Color = Colors.Black.WithOpacity(.1)
+    };
+
+    public static LineStyle DefaultMinorStyle => new()
+    {
+        Width = 0,
+        Color = Colors.Black.WithOpacity(.05)
+    };
+
     public void Render(SKCanvas canvas, SKPaint paint, PixelLine line)
     {
         if (CanBeRendered == false) return;

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/RenderGridsAbovePlottables.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/RenderGridsAbovePlottables.cs
@@ -4,7 +4,7 @@ public class RenderGridsAbovePlottables : IRenderAction
 {
     public void Render(RenderPack rp)
     {
-        foreach (IGrid grid in rp.Plot.Axes.Grids.Where(x => !x.IsBeneathPlottables))
+        foreach (IGrid grid in rp.Plot.Axes.AllGrids.Where(x => !x.IsBeneathPlottables))
         {
             grid.Render(rp);
         }

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/RenderGridsBelowPlottables.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/RenderGridsBelowPlottables.cs
@@ -4,7 +4,7 @@ public class RenderGridsBelowPlottables : IRenderAction
 {
     public void Render(RenderPack rp)
     {
-        foreach (IGrid grid in rp.Plot.Axes.Grids.Where(x => x.IsBeneathPlottables))
+        foreach (IGrid grid in rp.Plot.Axes.AllGrids.Where(x => x.IsBeneathPlottables))
         {
             grid.Render(rp);
         }

--- a/src/ScottPlot5/ScottPlot5/Stylers/FontStyler.cs
+++ b/src/ScottPlot5/ScottPlot5/Stylers/FontStyler.cs
@@ -1,0 +1,55 @@
+﻿namespace ScottPlot.Stylers;
+
+/// <summary>
+/// Helper methods for setting fonts to all components of a plot
+/// </summary>
+public class FontStyler(Plot plot)
+{
+    private readonly Plot Plot = plot;
+
+    /// <summary>
+    /// Apply the given font name to all existing plot objects.
+    /// Also sets the default font name so this font will be used for plot objects added in the future.
+    /// </summary>
+    public void Set(string fontName)
+    {
+        fontName = Fonts.Exists(fontName) ? fontName : Fonts.Default;
+
+        // set default font so future added objects will use it
+        Fonts.Default = fontName;
+
+        // title
+        Plot.Axes.Title.Label.FontName = fontName;
+
+        // axis labels and ticks
+        foreach (IAxis axis in Plot.Axes.GetAxes())
+        {
+            axis.Label.FontName = fontName;
+            axis.TickLabelStyle.FontName = fontName;
+        }
+
+        // TODO: also modify plotted text by adding an IHasText interface
+    }
+
+    /// <summary>
+    /// Detects the best font to apply to every label in the plot based on the characters the they contain.
+    /// If the best font for a label cannot be detected, the font last defined by <see cref="Set(string)"/> will be used.
+    /// </summary>
+    public void Automatic()
+    {
+        // title
+        Plot.Axes.Title.Label.SetBestFont();
+
+        // axis labels and ticks
+        foreach (IAxis axis in Plot.Axes.GetAxes())
+        {
+            axis.Label.SetBestFont();
+            axis.TickLabelStyle.SetBestFont();
+        }
+
+        Plot.Legend.SetBestFontOnEachRender = true;
+
+        // TODO: also modify plotted text by adding an IHasText interface
+    }
+
+}

--- a/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
+++ b/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
@@ -34,7 +34,7 @@ public class PlotStyler(Plot plot)
 
         Plot.Axes.Color(Color.FromHex("#d7d7d7"));
 
-        Plot.Grid.LineColor = Color.FromHex("#404040");
+        Plot.Grid.MajorLineColor = Color.FromHex("#404040");
         Plot.FigureBackground.Color = Color.FromHex("#181818");
         Plot.DataBackground.Color = Color.FromHex("#1f1f1f");
 

--- a/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
+++ b/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
@@ -60,15 +60,7 @@ public class PlotStyler(Plot plot)
             axis.TickLabelStyle.FontName = fontName;
         }
 
-        // TODO: also modify tick labels
         // TODO: also modify plotted text
-    }
-
-    [Obsolete("use SetBestFonts()", true)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public bool SetFontFromText(string text)
-    {
-        throw new InvalidOperationException();
     }
 
     /// <summary>

--- a/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
+++ b/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
@@ -11,18 +11,13 @@ public class PlotStyler(Plot plot)
 {
     private readonly Plot Plot = plot;
 
-    /// <summary>
-    /// Apply background colors to the figure and data areas
-    /// </summary>
-    public void Background(Color figure, Color data)
-    {
-        Plot.FigureBackground.Color = figure;
-        Plot.DataBackground.Color = data;
-    }
+    [Obsolete("This method is deprecated. Assign Plot.FigureBackground.Color instead.", true)]
+    public void Background(Color figure, Color data) { }
 
     /// <summary>
     /// Apply a single color to all components of each axis (label, tick labels, tick marks, and frame)
     /// </summary>
+    [Obsolete("Call Plot.Axes.SetColor()")]
     public void ColorAxes(Color color)
     {
         foreach (AxisBase axis in Plot.Axes.GetAxes().OfType<AxisBase>())
@@ -33,29 +28,7 @@ public class PlotStyler(Plot plot)
         Plot.Axes.Title.Label.ForeColor = color;
     }
 
-    /// <summary>
-    /// Apply a color to all currently visible grids
-    /// </summary>
-    public void ColorGrids(Color majorColor)
-    {
-        foreach (DefaultGrid grid in Plot.Axes.Grids.OfType<DefaultGrid>())
-        {
-            grid.MajorLineStyle.Color = majorColor;
-        }
-    }
-
-    /// <summary>
-    /// Apply a color to all currently visible grids
-    /// </summary>
-    public void ColorGrids(Color majorColor, Color minorColor)
-    {
-        foreach (DefaultGrid grid in Plot.Axes.Grids.OfType<DefaultGrid>())
-        {
-            grid.MajorLineStyle.Color = majorColor;
-            grid.MinorLineStyle.Color = minorColor;
-        }
-    }
-
+    [Obsolete("Reference Plot.Legend properties directly.")]
     public void ColorLegend(Color background, Color foreground, Color border)
     {
         Plot.Legend.BackgroundFill.Color = background;
@@ -135,10 +108,10 @@ public class PlotStyler(Plot plot)
         Plot.Add.Palette = new Palettes.Penumbra();
 
         ColorAxes(Color.FromHex("#d7d7d7"));
-        ColorGrids(Color.FromHex("#404040"));
-        Background(
-            figure: Color.FromHex("#181818"),
-            data: Color.FromHex("#1f1f1f"));
+
+        Plot.Grid.LineColor = Color.FromHex("#404040");
+        Plot.FigureBackground.Color = Color.FromHex("#181818");
+        Plot.DataBackground.Color = Color.FromHex("#1f1f1f");
         ColorLegend(
             background: Color.FromHex("#404040"),
             foreground: Color.FromHex("#d7d7d7"),

--- a/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
+++ b/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
@@ -28,16 +28,8 @@ public class PlotStyler(Plot plot)
         Plot.Legend.OutlineStyle.Color = border;
     }
 
-    /// <summary>
-    /// Set frame thickness for each side of the plot
-    /// </summary>
-    public void AxisFrame(float left, float right, float bottom, float top)
-    {
-        Plot.Axes.Left.FrameLineStyle.Width = left;
-        Plot.Axes.Right.FrameLineStyle.Width = right;
-        Plot.Axes.Bottom.FrameLineStyle.Width = bottom;
-        Plot.Axes.Top.FrameLineStyle.Width = top;
-    }
+    [Obsolete("This method is deprecated. Call Plot.Axes.Frame() methods instead.", true)]
+    public void AxisFrame(float left, float right, float bottom, float top) { }
 
     /// <summary>
     /// Apply the given font name to all existing plot objects.

--- a/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
+++ b/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
@@ -17,16 +17,8 @@ public class PlotStyler(Plot plot)
     /// <summary>
     /// Apply a single color to all components of each axis (label, tick labels, tick marks, and frame)
     /// </summary>
-    [Obsolete("Call Plot.Axes.SetColor()")]
-    public void ColorAxes(Color color)
-    {
-        foreach (AxisBase axis in Plot.Axes.GetAxes().OfType<AxisBase>())
-        {
-            axis.Color(color);
-        }
-
-        Plot.Axes.Title.Label.ForeColor = color;
-    }
+    [Obsolete("This method is deprecated. Call Plot.Axes.Color() instead.", true)]
+    public void ColorAxes(Color color) { }
 
     [Obsolete("Reference Plot.Legend properties directly.", true)]
     public void ColorLegend(Color background, Color foreground, Color border)
@@ -107,7 +99,7 @@ public class PlotStyler(Plot plot)
     {
         Plot.Add.Palette = new Palettes.Penumbra();
 
-        ColorAxes(Color.FromHex("#d7d7d7"));
+        Plot.Axes.Color(Color.FromHex("#d7d7d7"));
 
         Plot.Grid.LineColor = Color.FromHex("#404040");
         Plot.FigureBackground.Color = Color.FromHex("#181818");

--- a/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
+++ b/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
@@ -1,11 +1,7 @@
-﻿using ScottPlot.AxisPanels;
-using ScottPlot.Grids;
-using System.ComponentModel;
-
-namespace ScottPlot.Stylers;
+﻿namespace ScottPlot.Stylers;
 
 /// <summary>
-/// A collection of high-level methods that make it easy to style many components of a plot at once
+/// Helper methods for applying common styling options to plots
 /// </summary>
 public class PlotStyler(Plot plot)
 {
@@ -14,67 +10,20 @@ public class PlotStyler(Plot plot)
     [Obsolete("This method is deprecated. Assign Plot.FigureBackground.Color instead.", true)]
     public void Background(Color figure, Color data) { }
 
-    /// <summary>
-    /// Apply a single color to all components of each axis (label, tick labels, tick marks, and frame)
-    /// </summary>
     [Obsolete("This method is deprecated. Call Plot.Axes.Color() instead.", true)]
     public void ColorAxes(Color color) { }
 
     [Obsolete("Reference Plot.Legend properties directly.", true)]
-    public void ColorLegend(Color background, Color foreground, Color border)
-    {
-        Plot.Legend.BackgroundFill.Color = background;
-        Plot.Legend.Font.Color = foreground;
-        Plot.Legend.OutlineStyle.Color = border;
-    }
+    public void ColorLegend(Color background, Color foreground, Color border) { }
 
     [Obsolete("This method is deprecated. Call Plot.Axes.Frame() methods instead.", true)]
     public void AxisFrame(float left, float right, float bottom, float top) { }
 
-    /// <summary>
-    /// Apply the given font name to all existing plot objects.
-    /// Also sets the default font name so this font will be used for plot objects added in the future.
-    /// </summary>
-    public void SetFont(string fontName)
-    {
-        fontName = Fonts.Exists(fontName) ? fontName : Fonts.Default;
+    [Obsolete("This method is deprecated. Call Plot.Font.Set() instead.", true)]
+    public void SetFont(string fontName) { }
 
-        // set default font so future added objects will use it
-        Fonts.Default = fontName;
-
-        // title
-        Plot.Axes.Title.Label.FontName = fontName;
-
-        // axis labels and ticks
-        foreach (IAxis axis in Plot.Axes.GetAxes())
-        {
-            axis.Label.FontName = fontName;
-            axis.TickLabelStyle.FontName = fontName;
-        }
-
-        // TODO: also modify plotted text
-    }
-
-    /// <summary>
-    /// Detects the best font to apply to every label in the plot based on the characters the they contain.
-    /// If the best font for a label cannot be detected, the font last defined by <see cref="SetFont(string)"/> will be used.
-    /// </summary>
-    public void SetBestFonts()
-    {
-        // title
-        Plot.Axes.Title.Label.SetBestFont();
-
-        // axis labels and ticks
-        foreach (IAxis axis in Plot.Axes.GetAxes())
-        {
-            axis.Label.SetBestFont();
-            axis.TickLabelStyle.SetBestFont();
-        }
-
-        Plot.Legend.SetBestFontOnEachRender = true;
-
-        // TODO: also modify plotted text by adding an IHasText interface
-    }
+    [Obsolete("This method is deprecated. Call Plot.Font.Automatic() instead.", true)]
+    public void SetBestFonts() { }
 
     /// <summary>
     /// Reset colors and palette do a dark mode style

--- a/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
+++ b/src/ScottPlot5/ScottPlot5/Stylers/PlotStyler.cs
@@ -28,7 +28,7 @@ public class PlotStyler(Plot plot)
         Plot.Axes.Title.Label.ForeColor = color;
     }
 
-    [Obsolete("Reference Plot.Legend properties directly.")]
+    [Obsolete("Reference Plot.Legend properties directly.", true)]
     public void ColorLegend(Color background, Color foreground, Color border)
     {
         Plot.Legend.BackgroundFill.Color = background;
@@ -112,9 +112,9 @@ public class PlotStyler(Plot plot)
         Plot.Grid.LineColor = Color.FromHex("#404040");
         Plot.FigureBackground.Color = Color.FromHex("#181818");
         Plot.DataBackground.Color = Color.FromHex("#1f1f1f");
-        ColorLegend(
-            background: Color.FromHex("#404040"),
-            foreground: Color.FromHex("#d7d7d7"),
-            border: Color.FromHex("#d7d7d7"));
+
+        Plot.Legend.BackgroundFill.Color = Color.FromHex("#404040");
+        Plot.Legend.Font.Color = Color.FromHex("#d7d7d7");
+        Plot.Legend.OutlineStyle.Color = Color.FromHex("#d7d7d7");
     }
 }


### PR DESCRIPTION
This PR deeply refactors the grid system to simplify how users interact with and customize the grid, as well as improving support for axis-specific grid customization and addition of custom grid systems. Many styling strategies are being simplified along the way.

* Resolves #3291 
* Resolves #3293

```cs
myPlot.Add.Signal(Generate.Sin(51));
myPlot.Add.Signal(Generate.Cos(51));

myPlot.Grid.XAxisStyle.MajorLineStyle.Color = Colors.Magenta.WithAlpha(.1);
myPlot.Grid.XAxisStyle.MajorLineStyle.Width = 5;

myPlot.Grid.YAxisStyle.MajorLineStyle.Color = Colors.Green.WithAlpha(.3);
myPlot.Grid.YAxisStyle.MajorLineStyle.Width = 2;
```

![image](https://github.com/ScottPlot/ScottPlot/assets/4165489/b945276b-a546-48ef-b45d-312a94db16fc)
