### PR TITLE
ScottPlot 4 Image: GetAxisLimits() returns incorrect value fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ _Not yet on NuGet..._
 * Ticks: Added `MinimumTickSpacing`, `TickDensity`, and `TargetTickCount` properties to the automatic tick generator (see Cookbook)
 * Avalonia: Fixed transparent background issue introduced in the previous version (#3502, #3516) @chjrom @MrOldOwl @kebox7
 
+## ScottPlot 4.1.73
+_Not yet on NuGet..._
+* Image: Improve automatic axis limit detection for images with manually defined positions (#3529, #3515) @bukkideme
+
 ## ScottPlot 5.0.22
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-16_
 * Rendering: Added additional options for gradient fills (#3324) @KroMignon

--- a/src/ScottPlot4/ScottPlot/Plottable/Image.cs
+++ b/src/ScottPlot4/ScottPlot/Plottable/Image.cs
@@ -84,11 +84,14 @@ namespace ScottPlot.Plottable
             if (Bitmap is null)
                 return AxisLimits.NoLimits;
 
+            float xOffset = (float)(WidthInAxisUnits ?? 0) / 2;
+            float yOffset = (float)(HeightInAxisUnits ?? 0) / 2;
+
             return new AxisLimits(
-                xMin: X,
-                xMax: X + WidthInAxisUnits ?? 0,
-                yMin: Y - HeightInAxisUnits ?? 0,
-                yMax: Y);
+                xMin: X - xOffset,
+                xMax: X + xOffset,
+                yMin: Y - yOffset,
+                yMax: Y + yOffset);
         }
 
         public LegendItem[] GetLegendItems() => LegendItem.None;


### PR DESCRIPTION
Hi @swharden ! 

Following your recommendation, here is a PR. I tested shortly, and it seems to work fine with the Image Plottable Mona Lisa...
thanks! :)

link for the issue: https://github.com/ScottPlot/ScottPlot/issues/3515
