### PR TITLE
Scatter: add support for smooth lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * Rendering: Improved performance for plot types with many lines (#3601) @drolevar
 * Function Plot: Improve support for functions with limited X ranges (#3595, #3603) @Dibyanshuaman
 * Controls: All controls now include `Reset()` overloads for resetting or replacing the `Plot` (#3604, #3353) @aniketkumar7 @jon-rizzo
-* Scatter: The `Smooth` property now allows points to be connected with smooth lines (#3274, #3566) @bjschwarz @ja1234567 @bwedding @CBrauer
+* Scatter: The `Smooth` property now allows points to be connected with smooth lines (#3606, #3274, #3566) @bjschwarz @ja1234567 @bwedding @CBrauer
 
 ## ScottPlot 5.0.23
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-24_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Rendering: Improved performance for plot types with many lines (#3601) @drolevar
 * Function Plot: Improve support for functions with limited X ranges (#3595, #3603) @Dibyanshuaman
 * Controls: All controls now include `Reset()` overloads for resetting or replacing the `Plot` (#3604, #3353) @aniketkumar7 @jon-rizzo
+* Scatter: The `Smooth` property now allows points to be connected with smooth lines (#3274, #3566) @bjschwarz @ja1234567 @bwedding @CBrauer
 
 ## ScottPlot 5.0.23
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-24_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Scatter.cs
@@ -270,4 +270,25 @@ public class Scatter : ICategory
             myPlot.Add.Scatter(xs, ys);
         }
     }
+
+    public class ScatterSmooth : RecipeBase
+    {
+        public override string Name => "Scatter Plot with Smooth Lines";
+        public override string Description => "Scatter plots draw straight lines " +
+            "between points by default, but setting the Smooth property allows the " +
+            "scatter plot to connect points with smooth lines.";
+
+        [Test]
+        public override void Execute()
+        {
+            double[] xs = Generate.Consecutive(10);
+            double[] ys = Generate.RandomSample(10, 5, 15);
+
+            var sp = myPlot.Add.Scatter(xs, ys);
+            sp.Smooth = true;
+            sp.Label = "Smooth";
+            sp.LineWidth = 2;
+            sp.MarkerSize = 7;
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -159,6 +159,8 @@ public static class Drawing
         DrawLines(canvas, paint, pixels, ls);
     }
 
+    private static readonly IPathStrategy StraightLineStrategy = new PathStrategies.Straight();
+
     public static void DrawLines(SKCanvas canvas, SKPaint paint, IEnumerable<Pixel> pixels, LineStyle lineStyle)
     {
         if (lineStyle.Width == 0 || lineStyle.IsVisible == false || pixels.Take(2).Count() < 2)
@@ -166,74 +168,16 @@ public static class Drawing
 
         lineStyle.ApplyToPaint(paint);
 
-        using SKPath path = new();
-
-        bool move = true;
-
-        foreach (var pixel in pixels)
-        {
-            if (float.IsNaN(pixel.X) || float.IsNaN(pixel.Y))
-            {
-                move = true;
-            }
-            else if (move)
-            {
-                path.MoveTo(pixel.ToSKPoint());
-                move = false;
-            }
-            else
-            {
-                path.LineTo(pixel.ToSKPoint());
-            }
-        }
-
+        using SKPath path = StraightLineStrategy.GetPath(pixels);
         canvas.DrawPath(path, paint);
     }
 
-    /// <summary>
-    /// This strategy divides each line in half and draws quadratic Bezier curves
-    /// through the midpoint. The result is smooth lines which never "overshoot" the points.
-    /// </summary>
-    public static void DrawSmoothLines1(SKCanvas canvas, SKPaint paint, IEnumerable<Pixel> pixels, LineStyle lineStyle)
+    public static void DrawLines(SKCanvas canvas, SKPaint paint, SKPath path, LineStyle lineStyle)
     {
-        if (lineStyle.Width == 0 || lineStyle.IsVisible == false || pixels.Take(2).Count() < 2)
+        if (lineStyle.Width == 0 || lineStyle.IsVisible == false)
             return;
 
         lineStyle.ApplyToPaint(paint);
-
-        using SKPath path = new();
-
-        bool moveToNextPoint = true;
-        foreach (var pixel in pixels)
-        {
-            if (float.IsNaN(pixel.X) || float.IsNaN(pixel.Y))
-            {
-                moveToNextPoint = true;
-            }
-
-            SKPoint thisPoint = pixel.ToSKPoint();
-
-            if (moveToNextPoint)
-            {
-                path.MoveTo(thisPoint);
-                moveToNextPoint = false;
-            }
-            else
-            {
-                SKPoint lastPoint = path.LastPoint;
-
-                float halfX = (lastPoint.X + thisPoint.X) / 2;
-                float halfY = (lastPoint.Y + thisPoint.Y) / 2;
-                SKPoint halfPoint = new(halfX, halfY);
-
-                SKPoint controlPoint1 = new(halfPoint.X, lastPoint.Y);
-                SKPoint controlPoint2 = new(halfPoint.X, thisPoint.Y);
-
-                path.QuadTo(controlPoint1, halfPoint);
-                path.QuadTo(controlPoint2, thisPoint);
-            }
-        }
-
         canvas.DrawPath(path, paint);
     }
 

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IPathStrategy.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IPathStrategy.cs
@@ -1,0 +1,9 @@
+﻿namespace ScottPlot;
+
+/// <summary>
+/// Strategy for generating a path that connects a collection of pixels
+/// </summary>
+public interface IPathStrategy
+{
+    public SKPath GetPath(IEnumerable<Pixel> pixels);
+}

--- a/src/ScottPlot5/ScottPlot5/PathStrategies/QuadHalfPoint.cs
+++ b/src/ScottPlot5/ScottPlot5/PathStrategies/QuadHalfPoint.cs
@@ -1,0 +1,47 @@
+﻿namespace ScottPlot.PathStrategies;
+
+/// <summary>
+/// Connect points with curved lines which ease into and out of the midpoint between each pair.
+/// This strategy does not "overshoot" points in the Y direction.
+/// </summary>
+public class QuadHalfPoint : IPathStrategy
+{
+    public SKPath GetPath(IEnumerable<Pixel> pixels)
+    {
+        SKPath path = new();
+
+        bool moveToNextPoint = true;
+
+        foreach (var pixel in pixels)
+        {
+            if (float.IsNaN(pixel.X) || float.IsNaN(pixel.Y))
+            {
+                moveToNextPoint = true;
+            }
+
+            SKPoint thisPoint = pixel.ToSKPoint();
+
+            if (moveToNextPoint)
+            {
+                path.MoveTo(thisPoint);
+                moveToNextPoint = false;
+            }
+            else
+            {
+                SKPoint lastPoint = path.LastPoint;
+
+                float halfX = (lastPoint.X + thisPoint.X) / 2;
+                float halfY = (lastPoint.Y + thisPoint.Y) / 2;
+                SKPoint halfPoint = new(halfX, halfY);
+
+                SKPoint controlPoint1 = new(halfPoint.X, lastPoint.Y);
+                SKPoint controlPoint2 = new(halfPoint.X, thisPoint.Y);
+
+                path.QuadTo(controlPoint1, halfPoint);
+                path.QuadTo(controlPoint2, thisPoint);
+            }
+        }
+
+        return path;
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/PathStrategies/Straight.cs
+++ b/src/ScottPlot5/ScottPlot5/PathStrategies/Straight.cs
@@ -1,0 +1,34 @@
+﻿namespace ScottPlot.PathStrategies;
+
+/// <summary>
+/// Connect points with straight lines.
+/// NaN values will be skipped, producing a gap in the path.
+/// </summary>
+internal class Straight : IPathStrategy
+{
+    public SKPath GetPath(IEnumerable<Pixel> pixels)
+    {
+        SKPath path = new();
+
+        bool move = true;
+
+        foreach (var pixel in pixels)
+        {
+            if (float.IsNaN(pixel.X) || float.IsNaN(pixel.Y))
+            {
+                move = true;
+            }
+            else if (move)
+            {
+                path.MoveTo(pixel.ToSKPoint());
+                move = false;
+            }
+            else
+            {
+                path.LineTo(pixel.ToSKPoint());
+            }
+        }
+
+        return path;
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
@@ -21,15 +21,9 @@ public class Scatter(IScatterSource data) : IPlottable
     public ConnectStyle ConnectStyle = ConnectStyle.Straight;
 
     /// <summary>
-    /// If enabled, points will be connected by smooth lines instead of straight diagnal lines.
-    /// <see cref="SmoothTension"/> adjusts the smoothnes of the lines.
+    /// If enabled, points will be connected by smooth lines instead of straight lines.
     /// </summary>
     public bool Smooth = false;
-
-    /// <summary>
-    /// Tension to use for smoothing when <see cref="Smooth"/> is enabled
-    /// </summary>
-    public double SmoothTension = 0.5;
 
     public Color Color
     {
@@ -63,7 +57,16 @@ public class Scatter(IScatterSource data) : IPlottable
         };
 
         using SKPaint paint = new();
-        Drawing.DrawLines(rp.Canvas, paint, linePixels, LineStyle);
+
+        if (Smooth)
+        {
+            Drawing.DrawSmoothLines1(rp.Canvas, paint, linePixels, LineStyle);
+        }
+        else
+        {
+            Drawing.DrawLines(rp.Canvas, paint, linePixels, LineStyle);
+        }
+
         Drawing.DrawMarkers(rp.Canvas, paint, markerPixels, MarkerStyle);
     }
 


### PR DESCRIPTION
This PR causes Scatter plot line segments to be connected with smooth lines when `Smooth` is `true`.

To avoid manually calculating interpolated pixels, this strategy uses SkiaSharp's built-in quadratic Bezier curved path functionality to draw a curved line from a starting point to an ending point with one control point https://learn.microsoft.com/en-us/dotnet/api/skiasharp.skpath.quadto?view=skiasharp-2.88

This strategy avoids "overshoot" by splitting each line segment in two and drawing a curve to and from that midpoint. The present code doesn't function as expected if X points are not always ascending. Additional strategies could be implemented, and the code could be refactored in the future to allow uses to select one of multiple strategies (including user-defined ones).

Related:
* #3566 
* #3274

![image](https://github.com/ScottPlot/ScottPlot/assets/4165489/3afa6435-e275-4826-a99d-90f0c6fe5995)
