### PR TITLE
Fix IPlottable Polygon axis limits calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _Not yet on NuGet..._
 * Heatmap: Intensity values that are `double.NaN` are now displayed as transparent cells (#3499, #3349) @BrianAtZetica
 * Text: Added an `OffsetX` and `OffsetY` properties for adjusting text position in pixel units (#3506) @jamaa
 * Demo: Added a demonstration window for highlight the point nearest the cursor across multiple scatter plots (#3507, #3503) @jamaa @RubensMigliore
+* Polygon: Improved automatic axis limit detection of polygons (#3501) @drphobos
 
 ## ScottPlot 5.0.22
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-16_

--- a/src/ScottPlot5/ScottPlot5/Plottables/Polygon.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Polygon.cs
@@ -72,7 +72,7 @@ public class Polygon : IPlottable
         foreach (var coord in Coordinates)
         {
             if (coord.X > xMax) xMax = coord.X;
-            if (coord.X < xMin) xMax = coord.X;
+            if (coord.X < xMin) xMin = coord.X;
             if (coord.Y > yMax) yMax = coord.Y;
             if (coord.Y < yMin) yMin = coord.Y;
         }


### PR DESCRIPTION
When update polygon coordinates, xMin and xMax values are incorrectly calculated.

This with wrong xMin and xMax values
![image](https://github.com/ScottPlot/ScottPlot/assets/106194046/d0c75692-d73f-4315-a75b-26693cd7e146)

This with correct values
![image](https://github.com/ScottPlot/ScottPlot/assets/106194046/247fbe9a-044a-478c-8c5c-5e76e1d3d93f)

```cs
BlazorPlot.Plot.Add.Plottable(new ScottPlot.Plottables.Polygon(new Coordinates[]
{
    new Coordinates(230326,  20654),
    new Coordinates(234604,  20696),
    new Coordinates(234603,  72121),
    new Coordinates(233163,  72076),
    new Coordinates(233047,  69547),
    new Coordinates(160908,  69311),
    new Coordinates(160737,  77781),
    new Coordinates(158938,  77273),
    new Coordinates(158717,  73368),
    new Coordinates(155658,  73687),
    new Coordinates(155560,  68718),
    new Coordinates(155645,  67517),
    new Coordinates(155300,  52133),
    new Coordinates(162674,  52258),
    new Coordinates(163929,  64912),
    new Coordinates(231187,  65342),
    new Coordinates(230949,  21750),
    new Coordinates(230216,  21808),
}));
```