### PR TITLE
SP5: fix missing ticks and tick lines on inverted axes when using Num…

### DIFF
--- a/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
@@ -16,15 +16,17 @@ public class NumericFixedInterval : ITickGenerator
     public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint)
     {
         List<Tick> ticks = new();
+        int sign = Math.Sign(range.Max - range.Min);
 
         double lowest = range.Min - range.Min % Interval;
-        double highest = range.Max - range.Max % Interval + Interval;
-        int tickCount = (int)((highest - lowest) / Interval);
+        double highest = range.Max - range.Max % Interval + Interval * sign;
+        double absSpan = Math.Abs(highest - lowest);
+        int tickCount = (int)(absSpan / Interval);
         tickCount = Math.Min(tickCount, MaxTickCount);
 
         for (int i = 0; i < tickCount; i++)
         {
-            double position = lowest + i * Interval;
+            double position = lowest + i * Interval * sign;
             string label = position.ToString();
             ticks.Add(new Tick(position, label, true));
         }


### PR DESCRIPTION
This fixes #3567

The code:
```cs
using System.Windows;
using ScottPlot.TickGenerators;

namespace Sandbox.WPF;

public partial class MainWindow : Window
{
    public MainWindow()
    {
        InitializeComponent();

        WpfPlot1.Plot.Axes.Left.TickGenerator = new NumericFixedInterval(10);
        WpfPlot1.Plot.Axes.SetLimitsY(0, -100);
        WpfPlot1.Plot.Axes.Bottom.TickGenerator = new NumericFixedInterval(10);
        WpfPlot1.Plot.Axes.SetLimitsX(0, -100);
    }
}
```

The result:
![image](https://github.com/ScottPlot/ScottPlot/assets/61787065/21deb656-dbd7-4d08-91dd-4ddf2a09602b)