### PR TITLE
SquareZoomOut Axis Rule: add support for inverted axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * Scatter: Added support for `NaN` values to display gaps in the line (#3577, #3276) @drolevar @Hub3r
 * DataLogger: Added support for `NaN` values to display gaps in the line (#3577) @drolevar
 * Finance: OHLC plots now have a `Sequential` mode (like candlestick plots) for displaying data without gaps (#3590) @oktrue
+* Axes: Added optional arguments to `Plot.Axes.AutoScale()` to add support for nonstandard axes (#3592)
+* Axis Rules: Improved `Plot.Axes.SquareUnits()` to support inverted axes (#3592) @VisMotrix
 
 ## ScottPlot 5.0.23
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-24_

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/AxisRules.Designer.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/AxisRules.Designer.cs
@@ -43,6 +43,8 @@ partial class AxisRules
         groupBox4 = new GroupBox();
         btnLockHorizontal = new Button();
         btnLockVertical = new Button();
+        cbInvertX = new CheckBox();
+        cbInvertY = new CheckBox();
         groupBox1.SuspendLayout();
         groupBox2.SuspendLayout();
         groupBox3.SuspendLayout();
@@ -55,7 +57,7 @@ partial class AxisRules
         formsPlot1.DisplayScale = 1F;
         formsPlot1.Location = new Point(12, 93);
         formsPlot1.Name = "formsPlot1";
-        formsPlot1.Size = new Size(1101, 521);
+        formsPlot1.Size = new Size(1180, 521);
         formsPlot1.TabIndex = 0;
         // 
         // btnBoundaryMin
@@ -134,7 +136,7 @@ partial class AxisRules
         // btnReset
         // 
         btnReset.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-        btnReset.Location = new Point(1005, 34);
+        btnReset.Location = new Point(1074, 34);
         btnReset.Name = "btnReset";
         btnReset.Size = new Size(96, 43);
         btnReset.TabIndex = 10;
@@ -204,11 +206,33 @@ partial class AxisRules
         btnLockVertical.UseVisualStyleBackColor = true;
         btnLockVertical.Click += btnLockVertical_Click;
         // 
+        // cbInvertX
+        // 
+        cbInvertX.AutoSize = true;
+        cbInvertX.Location = new Point(981, 34);
+        cbInvertX.Name = "cbInvertX";
+        cbInvertX.Size = new Size(79, 19);
+        cbInvertX.TabIndex = 13;
+        cbInvertX.Text = "Inverted X";
+        cbInvertX.UseVisualStyleBackColor = true;
+        // 
+        // cbInvertY
+        // 
+        cbInvertY.AutoSize = true;
+        cbInvertY.Location = new Point(981, 59);
+        cbInvertY.Name = "cbInvertY";
+        cbInvertY.Size = new Size(79, 19);
+        cbInvertY.TabIndex = 14;
+        cbInvertY.Text = "Inverted Y";
+        cbInvertY.UseVisualStyleBackColor = true;
+        // 
         // AxisRules
         // 
         AutoScaleDimensions = new SizeF(7F, 15F);
         AutoScaleMode = AutoScaleMode.Font;
-        ClientSize = new Size(1125, 626);
+        ClientSize = new Size(1204, 626);
+        Controls.Add(cbInvertY);
+        Controls.Add(cbInvertX);
         Controls.Add(groupBox4);
         Controls.Add(groupBox3);
         Controls.Add(btnReset);
@@ -222,6 +246,7 @@ partial class AxisRules
         groupBox3.ResumeLayout(false);
         groupBox4.ResumeLayout(false);
         ResumeLayout(false);
+        PerformLayout();
     }
 
     #endregion
@@ -241,4 +266,6 @@ partial class AxisRules
     private GroupBox groupBox4;
     private Button btnLockHorizontal;
     private Button btnLockVertical;
+    private CheckBox cbInvertX;
+    private CheckBox cbInvertY;
 }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/AxisRules.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/AxisRules.cs
@@ -1,5 +1,6 @@
 ﻿using ScottPlot;
 using System.Data;
+using System.Diagnostics;
 
 namespace WinForms_Demo.Demos;
 
@@ -14,18 +15,8 @@ public partial class AxisRules : Form, IDemoWindow
     {
         InitializeComponent();
         UnlockButtons();
-
-        Coordinates[] coordinates = Generate.RandomCoordinates(1000);
-        var sp = formsPlot1.Plot.Add.Scatter(coordinates);
-        sp.LineWidth = 0;
-        sp.MarkerStyle.Size = 5;
-        sp.Color = Colors.Magenta;
-
-        var rect = formsPlot1.Plot.Add.Rectangle(0, 1, 0, 1);
-        rect.FillStyle.Color = Colors.Transparent;
-        rect.LineStyle.Color = Colors.Green;
-        rect.LineStyle.Width = 3;
-        rect.LineStyle.IsVisible = true;
+        cbInvertX.CheckedChanged += (s, e) => btnReset_Click(this, EventArgs.Empty);
+        cbInvertY.CheckedChanged += (s, e) => btnReset_Click(this, EventArgs.Empty);
 
         btnReset_Click(this, EventArgs.Empty);
     }
@@ -170,9 +161,32 @@ public partial class AxisRules : Form, IDemoWindow
     private void btnReset_Click(object sender, EventArgs e)
     {
         formsPlot1.Plot.Axes.Rules.Clear();
-        formsPlot1.Plot.Axes.AutoScale();
+        PlotRandomData();
+        formsPlot1.Plot.Axes.AutoScale(invertX: cbInvertX.Checked, invertY: cbInvertY.Checked);
         formsPlot1.Plot.Title("No axis rules are in effect");
         formsPlot1.Refresh();
         UnlockButtons();
+    }
+
+    private void PlotRandomData()
+    {
+        formsPlot1.Plot.Clear();
+
+        // generate data that fits between (0, 0) and (1, 1)
+        int pointCount = 500;
+        double[] xs = Generate.Consecutive(pointCount, delta: 1.0 / pointCount);
+        double[] ys = Generate.Sin(pointCount, oscillations: 0.37);
+        Generate.AddNoiseInPlace(ys, 0.1);
+
+        var sp = formsPlot1.Plot.Add.Scatter(xs, ys);
+        sp.LineWidth = 0;
+        sp.MarkerStyle.Size = 5;
+        sp.Color = Colors.Magenta;
+
+        var rect = formsPlot1.Plot.Add.Rectangle(0, 1, 0, 1);
+        rect.FillStyle.Color = Colors.Transparent;
+        rect.LineStyle.Color = Colors.Green;
+        rect.LineStyle.Width = 3;
+        rect.LineStyle.IsVisible = true;
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPerformance.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPerformance.cs
@@ -26,8 +26,9 @@ public partial class SignalPerformance : Form, IDemoWindow
         Application.DoEvents();
 
         int pointCount = 1_000_000;
-        double[] ys = ScottPlot.Generate.NoisySin(new Random(), pointCount);
         double[] xs = ScottPlot.Generate.Consecutive(pointCount);
+        double[] ys = ScottPlot.Generate.Sin(pointCount);
+        Generate.AddNoiseInPlace(ys);
 
         if (rbSignal.Checked)
         {

--- a/src/ScottPlot5/ScottPlot5/AutoScalers/FractionalAutoScaler.cs
+++ b/src/ScottPlot5/ScottPlot5/AutoScalers/FractionalAutoScaler.cs
@@ -59,10 +59,12 @@ public class FractionalAutoScaler : IAutoScaler
             {
                 if (InvertedX)
                 {
-                    (left, right) = (right, left);
+                    xAxis.Range.Set(right, left);
                 }
-
-                xAxis.Range.Set(left, right);
+                else
+                {
+                    xAxis.Range.Set(left, right);
+                }
             }
         }
 
@@ -74,22 +76,20 @@ public class FractionalAutoScaler : IAutoScaler
             {
                 if (InvertedY)
                 {
-                    (bottom, top) = (top, bottom);
+                    yAxis.Range.Set(top, bottom);
                 }
-
-                yAxis.Range.Set(bottom, top);
+                else
+                {
+                    yAxis.Range.Set(bottom, top);
+                }
             }
         }
     }
 
     public AxisLimits GetAxisLimits(Plot plot, IXAxis xAxis, IYAxis yAxis)
     {
-        ExpandingAxisLimits limits = new();
-
-        foreach (IPlottable plottable in plot.PlottableList.Where(x => x.Axes.XAxis == xAxis && x.Axes.YAxis == yAxis))
-        {
-            limits.Expand(plottable.GetAxisLimits());
-        }
+        AxisLimits dataLimits = plot.Axes.GetDataLimits();
+        ExpandingAxisLimits limits = new(dataLimits);
 
         if (!limits.IsRealX)
         {

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -376,6 +376,32 @@ public class AxisManager
     }
 
     /// <summary>
+    /// Return the 2D axis limits of data for all plottables using the default axes
+    /// </summary>
+    public AxisLimits GetDataLimits()
+    {
+        return GetDataLimits(Plot.Axes.Bottom, Plot.Axes.Left);
+    }
+
+    /// <summary>
+    /// Return the 2D axis limits of data for all plottables using the given axes
+    /// </summary>
+    public AxisLimits GetDataLimits(IXAxis xAxis, IYAxis yAxis)
+    {
+        ExpandingAxisLimits expandingLimits = new();
+
+        foreach (IPlottable plottable in Plot.PlottableList)
+        {
+            if (plottable.Axes.XAxis != xAxis || plottable.Axes.YAxis != yAxis)
+                continue;
+
+            expandingLimits.Expand(plottable.GetAxisLimits());
+        }
+
+        return expandingLimits.AxisLimits;
+    }
+
+    /// <summary>
     /// Adds the default X and Y axes to all plottables with unset axes
     /// </summary>
     internal void ReplaceNullAxesWithDefaults()

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -393,9 +393,11 @@ public class AxisManager
     /// <summary>
     /// Automatically scale all axes to fit the data in all plottables
     /// </summary>
-    public void AutoScale()
+    public void AutoScale(bool? invertX = false, bool? invertY = false)
     {
         ReplaceNullAxesWithDefaults();
+        AutoScaler.InvertedX = invertX ?? AutoScaler.InvertedX;
+        AutoScaler.InvertedY = invertY ?? AutoScaler.InvertedY;
         AutoScaler.AutoScaleAll(Plot.PlottableList);
     }
 

--- a/src/ScottPlot5/ScottPlot5/AxisRules/SquareZoomOut.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/SquareZoomOut.cs
@@ -24,11 +24,21 @@ public class SquareZoomOut : IAxisRule
         double halfHeight = rp.DataRect.Height / 2 * maxUnitsPerPx;
         double yMin = YAxis.Range.Center - halfHeight;
         double yMax = YAxis.Range.Center + halfHeight;
-        YAxis.Range.Set(yMin, yMax);
+
+        var invertedY = YAxis.Min > YAxis.Max;
+        if (invertedY)
+            YAxis.Range.Set(yMax, yMin);
+        else
+            YAxis.Range.Set(yMin, yMax);
 
         double halfWidth = rp.DataRect.Width / 2 * maxUnitsPerPx;
         double xMin = XAxis.Range.Center - halfWidth;
         double xMax = XAxis.Range.Center + halfWidth;
-        XAxis.Range.Set(xMin, xMax);
+
+        var invertedX = XAxis.Min > XAxis.Max;
+        if (invertedX)
+            XAxis.Range.Set(xMax, xMin);
+        else
+            XAxis.Range.Set(xMin, xMax);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Generate.cs
+++ b/src/ScottPlot5/ScottPlot5/Generate.cs
@@ -50,14 +50,12 @@ public static class Generate
         return ys;
     }
 
-    public static double[] NoisySin(Random rand, int count = 51, double noiseLevel = 1)
+    [Obsolete("use Generate.Sin() then Generate.AddNoise()")]
+    public static double[] NoisySin(int count = 51, double magnitude = 1)
     {
-        double[] data = Sin(count);
-        for (int i = 0; i < data.Length; i++)
-        {
-            data[i] += rand.NextDouble() * noiseLevel;
-        }
-        return data;
+        double[] sin = Sin(count);
+        AddNoiseInPlace(sin, magnitude);
+        return sin;
     }
 
     /// <summary>
@@ -361,10 +359,7 @@ public static class Generate
     /// </summary>
     public static double[] AddNoise(double[] input, double magnitude = 1)
     {
-        double[] output = new double[input.Length];
-        Array.Copy(input, 0, output, 0, input.Length);
-        AddNoiseInPlace(output, magnitude);
-        return output;
+        return RandomData.AddNoise(input, magnitude);
     }
 
     /// <summary>
@@ -372,10 +367,7 @@ public static class Generate
     /// </summary>
     public static void AddNoiseInPlace(double[] values, double magnitude = 1)
     {
-        for (int i = 0; i < values.Length; i++)
-        {
-            values[i] = values[i] + RandomData.RandomNumber(-magnitude / 2, magnitude / 2);
-        }
+        RandomData.AddNoiseInPlace(values, magnitude);
     }
 
     #endregion

--- a/src/ScottPlot5/ScottPlot5/RandomDataGenerator.cs
+++ b/src/ScottPlot5/ScottPlot5/RandomDataGenerator.cs
@@ -122,6 +122,29 @@ public class RandomDataGenerator
     #endregion
 
     /// <summary>
+    /// Mutate the given array by adding noise (± magnitude) and return it
+    /// </summary>
+    public void AddNoiseInPlace(double[] values, double magnitude)
+    {
+        for (int i = 0; i < values.Length; i++)
+        {
+            double noise = (2 * RandomNumber() - .5) * magnitude;
+            values[i] = values[i] + noise;
+        }
+    }
+
+    /// <summary>
+    /// Return a copy of the given data with random noise added (± magnitude)
+    /// </summary>
+    public double[] AddNoise(double[] input, double magnitude)
+    {
+        double[] output = new double[input.Length];
+        Array.Copy(input, output, input.Length);
+        AddNoiseInPlace(output, magnitude);
+        return output;
+    }
+
+    /// <summary>
     /// Uniformly distributed random numbers between 0 and 1
     /// (multiplied by <paramref name="mult"/> then added to <paramref name="offset"/>).
     /// </summary>


### PR DESCRIPTION
…om: 1.5, top: -1.5);
This PR fixes the axis range setting if you use the SquareZoomOut  and AutoScaler.InvertedX / Y

This code did not "keep" the SetLimit / AutoScaler.InvertedY setting cause SquareZoomOut rule just sets YAxis.Range.Set(yMin, yMax); we need to distinguish if the axis got inverted.
```cs
ScottPlot.Plot myPlot = new();
myPlot.Add.Signal(Generate.Sin());
myPlot.Add.Signal(Generate.Cos());
myPlot.Axes.SetLimitsY(1.5, -1.5);
myPlot.Axes.SquareUnits();
```