### PR TITLE
Vector Field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ _Not yet on NuGet..._
 * Axis Lines: Added `ExcludeFromLegend` so text can be added to axis line labels without appearing in the legend (#3612) @MCF
 * WPF: Added `GetPlotPixelPosition()` for getting mouse position relative to the figure (#3622) @KroMignon
 * Scatter: Upgraded the default smooth behavior to use cubic spline interpolation (#3623, #3606, #3274, #3566) @drolevar
+* Vector Field: Added a new plot type to display a collection of rooted vectors (#3625, #3626) @bclehmann
 
 ## ScottPlot 5.0.25
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-04-08_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/VectorField.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/VectorField.cs
@@ -1,0 +1,43 @@
+﻿namespace ScottPlotCookbook.Recipes.PlotTypes;
+
+public class VectorField : ICategory
+{
+    public string Chapter => "Plot Types";
+    public string CategoryName => "Vector Field";
+    public string CategoryDescription => "Vector fields display a collection of " +
+        "vectors rooted at points in coordinate space";
+
+    public class VectorFieldQuickstart : RecipeBase
+    {
+        public override string Name => "Vector Field Quickstart";
+        public override string Description => "Vectors.";
+
+        [Test]
+        public override void Execute()
+        {
+            List<RootedCoordinateVector> vectors = new();
+
+            // generate a grid of positions
+            double[] xs = Generate.Consecutive(10);
+            double[] ys = Generate.Consecutive(10);
+
+            // add a vector rooted at each position on the grid
+            for (int i = 0; i < xs.Length; i++)
+            {
+                for (int j = 0; j < ys.Length; j++)
+                {
+                    float dX = (float)ys[j];
+                    float dY = -9.81f / 0.5f * (float)Math.Sin(xs[i]);
+                    System.Numerics.Vector2 v = new(dX, dY);
+                    Coordinates pt = new(xs[i], ys[j]);
+                    RootedCoordinateVector vector = new(pt, v);
+                    vectors.Add(vector);
+                }
+            }
+
+            ScottPlot.DataSources.VectorFieldDataSourceCoordinatesList vs = new(vectors);
+            ScottPlot.Plottables.VectorField field = new(vs);
+            myPlot.PlottableList.Add(field);
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/VectorField.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/VectorField.cs
@@ -15,29 +15,32 @@ public class VectorField : ICategory
         [Test]
         public override void Execute()
         {
-            List<RootedCoordinateVector> vectors = new();
-
             // generate a grid of positions
             double[] xs = Generate.Consecutive(10);
             double[] ys = Generate.Consecutive(10);
 
-            // add a vector rooted at each position on the grid
+            // create a collection of vectors
+            List<RootedCoordinateVector> vectors = new();
             for (int i = 0; i < xs.Length; i++)
             {
                 for (int j = 0; j < ys.Length; j++)
                 {
+                    // point on the grid
+                    Coordinates pt = new(xs[i], ys[j]);
+
+                    // direction & magnitude
                     float dX = (float)ys[j];
                     float dY = -9.81f / 0.5f * (float)Math.Sin(xs[i]);
                     System.Numerics.Vector2 v = new(dX, dY);
-                    Coordinates pt = new(xs[i], ys[j]);
+
+                    // add to the collection
                     RootedCoordinateVector vector = new(pt, v);
                     vectors.Add(vector);
                 }
             }
 
-            ScottPlot.DataSources.VectorFieldDataSourceCoordinatesList vs = new(vectors);
-            ScottPlot.Plottables.VectorField field = new(vs);
-            myPlot.PlottableList.Add(field);
+            // plot the collection of rooted vectors as a vector field
+            myPlot.Add.VectorField(vectors);
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Tests/CodeTests/ForbiddenCodeTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/CodeTests/ForbiddenCodeTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Reflection;
+using System.Text;
 
 namespace ScottPlotTests.CodeTests;
 
@@ -44,5 +45,15 @@ internal class ForbiddenCodeTests
             $"Call RenderPack.CanvasState Save() and Restore() instead." +
             $"{offences} offences:\n" +
             $"{errorMessages}");
+    }
+
+    [Test]
+    public void Test_PrimitivesNamespace_IsNeverUsed()
+    {
+        Assembly.GetAssembly(typeof(Plot))!
+            .GetTypes()
+            .Where(x => x.Namespace is not null && x.Namespace.Contains("ScottPlot.Primitives"))
+            .ToList()
+            .ForEach(t => Assert.Fail($"{t.Name} should be in the namespace ScottPlot (not ScottPlot.Primitives)"));
     }
 }

--- a/src/ScottPlot5/ScottPlot5/DataSources/VectorFieldDataSourceCoordinatesList.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/VectorFieldDataSourceCoordinatesList.cs
@@ -1,10 +1,4 @@
 ﻿using ScottPlot.Interfaces;
-using ScottPlot.Primitives;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ScottPlot.DataSources;
 
@@ -28,7 +22,7 @@ public class VectorFieldDataSourceCoordinatesList(IList<RootedCoordinateVector> 
     public AxisLimits GetLimits()
     {
         ExpandingAxisLimits limits = new();
-        limits.Expand(RootedVectors.Select(v => v.Tail).Skip(MinRenderIndex).Take(RenderIndexCount));
+        limits.Expand(RootedVectors.Select(v => v.Point).Skip(MinRenderIndex).Take(RenderIndexCount));
         return limits.AxisLimits;
     }
 
@@ -55,15 +49,15 @@ public class VectorFieldDataSourceCoordinatesList(IList<RootedCoordinateVector> 
         for (int i2 = 0; i2 < RenderIndexCount; i2++)
         {
             int i = MinRenderIndex + i2;
-            double dX = (RootedVectors[i].Tail.X - mouseLocation.X) * renderInfo.PxPerUnitX;
-            double dY = (RootedVectors[i].Tail.Y - mouseLocation.Y) * renderInfo.PxPerUnitY;
+            double dX = (RootedVectors[i].Point.X - mouseLocation.X) * renderInfo.PxPerUnitX;
+            double dY = (RootedVectors[i].Point.Y - mouseLocation.Y) * renderInfo.PxPerUnitY;
             double distanceSquared = dX * dX + dY * dY;
 
             if (distanceSquared <= closestDistanceSquared)
             {
                 closestDistanceSquared = distanceSquared;
-                closestX = RootedVectors[i].Tail.X;
-                closestY = RootedVectors[i].Tail.Y;
+                closestX = RootedVectors[i].Point.X;
+                closestY = RootedVectors[i].Point.Y;
                 closestIndex = i;
             }
         }

--- a/src/ScottPlot5/ScottPlot5/DataSources/VectorFieldDataSourceCoordinatesList.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/VectorFieldDataSourceCoordinatesList.cs
@@ -1,0 +1,75 @@
+﻿using ScottPlot.Interfaces;
+using ScottPlot.Primitives;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.DataSources;
+
+public class VectorFieldDataSourceCoordinatesList(IList<RootedCoordinateVector> rootedVectors) : IVectorFieldSource
+{
+    private readonly IList<RootedCoordinateVector> RootedVectors = rootedVectors;
+
+    public int MinRenderIndex { get; set; } = 0;
+    public int MaxRenderIndex { get; set; } = int.MaxValue;
+    private int RenderIndexCount => Math.Min(RootedVectors.Count - 1, MaxRenderIndex) - MinRenderIndex + 1;
+
+
+    public IReadOnlyList<RootedCoordinateVector> GetRootedVectors()
+    {
+        return RootedVectors
+            .Skip(MinRenderIndex)
+            .Take(RenderIndexCount)
+            .ToList();
+    }
+
+    public AxisLimits GetLimits()
+    {
+        ExpandingAxisLimits limits = new();
+        limits.Expand(RootedVectors.Select(v => v.Tail).Skip(MinRenderIndex).Take(RenderIndexCount));
+        return limits.AxisLimits;
+    }
+
+    public CoordinateRange GetLimitsX()
+    {
+        return GetLimits().Rect.XRange;
+    }
+
+    public CoordinateRange GetLimitsY()
+    {
+        return GetLimits().Rect.YRange;
+    }
+
+    // TODO: This matches to the closest tail, this might not be desirable depending if the arrows are anchored to their tail or their midpoint
+    public DataPoint GetNearest(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
+    {
+        double maxDistanceSquared = maxDistance * maxDistance;
+        double closestDistanceSquared = double.PositiveInfinity;
+
+        int closestIndex = 0;
+        double closestX = double.PositiveInfinity;
+        double closestY = double.PositiveInfinity;
+
+        for (int i2 = 0; i2 < RenderIndexCount; i2++)
+        {
+            int i = MinRenderIndex + i2;
+            double dX = (RootedVectors[i].Tail.X - mouseLocation.X) * renderInfo.PxPerUnitX;
+            double dY = (RootedVectors[i].Tail.Y - mouseLocation.Y) * renderInfo.PxPerUnitY;
+            double distanceSquared = dX * dX + dY * dY;
+
+            if (distanceSquared <= closestDistanceSquared)
+            {
+                closestDistanceSquared = distanceSquared;
+                closestX = RootedVectors[i].Tail.X;
+                closestY = RootedVectors[i].Tail.Y;
+                closestIndex = i;
+            }
+        }
+
+        return closestDistanceSquared <= maxDistanceSquared
+            ? new DataPoint(closestX, closestY, closestIndex)
+            : DataPoint.None;
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/DataSources/VectorFieldDataSourceCoordinatesList.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/VectorFieldDataSourceCoordinatesList.cs
@@ -10,7 +10,6 @@ public class VectorFieldDataSourceCoordinatesList(IList<RootedCoordinateVector> 
     public int MaxRenderIndex { get; set; } = int.MaxValue;
     private int RenderIndexCount => Math.Min(RootedVectors.Count - 1, MaxRenderIndex) - MinRenderIndex + 1;
 
-
     public IReadOnlyList<RootedCoordinateVector> GetRootedVectors()
     {
         return RootedVectors
@@ -36,7 +35,6 @@ public class VectorFieldDataSourceCoordinatesList(IList<RootedCoordinateVector> 
         return GetLimits().Rect.YRange;
     }
 
-    // TODO: This matches to the closest tail, this might not be desirable depending if the arrows are anchored to their tail or their midpoint
     public DataPoint GetNearest(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
     {
         double maxDistanceSquared = maxDistance * maxDistance;

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -1,4 +1,5 @@
 ﻿using ScottPlot.Extensions;
+using ScottPlot.Primitives;
 using System.Drawing;
 using System.Runtime.InteropServices;
 
@@ -306,6 +307,38 @@ public static class Drawing
         {
             renderer.Render(canvas, paint, pixel, style.Size, style.Fill, style.Outline);
         }
+    }
+
+    public static void DrawArrows(SKCanvas canvas, SKPaint paint, IEnumerable<RootedPixelVector> vectors, LineStyle style)
+    {
+        // TODO: This is inflexible
+        
+        float arrowSpread = 30.ToRadians();
+        
+        if (!style.CanBeRendered)
+            return;
+
+        style.ApplyToPaint(paint);
+        using SKPath path = new();
+
+        foreach (RootedPixelVector vector in vectors)
+        {
+            float bladeLength = 0.25f * vector.Distance;
+
+            path.MoveTo(vector.Tail.ToSKPoint());
+            path.RLineTo(vector.Vector.X, vector.Vector.Y);
+            var head = path.LastPoint;
+
+            var bladeDirection1 = -vector.Direction - arrowSpread;
+            var bladeDirection2 = -vector.Direction + arrowSpread;
+
+            path.RLineTo((float)(bladeLength * Math.Cos(bladeDirection1)), (float)(bladeLength * Math.Sin(bladeDirection1)));
+            
+            path.MoveTo(head);
+            path.RLineTo((float)(bladeLength * Math.Cos(bladeDirection2)), (float)(bladeLength * Math.Sin(bladeDirection2)));
+        }
+
+        canvas.DrawPath(path, paint);
     }
 
     public static SKBitmap BitmapFromArgbs(uint[] argbs, int width, int height)

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -306,47 +306,6 @@ public static class Drawing
         }
     }
 
-    public static void DrawArrows(SKCanvas canvas, SKPaint paint, IEnumerable<RootedPixelVector> vectors, ArrowStyle style)
-    {
-        const float bladeLengthFactor = 0.35f; // How long the arrowhead is as a proportion of arrow length
-        const float bladeWidthFactor = 0.2f; // How wide the arrowhead is as a proportion of arrow length
-        const float cutInFactor = 0.15f; // How much the base of the arrowhead is cut away as a proportion of arrow length (0 for perfect triangle)
-
-        if (!style.LineStyle.CanBeRendered)
-            return;
-
-        style.LineStyle.ApplyToPaint(paint);
-        paint.Style = SKPaintStyle.StrokeAndFill;
-        using SKPath path = new();
-
-        foreach (RootedPixelVector vector in vectors)
-        {
-            SKPoint start = style.Anchor switch
-            {
-                ArrowAnchor.Center => new(vector.Point.X - 0.5f * vector.Vector.X, vector.Point.Y - 0.5f * vector.Vector.Y),
-                ArrowAnchor.Tip => vector.Point.ToSKPoint(),
-                ArrowAnchor.Tail => new(vector.Point.X - vector.Vector.X, vector.Point.Y - vector.Vector.Y),
-                _ => throw new ArgumentOutOfRangeException(nameof(style), "Unexpected arrow anchor value"),
-            };
-
-            path.MoveTo(start);
-            path.RLineTo(vector.Vector.X, vector.Vector.Y);
-            var head = path.LastPoint;
-
-            var junction = head + new SKPoint(-bladeLengthFactor * vector.Vector.X, -bladeLengthFactor * vector.Vector.Y);
-
-            var perp = new SKPoint(-vector.Vector.Y, vector.Vector.X);
-            var bladeTip1 = junction + new SKPoint(bladeWidthFactor * perp.X, bladeWidthFactor * perp.Y);
-            var bladeTip2 = junction - new SKPoint(bladeWidthFactor * perp.X, bladeWidthFactor * perp.Y);
-
-            var arrowHeadBegin = junction + new SKPoint(cutInFactor * vector.Vector.X, cutInFactor * vector.Vector.Y);
-
-            path.AddPoly([head, bladeTip1, arrowHeadBegin, bladeTip2]);
-        }
-
-        canvas.DrawPath(path, paint);
-    }
-
     public static SKBitmap BitmapFromArgbs(uint[] argbs, int width, int height)
     {
         GCHandle handle = GCHandle.Alloc(argbs, GCHandleType.Pinned);

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -1,7 +1,4 @@
-﻿using ScottPlot.Extensions;
-using ScottPlot.Primitives;
-using System.Drawing;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace ScottPlot;
 
@@ -314,7 +311,7 @@ public static class Drawing
         const float bladeLengthFactor = 0.35f; // How long the arrowhead is as a proportion of arrow length
         const float bladeWidthFactor = 0.2f; // How wide the arrowhead is as a proportion of arrow length
         const float cutInFactor = 0.15f; // How much the base of the arrowhead is cut away as a proportion of arrow length (0 for perfect triangle)
-        
+
         if (!style.LineStyle.CanBeRendered)
             return;
 
@@ -326,9 +323,9 @@ public static class Drawing
         {
             SKPoint start = style.Anchor switch
             {
-                ArrowAnchor.Center => new(vector.Tail.X - 0.5f * vector.Vector.X, vector.Tail.Y - 0.5f * vector.Vector.Y),
-                ArrowAnchor.Tip => vector.Tail.ToSKPoint(),
-                ArrowAnchor.Tail => new(vector.Tail.X - vector.Vector.X, vector.Tail.Y - vector.Vector.Y),
+                ArrowAnchor.Center => new(vector.Point.X - 0.5f * vector.Vector.X, vector.Point.Y - 0.5f * vector.Vector.Y),
+                ArrowAnchor.Tip => vector.Point.ToSKPoint(),
+                ArrowAnchor.Tail => new(vector.Point.X - vector.Vector.X, vector.Point.Y - vector.Vector.Y),
                 _ => throw new ArgumentOutOfRangeException(nameof(style), "Unexpected arrow anchor value"),
             };
 
@@ -337,14 +334,14 @@ public static class Drawing
             var head = path.LastPoint;
 
             var junction = head + new SKPoint(-bladeLengthFactor * vector.Vector.X, -bladeLengthFactor * vector.Vector.Y);
-            
+
             var perp = new SKPoint(-vector.Vector.Y, vector.Vector.X);
             var bladeTip1 = junction + new SKPoint(bladeWidthFactor * perp.X, bladeWidthFactor * perp.Y);
             var bladeTip2 = junction - new SKPoint(bladeWidthFactor * perp.X, bladeWidthFactor * perp.Y);
 
             var arrowHeadBegin = junction + new SKPoint(cutInFactor * vector.Vector.X, cutInFactor * vector.Vector.Y);
 
-            path.AddPoly([head, bladeTip1, arrowHeadBegin,  bladeTip2]);
+            path.AddPoly([head, bladeTip1, arrowHeadBegin, bladeTip2]);
         }
 
         canvas.DrawPath(path, paint);

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IVectorFieldSource.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IVectorFieldSource.cs
@@ -1,6 +1,4 @@
-﻿using ScottPlot.Primitives;
-
-namespace ScottPlot.Interfaces;
+﻿namespace ScottPlot.Interfaces;
 
 public interface IVectorFieldSource
 {

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IVectorFieldSource.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IVectorFieldSource.cs
@@ -1,0 +1,21 @@
+﻿using ScottPlot.Primitives;
+
+namespace ScottPlot.Interfaces;
+
+public interface IVectorFieldSource
+{
+    public IReadOnlyList<RootedCoordinateVector> GetRootedVectors();
+
+    /// <summary>
+    /// Return the point nearest a specific location given the X/Y pixel scaling information from a previous render.
+    /// Will return <see cref="DataPoint.None"/> if the nearest point is greater than <paramref name="maxDistance"/> pixels away.
+    /// </summary>
+    DataPoint GetNearest(Coordinates location, RenderDetails renderInfo, float maxDistance = 15);
+
+    public CoordinateRange GetLimitsX();
+    public CoordinateRange GetLimitsY();
+
+    AxisLimits GetLimits();
+    public int MinRenderIndex { get; set; }
+    public int MaxRenderIndex { get; set; }
+}

--- a/src/ScottPlot5/ScottPlot5/PathStrategies/Arrows.cs
+++ b/src/ScottPlot5/ScottPlot5/PathStrategies/Arrows.cs
@@ -1,0 +1,40 @@
+﻿namespace ScottPlot.PathStrategies;
+
+public static class Arrows // TODO: use an interface to let users inject custom logic
+{
+    public static SKPath GetPath(IEnumerable<RootedPixelVector> vectors, ArrowStyle style)
+    {
+        const float bladeLengthFactor = 0.35f; // How long the arrowhead is as a proportion of arrow length
+        const float bladeWidthFactor = 0.2f; // How wide the arrowhead is as a proportion of arrow length
+        const float cutInFactor = 0.15f; // How much the base of the arrowhead is cut away as a proportion of arrow length (0 for perfect triangle)
+
+        SKPath path = new();
+
+        foreach (RootedPixelVector vector in vectors)
+        {
+            SKPoint start = style.Anchor switch
+            {
+                ArrowAnchor.Center => new(vector.Point.X - 0.5f * vector.Vector.X, vector.Point.Y - 0.5f * vector.Vector.Y),
+                ArrowAnchor.Tip => vector.Point.ToSKPoint(),
+                ArrowAnchor.Tail => new(vector.Point.X - vector.Vector.X, vector.Point.Y - vector.Vector.Y),
+                _ => throw new ArgumentOutOfRangeException(nameof(style), "Unexpected arrow anchor value"),
+            };
+
+            path.MoveTo(start);
+            path.RLineTo(vector.Vector.X, vector.Vector.Y);
+            var head = path.LastPoint;
+
+            var junction = head + new SKPoint(-bladeLengthFactor * vector.Vector.X, -bladeLengthFactor * vector.Vector.Y);
+
+            var perp = new SKPoint(-vector.Vector.Y, vector.Vector.X);
+            var bladeTip1 = junction + new SKPoint(bladeWidthFactor * perp.X, bladeWidthFactor * perp.Y);
+            var bladeTip2 = junction - new SKPoint(bladeWidthFactor * perp.X, bladeWidthFactor * perp.Y);
+
+            var arrowHeadBegin = junction + new SKPoint(cutInFactor * vector.Vector.X, cutInFactor * vector.Vector.Y);
+
+            path.AddPoly([head, bladeTip1, arrowHeadBegin, bladeTip2]);
+        }
+
+        return path;
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -2,7 +2,6 @@
 using ScottPlot.Control;
 using ScottPlot.Grids;
 using ScottPlot.Legends;
-using ScottPlot.Primitives;
 using ScottPlot.Rendering;
 using ScottPlot.Stylers;
 

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -781,6 +781,14 @@ public class PlottableAdder(Plot plot)
         return txt;
     }
 
+    public VectorField VectorField(IList<RootedCoordinateVector> vectors)
+    {
+        VectorFieldDataSourceCoordinatesList vs = new(vectors);
+        VectorField field = new(vs);
+        Plot.PlottableList.Add(field);
+        return field;
+    }
+
     public VerticalLine VerticalLine(double x, float width = 2, Color? color = null, LinePattern pattern = LinePattern.Solid)
     {
         VerticalLine line = new();

--- a/src/ScottPlot5/ScottPlot5/Plottables/VectorField.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/VectorField.cs
@@ -13,7 +13,7 @@ public class VectorField(IVectorFieldSource source) : IPlottable
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = new Axes();
     public string? Label { get; set; }
-    public ArrowStyle ArrowStyle { get; set; } = new(); // TODO: Maybe this should be a field within an ArrowStyle?
+    public ArrowStyle ArrowStyle { get; set; } = new();
 
     public IEnumerable<LegendItem> LegendItems => EnumerableExtensions.One(
         new LegendItem
@@ -46,6 +46,10 @@ public class VectorField(IVectorFieldSource source) : IPlottable
         }
 
         var range = new Range(Math.Sqrt(minMagnitudeSquared), Math.Sqrt(maxMagnitudeSquared));
+        if (range.Min == range.Max)
+        {
+            range = new Range(0, range.Max);
+        }
 
         for (int i = 0; i < vectors.Length; i++)
         {

--- a/src/ScottPlot5/ScottPlot5/Plottables/VectorField.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/VectorField.cs
@@ -1,10 +1,4 @@
 ﻿using ScottPlot.Interfaces;
-using ScottPlot.Primitives;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ScottPlot.Plottables;
 
@@ -32,7 +26,7 @@ public class VectorField(IVectorFieldSource source) : IPlottable
         float maxLength = 25;
 
         // TODO: Filter out those that are off-screen? This is subtle, an arrow may be fully off-screen except for its arrowhead, if the blades are long enough.
-        var vectors = Source.GetRootedVectors().Select(v => new RootedPixelVector(Axes.GetPixel(v.Tail), v.Vector)).ToArray();
+        var vectors = Source.GetRootedVectors().Select(v => new RootedPixelVector(Axes.GetPixel(v.Point), v.Vector)).ToArray();
         if (vectors.Length == 0)
             return;
 
@@ -40,7 +34,7 @@ public class VectorField(IVectorFieldSource source) : IPlottable
         var maxMagnitudeSquared = double.NegativeInfinity;
         foreach (var v in vectors)
         {
-            var magSquared = v.DistanceSquared;
+            var magSquared = v.MagnitudeSquared;
             minMagnitudeSquared = Math.Min(minMagnitudeSquared, magSquared);
             maxMagnitudeSquared = Math.Max(maxMagnitudeSquared, magSquared);
         }
@@ -53,9 +47,9 @@ public class VectorField(IVectorFieldSource source) : IPlottable
 
         for (int i = 0; i < vectors.Length; i++)
         {
-            var oldMagnitude = vectors[i].Distance;
+            var oldMagnitude = vectors[i].Magnitude;
             var newMagnitude = range.Normalize(oldMagnitude) * maxLength;
-            var direction = vectors[i].Direction;
+            var direction = vectors[i].Angle;
 
             vectors[i].Vector = new((float)(Math.Cos(direction) * newMagnitude), (float)(Math.Sin(direction) * newMagnitude));
         }

--- a/src/ScottPlot5/ScottPlot5/Plottables/VectorField.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/VectorField.cs
@@ -1,0 +1,62 @@
+﻿using ScottPlot.Interfaces;
+using ScottPlot.Primitives;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Plottables;
+
+public class VectorField(IVectorFieldSource source) : IPlottable
+{
+    public bool IsVisible { get; set; } = true;
+    public IAxes Axes { get; set; } = new Axes();
+    public string? Label { get; set; }
+    public LineStyle LineStyle { get; set; } = new(); // TODO: Maybe this should be a field within an ArrowStyle?
+
+    public IEnumerable<LegendItem> LegendItems => EnumerableExtensions.One(
+        new LegendItem
+        {
+            Label = Label,
+            Marker = MarkerStyle.None, // TODO: Should there be an arrow-style marker?
+            Line = LineStyle,
+        });
+
+    IVectorFieldSource Source { get; set; } = source;
+
+    public AxisLimits GetAxisLimits() => Source.GetLimits();
+
+    public void Render(RenderPack rp)
+    {
+        const float maxLength = 25;
+
+        // TODO: Filter out those that are off-screen? This is subtle, an arrow may be fully off-screen except for its arrowhead, if the blades are long enough.
+        var vectors = Source.GetRootedVectors().Select(v => new RootedPixelVector(Axes.GetPixel(v.Tail), v.Vector)).ToArray();
+        if (vectors.Length == 0)
+            return;
+
+        var minMagnitudeSquared = double.PositiveInfinity;
+        var maxMagnitudeSquared = double.NegativeInfinity;
+        foreach (var v in vectors)
+        {
+            var magSquared = v.DistanceSquared;
+            minMagnitudeSquared = Math.Min(minMagnitudeSquared, magSquared);
+            maxMagnitudeSquared = Math.Max(maxMagnitudeSquared, magSquared);
+        }
+
+        var range = new Range(Math.Sqrt(minMagnitudeSquared), Math.Sqrt(maxMagnitudeSquared));
+
+        for (int i = 0; i < vectors.Length; i++)
+        {
+            var oldMagnitude = vectors[i].Distance;
+            var newMagnitude = range.Normalize(oldMagnitude) * maxLength;
+            var direction = vectors[i].Direction;
+
+            vectors[i].Vector = new((float)(Math.Cos(direction) * newMagnitude), (float)(Math.Sin(direction) * newMagnitude));
+        }
+
+        using SKPaint paint = new();
+        Drawing.DrawArrows(rp.Canvas, paint, vectors, LineStyle);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/VectorField.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/VectorField.cs
@@ -13,14 +13,14 @@ public class VectorField(IVectorFieldSource source) : IPlottable
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = new Axes();
     public string? Label { get; set; }
-    public LineStyle LineStyle { get; set; } = new(); // TODO: Maybe this should be a field within an ArrowStyle?
+    public ArrowStyle ArrowStyle { get; set; } = new(); // TODO: Maybe this should be a field within an ArrowStyle?
 
     public IEnumerable<LegendItem> LegendItems => EnumerableExtensions.One(
         new LegendItem
         {
             Label = Label,
             Marker = MarkerStyle.None, // TODO: Should there be an arrow-style marker?
-            Line = LineStyle,
+            Line = ArrowStyle.LineStyle,
         });
 
     IVectorFieldSource Source { get; set; } = source;
@@ -29,7 +29,7 @@ public class VectorField(IVectorFieldSource source) : IPlottable
 
     public void Render(RenderPack rp)
     {
-        const float maxLength = 25;
+        float maxLength = 25;
 
         // TODO: Filter out those that are off-screen? This is subtle, an arrow may be fully off-screen except for its arrowhead, if the blades are long enough.
         var vectors = Source.GetRootedVectors().Select(v => new RootedPixelVector(Axes.GetPixel(v.Tail), v.Vector)).ToArray();
@@ -57,6 +57,6 @@ public class VectorField(IVectorFieldSource source) : IPlottable
         }
 
         using SKPaint paint = new();
-        Drawing.DrawArrows(rp.Canvas, paint, vectors, LineStyle);
+        Drawing.DrawArrows(rp.Canvas, paint, vectors, ArrowStyle);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/VectorField.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/VectorField.cs
@@ -23,6 +23,9 @@ public class VectorField(IVectorFieldSource source) : IPlottable
 
     public void Render(RenderPack rp)
     {
+        if (!ArrowStyle.LineStyle.CanBeRendered)
+            return;
+
         float maxLength = 25;
 
         // TODO: Filter out those that are off-screen? This is subtle, an arrow may be fully off-screen except for its arrowhead, if the blades are long enough.
@@ -54,7 +57,12 @@ public class VectorField(IVectorFieldSource source) : IPlottable
             vectors[i].Vector = new((float)(Math.Cos(direction) * newMagnitude), (float)(Math.Sin(direction) * newMagnitude));
         }
 
+
         using SKPaint paint = new();
-        Drawing.DrawArrows(rp.Canvas, paint, vectors, ArrowStyle);
+        ArrowStyle.LineStyle.ApplyToPaint(paint);
+        paint.Style = SKPaintStyle.StrokeAndFill;
+
+        using SKPath path = PathStrategies.Arrows.GetPath(vectors, ArrowStyle);
+        rp.Canvas.DrawPath(path, paint);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/ArrowAnchor.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/ArrowAnchor.cs
@@ -1,0 +1,8 @@
+﻿namespace ScottPlot;
+
+public enum ArrowAnchor
+{
+    Center,
+    Tip,
+    Tail,
+}

--- a/src/ScottPlot5/ScottPlot5/Primitives/ArrowStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/ArrowStyle.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Primitives;
+
+public enum ArrowAnchor
+{
+   Center,
+   Tip,
+   Tail,
+}
+
+public struct ArrowStyle
+{
+
+    public LineStyle LineStyle { get; set; } = new();
+    public ArrowAnchor Anchor { get; set; } = ArrowAnchor.Center;
+
+    public ArrowStyle(LineStyle lineStyle, ArrowAnchor anchor)
+    {
+        LineStyle = lineStyle;
+        Anchor = anchor;
+    }
+
+    public ArrowStyle()
+    {
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Primitives/ArrowStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/ArrowStyle.cs
@@ -1,22 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace ScottPlot.Primitives;
-
-public enum ArrowAnchor
-{
-   Center,
-   Tip,
-   Tail,
-}
+﻿namespace ScottPlot;
 
 public struct ArrowStyle
 {
-
     public LineStyle LineStyle { get; set; } = new();
+
     public ArrowAnchor Anchor { get; set; } = ArrowAnchor.Center;
 
     public ArrowStyle(LineStyle lineStyle, ArrowAnchor anchor)

--- a/src/ScottPlot5/ScottPlot5/Primitives/BackgroundStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/BackgroundStyle.cs
@@ -1,4 +1,4 @@
-﻿namespace ScottPlot.Primitives;
+﻿namespace ScottPlot;
 
 public class BackgroundStyle : IDisposable
 {

--- a/src/ScottPlot5/ScottPlot5/Primitives/RootedCoordinateVector.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/RootedCoordinateVector.cs
@@ -1,13 +1,27 @@
 ﻿using System.Numerics;
 
-namespace ScottPlot.Primitives;
+namespace ScottPlot;
 
-public struct RootedCoordinateVector(Coordinates tail, Vector2 vector)
+/// <summary>
+/// Represents a vector at a point in coordinate space
+/// </summary>
+public struct RootedCoordinateVector(Coordinates point, Vector2 vector)
 {
-    public Coordinates Tail { get; set; } = tail;
+    public Coordinates Point { get; set; } = point;
     public Vector2 Vector { get; set; } = vector;
 
-    public readonly float Direction => (float)Math.Atan2(Vector.Y, Vector.X); // Note that this is properly defined for x,y = 0, unlike Math.Atan(y / x)
-    public readonly float DistanceSquared => Vector.LengthSquared();
-    public readonly float Distance => Vector.Length();
+    /// <summary>
+    /// Angle of the vector in radians
+    /// </summary>
+    public readonly float Angle => (float)Math.Atan2(Vector.Y, Vector.X); // Note that this is properly defined for x,y = 0, unlike Math.Atan(y / x)
+
+    /// <summary>
+    /// Length of the vector squared in coordinate units
+    /// </summary>
+    public readonly float MagnitudeSquared => Vector.LengthSquared();
+
+    /// <summary>
+    /// Length of the vector in coordinate units
+    /// </summary>
+    public readonly float Magnitude => Vector.Length();
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/RootedCoordinateVector.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/RootedCoordinateVector.cs
@@ -1,0 +1,13 @@
+﻿using System.Numerics;
+
+namespace ScottPlot.Primitives;
+
+public struct RootedCoordinateVector(Coordinates tail, Vector2 vector)
+{
+    public Coordinates Tail { get; set; } = tail;
+    public Vector2 Vector { get; set; } = vector;
+
+    public readonly float Direction => (float)Math.Atan2(Vector.Y, Vector.X); // Note that this is properly defined for x = 0, unlike Math.Atan(y / x)
+    public readonly float DistanceSquared => Vector.LengthSquared();
+    public readonly float Distance => Vector.Length();
+}

--- a/src/ScottPlot5/ScottPlot5/Primitives/RootedCoordinateVector.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/RootedCoordinateVector.cs
@@ -7,7 +7,7 @@ public struct RootedCoordinateVector(Coordinates tail, Vector2 vector)
     public Coordinates Tail { get; set; } = tail;
     public Vector2 Vector { get; set; } = vector;
 
-    public readonly float Direction => (float)Math.Atan2(Vector.Y, Vector.X); // Note that this is properly defined for x = 0, unlike Math.Atan(y / x)
+    public readonly float Direction => (float)Math.Atan2(Vector.Y, Vector.X); // Note that this is properly defined for x,y = 0, unlike Math.Atan(y / x)
     public readonly float DistanceSquared => Vector.LengthSquared();
     public readonly float Distance => Vector.Length();
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/RootedPixelVector.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/RootedPixelVector.cs
@@ -7,7 +7,7 @@ public struct RootedPixelVector(Pixel tail, Vector2 vector)
     public Pixel Tail { get; set; } = tail;
     public Vector2 Vector { get; set; } = vector;
 
-    public readonly float Direction => (float)Math.Atan2(Vector.Y, Vector.X); // Note that this is properly defined for x = 0, unlike Math.Atan(y / x)
+    public readonly float Direction => (float)Math.Atan2(Vector.Y, Vector.X); // Note that this is properly defined for x,y = 0, unlike Math.Atan(y / x)
     public readonly float DistanceSquared => Vector.LengthSquared();
     public readonly float Distance => Vector.Length();
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/RootedPixelVector.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/RootedPixelVector.cs
@@ -1,13 +1,27 @@
 ﻿using System.Numerics;
 
-namespace ScottPlot.Primitives;
+namespace ScottPlot;
 
-public struct RootedPixelVector(Pixel tail, Vector2 vector)
+/// <summary>
+/// Represents a vector at a point in pixel space
+/// </summary>
+public struct RootedPixelVector(Pixel point, Vector2 vector)
 {
-    public Pixel Tail { get; set; } = tail;
+    public Pixel Point { get; set; } = point;
     public Vector2 Vector { get; set; } = vector;
 
-    public readonly float Direction => (float)Math.Atan2(Vector.Y, Vector.X); // Note that this is properly defined for x,y = 0, unlike Math.Atan(y / x)
-    public readonly float DistanceSquared => Vector.LengthSquared();
-    public readonly float Distance => Vector.Length();
+    /// <summary>
+    /// Angle of the vector in radians
+    /// </summary>
+    public readonly float Angle => (float)Math.Atan2(Vector.Y, Vector.X);
+
+    /// <summary>
+    /// Length of the vector squared in pixel units
+    /// </summary>
+    public readonly float MagnitudeSquared => Vector.LengthSquared();
+
+    /// <summary>
+    /// Length of the vector in pixel units
+    /// </summary>
+    public readonly float Magnitude => Vector.Length();
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/RootedPixelVector.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/RootedPixelVector.cs
@@ -1,0 +1,13 @@
+﻿using System.Numerics;
+
+namespace ScottPlot.Primitives;
+
+public struct RootedPixelVector(Pixel tail, Vector2 vector)
+{
+    public Pixel Tail { get; set; } = tail;
+    public Vector2 Vector { get; set; } = vector;
+
+    public readonly float Direction => (float)Math.Atan2(Vector.Y, Vector.X); // Note that this is properly defined for x = 0, unlike Math.Atan(y / x)
+    public readonly float DistanceSquared => Vector.LengthSquared();
+    public readonly float Distance => Vector.Length();
+}


### PR DESCRIPTION
This example is lifted from the 4.1 cookbook:
```cs
var vectors = new List<RootedCoordinateVector>();
double[] xs = Generate.Consecutive(20, 0.5, -5);
double[] ys = Generate.Consecutive(20, 0.5, -5);
float r = 0.5f;

for (int i = 0; i < xs.Length; i++)
{
    for (int j = 0; j < ys.Length; j++)
    {
        vectors.Add(new RootedCoordinateVector(new(xs[i], ys[j]), new((float)ys[j], -9.81f / r * (float)Math.Sin(xs[i]))));
    }
}

var field = new VectorField(new VectorFieldDataSourceCoordinatesList(vectors));
WpfPlot1.Plot.PlottableList.Add(field);
```
![image](https://github.com/ScottPlot/ScottPlot/assets/8635304/264a1167-d8a2-4578-b504-31d199879768)
