### PR TITLE
Controls: Improve ZoomRectangle behavior and axis locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ _Not yet on NuGet..._
 * Grid: Added `Plot.Grid` with axis-specific styling options as seen in the cookbook (#3291, #3293) @bjschwarz, @PaxITIS
 * SignalXY: Fixed a bug where the final line segment was not drawn (#3495, #3423) @MareMare @mjazd
 * SignalXY: Improved support for inverted vertical axes (#3495) @MareMare
+* Controls: Ignore mouse wheel zooming if a zoom rectangle is being drawn (#3498) @BrianAtZetica
+* Controls: Improve axis lock behavior when dragging the mouse on a control (#3498) @BrianAtZetica
 
 ## ScottPlot 5.0.22
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-16_

--- a/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
@@ -170,6 +170,8 @@ public class Interaction : IPlotInteraction
 
     public virtual void MouseWheelVertical(Pixel pixel, float delta)
     {
+        if (IsZoomingRectangle) return;
+
         MouseWheelDirection direction = delta > 0 ? MouseWheelDirection.Up : MouseWheelDirection.Down;
 
         if (Inputs.ZoomInWheelDirection.HasValue && Inputs.ZoomInWheelDirection == direction)

--- a/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
@@ -92,7 +92,7 @@ public class Interaction : IPlotInteraction
     {
         bool lockY = Inputs.ShouldLockY(keys);
         bool lockX = Inputs.ShouldLockX(keys);
-        LockedAxes locks = new(lockX, LockY);
+        LockedAxes locks = new(lockX, lockY);
 
         MouseDrag drag = new(start, from, to);
 


### PR DESCRIPTION
When using the middle button to draw a zoom rectangle, it was easy to accidentally roll the wheel and cause the canvas to zoom. This resulted in the zoom rectangle no longer representing the intended extents. 

This simple fix just ignores mousewheel zooming if a zoom window is currently being drawn. 