### PR TITLE
Scatter: Add cubic spline interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ _Not yet on NuGet..._
 * Function: Exposed `MinX` and `MaxX` to allow users to restrict display to a horizontal range (#3595, #3603) @Matthew-Chidlow @Dibyanshuaman
 * Axis Lines: Added `ExcludeFromLegend` so text can be added to axis line labels without appearing in the legend (#3612) @MCF
 * WPF: Added `GetPlotPixelPosition()` for getting mouse position relative to the figure (#3622) @KroMignon
+* Scatter: Upgraded the default smooth behavior to use cubic spline interpolation (#3623, #3606, #3274, #3566) @drolevar
 
 ## ScottPlot 5.0.25
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-04-08_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Scatter.cs
@@ -276,7 +276,8 @@ public class Scatter : ICategory
         public override string Name => "Scatter Plot with Smooth Lines";
         public override string Description => "Scatter plots draw straight lines " +
             "between points by default, but setting the Smooth property allows the " +
-            "scatter plot to connect points with smooth lines.";
+            "scatter plot to connect points with smooth lines. Lines are smoothed " +
+            "using cubic spline interpolation.";
 
         [Test]
         public override void Execute()
@@ -288,28 +289,62 @@ public class Scatter : ICategory
             sp.Smooth = true;
             sp.Label = "Smooth";
             sp.LineWidth = 2;
-            sp.MarkerSize = 7;
+            sp.MarkerSize = 10;
         }
     }
 
-    public class ScatterSpline : RecipeBase
+    public class ScatterSmoothTension : RecipeBase
     {
-        public override string Name => "Scatter Plot with Cubic Spline Interpolation";
-        public override string Description => "Scatter plots draw straight lines " +
-            "between points by default, but setting the PathStrategy property to CubicSpline " +
-            "allows the scatter plot to connect points with smooth lines.";
+        public override string Name => "Smooth Line Tension";
+        public override string Description => "Tension of smooth lines can be " +
+            "adjusted for the CubicSpline path strategy. " +
+            "Low tensions lead to 'overshoot' and high tensions produce curves" +
+            "which appear more like straight lines.";
 
         [Test]
         public override void Execute()
         {
-            double[] xs = { -2, -3, -5, -3, 0, 3, 5, 3, 2, -2 };
-            double[] ys = { 0, -1, 0, 4, 4, 4, 0, -1, 0, 0 };
+            double[] xs = Generate.RandomWalk(10);
+            double[] ys = Generate.RandomWalk(10);
+
+            var mk = myPlot.Add.Markers(xs, ys);
+            mk.MarkerShape = MarkerShape.OpenCircle;
+            mk.Color = Colors.Black;
+
+            double[] tensions = { 2, 3, 6, 20 };
+
+            foreach (double tension in tensions)
+            {
+                ScottPlot.PathStrategies.CubicSpline cubic = new() { Tension = tension };
+
+                var sp = myPlot.Add.ScatterLine(xs, ys);
+                sp.PathStrategy = cubic;
+                sp.Label = $"Tension {tension}";
+                sp.LineWidth = 2;
+            }
+
+            myPlot.ShowLegend(Alignment.UpperLeft);
+        }
+    }
+
+    public class ScatterQuad : RecipeBase
+    {
+        public override string Name => "Smooth Scatter without Overshoot";
+        public override string Description => "The quadratic half point path strategy " +
+            "allows scatter plots to be displayed with smooth lines connecting points, but " +
+            "lines are eased in and out of points so they never 'overshoot' the values vertically.";
+
+        [Test]
+        public override void Execute()
+        {
+            double[] xs = Generate.Consecutive(10);
+            double[] ys = Generate.RandomSample(10, 5, 15);
 
             var sp = myPlot.Add.Scatter(xs, ys);
-            sp.PathStrategy = new ScottPlot.PathStrategies.CubicSpline();
-            sp.Label = "Spline";
+            sp.PathStrategy = new ScottPlot.PathStrategies.QuadHalfPoint();
+            sp.Label = "Smooth";
             sp.LineWidth = 2;
-            sp.MarkerSize = 7;
+            sp.MarkerSize = 10;
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Scatter.cs
@@ -292,6 +292,27 @@ public class Scatter : ICategory
         }
     }
 
+    public class ScatterSpline : RecipeBase
+    {
+        public override string Name => "Scatter Plot with Cubic Spline Interpolation";
+        public override string Description => "Scatter plots draw straight lines " +
+            "between points by default, but setting the PathStrategy property to CubicSpline " +
+            "allows the scatter plot to connect points with smooth lines.";
+
+        [Test]
+        public override void Execute()
+        {
+            double[] xs = { -2, -3, -5, -3, 0, 3, 5, 3, 2, -2 };
+            double[] ys = { 0, -1, 0, 4, 4, 4, 0, -1, 0, 0 };
+
+            var sp = myPlot.Add.Scatter(xs, ys);
+            sp.PathStrategy = new ScottPlot.PathStrategies.CubicSpline();
+            sp.Label = "Spline";
+            sp.LineWidth = 2;
+            sp.MarkerSize = 7;
+        }
+    }
+
     public class ScatterLimitIndex : RecipeBase
     {
         public override string Name => "Limiting Display with Render Indexes";

--- a/src/ScottPlot5/ScottPlot5/PathStrategies/CubicSpline.cs
+++ b/src/ScottPlot5/ScottPlot5/PathStrategies/CubicSpline.cs
@@ -1,0 +1,53 @@
+﻿namespace ScottPlot.PathStrategies;
+
+using System.Linq;
+
+/// <summary>
+/// Connect points with Catmull-Rom cubic splines, see https://doi.org/10.1007/s42979-021-00770-x
+/// NaN values will be skipped, producing a gap in the path.
+/// </summary>
+public class CubicSpline : IPathStrategy
+{
+    public SKPath GetPath(IEnumerable<Pixel> pixels)
+    {
+        SKPath path = new();
+
+        // Organize into groups of connected points
+        IEnumerable<IEnumerable<Pixel>> segments = pixels.GroupBy(pixel => float.IsNaN(pixel.X) || float.IsNaN(pixel.Y))
+                                                         .Where(group => group.Key == false);
+
+        foreach (var segment in segments.Where(segment => segment.Take(2).Count() == 2))
+        {
+            // Reserve two empty elements at the front and at the back
+            Pixel[] array = EnumerableExtensions.One(Pixel.NaN).Concat(segment)
+                                                               .Concat(EnumerableExtensions.One(Pixel.NaN))
+                                                               .ToArray();
+
+            Pixel first = array[1];
+            Pixel second = array[2];
+            Pixel nextLast = array[array.Length - 3];
+            Pixel last = array[array.Length - 2];
+
+            bool closed = first == last;
+
+            array[0] = closed ? nextLast : first - (second - first);
+            array[array.Length - 1] = closed ? second : last + (last - nextLast);
+
+            path.MoveTo(first.ToSKPoint());
+
+            for (int i = 2; i < array.Length - 1; ++i)
+            {
+                Pixel p0 = array[i - 2];
+                Pixel p1 = array[i - 1];
+                Pixel p2 = array[i];
+                Pixel p3 = array[i + 1];
+                Pixel c1 = p1 + (p2 - p0) / 6.0f;
+                Pixel c2 = p2 - (p3 - p1) / 6.0f;
+
+                path.CubicTo(c1.ToSKPoint(), c2.ToSKPoint(), p2.ToSKPoint());
+            }
+        }
+
+        return path;
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/PathStrategies/CubicSpline.cs
+++ b/src/ScottPlot5/ScottPlot5/PathStrategies/CubicSpline.cs
@@ -8,6 +8,8 @@ using System.Linq;
 /// </summary>
 public class CubicSpline : IPathStrategy
 {
+    public double Tension = 6;
+
     public SKPath GetPath(IEnumerable<Pixel> pixels)
     {
         SKPath path = new();
@@ -41,8 +43,8 @@ public class CubicSpline : IPathStrategy
                 Pixel p1 = array[i - 1];
                 Pixel p2 = array[i];
                 Pixel p3 = array[i + 1];
-                Pixel c1 = p1 + (p2 - p0) / 6.0f;
-                Pixel c2 = p2 - (p3 - p1) / 6.0f;
+                Pixel c1 = p1 + (p2 - p0) / (float)Tension;
+                Pixel c2 = p2 - (p3 - p1) / (float)Tension;
 
                 path.CubicTo(c1.ToSKPoint(), c2.ToSKPoint(), p2.ToSKPoint());
             }

--- a/src/ScottPlot5/ScottPlot5/Plottables/Markers.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Markers.cs
@@ -11,6 +11,7 @@ public class Markers(IScatterSource data) : IPlottable
     public IScatterSource Data { get; } = data;
 
     public float MarkerSize { get => MarkerStyle.Size; set => MarkerStyle.Size = value; }
+    public MarkerShape MarkerShape { get => MarkerStyle.Shape; set => MarkerStyle.Shape = value; }
 
     public Color Color
     {

--- a/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
@@ -16,6 +16,7 @@ public class Scatter(IScatterSource data) : IPlottable
     public LinePattern LinePattern { get => LineStyle.Pattern; set => LineStyle.Pattern = value; }
     public float LineWidth { get => LineStyle.Width; set => LineStyle.Width = value; }
     public float MarkerSize { get => MarkerStyle.Size; set => MarkerStyle.Size = value; }
+    public MarkerShape MarkerShape { get => MarkerStyle.Shape; set => MarkerStyle.Shape = value; }
 
     /// <summary>
     /// The style of lines to use when connecting points.
@@ -30,7 +31,7 @@ public class Scatter(IScatterSource data) : IPlottable
         set
         {
             PathStrategy = value
-                ? new PathStrategies.QuadHalfPoint()
+                ? new PathStrategies.CubicSpline()
                 : new PathStrategies.Straight();
         }
     }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Pixel.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Pixel.cs
@@ -97,4 +97,14 @@ public struct Pixel : IEquatable<Pixel>
     {
         return new Pixel(a.X - b.X, a.Y - b.Y);
     }
+
+    public static Pixel operator *(Pixel a, float b)
+    {
+        return new Pixel(a.X * b, a.Y * b);
+    }
+
+    public static Pixel operator /(Pixel a, float b)
+    {
+        return new Pixel(a.X / b, a.Y / b);
+    }
 }


### PR DESCRIPTION
Implement cubic spline interpolation.

Catmull-rom splines are converted to Bezier curves according to this article:
https://link.springer.com/article/10.1007/s42979-021-00770-x