### PR TITLE
Label: Don't draw border when line width is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Annotation: Improve positioning so it is unaffected by typeface or font (#3558) @MCF
 * Controls: Improve render artifacts on platforms that allow concurrent rendering and UI manipulation (#3559, #3557) @chjrom @Limula-PMA
 * Controls: Improve behavior of interactions started outside the plot area (#3571, #3543) @bwedding @pkstrsk
+* Label: Prevent rendering borders when line width is zero (#3572, #3538) @bwedding
 
 ## ScottPlot 5.0.23
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-24_

--- a/src/ScottPlot5/ScottPlot5/Primitives/Label.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Label.cs
@@ -270,8 +270,11 @@ public class Label
             canvas.DrawText(Text, textRect.Left, textRect.Bottom, paint);
         }
 
-        ApplyBorderPaint(paint);
-        canvas.DrawRect(backgroundRect.ToSKRect(), paint);
+        if (BorderWidth > 0)
+        {
+            ApplyBorderPaint(paint);
+            canvas.DrawRect(backgroundRect.ToSKRect(), paint);
+        }
         canvas.Restore(); // WARNING: Save() must be paired 1:1 with Restore()
 
         canvas.Save(); // WARNING: Save() must be paired 1:1 with Restore()


### PR DESCRIPTION
For issue #3538 
In SkiaSharp, setting the StrokeWidth to 0 does not guarantee that no border will be drawn. A StrokeWidth of 0 is interpreted as the thinnest line that can be drawn on the device, which is not the same as not drawing a line at all.

So I just wrapped the code to draw the border with a conditional to only paint it if borderwidth is greater than 0. This works fine on the recipe code when setting BorderWidth = 0;

![image](https://github.com/ScottPlot/ScottPlot/assets/1916594/ad2d31f6-8c3d-435a-814f-1c34ae54d369)


[Issue 3538](https://github.com/ScottPlot/ScottPlot/issues/3538)

```cs
[ScottPlot.Plot myPlot = new();
if (BorderWidth > 0)
{
    ApplyBorderPaint(paint);
    canvas.DrawRect(backgroundRect.ToSKRect(), paint);
}
```