### PR TITLE
Text: add Offset support

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Plottables/Text.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Text.cs
@@ -70,6 +70,8 @@ public class Text : IPlottable
     public void Render(RenderPack rp)
     {
         Pixel pixelLocation = Axes.GetPixel(Location);
+        pixelLocation.X += PixelOffset.Width;
+        pixelLocation.Y += PixelOffset.Height;
         Label.Render(rp.Canvas, pixelLocation);
     }
 }


### PR DESCRIPTION
When rendering a `Text` plottable, add its `PixelOffset` to the rendering location.

```cs
ScottPlot.Plot myPlot = new();
ScottPlot.Plottables.Text myText = myPlot.Add.Text("test", 0, 0);
myText.Label.Alignment = Alignment.LowerLeft;
myText.PixelOffset = new PixelSize(5, -5); // offset text 5 pixels right and up
myPlot.SavePng("Text with offset.png", 600, 400);
```

![grafik](https://github.com/ScottPlot/ScottPlot/assets/90166/928c321b-9845-4dbb-bfdc-b603a799ab81)
