### PR TITLE
Prevent too many calls to Canvas.Restore()

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Control/StandardZoomRectangle.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/StandardZoomRectangle.cs
@@ -72,8 +72,7 @@ public class StandardZoomRectangle : IZoomRectangle
 
         SKRect rect = new(MouseDown.X, MouseDown.Y, MouseUp.X, MouseUp.Y);
 
-        canvas.Save();
-        canvas.ClipRect(dataRect.ToSKRect());
+        using RenderPack.RestoreState _ = rp.PushClipToDataArea();
 
         if (HorizontalSpan)
         {
@@ -100,7 +99,5 @@ public class StandardZoomRectangle : IZoomRectangle
         paint.StrokeWidth = LineStyle.Width;
         paint.IsStroke = true;
         canvas.DrawRect(rect, paint);
-
-        canvas.Restore();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/Ellipse.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Ellipse.cs
@@ -93,7 +93,5 @@ public class Ellipse : IPlottable
         PixelRect rect = new(-rx, rx, ry, -ry);
         Drawing.FillOval(rp.Canvas, paint, FillStyle, rect);
         Drawing.DrawOval(rp.Canvas, paint, LineStyle, rect);
-
-        rp.Canvas.Restore();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/HorizontalLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/HorizontalLine.cs
@@ -68,9 +68,6 @@ public class HorizontalLine : AxisLine
             ? Alignment.UpperCenter
             : Alignment.LowerCenter;
 
-        // draw label outside the data area
-        rp.DisableClipping();
-
         using SKPaint paint = new();
         Label.Render(rp.Canvas, x, y, paint);
     }

--- a/src/ScottPlot5/ScottPlot5/Plottables/VerticalLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/VerticalLine.cs
@@ -67,9 +67,6 @@ public class VerticalLine : AxisLine
             ? Alignment.LowerCenter
             : Alignment.UpperCenter;
 
-        // draw label outside the data area
-        rp.DisableClipping();
-
         using SKPaint paint = new();
         Label.Render(rp.Canvas, x, y, paint);
     }

--- a/src/ScottPlot5/ScottPlot5/RenderPack.cs
+++ b/src/ScottPlot5/ScottPlot5/RenderPack.cs
@@ -42,13 +42,43 @@ public class RenderPack
         return $"RenderPack FigureRect={FigureRect} DataRect={DataRect}";
     }
 
+    public RestoreState PushClip(PixelRect rect)
+    {
+        Canvas.Save();
+        Canvas.ClipRect(rect.ToSKRect());
+
+        return new(this);
+    }
+
+    public RestoreState PushClipToDataArea()
+    {
+        return PushClip(DataRect);
+    }
+
+    [Obsolete($"Use {nameof(PushClipToDataArea)} instead.")]
     public void ClipToDataArea()
     {
         Canvas.ClipRect(DataRect.ToSKRect());
     }
 
+    [Obsolete($"Use {nameof(PushClipToDataArea)} instead.")]
     public void DisableClipping()
     {
         Canvas.Restore();
+    }
+
+    public readonly struct RestoreState : IDisposable
+    {
+        private readonly RenderPack _rp;
+
+        public RestoreState(RenderPack rp)
+        {
+            _rp = rp;
+        }
+
+        public void Dispose()
+        {
+            _rp.Canvas.Restore();
+        }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/RenderDataBackground.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/RenderDataBackground.cs
@@ -4,8 +4,7 @@ public class RenderDataBackground : IRenderAction
 {
     public void Render(RenderPack rp)
     {
-        rp.ClipToDataArea();
+        using RenderPack.RestoreState _ = rp.PushClipToDataArea();
         rp.Plot.DataBackground?.Render(rp.Canvas, rp.DataRect);
-        rp.DisableClipping();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/RenderPlottables.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/RenderPlottables.cs
@@ -18,11 +18,11 @@ public class RenderPlottables : IRenderAction
             }
             else
             {
-                rp.ClipToDataArea();
+                using RenderPack.RestoreState _ = rp.PushClipToDataArea();
                 plottable.Render(rp);
             }
 
-            rp.DisableClipping();
+            rp.Canvas.Restore();
         }
     }
 }


### PR DESCRIPTION
Changes due to comments in https://github.com/ScottPlot/ScottPlot/issues/3523#issuecomment-2016237841.

Added the  `RenderPack.PushClip` method that returns an` IDisposable` so that the caller is responsible for disable clipping.

The `RenderPack.ClipToDataArea` and `RenderPack.DisableClipping` methods are marked as obsolete.

Resolve #3523.
Same as #3527.