### PR TITLE
Controls: fix `InvalidCastException` when starting mouse interaction in the Title area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 * Demo: Added demonstration for draggable `SignalXY` plots which respond to the cursor (#3550) @endreew
 * Legend: Do not display plottables where `IsVisible` is `false` (#3552, #3545, #3541) @KroMignon, @blahetal, @pkstrsk
 * Annotation: Improve positioning so it is unaffected by typeface or font (#3558) @MCF
-* Controls: Improve render artifacts on platforms that allow concurrent rendering and UI manipulation (#3559) @chjrom @Limula-PMA
+* Controls: Improve render artifacts on platforms that allow concurrent rendering and UI manipulation (#3559, #3557) @chjrom @Limula-PMA
+* Controls: Improve behavior of interactions started outside the plot area (#3571, #3543) @bwedding @pkstrsk
 
 ## ScottPlot 5.0.23
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-24_

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -173,7 +173,7 @@ public class Plot : IDisposable
     public IAxis? GetAxis(Pixel pixel)
     {
         IPanel? panel = GetPanel(pixel, axesOnly: true);
-        return panel is null ? null : (IAxis)panel;
+        return panel is IAxis axis ? axis : null;
     }
 
     /// <summary>
@@ -187,8 +187,8 @@ public class Plot : IDisposable
 
         // Reverse here so the "highest" axis is returned in the case some overlap.
         var panels = axesOnly
-            ? Axes.GetPanels().Reverse()
-            : Axes.GetPanels().Reverse().OfType<IAxis>();
+            ? Axes.GetPanels().Reverse().OfType<IAxis>()
+            : Axes.GetPanels().Reverse();
 
         foreach (IPanel panel in panels)
         {


### PR DESCRIPTION
Fixes [#3543](https://github.com/ScottPlot/ScottPlot/issues/3543)
The exception was caused because the logic in the ternary operator was reversed. When axesOnly was true, it was returning all panels and vice versa:

```cs
        // Reverse here so the "highest" axis is returned in the case some overlap.
        var panels = axesOnly
            ? Axes.GetPanels().Reverse().OfType<IAxis>()
            : Axes.GetPanels().Reverse();
 ```
Added check to ensure type is IAxis before returning it rather than casting the wrong type, which was what threw the exception.

```cs
    public IAxis? GetAxis(Pixel pixel)
    {
        IPanel? panel = GetPanel(pixel, axesOnly: true);
        return panel is IAxis axis ? axis : null;
    }

```
