### PR TITLE
AxisLines: Allow them to be excluded from the legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 _Not yet on NuGet..._
 * Function: Improved autoscaling behavior and respect for user-defined horizontal ranges (#3618) @Matthew-Chidlow  
 * Function: Exposed `MinX` and `MaxX` to allow users to restrict display to a horizontal range (#3595, #3603) @Matthew-Chidlow @Dibyanshuaman
+* Axis Lines: Added `ExcludeFromLegend` so text can be added to axis line labels without appearing in the legend (#3612) @MCF
 
 ## ScottPlot 5.0.25
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-04-08_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/AxisLines.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/AxisLines.cs
@@ -84,4 +84,36 @@ public class AxisLines : ICategory
             hl2.LinePattern = LinePattern.DenselyDashed;
         }
     }
+
+    public class AxisLineInLegend : RecipeBase
+    {
+        public override string Name => "Axis Line In Legend";
+        public override string Description => "Axis lines will be added to the legend if their " +
+            "Text property is set unless their ExcludeFromLegend property is true.";
+
+        [Test]
+        public override void Execute()
+        {
+            myPlot.Add.Signal(Generate.Sin());
+            myPlot.Add.Signal(Generate.Cos());
+
+            var axLine1 = myPlot.Add.VerticalLine(24);
+            axLine1.Text = "Line 1";
+
+            var axLine2 = myPlot.Add.HorizontalLine(0.75);
+
+            var axLine3 = myPlot.Add.VerticalLine(37);
+            axLine3.Text = "Line 3";
+            axLine3.ExcludeFromLegend = true;
+
+            var axLine4 = myPlot.Add.HorizontalLine(0.25);
+            axLine4.Text = "Line 4";
+
+            var axLine5 = myPlot.Add.HorizontalLine(-.75);
+            axLine5.Text = "Line 5";
+            axLine5.ExcludeFromLegend = true;
+
+            myPlot.ShowLegend();
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
@@ -42,9 +42,8 @@ public abstract class AxisLine : IPlottable, IRenderLast
         {
             return LegendItem.Single(new LegendItem()
             {
-                Label = Label.Text,
+                Label = ExcludeFromLegend ? string.Empty : Label.Text,
                 Line = LineStyle,
-                IsVisible = !ExcludeFromLegend,
             });
         }
     }

--- a/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
@@ -22,6 +22,8 @@ public abstract class AxisLine : IPlottable, IRenderLast
 
     public bool IsDraggable { get; set; } = false;
 
+    public bool ExcludeFromLegend { get; set; } = false;
+
     public Color Color
     {
         get => LineStyle.Color;
@@ -42,6 +44,7 @@ public abstract class AxisLine : IPlottable, IRenderLast
             {
                 Label = Label.Text,
                 Line = LineStyle,
+                IsVisible = !ExcludeFromLegend,
             });
         }
     }


### PR DESCRIPTION
If an AxisLine (horizontal or vertical) has its Text property set it would always be included in any legend - both the automatic or manually built legends. The Text property is also used to display the text along the appropriate axis for the line so it is a valid use case to want the Text set but not add the line to the legend.

This change adds an ExcludeFromLegend property to the AxisLine base class which defaults to false (no change to current default behavior). Setting this property to true keeps the line out of the legend regardless of the Text property being set or not.

A cookbook recipe was added demonstrating how the AxisLines and legend work together.  The recipe code and result is shown below.

```cs
myPlot.Add.Signal(Generate.Sin());
myPlot.Add.Signal(Generate.Cos());

var axLine1 = myPlot.Add.VerticalLine(24);
axLine1.Text = "Line 1";

var axLine2 = myPlot.Add.HorizontalLine(0.75);

var axLine3 = myPlot.Add.VerticalLine(37);
axLine3.Text = "Line 3";
axLine3.ExcludeFromLegend = true;

var axLine4 = myPlot.Add.HorizontalLine(0.25);
axLine4.Text = "Line 4";

var axLine5 = myPlot.Add.HorizontalLine(-.75);
axLine5.Text = "Line 5";
axLine5.ExcludeFromLegend = true;

myPlot.ShowLegend();
```

![AxisLineInLegend](https://github.com/ScottPlot/ScottPlot/assets/223530/f93c55ad-4ba4-4ce8-99bf-20965141ace6)
