### PR TITLE
Signal: support inverted axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Axes: Added optional arguments to `Plot.Axes.AutoScale()` to add support for nonstandard axes (#3592)
 * Axis Rules: Improved `Plot.Axes.SquareUnits()` to support inverted axes (#3592) @VisMotrix
 * WinForms: Improve `FormsPlot` disposal so the control displays properly when re-launched (#3593, #3589) @bwedding @Kruno313
+* Signal: Added support for inverted horizontal axes (#3594) @Excustic
 
 ## ScottPlot 5.0.23
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-24_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Axis Rules: Improved `Plot.Axes.SquareUnits()` to support inverted axes (#3592) @VisMotrix
 * WinForms: Improve `FormsPlot` disposal so the control displays properly when re-launched (#3593, #3589) @bwedding @Kruno313
 * Signal: Added support for inverted horizontal axes (#3594) @Excustic
+* Axes: New helper methods `Plot.Axes.InvertX()`, `Plot.Axes.RectifyX()`, and similar for Y (#3594)
 
 ## ScottPlot 5.0.23
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-24_

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml.cs
@@ -9,6 +9,7 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         WpfPlot1.Plot.Add.Signal(Generate.Sin());
-        WpfPlot1.Plot.Add.Signal(Generate.Cos());
+        WpfPlot1.Plot.Axes.SetLimitsX(0, -100);
+        WpfPlot1.Plot.Axes.SetLimitsY(1, -1);
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
@@ -10,5 +10,6 @@ public partial class Form1 : Form
 
         formsPlot1.Plot.Add.Signal(Generate.Sin());
         formsPlot1.Plot.Add.Signal(Generate.Cos());
+        formsPlot1.Plot.Axes.InvertX();
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/SignalTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/SignalTests.cs
@@ -76,4 +76,22 @@ internal class SignalTests
         plt.Add.Signal(values);
         plt.SaveTestImage();
     }
+
+    [Test]
+    public void Test_SignalLowDensity_InvertedX()
+    {
+        ScottPlot.Plot plt = new();
+        plt.Add.Signal(Generate.Sin());
+        plt.Axes.SetLimitsX(75, -25); // inverted X
+        plt.SaveTestImage();
+    }
+
+    [Test]
+    public void Test_SignalHighDensity_InvertedX()
+    {
+        ScottPlot.Plot plt = new();
+        plt.Add.Signal(Generate.Sin(100_000));
+        plt.Axes.SetLimitsX(-75, 25); // inverted X
+        plt.SaveTestImage();
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/SignalTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/SignalTests.cs
@@ -91,7 +91,7 @@ internal class SignalTests
     {
         ScottPlot.Plot plt = new();
         plt.Add.Signal(Generate.Sin(100_000));
-        plt.Axes.SetLimitsX(-75, 25); // inverted X
+        plt.Axes.SetLimitsX(150_000, -50_000); // inverted X
         plt.SaveTestImage();
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/SignalTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/SignalTests.cs
@@ -82,7 +82,7 @@ internal class SignalTests
     {
         ScottPlot.Plot plt = new();
         plt.Add.Signal(Generate.Sin());
-        plt.Axes.SetLimitsX(75, -25); // inverted X
+        plt.Axes.InvertX();
         plt.SaveTestImage();
     }
 
@@ -91,7 +91,7 @@ internal class SignalTests
     {
         ScottPlot.Plot plt = new();
         plt.Add.Signal(Generate.Sin(100_000));
-        plt.Axes.SetLimitsX(150_000, -50_000); // inverted X
+        plt.Axes.InvertX();
         plt.SaveTestImage();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -70,6 +70,11 @@ public class AxisManager
     public IYAxis Right => YAxes.First(x => x.Edge == Edge.Right);
 
     /// <summary>
+    /// Indicates whether the axis limits have been set (manually or by autoscale)
+    /// </summary>
+    public bool LimitsHaveBeenSet => Bottom.Range.HasBeenSet && Left.Range.HasBeenSet;
+
+    /// <summary>
     /// The standard grid that is added when a Plot is created.
     /// Users can achieve custom grid functionality by disabling the visibility
     /// of this grid and adding their own classes to the List of <see cref="CustomGrids"/>.
@@ -345,6 +350,62 @@ public class AxisManager
     {
         AxisLimits limits = new(xRange.Min, xRange.Max, yRange.Min, yRange.Max);
         SetLimits(limits);
+    }
+
+    /// <summary>
+    /// Adjust the horizontal axis so values descend from left to right
+    /// </summary>
+    public void InvertX()
+    {
+        if (!LimitsHaveBeenSet)
+            AutoScale();
+
+        AxisLimits limits = GetLimits();
+        double xMin = Math.Min(limits.Left, limits.Right);
+        double xMax = Math.Max(limits.Left, limits.Right);
+        SetLimitsX(xMax, xMin);
+    }
+
+    /// <summary>
+    /// Adjust the horizontal axis so values ascend from left to right
+    /// </summary>
+    public void RectifyX()
+    {
+        if (!LimitsHaveBeenSet)
+            AutoScale();
+
+        AxisLimits limits = GetLimits();
+        double xMin = Math.Min(limits.Left, limits.Right);
+        double xMax = Math.Max(limits.Left, limits.Right);
+        SetLimitsX(xMin, xMax);
+    }
+
+    /// <summary>
+    /// Adjust the vertical axis so values descend from bottom to top
+    /// </summary>
+    public void InvertY()
+    {
+        if (!LimitsHaveBeenSet)
+            AutoScale();
+
+        AxisLimits limits = GetLimits();
+        double yMin = Math.Min(limits.Bottom, limits.Top);
+        double yMax = Math.Max(limits.Bottom, limits.Top);
+        SetLimitsY(yMax, yMin);
+    }
+
+    /// <summary>
+    /// Adjust the vertical axis so values ascend from bottom to top
+    /// </summary>
+    public void RectifyY()
+    {
+        if (!LimitsHaveBeenSet)
+            AutoScale();
+
+        AxisLimits limits = GetLimits();
+        double yMin = Math.Min(limits.Bottom, limits.Top);
+        double yMax = Math.Max(limits.Bottom, limits.Top);
+        SetLimitsY(yMin, yMax);
     }
 
     /// <summary>

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceDouble.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceDouble.cs
@@ -48,7 +48,7 @@ public class SignalSourceDouble : SignalSourceBase, ISignalSource
         float xPixel = axes.DataRect.Left + xPixelIndex;
         double xRangeMin = axes.GetCoordinateX(xPixel);
         float xUnitsPerPixel = (float)(axes.XAxis.Width / axes.DataRect.Width);
-        double xRangeMax = xRangeMin + xUnitsPerPixel;
+        double xRangeMax = xRangeMin + Math.Abs(xUnitsPerPixel);
 
         if (RangeContainsSignal(xRangeMin, xRangeMax) == false)
             return PixelColumn.WithoutData(xPixel);

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -102,11 +102,9 @@ public class Signal : IPlottable
     /// </summary>
     private void RenderLowDensity(RenderPack rp)
     {
-        CoordinateRange visibleXRange = GetVisibleXRange(Axes.DataRect), 
-            visibleYRange = GetVisibleYRange(Axes.DataRect);
+        CoordinateRange visibleXRange = GetVisibleXRange(Axes.DataRect), visibleYRange = GetVisibleYRange(Axes.DataRect);
 
-        int DirectionX = visibleXRange.Max < visibleXRange.Min ? -1 : 1, 
-            DirectionY = visibleYRange.Max < visibleYRange.Min ? -1 : 1;
+        int DirectionX = visibleXRange.Max < visibleXRange.Min ? -1 : 1, DirectionY = visibleYRange.Max < visibleYRange.Min ? -1 : 1;
 
         int FirstVisible = Data.GetIndex(DirectionX * visibleXRange.Min, true),
             LastVisible = Data.GetIndex(DirectionX * visibleXRange.Max + Data.Period, true);

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -70,6 +70,15 @@ public class Signal : IPlottable
         return new CoordinateRange(xViewLeft, xViewRight);
     }
 
+    private CoordinateRange GetVisibleYRange(PixelRect dataRect)
+    {
+        // TODO: put GetRange in axis translator
+        double yViewBottom = Axes.GetCoordinateX(dataRect.Bottom);
+        double yViewTop = Axes.GetCoordinateX(dataRect.Top);
+        return new CoordinateRange(yViewBottom, yViewTop);
+    }
+
+
     private double PointsPerPixel()
     {
         return GetVisibleXRange(Axes.DataRect).Span / Axes.DataRect.Width / Data.Period;
@@ -93,16 +102,21 @@ public class Signal : IPlottable
     /// </summary>
     private void RenderLowDensity(RenderPack rp)
     {
-        CoordinateRange visibleXRange = GetVisibleXRange(Axes.DataRect);
-        int i1 = Data.GetIndex(visibleXRange.Min, true);
-        int i2 = Data.GetIndex(visibleXRange.Max + Data.Period, true);
+        CoordinateRange visibleXRange = GetVisibleXRange(Axes.DataRect), 
+            visibleYRange = GetVisibleYRange(Axes.DataRect);
+
+        int DirectionX = visibleXRange.Max < visibleXRange.Min ? -1 : 1, 
+            DirectionY = visibleYRange.Max < visibleYRange.Min ? -1 : 1;
+
+        int FirstVisible = Data.GetIndex(DirectionX * visibleXRange.Min, true),
+            LastVisible = Data.GetIndex(DirectionX * visibleXRange.Max + Data.Period, true);
 
         List<Pixel> points = [];
 
-        for (int i = i1; i <= i2; i++)
+        for (int i = FirstVisible; i <= LastVisible; i++)
         {
-            float x = Axes.GetPixelX(Data.GetX(i));
-            float y = Axes.GetPixelY(Data.GetY(i) + Data.YOffset);
+            float x = Axes.GetPixelX(DirectionX * Data.GetX(i));
+            float y = Axes.GetPixelY(DirectionY * Data.GetY(i) + Data.YOffset);
             Pixel px = new(x, y);
             points.Add(px);
         }

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -96,7 +96,6 @@ public class Signal : IPlottable
     private void RenderLowDensity(RenderPack rp)
     {
         CoordinateRange visibleXRange = GetVisibleXRange(Axes.DataRect);
-
         int i1 = Data.GetIndex(visibleXRange.Min, true);
         int i2 = Data.GetIndex(visibleXRange.Max + Data.Period, true);
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -67,17 +67,10 @@ public class Signal : IPlottable
         // TODO: put GetRange in axis translator
         double xViewLeft = Axes.GetCoordinateX(dataRect.Left);
         double xViewRight = Axes.GetCoordinateX(dataRect.Right);
-        return new CoordinateRange(xViewLeft, xViewRight);
+        return (xViewLeft <= xViewRight)
+            ? new CoordinateRange(xViewLeft, xViewRight)
+            : new CoordinateRange(xViewRight, xViewLeft);
     }
-
-    private CoordinateRange GetVisibleYRange(PixelRect dataRect)
-    {
-        // TODO: put GetRange in axis translator
-        double yViewBottom = Axes.GetCoordinateX(dataRect.Bottom);
-        double yViewTop = Axes.GetCoordinateX(dataRect.Top);
-        return new CoordinateRange(yViewBottom, yViewTop);
-    }
-
 
     private double PointsPerPixel()
     {
@@ -102,19 +95,17 @@ public class Signal : IPlottable
     /// </summary>
     private void RenderLowDensity(RenderPack rp)
     {
-        CoordinateRange visibleXRange = GetVisibleXRange(Axes.DataRect), visibleYRange = GetVisibleYRange(Axes.DataRect);
+        CoordinateRange visibleXRange = GetVisibleXRange(Axes.DataRect);
 
-        int DirectionX = visibleXRange.Max < visibleXRange.Min ? -1 : 1, DirectionY = visibleYRange.Max < visibleYRange.Min ? -1 : 1;
-
-        int FirstVisible = Data.GetIndex(DirectionX * visibleXRange.Min, true),
-            LastVisible = Data.GetIndex(DirectionX * visibleXRange.Max + Data.Period, true);
+        int i1 = Data.GetIndex(visibleXRange.Min, true);
+        int i2 = Data.GetIndex(visibleXRange.Max + Data.Period, true);
 
         List<Pixel> points = [];
 
-        for (int i = FirstVisible; i <= LastVisible; i++)
+        for (int i = i1; i <= i2; i++)
         {
-            float x = Axes.GetPixelX(DirectionX * Data.GetX(i));
-            float y = Axes.GetPixelY(DirectionY * Data.GetY(i) + Data.YOffset);
+            float x = Axes.GetPixelX(Data.GetX(i));
+            float y = Axes.GetPixelY(Data.GetY(i) + Data.YOffset);
             Pixel px = new(x, y);
             points.Add(px);
         }


### PR DESCRIPTION
Fixed issue  #3570 - enabling the option to invert axes of Signal plots.

- Added direction constants for inverting the axes in Signal plots. 
- Added GetVisibleYRange private method in Signal.
- Refactored variable names inside RenderLowDensity method of Signal.



![image](https://github.com/ScottPlot/ScottPlot/assets/47672175/a2cc6bfa-6b6e-40e6-be88-f62dcd517503)
