### PR TITLE
SP5 / WpfPlot: simplify mouse coordinate with display scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ _Not yet on NuGet..._
 * Function: Improved autoscaling behavior and respect for user-defined horizontal ranges (#3618) @Matthew-Chidlow  
 * Function: Exposed `MinX` and `MaxX` to allow users to restrict display to a horizontal range (#3595, #3603) @Matthew-Chidlow @Dibyanshuaman
 * Axis Lines: Added `ExcludeFromLegend` so text can be added to axis line labels without appearing in the legend (#3612) @MCF
+* WPF: Added `GetPlotPixelPosition()` for getting mouse position relative to the figure (#3622) @KroMignon
 
 ## ScottPlot 5.0.25
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-04-08_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlot.cs
@@ -11,6 +11,7 @@ namespace ScottPlot.WPF
         private const string PART_SKElement = "PART_SKElement";
 
         private SkiaSharp.Views.WPF.SKElement? SKElement;
+        protected override FrameworkElement PlotFrameworkElement => SKElement!;
 
         public override GRContext GRContext => null!;
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotBase.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotBase.cs
@@ -19,6 +19,10 @@ namespace ScottPlot.WPF
         public float DisplayScale { get; set; }
         public IPlotMenu Menu { get; set; }
 
+        /// <summary>
+        /// Framework element used to show the resulting plot
+        /// </summary>
+        protected abstract FrameworkElement PlotFrameworkElement { get; }
         static WpfPlotBase()
         {
             DefaultStyleKeyProperty.OverrideMetadata(
@@ -67,7 +71,7 @@ namespace ScottPlot.WPF
         {
             Keyboard.Focus(this);
 
-            Interaction.MouseDown(e.Pixel(this), e.ToButton());
+            Interaction.MouseDown(e.Pixel(PlotFrameworkElement), e.ToButton());
 
             (sender as UIElement)?.CaptureMouse();
 
@@ -79,18 +83,18 @@ namespace ScottPlot.WPF
 
         internal void SKElement_MouseUp(object? sender, System.Windows.Input.MouseButtonEventArgs e)
         {
-            Interaction.MouseUp(e.Pixel(this), e.ToButton());
+            Interaction.MouseUp(e.Pixel(PlotFrameworkElement), e.ToButton());
             (sender as UIElement)?.ReleaseMouseCapture();
         }
 
         internal void SKElement_MouseMove(object? sender, MouseEventArgs e)
         {
-            Interaction.OnMouseMove(e.Pixel(this));
+            Interaction.OnMouseMove(e.Pixel(PlotFrameworkElement));
         }
 
         internal void SKElement_MouseWheel(object? sender, System.Windows.Input.MouseWheelEventArgs e)
         {
-            Interaction.MouseWheelVertical(e.Pixel(this), e.Delta);
+            Interaction.MouseWheelVertical(e.Pixel(PlotFrameworkElement), e.Delta);
         }
 
         internal void SKElement_KeyDown(object? sender, KeyEventArgs e)
@@ -106,6 +110,24 @@ namespace ScottPlot.WPF
         public float DetectDisplayScale()
         {
             return (float)VisualTreeHelper.GetDpi(this).DpiScaleX;
+        }
+
+        /// <summary>
+        /// Returns the position of the mouse pointer relative to Plot drawing surface.
+        /// </summary>
+        /// <param name="e">Provides data for mouse related routed events</param>
+        /// <returns>The x and y coordinates in pixel of the mouse pointer position relative to Plot. The point (0,0) is the upper-left corner of the plot.</returns>
+        public Pixel GetPlotPixelPosition(MouseEventArgs e)
+        {
+            return e.Pixel(PlotFrameworkElement);
+        }
+        /// <summary>
+        /// Returns the current position of the mouse pointer relative to Plot drawing surface
+        /// </summary>
+        /// <returns>The x and y coordinates in pixel of the mouse pointer position relative to Plot. The point (0,0) is the upper-left corner of the plot.</returns>
+        public Pixel GetCurrentPlotPixelPosition()
+        {
+            return PlotFrameworkElement.Pixel(Mouse.GetPosition(PlotFrameworkElement));
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotExtensions.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotExtensions.cs
@@ -10,12 +10,14 @@ namespace ScottPlot.WPF;
 
 internal static class WpfPlotExtensions
 {
-    internal static Pixel Pixel(this MouseEventArgs e, WpfPlotBase plot)
+    internal static Pixel Pixel(this MouseEventArgs e, FrameworkElement fe)
     {
-        DpiScale dpiScale = VisualTreeHelper.GetDpi(plot);
-        double x = e.GetPosition(plot).X * dpiScale.DpiScaleX;
-        double y = e.GetPosition(plot).Y * dpiScale.DpiScaleY;
-        return new Pixel((float)x, (float)y);
+        return fe.Pixel(e.GetPosition(fe));
+    }
+    internal static Pixel Pixel(this FrameworkElement fe, Point position)
+    {
+        DpiScale dpiScale = VisualTreeHelper.GetDpi(fe);
+        return new Pixel((float)(position.X * dpiScale.DpiScaleX), (float)(position.Y * dpiScale.DpiScaleY));
     }
 
     internal static Control.MouseButton ToButton(this MouseButtonEventArgs e)

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotGL.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotGL.cs
@@ -12,6 +12,7 @@ public class WpfPlotGL : WpfPlotBase
 
     private SkiaSharp.Views.WPF.SKGLElement? SKElement;
 
+    protected override FrameworkElement PlotFrameworkElement => SKElement!;
     public override GRContext GRContext => SKElement?.GRContext ?? GRContext.CreateGl();
 
     static WpfPlotGL()


### PR DESCRIPTION
Mouse interaction with `ScottPlot` 5 WPF control is not very user friendly.

There are some internals to know:
- the WPF control is a **Custom Control** to allow customization via a user define style
- the style must contains an item called `PART_SKElement`. For "standard" SkiaSharp it must be a `SKElement`, and for the OpenGL version it must be a `SKGLElement`.
- the plot rendered output will be draw on `PART_SKElement`. So if the style do not contain it, there will be nothing visible for the user.
- as the style can be customized, the origin of `PART_SKElement` may not be the upper left corner of the WPF control

Because this maybe very confusing for the control user, I have updated the SP5 WPF control to:
- use `PART_SKElement` as reference to calculate mouse pixel position on plot rendering
- add helper methods to get mouse position on rendered plot which also take active scaling factor in account

This should partially fix issues #3585, #3622, #3469 and #3465

This methods can than be used in C# code for example to show the crosshair like this in the WPF Sandbox App:

```cs
public partial class MainWindow : Window
{
    readonly ScottPlot.Plottables.Crosshair Crosshair;
    public MainWindow()
    {
        InitializeComponent();
        WpfPlot1.Plot.Add.Signal(Generate.Sin());
        Crosshair = WpfPlot1.Plot.Add.Crosshair(0, 0);
        Crosshair.IsVisible = false;
        WpfPlot1.MouseEnter += (o, e) =>
        {
            if (Crosshair?.IsVisible == false)
            {
                Crosshair.IsVisible = true;
                WpfPlot1.Refresh();
            }
        };
        WpfPlot1.MouseLeave += (o, e) =>
        {
            if (Crosshair?.IsVisible == true)
            {
                Crosshair.IsVisible = false;
                WpfPlot1.Refresh();
            }
        };
        WpfPlot1.MouseMove += (o, e) =>
        {
            if (Crosshair is not null)
            {
                var p = WpfPlot1.GetPlotPixelPosition(e);
                var mouseCord = WpfPlot1.Plot.GetCoordinates(p, Crosshair.Axes.XAxis, Crosshair.Axes.YAxis);

                if (mouseCord.AreReal)
                {
                    Crosshair.IsVisible = true;
                    Crosshair.Position = mouseCord;
                    WpfPlot1.Refresh();
                }
                else if (Crosshair.IsVisible)
                {
                    Crosshair.IsVisible = false;
                    WpfPlot1.Refresh();
                }
            }
        };
    }
}
```