### PR TITLE
Demo: show value near cursor with multiple scatter plots

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/ShowValueOnHoverMultiple.Designer.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/ShowValueOnHoverMultiple.Designer.cs
@@ -1,0 +1,57 @@
+﻿namespace WinForms_Demo.Demos;
+
+partial class ShowValueOnHoverMultiple
+{
+    /// <summary>
+    /// Required designer variable.
+    /// </summary>
+    private System.ComponentModel.IContainer components = null;
+
+    /// <summary>
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && (components != null))
+        {
+            components.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+
+    #region Windows Form Designer generated code
+
+    /// <summary>
+    /// Required method for Designer support - do not modify
+    /// the contents of this method with the code editor.
+    /// </summary>
+    private void InitializeComponent()
+    {
+        formsPlot1 = new ScottPlot.WinForms.FormsPlot();
+        SuspendLayout();
+        // 
+        // formsPlot1
+        // 
+        formsPlot1.DisplayScale = 1F;
+        formsPlot1.Dock = DockStyle.Fill;
+        formsPlot1.Location = new Point(0, 0);
+        formsPlot1.Name = "formsPlot1";
+        formsPlot1.Size = new Size(800, 450);
+        formsPlot1.TabIndex = 1;
+        // 
+        // ShowValueOnHover
+        // 
+        AutoScaleDimensions = new SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
+        ClientSize = new Size(800, 450);
+        Controls.Add(formsPlot1);
+        Name = "ShowValueOnHover";
+        Text = "ShowValueOnHover";
+        ResumeLayout(false);
+    }
+
+    #endregion
+
+    private ScottPlot.WinForms.FormsPlot formsPlot1;
+}

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/ShowValueOnHoverMultiple.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/ShowValueOnHoverMultiple.cs
@@ -1,0 +1,115 @@
+﻿using ScottPlot;
+using ScottPlot.Plottables;
+using ScottPlotCookbook.Recipes.PlotTypes;
+
+namespace WinForms_Demo.Demos;
+
+public partial class ShowValueOnHoverMultiple : Form, IDemoWindow
+{
+    public string Title => "Show Value Under Mouse, Multiple Series";
+
+    public string Description => "How to sense where the mouse is in coordinate space " +
+        "and retrieve information about the plottable and data the cursor is hovering over";
+
+    List<ScottPlot.Plottables.Scatter> MyScatters = new();
+    ScottPlot.Plottables.Crosshair MyCrosshair;
+    ScottPlot.Plottables.Marker MyMarker;
+    ScottPlot.Plottables.Text MyText;
+
+    int NumScatters = 3;
+
+    public ShowValueOnHoverMultiple()
+    {
+        InitializeComponent();
+
+        // create multiple scatter plots with random points
+        for (int i = 0; i < NumScatters; i++)
+        {
+            double[] xs = Generate.RandomSample(30);
+            double[] ys = Generate.RandomSample(30);
+            ScottPlot.Plottables.Scatter scatter = formsPlot1.Plot.Add.ScatterPoints(xs, ys);
+            scatter.Label = $"Scatter {i}";
+            MyScatters.Add(scatter);
+        }
+
+        formsPlot1.Plot.ShowLegend();
+
+        MyCrosshair = formsPlot1.Plot.Add.Crosshair(0, 0);
+
+        MyMarker = formsPlot1.Plot.Add.Marker(0, 0, shape:MarkerShape.OpenCircle);
+
+        MyText = formsPlot1.Plot.Add.Text("", 0, 0);
+        MyText.Label.Alignment = Alignment.LowerLeft;
+        MyText.PixelOffset = new PixelSize(5, -5);
+
+        formsPlot1.Plot.Axes.AutoScale();
+        formsPlot1.Refresh();
+
+        formsPlot1.MouseMove += (s, e) =>
+        {
+            // determine where the mouse is
+            Pixel mousePixel = new(e.Location.X, e.Location.Y);
+            Coordinates mouseLocation = formsPlot1.Plot.GetCoordinates(mousePixel);
+
+            // get the nearest point of each scatter
+            Dictionary<int, DataPoint> nearestPoints = new();
+            for (int i = 0; i < NumScatters; i++)
+            {
+                DataPoint nearestPoint = MyScatters[i].Data.GetNearest(mouseLocation, formsPlot1.Plot.LastRender);
+                nearestPoints.Add(i, nearestPoint);
+            }
+
+            // determine which scatter's nearest point is nearest to the mouse
+            bool pointSelected = false;
+            int scatterIndex = -1;
+            double smallestDistance = double.MaxValue;
+            for (int i = 0; i < NumScatters; i++)
+            {
+                if (nearestPoints[i].IsReal)
+                {
+                    // calculate the distance of the point to the mouse
+                    double distance = nearestPoints[i].Coordinates.Distance(mouseLocation);
+                    if (distance < smallestDistance)
+                    {
+                        // store the index
+                        scatterIndex = i;
+                        pointSelected = true;
+                    }
+                }
+            }
+
+            // place the crosshair, marker and text over the selected point
+            if (pointSelected)
+            {
+                ScottPlot.Plottables.Scatter scatter = MyScatters[scatterIndex];
+                DataPoint point = nearestPoints[scatterIndex];
+
+                MyCrosshair.IsVisible = true;
+                MyCrosshair.Position = point.Coordinates;
+                MyCrosshair.LineStyle.Color = scatter.MarkerStyle.Fill.Color;
+
+                MyMarker.IsVisible = true;
+                MyMarker.Location = point.Coordinates;
+                MyMarker.MarkerStyle.Outline.Color = scatter.MarkerStyle.Fill.Color;
+
+                MyText.IsVisible = true;
+                MyText.Location = point.Coordinates;
+                MyText.LabelText = $"{point.X:0.##}, {point.Y:0.##}";
+                MyText.Color = scatter.MarkerStyle.Fill.Color;
+
+                formsPlot1.Refresh();
+                base.Text = $"Selected Scatter={scatter.Label}, Index={point.Index}, X={point.X:0.##}, Y={point.Y:0.##}";
+            }
+
+            // hide the crosshair, marker and text when no point is selected
+            if (!pointSelected && MyCrosshair.IsVisible)
+            {
+                MyCrosshair.IsVisible = false;
+                MyMarker.IsVisible = false;
+                MyText.IsVisible = false;
+                formsPlot1.Refresh();
+                base.Text = $"No point selected";
+            }
+        };
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/ShowValueOnHoverMultiple.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/ShowValueOnHoverMultiple.cs
@@ -36,7 +36,7 @@ public partial class ShowValueOnHoverMultiple : Form, IDemoWindow
 
         MyCrosshair = formsPlot1.Plot.Add.Crosshair(0, 0);
 
-        MyMarker = formsPlot1.Plot.Add.Marker(0, 0, shape:MarkerShape.OpenCircle);
+        MyMarker = formsPlot1.Plot.Add.Marker(0, 0, MarkerShape.OpenCircle);
 
         MyText = formsPlot1.Plot.Add.Text("", 0, 0);
         MyText.Label.Alignment = Alignment.LowerLeft;

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/ShowValueOnHoverMultiple.resx
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/ShowValueOnHoverMultiple.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/WinForms Demo.csproj
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/WinForms Demo.csproj
@@ -27,6 +27,9 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Compile Update="Demos\ShowValueOnHoverMultiple.cs">
+          <SubType>Form</SubType>
+        </Compile>
         <Compile Update="Properties\Resources.Designer.cs">
             <DesignTime>True</DesignTime>
             <AutoGen>True</AutoGen>


### PR DESCRIPTION
As suggested in #3503, this adds a a demo for hovering over the nearest point of multiple scatter plots.

Title is "Show Value Under Mouse, Multiple Series", please advise whether to name it differently to differentiate it more from the existing demo "Show Value Under Mouse".

Also, maybe I went a little overboard by also adding a marker and a text to the hovered point?

![grafik](https://github.com/ScottPlot/ScottPlot/assets/90166/6aea23c8-f66c-4443-bd8c-b10bb4e44df8)
