### PR TITLE
Scatter: Allow `NaN` to draw noncontinuous lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Controls: Improve render artifacts on platforms that allow concurrent rendering and UI manipulation (#3559, #3557) @chjrom @Limula-PMA
 * Controls: Improve behavior of interactions started outside the plot area (#3571, #3543) @bwedding @pkstrsk
 * Label: Prevent rendering borders when line width is zero (#3572, #3538) @bwedding
+* Scatter: Added support for `NaN` values to display gaps in the line (#3577, #3276) @drolevar @Hub3r
+* DataLogger: Added support for `NaN` values to display gaps in the line (#3577) @drolevar
 
 ## ScottPlot 5.0.23
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-24_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Scatter.cs
@@ -241,4 +241,33 @@ public class Scatter : ICategory
             myPlot.ShowLegend();
         }
     }
+
+    public class ScatterWithGaps : RecipeBase
+    {
+        public override string Name => "Scatter with Gaps";
+        public override string Description => "NaN values in a scatter plot's data " +
+            "will appear as gaps in the line.";
+
+        [Test]
+        public override void Execute()
+        {
+            double[] xs = Generate.Consecutive(51);
+            double[] ys = Generate.Sin(51);
+
+            // long stretch of empty data
+            for (int i = 10; i < 20; i++)
+                ys[i] = double.NaN;
+
+            // single missing data point
+            ys[30] = double.NaN;
+
+            // single floating data point
+            for (int i = 35; i < 40; i++)
+                ys[i] = double.NaN;
+            for (int i = 40; i < 45; i++)
+                ys[i] = double.NaN;
+
+            myPlot.Add.Scatter(xs, ys);
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Tests/UnitTests/ScatterDataTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/UnitTests/ScatterDataTests.cs
@@ -1,0 +1,200 @@
+﻿using ScottPlot.DataSources;
+
+namespace ScottPlotTests.UnitTests;
+
+internal class ScatterDataTests
+{
+    [Test]
+    public void Test_ScatterLimits()
+    {
+        double[] xs = Generate.Consecutive(51);
+        double[] ys = Generate.Sin(51);
+
+        ScatterSourceDoubleArray source = new(xs, ys);
+        AxisLimits limits = source.GetLimits();
+
+        limits.Left.Should().Be(0);
+        limits.Right.Should().Be(50);
+        limits.Bottom.Should().BeApproximately(-1, .1);
+        limits.Top.Should().BeApproximately(1, .1);
+    }
+
+    [Test]
+    public void Test_ScatterLimits_WithNoRealPoint()
+    {
+        double[] xs = Generate.NaN(51);
+        double[] ys = Generate.NaN(51);
+
+        xs[22] = 5; // single real X
+        ys[33] = 7; // single real Y
+        // but no real X,Y point
+
+        ScatterSourceDoubleArray source = new(xs, ys);
+        AxisLimits limits = source.GetLimits();
+
+        limits.Left.Should().Be(5);
+        limits.Right.Should().Be(5);
+        limits.Bottom.Should().Be(7);
+        limits.Top.Should().Be(7);
+    }
+
+    [Test]
+    public void Test_ScatterLimits_WithOnePoint_DoubleArray()
+    {
+        double[] xs = Generate.NaN(51);
+        double[] ys = Generate.NaN(51);
+
+        xs[44] = 5;
+        ys[44] = 7;
+
+        ScatterSourceDoubleArray source = new(xs, ys);
+        AxisLimits limits = source.GetLimits();
+
+        limits.Left.Should().Be(5);
+        limits.Right.Should().Be(5);
+        limits.Bottom.Should().Be(7);
+        limits.Top.Should().Be(7);
+    }
+
+    [Test]
+    public void Test_ScatterLimits_WithOnePoint_CoordinatesArray()
+    {
+        double[] xs = Generate.NaN(51);
+        double[] ys = Generate.NaN(51);
+
+        xs[44] = 5;
+        ys[44] = 7;
+
+        Coordinates[] cs = Enumerable
+            .Range(0, xs.Length)
+            .Select(x => new Coordinates(xs[x], ys[x]))
+            .ToArray();
+
+        ScatterSourceCoordinatesArray source = new(cs);
+        AxisLimits limits = source.GetLimits();
+
+        limits.Left.Should().Be(5);
+        limits.Right.Should().Be(5);
+        limits.Bottom.Should().Be(7);
+        limits.Top.Should().Be(7);
+    }
+
+    [Test]
+    public void Test_ScatterLimits_WithOnePoint_CoordinatesList()
+    {
+        double[] xs = Generate.NaN(51);
+        double[] ys = Generate.NaN(51);
+
+        xs[44] = 5;
+        ys[44] = 7;
+
+        List<Coordinates> cs = Enumerable
+            .Range(0, xs.Length)
+            .Select(x => new Coordinates(xs[x], ys[x]))
+            .ToList();
+
+        ScatterSourceCoordinatesList source = new(cs);
+        AxisLimits limits = source.GetLimits();
+
+        limits.Left.Should().Be(5);
+        limits.Right.Should().Be(5);
+        limits.Bottom.Should().Be(7);
+        limits.Top.Should().Be(7);
+    }
+
+    [Test]
+    public void Test_ScatterLimits_WithOnePoint_CoordinatesGenericArray()
+    {
+        float[] xs = Enumerable.Range(0, 51).Select(x => float.NaN).ToArray();
+        float[] ys = Enumerable.Range(0, 51).Select(x => float.NaN).ToArray();
+
+        xs[44] = 5;
+        ys[44] = 7;
+
+        ScatterSourceGenericArray<float, float> source = new(xs, ys);
+        AxisLimits limits = source.GetLimits();
+
+        limits.Left.Should().Be(5);
+        limits.Right.Should().Be(5);
+        limits.Bottom.Should().Be(7);
+        limits.Top.Should().Be(7);
+    }
+
+    [Test]
+    public void Test_ScatterLimits_WithOnePoint_CoordinatesGenericList()
+    {
+        List<float> xs = Enumerable.Range(0, 51).Select(x => float.NaN).ToList();
+        List<float> ys = Enumerable.Range(0, 51).Select(x => float.NaN).ToList();
+
+        xs[44] = 5;
+        ys[44] = 7;
+
+        ScatterSourceGenericList<float, float> source = new(xs, ys);
+        AxisLimits limits = source.GetLimits();
+
+        limits.Left.Should().Be(5);
+        limits.Right.Should().Be(5);
+        limits.Bottom.Should().Be(7);
+        limits.Top.Should().Be(7);
+    }
+
+    [Test]
+    public void Test_ScatterLimits_WithOneMissingPoint()
+    {
+        double[] xs = Generate.Consecutive(51);
+        double[] ys = Generate.Sin(51);
+
+        xs[44] = double.NaN;
+        ys[44] = double.NaN;
+
+        ScatterSourceDoubleArray source = new(xs, ys);
+        AxisLimits limits = source.GetLimits();
+
+        limits.Left.Should().Be(0);
+        limits.Right.Should().Be(50);
+        limits.Bottom.Should().BeApproximately(-1, .1);
+        limits.Top.Should().BeApproximately(1, .1);
+    }
+
+    [Test]
+    public void Test_ScatterLimits_MissingLeft()
+    {
+        double[] xs = Generate.Consecutive(51);
+        double[] ys = Generate.Sin(51);
+
+        for (int i = 0; i < 25; i++)
+        {
+            xs[i] = double.NaN;
+            ys[i] = double.NaN;
+        }
+
+        ScatterSourceDoubleArray source = new(xs, ys);
+        AxisLimits limits = source.GetLimits();
+
+        limits.Left.Should().Be(25);
+        limits.Right.Should().Be(50);
+        limits.Bottom.Should().BeApproximately(-1, .1);
+        limits.Top.Should().BeApproximately(0, .1);
+    }
+
+    [Test]
+    public void Test_ScatterLimits_MissingRight()
+    {
+        double[] xs = Generate.Consecutive(51);
+        double[] ys = Generate.Sin(51);
+
+        for (int i = 26; i < ys.Length; i++)
+        {
+            xs[i] = double.NaN;
+            ys[i] = double.NaN;
+        }
+
+        ScatterSourceDoubleArray source = new(xs, ys);
+        AxisLimits limits = source.GetLimits();
+
+        limits.Left.Should().Be(0);
+        limits.Right.Should().Be(25);
+        limits.Bottom.Should().BeApproximately(0, .1);
+        limits.Top.Should().BeApproximately(1, .1);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/DataSources/DataLoggerSource.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/DataLoggerSource.cs
@@ -9,15 +9,11 @@ public class DataLoggerSource
     public readonly List<Coordinates> Coordinates = [];
     public double Period = 1;
 
-    double YMin = double.PositiveInfinity;
-    double YMax = double.NegativeInfinity;
+    double YMin = double.NaN;
+    double YMax = double.NaN;
 
     public int CountOnLastRender = -1;
     public int CountTotal => Coordinates.Count;
-
-    public DataLoggerSource()
-    {
-    }
 
     public void Add(double y)
     {
@@ -41,15 +37,22 @@ public class DataLoggerSource
         }
 
         Coordinates.Add(coordinates);
-        YMin = Math.Min(YMin, coordinates.Y);
-        YMax = Math.Max(YMax, coordinates.Y);
+
+        double y = coordinates.Y;
+
+        if (!double.IsNaN(y))
+        {
+            YMin = double.IsNaN(YMin) ? y : Math.Min(YMin, y);
+            YMax = double.IsNaN(YMax) ? y : Math.Max(YMax, y);
+        }
     }
 
     public void Clear()
     {
         Coordinates.Clear();
-        YMin = double.PositiveInfinity;
-        YMax = double.NegativeInfinity;
+
+        YMin = double.NaN;
+        YMax = double.NaN;
     }
 
     public AxisLimits GetAxisLimits()

--- a/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceDoubleArray.cs
@@ -27,18 +27,12 @@ public class ScatterSourceDoubleArray : IScatterSource
 
     public CoordinateRange GetLimitsX()
     {
-        if (!Xs.Any())
-            return CoordinateRange.NotSet;
-
-        return new CoordinateRange(Xs.Min(), Xs.Max());
+        return CoordinateRange.MinMaxNan(Xs);
     }
 
     public CoordinateRange GetLimitsY()
     {
-        if (!Ys.Any())
-            return CoordinateRange.NotSet;
-
-        return new CoordinateRange(Ys.Min(), Ys.Max());
+        return CoordinateRange.MinMaxNan(Ys);
     }
 
     public DataPoint GetNearest(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)

--- a/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceGenericArray.cs
@@ -30,22 +30,14 @@ public class ScatterSourceGenericArray<T1, T2> : IScatterSource
 
     public CoordinateRange GetLimitsX()
     {
-        if (Xs.Length == 0)
-            return CoordinateRange.NotSet;
-
         double[] values = NumericConversion.GenericToDoubleArray(Xs);
-
-        return new CoordinateRange(values.Min(), values.Max());
+        return CoordinateRange.MinMaxNan(values);
     }
 
     public CoordinateRange GetLimitsY()
     {
-        if (Ys.Length == 0)
-            return CoordinateRange.NotSet;
-
         double[] values = NumericConversion.GenericToDoubleArray(Ys);
-
-        return new CoordinateRange(values.Min(), values.Max());
+        return CoordinateRange.MinMaxNan(values);
     }
 
     public DataPoint GetNearest(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)

--- a/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceGenericList.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceGenericList.cs
@@ -30,22 +30,14 @@ public class ScatterSourceGenericList<T1, T2> : IScatterSource
 
     public CoordinateRange GetLimitsX()
     {
-        if (Xs.Count == 0)
-            return CoordinateRange.NotSet;
-
         double[] values = NumericConversion.GenericToDoubleArray(Xs);
-
-        return new CoordinateRange(values.Min(), values.Max());
+        return CoordinateRange.MinMaxNan(values);
     }
 
     public CoordinateRange GetLimitsY()
     {
-        if (Ys.Count == 0)
-            return CoordinateRange.NotSet;
-
         double[] values = NumericConversion.GenericToDoubleArray(Ys);
-
-        return new CoordinateRange(values.Min(), values.Max());
+        return CoordinateRange.MinMaxNan(values);
     }
 
     public DataPoint GetNearest(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
@@ -109,7 +109,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     /// <summary>
     /// Return the vertical range covered by data between the given indices (inclusive)
     /// </summary>
-    public CoordinateRange GetRangeY(int index1, int index2)
+    private CoordinateRange GetRangeY(int index1, int index2)
     {
         double min = Ys[index1];
         double max = Ys[index1];
@@ -129,7 +129,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     /// <summary>
     /// Get the index associated with the given X position
     /// </summary>
-    public int GetIndex(double x)
+    private int GetIndex(double x)
     {
         IndexRange range = new(MinimumIndex, MaximumIndex);
         return GetIndex(x, range);
@@ -138,7 +138,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     /// <summary>
     /// Get the index associated with the given X position limited to the given range
     /// </summary>
-    public int GetIndex(double x, IndexRange indexRange)
+    private int GetIndex(double x, IndexRange indexRange)
     {
         var (_, index) = SearchIndex(x, indexRange);
         return index;
@@ -150,7 +150,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     /// If the column contains one point, return that one pixel.
     /// If the column contains multiple points, return 4 pixels: enter, min, max, and exit
     /// </summary>
-    public IEnumerable<Pixel> GetColumnPixelsX(int pixelColumnIndex, IndexRange rng, RenderPack rp, IAxes axes)
+    private IEnumerable<Pixel> GetColumnPixelsX(int pixelColumnIndex, IndexRange rng, RenderPack rp, IAxes axes)
     {
         float xPixel = pixelColumnIndex + rp.DataRect.Left;
         double unitsPerPixelX = axes.XAxis.Width / rp.DataRect.Width;
@@ -183,7 +183,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     /// If the column contains one point, return that one pixel.
     /// If the column contains multiple points, return 4 pixels: enter, min, max, and exit
     /// </summary>
-    public IEnumerable<Pixel> GetColumnPixelsY(int rowColumnIndex, IndexRange rng, RenderPack rp, IAxes axes)
+    private IEnumerable<Pixel> GetColumnPixelsY(int rowColumnIndex, IndexRange rng, RenderPack rp, IAxes axes)
     {
         float yPixel = rp.DataRect.Bottom - rowColumnIndex;
         double unitsPerPixelY = axes.YAxis.Height / rp.DataRect.Height;

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -146,7 +146,7 @@ public static class Drawing
         canvas.DrawPath(path, paint);
     }
 
-    public static void DrawLines(SKCanvas canvas, SKPaint paint, IEnumerable<Pixel> pixels, Color color, float width = 1, bool antiAlias = true, LinePattern pattern = LinePattern.Solid)
+    public static void DrawLines(SKCanvas canvas, SKPaint paint, ICollection<Pixel> pixels, Color color, float width = 1, bool antiAlias = true, LinePattern pattern = LinePattern.Solid)
     {
         LineStyle ls = new()
         {
@@ -159,20 +159,32 @@ public static class Drawing
         DrawLines(canvas, paint, pixels, ls);
     }
 
-    public static void DrawLines(SKCanvas canvas, SKPaint paint, IEnumerable<Pixel> pixels, LineStyle lineStyle)
+    public static void DrawLines(SKCanvas canvas, SKPaint paint, ICollection<Pixel> pixels, LineStyle lineStyle)
     {
-        if (lineStyle.Width == 0 || lineStyle.IsVisible == false || pixels.Count() < 2)
+        if (lineStyle.Width == 0 || lineStyle.IsVisible == false || pixels.Count < 2)
             return;
 
         lineStyle.ApplyToPaint(paint);
 
         using SKPath path = new();
 
-        path.MoveTo(pixels.First().ToSKPoint());
+        bool move = true;
 
-        foreach (var pixel in pixels.Skip(1))
+        foreach (var pixel in pixels)
         {
-            path.LineTo(pixel.ToSKPoint());
+            if (float.IsNaN(pixel.X) || float.IsNaN(pixel.Y))
+            {
+                move = true;
+            }
+            else if (move)
+            {
+                path.MoveTo(pixel.ToSKPoint());
+                move = false;
+            }
+            else
+            {
+                path.LineTo(pixel.ToSKPoint());
+            }
         }
 
         canvas.DrawPath(path, paint);

--- a/src/ScottPlot5/ScottPlot5/Generate.cs
+++ b/src/ScottPlot5/ScottPlot5/Generate.cs
@@ -133,6 +133,11 @@ public static class Generate
         return values;
     }
 
+    public static double[] NaN(int count)
+    {
+        return Repeating(count, double.NaN);
+    }
+
     #endregion
 
     #region numerical 2D

--- a/src/ScottPlot5/ScottPlot5/Plottables/DataLogger.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/DataLogger.cs
@@ -85,7 +85,7 @@ public class DataLogger : IPlottable, IManagesAxisLimits
 
     public void Render(RenderPack rp)
     {
-        IEnumerable<Pixel> points = Data.Coordinates.Select(Axes.GetPixel);
+        Pixel[] points = Data.Coordinates.Select(Axes.GetPixel).ToArray();
 
         using SKPaint paint = new();
         Drawing.DrawLines(rp.Canvas, paint, points, LineStyle);

--- a/src/ScottPlot5/ScottPlot5/Plottables/Polygon.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Polygon.cs
@@ -92,17 +92,17 @@ public class Polygon : IPlottable
 
         bool close = true; // TODO: make property
         var coordinates = close
-            ? Coordinates.Concat(new Coordinates[] { Coordinates.First() })
+            ? Coordinates.Concat(new[] { Coordinates.First() })
             : Coordinates;
-        IEnumerable<Pixel> pixels = coordinates.Select(Axes.GetPixel);
+        Pixel[] pixels = coordinates.Select(Axes.GetPixel).ToArray();
 
         // TODO: stop using skia primitives directly
-        IEnumerable<SKPoint> skPoints = pixels.Select(x => x.ToSKPoint());
+        SKPoint[] skPoints = pixels.Select(x => x.ToSKPoint()).ToArray();
         using SKPath path = new();
-        path.MoveTo(skPoints.First());
+        path.MoveTo(skPoints[0]);
         float xMax, xMin, yMax, yMin;
-        xMax = xMin = skPoints.First().X;
-        yMax = yMin = skPoints.First().Y;
+        xMax = xMin = skPoints[0].X;
+        yMax = yMin = skPoints[0].Y;
         foreach (SKPoint p in skPoints.Skip(1))
         {
             xMax = Math.Max(xMax, p.X);
@@ -113,14 +113,14 @@ public class Polygon : IPlottable
         }
 
         using var paint = new SKPaint();
-        if (FillStyle != null && FillStyle.HasValue)
+        if (FillStyle.HasValue)
         {
             FillStyle.ApplyToPaint(paint, new PixelRect(xMin, xMax, yMin, yMax));
             paint.Style = SKPaintStyle.Fill;
             rp.Canvas.DrawPath(path, paint);
         }
 
-        if (LineStyle != null && LineStyle.IsVisible && LineStyle.Width > 0)
+        if (LineStyle is { IsVisible: true, Width: > 0 })
         {
             paint.Style = SKPaintStyle.Stroke;
             LineStyle.ApplyToPaint(paint);
@@ -128,7 +128,7 @@ public class Polygon : IPlottable
             Drawing.DrawLines(rp.Canvas, paint, pixels, LineStyle);
         }
 
-        if (MarkerStyle != null && MarkerStyle.IsVisible)
+        if (MarkerStyle.IsVisible)
         {
             Drawing.DrawMarkers(rp.Canvas, paint, pixels, MarkerStyle);
         }

--- a/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
@@ -54,7 +54,7 @@ public class Scatter(IScatterSource data) : IPlottable
         if (!markerPixels.Any())
             return;
 
-        IEnumerable<Pixel> linePixels = ConnectStyle switch
+        Pixel[] linePixels = ConnectStyle switch
         {
             ConnectStyle.Straight => markerPixels,
             ConnectStyle.StepHorizontal => GetStepDisplayPixels(markerPixels, true),
@@ -73,7 +73,7 @@ public class Scatter(IScatterSource data) : IPlottable
     /// </summary>
     /// <param name="points">Array of corner positions</param>
     /// <param name="right">Indicates that a line will extend to the right before rising or falling.</param>
-    public static IEnumerable<Pixel> GetStepDisplayPixels(Pixel[] pixels, bool right)
+    public static Pixel[] GetStepDisplayPixels(Pixel[] pixels, bool right)
     {
         Pixel[] pixelsStep = new Pixel[pixels.Count() * 2 - 1];
 

--- a/src/ScottPlot5/ScottPlot5/Primitives/CoordinateRange.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/CoordinateRange.cs
@@ -44,4 +44,42 @@ public readonly record struct CoordinateRange(double Min, double Max)
 
         return false;
     }
+
+    /// <summary>
+    /// Return the range of values spanned by the given collection
+    /// </summary>
+    public static CoordinateRange MinMax(IEnumerable<double> values)
+    {
+        if (values.Any())
+            return NotSet;
+
+        double min = double.MaxValue;
+        double max = double.MinValue;
+
+        foreach (double value in values)
+        {
+            min = Math.Min(min, value);
+            max = Math.Max(max, value);
+        }
+
+        return new CoordinateRange(min, max);
+    }
+
+    /// <summary>
+    /// Return the range of values spanned by the given collection (ignoring NaN)
+    /// </summary>
+    public static CoordinateRange MinMaxNan(IEnumerable<double> values)
+    {
+        double min = double.NaN;
+        double max = double.NaN;
+
+        foreach (double value in values)
+        {
+            if (double.IsNaN(value)) continue;
+            min = double.IsNaN(min) ? value : Math.Min(min, value);
+            max = double.IsNaN(max) ? value : Math.Max(max, value);
+        }
+
+        return new CoordinateRange(min, max);
+    }
 }


### PR DESCRIPTION
Enable plotting noncontinuous lines. For example, when a DataLogger has several NaN values, those are not plotted and just skipped.