### PR TITLE
Colorbar: improve layout and add support for multiple colorbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 * Function Plot: Improve support for functions with limited X ranges (#3595, #3603) @Dibyanshuaman
 * Controls: All controls now include `Reset()` overloads for resetting or replacing the `Plot` (#3604, #3353) @aniketkumar7 @jon-rizzo
 * Scatter: The `Smooth` property now allows points to be connected with smooth lines (#3606, #3274, #3566) @bjschwarz @ja1234567 @bwedding @CBrauer
+* Layout: Added logic to reduce the size of axes which are visible but not used by any plottable (#3608)
+* Colorbar: Improved positioning and support for adding multiple colorbars to plots (#3294, #3560, #3586) @NateEbling @mawbydp @hnMel
 
 ## ScottPlot 5.0.23
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-03-24_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Heatmap.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Heatmap.cs
@@ -62,6 +62,28 @@ public class Heatmap : ICategory
         }
     }
 
+    public class HeatmapMultipleColorbar : RecipeBase
+    {
+        public override string Name => "Multiple Colorbars";
+        public override string Description => "Multiple colorbars may be added to plots.";
+
+        [Test]
+        public override void Execute()
+        {
+            double[,] data = SampleData.MonaLisa();
+
+            var hm1 = myPlot.Add.Heatmap(data);
+            hm1.Extent = new(0, 1, 0, 1);
+            hm1.Colormap = new ScottPlot.Colormaps.Turbo();
+            myPlot.Add.ColorBar(hm1);
+
+            var hm2 = myPlot.Add.Heatmap(data);
+            hm2.Extent = new(1.5, 2.5, 0, 1);
+            hm2.Colormap = new ScottPlot.Colormaps.Viridis();
+            myPlot.Add.ColorBar(hm2);
+        }
+    }
+
     public class HeatmapFlip : RecipeBase
     {
         public override string Name => "Flipped Heatmap";

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Heatmap.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Heatmap.cs
@@ -58,7 +58,6 @@ public class Heatmap : ICategory
             var hm1 = myPlot.Add.Heatmap(data);
             hm1.Colormap = new ScottPlot.Colormaps.Turbo();
 
-            // TODO: this isn't working quite right yet...
             myPlot.Add.ColorBar(hm1);
         }
     }

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
@@ -8,8 +8,11 @@ public partial class Form1 : Form
     {
         InitializeComponent();
 
-        formsPlot1.Plot.Add.Signal(Generate.Sin());
-        formsPlot1.Plot.Add.Signal(Generate.Cos());
-        formsPlot1.Plot.Axes.InvertX();
+        double[,] data = SampleData.MonaLisa();
+
+        var hm1 = formsPlot1.Plot.Add.Heatmap(data);
+        hm1.Colormap = new ScottPlot.Colormaps.Turbo();
+
+        formsPlot1.Plot.Add.ColorBar(hm1);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
@@ -9,6 +9,7 @@ public abstract class AxisBase
     public virtual CoordinateRangeMutable Range { get; private set; } = CoordinateRangeMutable.NotSet;
     public float MinimumSize { get; set; } = 0;
     public float MaximumSize { get; set; } = float.MaxValue;
+    public float SizeWhenNoData { get; set; } = 7;
 
     public double Min
     {

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/XAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/XAxisBase.cs
@@ -14,6 +14,9 @@ public abstract class XAxisBase : AxisBase, IAxis
         if (!IsVisible)
             return 0;
 
+        if (!Range.HasBeenSet)
+            return SizeWhenNoData;
+
         using SKPaint paint = new();
 
         float tickHeight = MajorTickStyle.Length;

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
@@ -25,6 +25,9 @@ public abstract class YAxisBase : AxisBase, IAxis
         if (!IsVisible)
             return 0;
 
+        if (!Range.HasBeenSet)
+            return SizeWhenNoData;
+
         float largestTickSize = MeasureTicks();
         float largestTickLabelSize = Label.Measure().Height;
         float spaceBetweenTicksAndAxisLabel = 15;

--- a/src/ScottPlot5/ScottPlot5/DataOperations.cs
+++ b/src/ScottPlot5/ScottPlot5/DataOperations.cs
@@ -65,4 +65,15 @@ public static class DataOperations
 
         return output;
     }
+
+    public static void Multiply2D(double[,] values, double mult)
+    {
+        for (int i = 0; i < values.GetLength(0); i++)
+        {
+            for (int j = 0; j < values.GetLength(1); j++)
+            {
+                values[i, j] *= mult;
+            }
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -234,11 +234,14 @@ public static class Drawing
         DrawRectangle(canvas, rect, paint);
     }
 
-    public static void DrawDebugRectangle(SKCanvas canvas, PixelRect rect, Pixel point, Color color, float lineWidth = 1)
+    public static void DrawDebugRectangle(SKCanvas canvas, PixelRect rect, Pixel? point = null, Color? color = null, float lineWidth = 3)
     {
+        point ??= Pixel.NaN;
+        color ??= Colors.Magenta;
+
         using SKPaint paint = new()
         {
-            Color = color.ToSKColor(),
+            Color = color.Value.ToSKColor(),
             IsStroke = true,
             StrokeWidth = lineWidth,
             IsAntialias = true,
@@ -248,7 +251,7 @@ public static class Drawing
         canvas.DrawLine(rect.BottomLeft.ToSKPoint(), rect.TopRight.ToSKPoint(), paint);
         canvas.DrawLine(rect.TopLeft.ToSKPoint(), rect.BottomRight.ToSKPoint(), paint);
 
-        canvas.DrawCircle(point.ToSKPoint(), 5, paint);
+        canvas.DrawCircle(point.Value.ToSKPoint(), 5, paint);
 
         paint.IsStroke = false;
         paint.Color = paint.Color.WithAlpha(20);

--- a/src/ScottPlot5/ScottPlot5/Extensions/SkiaSharpExtensions.cs
+++ b/src/ScottPlot5/ScottPlot5/Extensions/SkiaSharpExtensions.cs
@@ -9,6 +9,11 @@ public static class SkiaSharpExtensions
         return new PixelSize(rect.Width, rect.Height);
     }
 
+    public static Pixel ToPixel(this SKPoint point)
+    {
+        return new Pixel(point.X, point.Y);
+    }
+
     public static SKTextAlign ToSKTextAlign(this Alignment alignment)
     {
         return alignment switch
@@ -99,5 +104,22 @@ public static class SkiaSharpExtensions
         paint.Color = fontStyle.Color.ToSKColor();
         paint.IsAntialias = fontStyle.AntiAlias;
         paint.FakeBoldText = fontStyle.Bold;
+    }
+
+    /// <summary>
+    /// Create a 1 by 256 bitmap displaying all values of a heatmap
+    /// </summary>
+    public static SKBitmap GetBitmap(this IColormap colormap, bool vertical)
+    {
+        uint[] argbs = Enumerable.Range(0, 256)
+           .Select(i => colormap.GetColor((vertical ? 255 - i : i) / 255f).ARGB)
+           .ToArray();
+
+        int bmpWidth = vertical ? 1 : 256;
+        int bmpHeight = !vertical ? 1 : 256;
+
+        SKBitmap bmp = Drawing.BitmapFromArgbs(argbs, bmpWidth, bmpHeight);
+
+        return bmp;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Interfaces/ILayoutEngine.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/ILayoutEngine.cs
@@ -7,5 +7,5 @@
 /// </summary>
 public interface ILayoutEngine
 {
-    public Layout GetLayout(PixelRect figureRect, IEnumerable<IPanel> panels);
+    public Layout GetLayout(PixelRect figureRect, Plot plot);
 }

--- a/src/ScottPlot5/ScottPlot5/LayoutEngines/Automatic.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutEngines/Automatic.cs
@@ -6,7 +6,7 @@
 /// </summary>
 public class Automatic : LayoutEngineBase, ILayoutEngine
 {
-    public Layout GetLayout(PixelRect figureRect, IEnumerable<IPanel> panels)
+    public Layout GetLayout(PixelRect figureRect, Plot plot)
     {
         /* PROBLEM: There is a chicken-or-egg situation
          * where the ideal layout depends on the ticks,
@@ -18,6 +18,8 @@ public class Automatic : LayoutEngineBase, ILayoutEngine
          * according to the layout determined by this function.
          * 
          */
+
+        IEnumerable<IPanel> panels = plot.Axes.GetPanels();
 
         // NOTE: the actual ticks will be regenerated later, after the layout is determined
         panels.OfType<IXAxis>().ToList().ForEach(x => x.RegenerateTicks(figureRect.Width));

--- a/src/ScottPlot5/ScottPlot5/LayoutEngines/Automatic.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutEngines/Automatic.cs
@@ -1,4 +1,6 @@
-﻿namespace ScottPlot.LayoutEngines;
+﻿using ScottPlot.AxisPanels;
+
+namespace ScottPlot.LayoutEngines;
 
 /// <summary>
 /// Generate the layout by measuring all panels and adding
@@ -6,6 +8,8 @@
 /// </summary>
 public class Automatic : LayoutEngineBase, ILayoutEngine
 {
+    public float SizeForAxisPanelsWithoutData = 10;
+
     public Layout GetLayout(PixelRect figureRect, Plot plot)
     {
         /* PROBLEM: There is a chicken-or-egg situation

--- a/src/ScottPlot5/ScottPlot5/LayoutEngines/FixedDataArea.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutEngines/FixedDataArea.cs
@@ -3,17 +3,13 @@
 /// <summary>
 /// Generate a layout using a fixed rectangle for the data area
 /// </summary>
-public class FixedDataArea : LayoutEngineBase, ILayoutEngine
+public class FixedDataArea(PixelRect dataRect) : LayoutEngineBase, ILayoutEngine
 {
-    private PixelRect DataRect { get; }
+    private PixelRect DataRect { get; } = dataRect;
 
-    public FixedDataArea(PixelRect dataRect)
+    public Layout GetLayout(PixelRect figureRect, Plot plot)
     {
-        DataRect = dataRect;
-    }
-
-    public Layout GetLayout(PixelRect figureRect, IEnumerable<IPanel> panels)
-    {
+        IEnumerable<IPanel> panels = plot.Axes.GetPanels();
         Dictionary<IPanel, float> panelSizes = LayoutEngineBase.MeasurePanels(panels);
         Dictionary<IPanel, float> panelOffsets = GetPanelOffsets(panels, panelSizes);
         return new Layout(figureRect, DataRect, panelSizes, panelOffsets);

--- a/src/ScottPlot5/ScottPlot5/LayoutEngines/FixedPadding.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutEngines/FixedPadding.cs
@@ -3,17 +3,14 @@
 /// <summary>
 /// Generate layouts where the data area has a fixed padding from the edge of the figure
 /// </summary>
-public class FixedPadding : LayoutEngineBase, ILayoutEngine
+public class FixedPadding(PixelPadding padding) : LayoutEngineBase, ILayoutEngine
 {
-    private PixelPadding Padding { get; }
+    private PixelPadding Padding { get; } = padding;
 
-    public FixedPadding(PixelPadding padding)
+    public Layout GetLayout(PixelRect figureRect, Plot plot)
     {
-        Padding = padding;
-    }
+        IEnumerable<IPanel> panels = plot.Axes.GetPanels();
 
-    public Layout GetLayout(PixelRect figureRect, IEnumerable<IPanel> panels)
-    {
         // must recalculate ticks before measuring panels
 
         // NOTE: the actual ticks will be regenerated later, after the layout is determined

--- a/src/ScottPlot5/ScottPlot5/LayoutEngines/MatchedDataRect.cs
+++ b/src/ScottPlot5/ScottPlot5/LayoutEngines/MatchedDataRect.cs
@@ -3,17 +3,13 @@
 /// <summary>
 /// Generate layouts that match layouts of another control
 /// </summary>
-public class MatchedDataRect : LayoutEngineBase, ILayoutEngine
+public class MatchedDataRect(Plot referencePlot) : LayoutEngineBase, ILayoutEngine
 {
-    private Plot ReferencePlot { get; }
+    private Plot ReferencePlot { get; } = referencePlot;
 
-    public MatchedDataRect(Plot referencePlot)
+    public Layout GetLayout(PixelRect figureRect, Plot plot)
     {
-        ReferencePlot = referencePlot;
-    }
-
-    public Layout GetLayout(PixelRect figureRect, IEnumerable<IPanel> panels)
-    {
+        IEnumerable<IPanel> panels = plot.Axes.GetPanels();
         Dictionary<IPanel, float> panelSizes = LayoutEngineBase.MeasurePanels(panels);
         Dictionary<IPanel, float> panelOffsets = GetPanelOffsets(panels, panelSizes);
 

--- a/src/ScottPlot5/ScottPlot5/Panels/ColorBar.cs
+++ b/src/ScottPlot5/ScottPlot5/Panels/ColorBar.cs
@@ -1,39 +1,78 @@
-﻿namespace ScottPlot.Panels;
+﻿using System.Data;
 
-public class ColorBar : IPanel
+namespace ScottPlot.Panels;
+
+/// <summary>
+/// An axis panel which displays a colormap and range of values
+/// </summary>
+public class ColorBar(IHasColorAxis source, Edge edge = Edge.Right) : IPanel
 {
     public bool IsVisible { get; set; } = true;
 
-    public IHasColorAxis Source { get; set; }
+    public IHasColorAxis Source { get; set; } = source;
 
-    public Edge Edge { get; set; }
+    public Edge Edge { get; set; } = edge;
     public float Width { get; set; } = 50;
     public float Margin { get; set; } = 15;
     public bool ShowDebugInformation { get; set; } = false;
     public float MinimumSize { get; set; } = 0;
     public float MaximumSize { get; set; } = float.MaxValue;
 
-    public ColorBar(IHasColorAxis source, Edge edge = Edge.Right)
-    {
-        Source = source;
-        Edge = edge;
-    }
-
-    // Unfortunately the size of the axis depends on the size of the plotting window, so we just have to guess here. 2000 should be larger than most
-    public float Measure() => IsVisible ? Margin + GetAxis(2000).Measure() + Width : 0;
-
-    public PixelRect GetPanelRect(PixelRect dataRect, float size, float offset)
+    public float Measure()
     {
         if (!IsVisible)
-            return PixelRect.Zero;
+            return 0;
 
+        float bitmapAndMarginSize = Width + Margin;
+
+        // use an example DataRect to estimate the size required by the ticks
+        PixelRect guessedDataArea = new(0, 600, 400, 0);
+        IAxis guessAxis = GetAxisWithGeneratedTicks(guessedDataArea);
+        float guessedAxisSize = guessAxis.Measure();
+
+        return bitmapAndMarginSize + guessedAxisSize;
+    }
+
+    /// <summary>
+    /// Return a rectangle encapsulating the colormap
+    /// bitmap plus the axis and ticks.
+    /// </summary>
+    public PixelRect GetPanelRect(PixelRect dataRect, float size, float offset)
+    {
+        // TODO: use size and offset
+        // TODO: include the axis and ticks
+        return GetColormapBitmapRect(dataRect);
+    }
+
+    /// <summary>
+    /// Return the rectangle to the side of the data area
+    /// where the colormap bitmap will be drawn.
+    /// </summary>
+    private PixelRect GetColormapBitmapRect(PixelRect dataRect)
+    {
         return Edge switch
         {
-            Edge.Left => new SKRect(dataRect.Left - Width, dataRect.Top, dataRect.Left, dataRect.Top + dataRect.Height).ToPixelRect(),
-            Edge.Right => new SKRect(dataRect.Right, dataRect.Top, dataRect.Right + Width, dataRect.Top + dataRect.Height).ToPixelRect(),
-            Edge.Bottom => new SKRect(dataRect.Left, dataRect.Bottom, dataRect.Left + dataRect.Width, dataRect.Bottom + Width).ToPixelRect(),
-            Edge.Top => new SKRect(dataRect.Left, dataRect.Top - Width, dataRect.Left + dataRect.Width, dataRect.Top).ToPixelRect(),
-            _ => throw new NotImplementedException()
+            Edge.Left => new(
+                left: dataRect.Left - Width - Margin,
+                right: dataRect.Left - Margin,
+                bottom: dataRect.Bottom,
+                top: dataRect.Top),
+            Edge.Right => new(
+                left: dataRect.Right + Margin,
+                right: dataRect.Right + Width + Margin,
+                bottom: dataRect.Bottom,
+                top: dataRect.Top),
+            Edge.Bottom => new(
+                left: dataRect.Left,
+                right: dataRect.Right,
+                bottom: dataRect.Bottom + Width + Margin,
+                top: dataRect.Bottom + Margin),
+            Edge.Top => new(
+                left: dataRect.Left,
+                right: dataRect.Right,
+                bottom: dataRect.Top - Margin,
+                top: dataRect.Top - Width - Margin),
+            _ => throw new NotImplementedException($"{Edge}")
         };
     }
 
@@ -42,45 +81,25 @@ public class ColorBar : IPanel
         if (!IsVisible)
             return;
 
-        using var _ = new SKAutoCanvasRestore(rp.Canvas);
+        // TODO: use the size and offset to generate the rect
+        RenderColorbarBitmap(rp, size, offset);
+        RenderColorbarAxis(rp, size, offset + Margin);
+    }
 
-        PixelRect panelRect = GetPanelRect(rp.DataRect, size, offset);
+    private void RenderColorbarBitmap(RenderPack rp, float size, float offset)
+    {
+        PixelRect colormapRect = GetPanelRect(rp.DataRect, size, offset);
+        using SKBitmap bmp = Source.Colormap.GetBitmap(Edge.IsVertical());
+        rp.Canvas.DrawBitmap(bmp, colormapRect.ToSKRect());
+    }
 
-        SKPoint marginTranslation = GetTranslation(Margin);
-        SKPoint axisTranslation = GetTranslation(Width);
-
-        using var bmp = GetBitmap();
-
-        rp.Canvas.Translate(marginTranslation);
-        rp.Canvas.DrawBitmap(bmp, panelRect.ToSKRect());
-
-        var colorbarLength = Edge.IsVertical() ? rp.DataRect.Height : rp.DataRect.Width;
-        var axis = GetAxis(colorbarLength);
-
-        rp.Canvas.Translate(axisTranslation);
+    private void RenderColorbarAxis(RenderPack rp, float size, float offset)
+    {
+        IAxis axis = GetAxisWithGeneratedTicks(rp.DataRect);
         axis.Render(rp, size, offset);
     }
 
-    private SKPoint GetTranslation(float magnitude) => Edge switch
-    {
-        Edge.Left => new(-magnitude, 0),
-        Edge.Right => new(magnitude, 0),
-        Edge.Bottom => new(0, magnitude),
-        Edge.Top => new(0, -magnitude),
-        _ => throw new ArgumentOutOfRangeException(nameof(Edge))
-    };
-
-    private SKBitmap GetBitmap()
-    {
-        uint[] argbs = Enumerable.Range(0, 256).Select(i => Source.Colormap.GetColor((Edge.IsVertical() ? 255 - i : i) / 255f).ARGB).ToArray();
-
-        int bmpWidth = Edge.IsVertical() ? 1 : 256;
-        int bmpHeight = !Edge.IsVertical() ? 1 : 256;
-
-        return Drawing.BitmapFromArgbs(argbs, bmpWidth, bmpHeight);
-    }
-
-    private IAxis GetAxis(float length)
+    private IAxis GetAxisWithGeneratedTicks(PixelRect dataRect)
     {
         IAxis axis = Edge switch
         {
@@ -88,16 +107,18 @@ public class ColorBar : IPanel
             Edge.Right => new AxisPanels.RightAxis(),
             Edge.Bottom => new AxisPanels.BottomAxis(),
             Edge.Top => new AxisPanels.TopAxis(),
-            _ => throw new ArgumentOutOfRangeException(nameof(Edge))
+            _ => throw new NotImplementedException(nameof(Edge))
         };
 
-        axis.Label.Text = "";
-
-        var range = Source.GetRange();
+        Range range = Source.GetRange();
         axis.Min = range.Min;
         axis.Max = range.Max;
 
-        axis.RegenerateTicks(length);
+        float edgeLength = Edge.IsVertical()
+            ? dataRect.Height
+            : dataRect.Width;
+
+        axis.RegenerateTicks(edgeLength);
 
         return axis;
     }

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -5,7 +5,6 @@ using ScottPlot.Legends;
 using ScottPlot.Primitives;
 using ScottPlot.Rendering;
 using ScottPlot.Stylers;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace ScottPlot;
 

--- a/src/ScottPlot5/ScottPlot5/Primitives/PixelRect.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/PixelRect.cs
@@ -115,6 +115,20 @@ public readonly struct PixelRect : IEquatable<PixelRect>
         return Contract(-delta);
     }
 
+    public PixelRect ExpandX(float x)
+    {
+        float left = Math.Min(Left, x);
+        float right = Math.Max(Right, x);
+        return new PixelRect(left, right, Bottom, Top);
+    }
+
+    public PixelRect ExpandY(float y)
+    {
+        float top = Math.Min(Top, y);
+        float bottom = Math.Max(Bottom, y);
+        return new PixelRect(Left, Right, bottom, top);
+    }
+
     // TODO: use operator logic?
     public PixelRect WithDelta(float x, float y)
     {

--- a/src/ScottPlot5/ScottPlot5/RenderPack.cs
+++ b/src/ScottPlot5/ScottPlot5/RenderPack.cs
@@ -5,59 +5,33 @@
 /// and is passed throughout the render system to provide
 /// screen and canvas information to methods performing rendering.
 /// </summary>
-public class RenderPack
+public class RenderPack(Plot plot, PixelRect figureRect, SKCanvas canvas)
 {
-    public SKCanvas Canvas { get; }
-    public CanvasState CanvasState { get; }
-    public PixelRect FigureRect { get; }
+    public SKCanvas Canvas { get; } = canvas;
+    public CanvasState CanvasState { get; } = new(canvas);
+    public PixelRect FigureRect { get; } = figureRect;
     public PixelRect DataRect { get; private set; }
     public Layout Layout { get; private set; }
-    public Plot Plot { get; }
-    private Stopwatch Stopwatch { get; }
+    public Plot Plot { get; } = plot;
+    private Stopwatch Stopwatch { get; } = Stopwatch.StartNew();
     public TimeSpan Elapsed => Stopwatch.Elapsed;
 
     /// <summary>
-    /// This object is passed through the render system.
-    /// The plot will be drawn on the canvas to create a figure of the given size.
+    /// Uses the layout engine to measure panels and set the
+    /// Layout and DataRect for this render pack
     /// </summary>
-    public RenderPack(Plot plot, PixelRect figureRect, SKCanvas canvas)
-    {
-        Canvas = canvas;
-        CanvasState = new(canvas);
-        FigureRect = figureRect;
-        Plot = plot;
-        Stopwatch = Stopwatch.StartNew();
-    }
-
-    public void CalculateLayout()
+    internal void CalculateLayout()
     {
         if (DataRect.HasArea)
-            throw new InvalidOperationException("DataRect must only be calculated once per render");
+            throw new InvalidOperationException("CalculateLayout() must only be called once per render");
 
-        PixelRect scaledRect = new(
+        PixelRect scaledFigureRect = new(
             left: FigureRect.Left / Plot.ScaleFactorF,
             right: FigureRect.Right / Plot.ScaleFactorF,
             bottom: FigureRect.Bottom / Plot.ScaleFactorF,
             top: FigureRect.Top / Plot.ScaleFactorF);
 
-        Layout = Plot.Layout.LayoutEngine.GetLayout(scaledRect, Plot.Axes.GetPanels());
+        Layout = Plot.Layout.LayoutEngine.GetLayout(scaledFigureRect, Plot);
         DataRect = Layout.DataRect;
-    }
-
-    public override string ToString()
-    {
-        return $"RenderPack FigureRect={FigureRect} DataRect={DataRect}";
-    }
-
-    [Obsolete("Call CanvasState.Clip() instead", true)]
-    public void ClipToDataArea()
-    {
-        CanvasState.Clip(DataRect);
-    }
-
-    [Obsolete("Call CanvasState.DisableClipping() instead", true)]
-    public void DisableClipping()
-    {
-        CanvasState.DisableClipping();
     }
 }


### PR DESCRIPTION
Addresses:
* #3294 
* #3560 
* #3586
* #3608 

```cs
double[,] data = SampleData.MonaLisa();

var hm1 = myPlot.Add.Heatmap(data);
hm1.Extent = new(0, 1, 0, 1);
hm1.Colormap = new ScottPlot.Colormaps.Turbo();
myPlot.Add.ColorBar(hm1);

var hm2 = myPlot.Add.Heatmap(data);
hm2.Extent = new(1.5, 2.5, 0, 1);
hm2.Colormap = new ScottPlot.Colormaps.Viridis();
myPlot.Add.ColorBar(hm2);
```

![image](https://github.com/ScottPlot/ScottPlot/assets/4165489/8632e6c5-05c7-4c6e-9355-5140e2e42220)
