### PR TITLE
Fix rendering problems in AvaloniaUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _Not yet on NuGet..._
 * Polygon: Improved automatic axis limit detection of polygons (#3501) @drphobos
 * Annotation: New plot type for adding text labels aligned to the data area which are always visible (#3510, #3356) @dlampa
 * Ticks: Added `MinimumTickSpacing`, `TickDensity`, and `TargetTickCount` properties to the automatic tick generator (see Cookbook)
+* Avalonia: Fixed transparent background issue introduced in the previous version (#3502, #3516) @chjrom @MrOldOwl @kebox7
 
 ## ScottPlot 5.0.22
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-16_

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
@@ -104,7 +104,6 @@ public class RenderManager(Plot plot)
             rp.Canvas.Save();
             action.Render(rp);
             rp.Canvas.Restore();
-            rp.DisableClipping();
             actionTimes.Add((action.ToString() ?? string.Empty, sw.Elapsed));
         }
 


### PR DESCRIPTION
This reverts commit dc0c4b345eb3991dfe18de869d860ded7b8aa5b6.
I think the issue occurs because the methods `Canvas.Restore` are called multiple times.

Fix #3516, #3502.