### PR TITLE
Heatmap transparency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ _Not yet on NuGet..._
 * SignalXY: Improved support for inverted vertical axes (#3495) @MareMare
 * Controls: Ignore mouse wheel zooming if a zoom rectangle is being drawn (#3498) @BrianAtZetica
 * Controls: Improve axis lock behavior when dragging the mouse on a control (#3498) @BrianAtZetica
+* Heatmap: Added `Opacity` and `AlphaMap` properties to enhance transparency customization (#3499, #3349) @BrianAtZetica
+* Heatmap: Intensity values that are `double.NaN` are now displayed as transparent cells (#3499, #3349) @BrianAtZetica
 
 ## ScottPlot 5.0.22
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-16_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Heatmap.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Heatmap.cs
@@ -150,4 +150,25 @@ public class Heatmap : ICategory
             hm2.NaNCellColor = Colors.Magenta.WithAlpha(.4);
         }
     }
+
+    public class HeatmapGlobalTransparency : RecipeBase
+    {
+        public override string Name => "Global Transparency";
+        public override string Description => "The alpha (transparency) of the entire heatmap can be adjusted.";
+
+        [Test]
+        public override void Execute()
+        {
+            double[,] data = SampleData.MonaLisa();
+
+            // create a line chart
+            myPlot.Add.Signal(Generate.Sin());
+            myPlot.Add.Signal(Generate.Cos());
+
+            // plot the heatmap on top of the line chart
+            var hm1 = myPlot.Add.Heatmap(data);
+            hm1.Extent = new(10, 35, -1.5, .5);
+            hm1.Opacity = 0.5;
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Heatmap.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Heatmap.cs
@@ -33,11 +33,11 @@ public class Heatmap : ICategory
 
             var hm1 = myPlot.Add.Heatmap(data);
             hm1.Colormap = new ScottPlot.Colormaps.Viridis();
-            hm1.Extent = new(0, 65, 0, 100);
+            hm1.Position = new(0, 65, 0, 100);
 
             var hm2 = myPlot.Add.Heatmap(data);
             hm2.Colormap = new ScottPlot.Colormaps.Viridis().Reversed();
-            hm2.Extent = new(100, 165, 0, 100);
+            hm2.Position = new(100, 165, 0, 100);
         }
     }
 
@@ -75,21 +75,21 @@ public class Heatmap : ICategory
 
             myPlot.Add.Text("default", 0, 1.5);
             var hm1 = myPlot.Add.Heatmap(data);
-            hm1.Extent = new CoordinateRect(0, 1, 0, 1);
+            hm1.Position = new CoordinateRect(0, 1, 0, 1);
 
             myPlot.Add.Text("flip X", 2, 1.5);
             var hm2 = myPlot.Add.Heatmap(data);
-            hm2.Extent = new CoordinateRect(2, 3, 0, 1);
+            hm2.Position = new CoordinateRect(2, 3, 0, 1);
             hm2.FlipHorizontally = true;
 
             myPlot.Add.Text("flip Y", 4, 1.5);
             var hm3 = myPlot.Add.Heatmap(data);
-            hm3.Extent = new CoordinateRect(4, 5, 0, 1);
+            hm3.Position = new CoordinateRect(4, 5, 0, 1);
             hm3.FlipVertically = true;
 
             myPlot.Add.Text("flip X&Y", 6, 1.5);
             var hm4 = myPlot.Add.Heatmap(data);
-            hm4.Extent = new CoordinateRect(6, 7, 0, 1);
+            hm4.Position = new CoordinateRect(6, 7, 0, 1);
             hm4.FlipHorizontally = true;
             hm4.FlipVertically = true;
 
@@ -109,11 +109,11 @@ public class Heatmap : ICategory
 
             myPlot.Add.Text("Smooth = false", 0, 1.1);
             var hm1 = myPlot.Add.Heatmap(data);
-            hm1.Extent = new CoordinateRect(0, 1, 0, 1);
+            hm1.Position = new CoordinateRect(0, 1, 0, 1);
 
             myPlot.Add.Text("Smooth = true", 1.1, 1.1);
             var hm2 = myPlot.Add.Heatmap(data);
-            hm2.Extent = new CoordinateRect(1.1, 2.1, 0, 1);
+            hm2.Position = new CoordinateRect(1.1, 2.1, 0, 1);
             hm2.Smooth = true;
         }
     }
@@ -142,11 +142,11 @@ public class Heatmap : ICategory
 
             // plot the heatmap on top of the line chart
             var hm1 = myPlot.Add.Heatmap(data);
-            hm1.Extent = new(10, 35, -1.5, .5);
+            hm1.Position = new(10, 35, -1.5, .5);
 
             // the NaN transparency color can be customized
             var hm2 = myPlot.Add.Heatmap(data);
-            hm2.Extent = new(40, 55, -.5, .75);
+            hm2.Position = new(40, 55, -.5, .75);
             hm2.NaNCellColor = Colors.Magenta.WithAlpha(.4);
         }
     }
@@ -154,7 +154,7 @@ public class Heatmap : ICategory
     public class HeatmapGlobalTransparency : RecipeBase
     {
         public override string Name => "Global Transparency";
-        public override string Description => "The alpha (transparency) of the entire heatmap can be adjusted.";
+        public override string Description => "The transparency of the entire heatmap can be adjusted.";
 
         [Test]
         public override void Execute()

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Heatmap.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Heatmap.cs
@@ -166,9 +166,45 @@ public class Heatmap : ICategory
             myPlot.Add.Signal(Generate.Cos());
 
             // plot the heatmap on top of the line chart
-            var hm1 = myPlot.Add.Heatmap(data);
-            hm1.Extent = new(10, 35, -1.5, .5);
-            hm1.Opacity = 0.5;
+            var hm = myPlot.Add.Heatmap(data);
+            hm.Position = new(10, 35, -1.5, .5);
+            hm.Opacity = 0.5;
+        }
+    }
+
+    public class HeatmapAlphaMap : RecipeBase
+    {
+        public override string Name => "Alpha Map";
+        public override string Description => "An alpha map (a 2d array of byte values) can be used to " +
+            "apply custom transparency to each cell of a heatmap.";
+
+        [Test]
+        public override void Execute()
+        {
+            // data values are translated to color based on the heatmap's colormap
+            double[,] data = SampleData.MonaLisa();
+
+            // an alpha map controls transparency of each cell
+            byte[,] alphaMap = new byte[data.GetLength(0), data.GetLength(1)];
+
+            // fill the alpha map with values from 0 (transparent) to 255 (opaque)
+            for (int y = 0; y < alphaMap.GetLength(0); y++)
+            {
+                for (int x = 0; x < alphaMap.GetLength(1); x++)
+                {
+                    double fractionAcross = (double)x / alphaMap.GetLength(1);
+                    alphaMap[y, x] = (byte)(fractionAcross * 255);
+                }
+            }
+
+            // create a line chart
+            myPlot.Add.Signal(Generate.Sin());
+            myPlot.Add.Signal(Generate.Cos());
+
+            // plot the heatmap on top of the line chart
+            var hm = myPlot.Add.Heatmap(data);
+            hm.Position = new(10, 35, -1.5, .5);
+            hm.AlphaMap = alphaMap;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Heatmap.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Heatmap.cs
@@ -117,4 +117,32 @@ public class Heatmap : ICategory
             hm2.Smooth = true;
         }
     }
+
+    public class HeatmapTransparentCells : RecipeBase
+    {
+        public override string Name => "Transparent Cells";
+        public override string Description => "Assign double.NaN to a heatmap cell to make it transparent.";
+
+        [Test]
+        public override void Execute()
+        {
+            // start with 2D data and set some cells to NaN
+            double[,] data = SampleData.MonaLisa();
+            for (int y = 20; y < 80; y++)
+            {
+                for (int x = 20; x < 60; x++)
+                {
+                    data[y, x] = double.NaN;
+                }
+            }
+
+            // create a line chart
+            myPlot.Add.Signal(Generate.Sin());
+            myPlot.Add.Signal(Generate.Cos());
+
+            // plot the heatmap on top of the line chart
+            var hm = myPlot.Add.Heatmap(data);
+            hm.Extent = new(10, 40, -1, .5);
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Heatmap.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Heatmap.cs
@@ -141,8 +141,13 @@ public class Heatmap : ICategory
             myPlot.Add.Signal(Generate.Cos());
 
             // plot the heatmap on top of the line chart
-            var hm = myPlot.Add.Heatmap(data);
-            hm.Extent = new(10, 40, -1, .5);
+            var hm1 = myPlot.Add.Heatmap(data);
+            hm1.Extent = new(10, 35, -1.5, .5);
+
+            // the NaN transparency color can be customized
+            var hm2 = myPlot.Add.Heatmap(data);
+            hm2.Extent = new(40, 55, -.5, .75);
+            hm2.NaNCellColor = Colors.Magenta.WithAlpha(.4);
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Tests/UnitTests/ColorTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/UnitTests/ColorTests.cs
@@ -1,0 +1,45 @@
+﻿namespace ScottPlotTests.UnitTests;
+
+public class ColorTests
+{
+    [Test]
+    public void Test_Color_ValuesMatchKnown()
+    {
+        Color color = Color.FromHex("#2e5b6d");
+
+        // https://www.rapidtables.com/convert/color/hex-to-rgb.html
+        color.Red.Should().Be(46);
+        color.Green.Should().Be(91);
+        color.Blue.Should().Be(109);
+        color.Alpha.Should().Be(255);
+
+        color.ARGB.Should().Be(0xff2e5b6d);
+    }
+
+    [Test]
+    public void Test_Color_Transparent()
+    {
+        // If requesting a semitransparent black, make it slightly non-black
+        // to prevent SVG export from rendering the color as opaque.
+        // https://github.com/ScottPlot/ScottPlot/issues/3063
+
+        Color color = Colors.Transparent;
+        color.Red.Should().Be(1);
+        color.Green.Should().Be(1);
+        color.Blue.Should().Be(1);
+        color.Alpha.Should().Be(0);
+        color.ARGB.Should().Be(0x00010101);
+        color.ARGB.Should().Be(65793);
+    }
+
+    [Test]
+    public void Test_Color_AlphaARGB()
+    {
+        Color color = Color.FromHex("#2e5b6d").WithAlpha(123);
+        color.Red.Should().Be(46);
+        color.Green.Should().Be(91);
+        color.Blue.Should().Be(109);
+        color.Alpha.Should().Be(123);
+        color.ARGB.Should().Be(0x7B2E5B6D);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
@@ -241,12 +241,19 @@ public class Heatmap : IPlottable, IHasColorAxis
         bool FlipY = FlipVertically ^ ExtentOrDefault.IsInvertedY;
         bool FlipX = FlipHorizontally ^ ExtentOrDefault.IsInvertedX;
 
+        uint transparentBlack = 0x00000000;
+
         for (int y = 0; y < Height; y++)
         {
             int rowOffset = FlipY ? (Height - 1 - y) * Width : y * Width;
             for (int x = 0; x < Width; x++)
             {
                 int xIndex = FlipX ? (Width - 1 - x) : x;
+                if (Double.IsNaN(Intensities[y,xIndex]))
+                {
+                    argb[rowOffset + x] = transparentBlack;
+                    continue;
+                }
                 var colorWithoutAlpha = Colormap.GetColor(Intensities[y, xIndex], range).ARGB;
                 var alpha = AlphaMap[y, xIndex];
                 // Extract the RGB components

--- a/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
@@ -249,7 +249,7 @@ public class Heatmap : IPlottable, IHasColorAxis
             for (int x = 0; x < Width; x++)
             {
                 int xIndex = FlipX ? (Width - 1 - x) : x;
-                if (Double.IsNaN(Intensities[y,xIndex]))
+                if (Double.IsNaN(Intensities[y, xIndex]))
                 {
                     argb[rowOffset + x] = transparentBlack;
                     continue;

--- a/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
@@ -259,34 +259,15 @@ public class Heatmap(double[,] intensities) : IPlottable, IHasColorAxis
                     continue;
                 }
 
-                // Extract the RGB components
                 Color cellColor = Colormap.GetColor(Intensities[y, xIndex], range);
-                uint cellArgb = cellColor.ARGB;
-                byte Red = (byte)((cellArgb >> 16) & 0xFF);
-                byte Green = (byte)((cellArgb >> 8) & 0xFF);
-                byte Blue = (byte)(cellArgb & 0xFF);
 
-                // Calculate premultiplied RGB components
-
-                // start with the original color
-                byte alpha = cellColor.Alpha;
-
-                // apply the alpha map if it is present
                 if (AlphaMap is not null)
-                    alpha = AlphaMap[y, xIndex];
+                    cellColor = cellColor.WithAlpha(AlphaMap[y, xIndex]);
 
-                // apply global opacity if it has been customized
                 if (Opacity != 1)
-                    alpha = (byte)(alpha * Opacity);
+                    cellColor = cellColor.WithAlpha((byte)(cellColor.Alpha * Opacity));
 
-                byte premultipliedRed = (byte)((Red * alpha) / 255);
-                byte premultipliedGreen = (byte)((Green * alpha) / 255);
-                byte premultipliedBlue = (byte)((Blue * alpha) / 255);
-                argb[rowOffset + x] =
-                    ((uint)alpha << 24) |
-                    ((uint)premultipliedRed << 16) |
-                    ((uint)premultipliedGreen << 8) |
-                    ((uint)premultipliedBlue << 0);
+                argb[rowOffset + x] = cellColor.PremultipliedARGB;
             }
         }
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
@@ -35,7 +35,7 @@ public class Heatmap(double[,] intensities) : IPlottable, IHasColorAxis
     /// Note that the actual heatmap area is 1 cell larger than this rectangle.
     /// </summary>
     private CoordinateRect? _extent;
-    public CoordinateRect? Extent
+    public CoordinateRect? Extent // TODO: obsolete this
     {
         get { return _extent; }
         set
@@ -44,6 +44,12 @@ public class Heatmap(double[,] intensities) : IPlottable, IHasColorAxis
             Update();
         }
     }
+
+    /// <summary>
+    /// If defined, the this rectangle sets the axis boundaries of heatmap data.
+    /// Note that the actual heatmap area is 1 cell larger than this rectangle.
+    /// </summary>
+    public CoordinateRect? Position { get => Extent; set => Extent = value; }
 
     /// <summary>
     /// This variable controls whether row 0 of the 2D source array is the top or bottom of the heatmap.

--- a/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
@@ -194,35 +194,17 @@ public class Heatmap(double[,] intensities) : IPlottable, IHasColorAxis
         }
     }
 
-    private byte _globalAlpha = 255;
+    private double _Opacity = 1;
 
     /// <summary>
-    /// Controls the transparency of the entire heatmap
+    /// Controls the opacity of the entire heatmap from 0 (transparent) to 1 (opaque)
     /// </summary>
-    public byte GlobalAlpha
+    public double Opacity
     {
-        get => _globalAlpha;
+        get => _Opacity;
         set
         {
-
-            _globalAlpha = value;
-
-            if (GlobalAlpha == 255)
-            {
-                AlphaMap = null;
-                return;
-            }
-
-            AlphaMap = new byte[Height, Width];
-
-            for (int i = 0; i < Height; i++)
-            {
-                for (int j = 0; j < Width; j++)
-                {
-                    AlphaMap[i, j] = value;
-                }
-            }
-
+            _Opacity = NumericConversion.Clamp(value, 0, 1);
             Update();
         }
     }
@@ -285,7 +267,18 @@ public class Heatmap(double[,] intensities) : IPlottable, IHasColorAxis
                 byte Blue = (byte)(cellArgb & 0xFF);
 
                 // Calculate premultiplied RGB components
-                byte alpha = AlphaMap is null ? cellColor.Alpha : AlphaMap[y, xIndex];
+
+                // start with the original color
+                byte alpha = cellColor.Alpha;
+
+                // apply the alpha map if it is present
+                if (AlphaMap is not null)
+                    alpha = AlphaMap[y, xIndex];
+
+                // apply global opacity if it has been customized
+                if (Opacity != 1)
+                    alpha = (byte)(alpha * Opacity);
+
                 byte premultipliedRed = (byte)((Red * alpha) / 255);
                 byte premultipliedGreen = (byte)((Green * alpha) / 255);
                 byte premultipliedBlue = (byte)((Blue * alpha) / 255);

--- a/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
@@ -319,4 +319,19 @@ public readonly struct Color
         }
         return array;
     }
+
+    public uint PremultipliedARGB
+    {
+        get
+        {
+            byte premultipliedRed = (byte)((Red * Alpha) / 255);
+            byte premultipliedGreen = (byte)((Green * Alpha) / 255);
+            byte premultipliedBlue = (byte)((Blue * Alpha) / 255);
+            return
+                ((uint)Alpha << 24) |
+                ((uint)premultipliedRed << 16) |
+                ((uint)premultipliedGreen << 8) |
+                ((uint)premultipliedBlue << 0);
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
@@ -41,7 +41,7 @@ public readonly struct Color
 
     public override string ToString()
     {
-        return $"Color R={R}, G={G}, B={B}";
+        return $"Color R={R}, G={G}, B={B}, A={A}";
     }
 
     public Color(byte red, byte green, byte blue, byte alpha = 255)


### PR DESCRIPTION
This PR adds the capability to plot heatmaps with transparency. 
I see it as a stepping stone towards addressing issue #3349 
Intention is that a mask function could be defined (inside or outside of the heatmap class) to set the alpha to zero for all cells outside of a defined polygon.

I am sumbitting as a PR now because I may not tackle the masking functionality, and I think this capability stands on its own as a useful update. 

I've implemented two options. 
**A globalAlpha value** 
This sets the heatmap tansaparency to the same value over all cells.
Shown here with an underlying SignalXY:

```cs
        double[] Xs = Enumerable.Range(1, 5000).Select(i => (double)i / 1000).ToArray();
        var signal = WpfPlot1.Plot.Add.SignalXY(Xs, Generate.Sin(count: 5000, oscillations: 4));
        double[,] data2 = SampleData.MonaLisa();
        var hm2 = WpfPlot1.Plot.Add.Heatmap(data2);
        hm2.Extent = new(-2, 3, -5, 5);
        hm2.Smooth = true;
        WpfPlot1.Plot.Title("Default GlobalAlpha is 255");
        WpfPlot1.Plot.SavePng("NoAlpha.png", 400, 400);

        hm2.GlobalAlpha = (byte)100;
        WpfPlot1.Plot.Title("Setting GlobalAlpha to 100");
        WpfPlot1.Plot.SavePng("GlobalHeatmapAlpha.png", 400, 400);
```
![NoAlpha](https://github.com/ScottPlot/ScottPlot/assets/119825052/69f2c0cd-3417-4918-b3cf-1d3f2a237afb)
![GlobalHeatmapAlpha](https://github.com/ScottPlot/ScottPlot/assets/119825052/2fb992d5-915d-4e14-9162-9b59432484d0)

**An AlphaMap** 
This sets the alpha for individual cells within the heatmap. 
Shown here with alpha increasing form 100% transparent on the left to 100% opaque on the right:

```cs
        double[] Xs = Enumerable.Range(1, 5000).Select(i => (double)i / 1000).ToArray();
        var signal = WpfPlot1.Plot.Add.SignalXY(Xs, Generate.Sin(count: 5000, oscillations: 4));
        double[,] data2 = SampleData.MonaLisa();
        var hm2 = WpfPlot1.Plot.Add.Heatmap(data2);
        hm2.Extent = new(-2, 3, -5, 5);
        hm2.Smooth = true;
        
        var AlphaMap = new byte[data2.GetLength(0), data2.GetLength(1)];
        for (int i = 0; i < data2.GetLength(0); i++)
        {
            for (int j = 0; j < data2.GetLength(1); j++)
            {
                AlphaMap[i, j] = (byte)((double)j / (double)data2.GetLength(1) * 255);
            }
        }
        hm2.AlphaMap = AlphaMap;

        WpfPlot1.Plot.Title("AlphaMap Applied");
        WpfPlot1.Plot.SavePng("AlphaMap.png", 400, 400);
```
![AlphaMap](https://github.com/ScottPlot/ScottPlot/assets/119825052/057ad6f2-90af-447e-b6c3-805da99ce8a7)

