### PR TITLE
improve performance of Signal.RenderLowDensity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ _Not yet on NuGet..._
 * Ticks: Added `MinimumTickSpacing`, `TickDensity`, and `TargetTickCount` properties to the automatic tick generator (see Cookbook)
 * Avalonia: Fixed transparent background issue introduced in the previous version (#3502, #3516) @chjrom @MrOldOwl @kebox7
 * Rendering: Improved canvas state management to prevent duplicate restoration calls (#3527, #3523, #3528) @BrianAtZetica @chjrom
+* Signal: Improved performance of large signal plots when zoomed in (#3530, #3229) @minjjKang 
 
 ## ScottPlot 4.1.73
 _Not yet on NuGet..._

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceDouble.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceDouble.cs
@@ -24,6 +24,11 @@ public class SignalSourceDouble : SignalSourceBase, ISignalSource
         }
     }
 
+    public double GetY(int index)
+    {
+        return Ys[index];
+    }
+
     public override SignalRangeY GetLimitsY(int firstIndex, int lastIndex)
     {
         double min = double.PositiveInfinity;

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceDouble.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceDouble.cs
@@ -16,6 +16,14 @@ public class SignalSourceDouble : SignalSourceBase, ISignalSource
         return Ys;
     }
 
+    public IEnumerable<double> GetYs(int i1, int i2)
+    {
+        for (int i = i1; i <= i2; i++)
+        {
+            yield return Ys[i];
+        }
+    }
+
     public override SignalRangeY GetLimitsY(int firstIndex, int lastIndex)
     {
         double min = double.PositiveInfinity;

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericArray.cs
@@ -16,6 +16,14 @@ public class SignalSourceGenericArray<T> : SignalSourceBase, ISignalSource
         return NumericConversion.GenericToDoubleArray(Ys);
     }
 
+    public IEnumerable<double> GetYs(int i1, int i2)
+    {
+        for (int i = i1; i <= i2; i++)
+        {
+            yield return NumericConversion.GenericToDouble(ref Ys[i]);
+        }
+    }
+
     public override SignalRangeY GetLimitsY(int firstIndex, int lastIndex)
     {
         double min = double.PositiveInfinity;

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericArray.cs
@@ -24,6 +24,11 @@ public class SignalSourceGenericArray<T> : SignalSourceBase, ISignalSource
         }
     }
 
+    public double GetY(int index)
+    {
+        return NumericConversion.GenericToDouble(ref Ys[index]);
+    }
+
     public override SignalRangeY GetLimitsY(int firstIndex, int lastIndex)
     {
         double min = double.PositiveInfinity;

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericList.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericList.cs
@@ -25,6 +25,12 @@ public class SignalSourceGenericList<T> : SignalSourceBase, ISignalSource
         }
     }
 
+    public double GetY(int index)
+    {
+        T genericValue = Ys[index];
+        return NumericConversion.GenericToDouble(ref genericValue);
+    }
+
     public override SignalRangeY GetLimitsY(int firstIndex, int lastIndex)
     {
         double min = double.PositiveInfinity;

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericList.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericList.cs
@@ -16,6 +16,15 @@ public class SignalSourceGenericList<T> : SignalSourceBase, ISignalSource
         return NumericConversion.GenericToDoubleArray(Ys);
     }
 
+    public IEnumerable<double> GetYs(int i1, int i2)
+    {
+        for (int i = i1; i <= i2; i++)
+        {
+            T genericValue = Ys[i];
+            yield return NumericConversion.GenericToDouble(ref genericValue);
+        }
+    }
+
     public override SignalRangeY GetLimitsY(int firstIndex, int lastIndex)
     {
         double min = double.PositiveInfinity;

--- a/src/ScottPlot5/ScottPlot5/Interfaces/ISignalSource.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/ISignalSource.cs
@@ -45,7 +45,12 @@ public interface ISignalSource
     /// <summary>
     /// Returns the X position for a given index.
     /// </summary>
-    double GetX(int index); // TODO: there should be a complimentary GetY
+    double GetX(int index);
+
+    /// <summary>
+    /// Returns the Y position for a given index.
+    /// </summary>
+    double GetY(int index);
 
     /// <summary>
     /// Return an object for working with all Y values.
@@ -57,9 +62,9 @@ public interface ISignalSource
     /// </summary>
     IEnumerable<double> GetYs(int index1, int index2);
 
-    public CoordinateRange GetLimitsX(); // TODO: struct
+    public CoordinateRange GetLimitsX();
 
-    public CoordinateRange GetLimitsY(); // TODO: struct
+    public CoordinateRange GetLimitsY();
 
     AxisLimits GetLimits();
 }

--- a/src/ScottPlot5/ScottPlot5/Interfaces/ISignalSource.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/ISignalSource.cs
@@ -51,8 +51,11 @@ public interface ISignalSource
     /// Return an object for working with all Y values.
     /// </summary>
     IReadOnlyList<double> GetYs();
-    // NOTE: GetYs() is only called in low density mode to plot a few ploints
-    // TODO: Add min/max X arguments so large datasets are not copied
+
+    /// <summary>
+    /// Return an IEnumerable for working with Y values of selected index range
+    /// </summary>
+    IEnumerable<double> GetYs(int i1, int i2);
 
     public CoordinateRange GetLimitsX(); // TODO: struct
 

--- a/src/ScottPlot5/ScottPlot5/Interfaces/ISignalSource.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/ISignalSource.cs
@@ -45,17 +45,17 @@ public interface ISignalSource
     /// <summary>
     /// Returns the X position for a given index.
     /// </summary>
-    double GetX(int index);
+    double GetX(int index); // TODO: there should be a complimentary GetY
 
     /// <summary>
     /// Return an object for working with all Y values.
     /// </summary>
-    IReadOnlyList<double> GetYs();
+    IReadOnlyList<double> GetYs(); // TODO: should this be IEnumerable?
 
     /// <summary>
-    /// Return an IEnumerable for working with Y values of selected index range
+    /// Y values between a range of indexes (inclusive).
     /// </summary>
-    IEnumerable<double> GetYs(int i1, int i2);
+    IEnumerable<double> GetYs(int index1, int index2);
 
     public CoordinateRange GetLimitsX(); // TODO: struct
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -97,17 +97,14 @@ public class Signal : IPlottable
         int i1 = Data.GetIndex(visibleXRange.Min, true);
         int i2 = Data.GetIndex(visibleXRange.Max + Data.Period, true);
 
-        List<Pixel> points = new();
+        List<Pixel> points = [];
 
-        IEnumerable<double> ysInRange = Data.GetYs(i1, i2);
-        int i = i1;
-        foreach (double yValue in ysInRange)
+        for (int i = i1; i <= i2; i++)
         {
             float x = Axes.GetPixelX(Data.GetX(i));
-            float y = Axes.GetPixelY(yValue + Data.YOffset);
+            float y = Axes.GetPixelY(Data.GetY(i) + Data.YOffset);
             Pixel px = new(x, y);
             points.Add(px);
-            i++;
         }
 
         using SKPath path = new();

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -97,8 +97,6 @@ public class Signal : IPlottable
         int i1 = Data.GetIndex(visibleXRange.Min, true);
         int i2 = Data.GetIndex(visibleXRange.Max + Data.Period, true);
 
-        
-
         List<Pixel> points = new();
 
         IEnumerable<double> Ys = Data.GetYs(i1, i2);
@@ -111,15 +109,6 @@ public class Signal : IPlottable
             points.Add(px);
             i++;
         }
-
-        //IReadOnlyList<double> Ys = Data.GetYs();
-        //for (int i = i1; i <= i2; i++)
-        //{
-        //    float x = Axes.GetPixelX(Data.GetX(i));
-        //    float y = Axes.GetPixelY(Ys[i] + Data.YOffset);
-        //    Pixel px = new(x, y);
-        //    points.Add(px);
-        //}
 
         using SKPath path = new();
         path.MoveTo(points[0].ToSKPoint());

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -99,9 +99,9 @@ public class Signal : IPlottable
 
         List<Pixel> points = new();
 
-        IEnumerable<double> Ys = Data.GetYs(i1, i2);
+        IEnumerable<double> ysInRange = Data.GetYs(i1, i2);
         int i = i1;
-        foreach (double yValue in Ys)
+        foreach (double yValue in ysInRange)
         {
             float x = Axes.GetPixelX(Data.GetX(i));
             float y = Axes.GetPixelY(yValue + Data.YOffset);

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -97,16 +97,29 @@ public class Signal : IPlottable
         int i1 = Data.GetIndex(visibleXRange.Min, true);
         int i2 = Data.GetIndex(visibleXRange.Max + Data.Period, true);
 
-        IReadOnlyList<double> Ys = Data.GetYs();
+        
 
         List<Pixel> points = new();
-        for (int i = i1; i <= i2; i++)
+
+        IEnumerable<double> Ys = Data.GetYs(i1, i2);
+        int i = i1;
+        foreach (double yValue in Ys)
         {
             float x = Axes.GetPixelX(Data.GetX(i));
-            float y = Axes.GetPixelY(Ys[i] + Data.YOffset);
+            float y = Axes.GetPixelY(yValue + Data.YOffset);
             Pixel px = new(x, y);
             points.Add(px);
+            i++;
         }
+
+        //IReadOnlyList<double> Ys = Data.GetYs();
+        //for (int i = i1; i <= i2; i++)
+        //{
+        //    float x = Axes.GetPixelX(Data.GetX(i));
+        //    float y = Axes.GetPixelY(Ys[i] + Data.YOffset);
+        //    Pixel px = new(x, y);
+        //    points.Add(px);
+        //}
 
         using SKPath path = new();
         path.MoveTo(points[0].ToSKPoint());


### PR DESCRIPTION
Hi Scott,

This is PR to solve the issue of #3229 

# Issue
at the Signal.LowRenderDensity,
Very slow on **SignalSourceDouble and SignalSourceGenericArray** with large size data.

Because that all of SignalSource are uses GetYs() from RenderLowDensity, and it copy all the data,
and that two sources convert all data by **NumericConversion.GenericToDoubleArray**, it reduced performance.

# Solution
I refer to the TODO of ISignalSource that you written,
I added IEnumerable<double> GetYs function, have arguments of index range.
(I used IEnumerable instead of IReadOnlyList,
You just decide what you think is better.)

And, SignalSource used it in the following way:
```cs
public IEnumerable<double> GetYs(int i1, int i2)
{
    for (int i = i1; i <= i2; i++)
    {
        yield return NumericConversion.GenericToDouble(ref Ys[i]);
    }
}
```

Signal.RenderLowDensity changed it to have Pixel:
```cs
IEnumerable<double> Ys = Data.GetYs(i1, i2);
int i = i1;
foreach (double yValue in Ys)
{
    float x = Axes.GetPixelX(Data.GetX(i));
    float y = Axes.GetPixelY(yValue + Data.YOffset);
    Pixel px = new(x, y);
    points.Add(px);
    i++;
}
```

I checked that the performance imporved from LowDensity with like this:

  | RenderLowDensity avg FPS| |
-- | -- | --
Source  | Before | After
SignalSource | 242 | 243
SignalSourceDouble | 3 | 248
SignalSourceGenericArray<double> | 3 | 246
(50M 0-500 random data, display only 50 data)

 Thanks!