### PR TITLE
Used two lines in Crosshair to reuse their functionalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ _Not yet on NuGet..._
 * Scatter: Upgraded the default smooth behavior to use cubic spline interpolation and exposed `SmoothTension` (#3623, #3606, #3274, #3566, #3629) @drolevar
 * Vector Field: Added a new plot type to display a collection of rooted vectors (#3625, #3626, #3632, #3630, #3631) @bclehmann
 * AxisLine: Improve appearance in of the key displayed in the legend (#3627, #3613) @MCF
-* Crosshair: Expose `VerticalLine` and `HorizontalLine` for to allow axis-specific customization (#3638) @Fruchtzwerg94
+* Crosshair: Expose `VerticalLine` and `HorizontalLine` for to allow axis-specific customization (#3638) @Fruchtzwerg94 @heartacker
 
 ## ScottPlot 5.0.25
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-04-08_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _Not yet on NuGet..._
 * Scatter: Upgraded the default smooth behavior to use cubic spline interpolation and exposed `SmoothTension` (#3623, #3606, #3274, #3566, #3629) @drolevar
 * Vector Field: Added a new plot type to display a collection of rooted vectors (#3625, #3626, #3632, #3630, #3631) @bclehmann
 * AxisLine: Improve appearance in of the key displayed in the legend (#3627, #3613) @MCF
+* Crosshair: Expose `VerticalLine` and `HorizontalLine` for to allow axis-specific customization (#3638) @Fruchtzwerg94
 
 ## ScottPlot 5.0.25
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-04-08_

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/MouseTracker.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/MouseTracker.cs
@@ -1,5 +1,4 @@
 ﻿using ScottPlot;
-using System.Diagnostics;
 
 namespace WinForms_Demo.Demos;
 
@@ -17,17 +16,19 @@ public partial class MouseTracker : Form, IDemoWindow
         InitializeComponent();
 
         CH = formsPlot1.Plot.Add.Crosshair(0, 0);
+        CH.TextColor = Colors.White;
+        CH.TextBackgroundColor = CH.HorizontalLine.Color;
+
         formsPlot1.Refresh();
 
         formsPlot1.MouseMove += (s, e) =>
         {
             Pixel mousePixel = new(e.X, e.Y);
             Coordinates mouseCoordinates = formsPlot1.Plot.GetCoordinates(mousePixel);
-            string msg = e.Button == MouseButtons.Left ? "dragging" : "hovering";
-            Text = $"X={mouseCoordinates.X:N3}, Y={mouseCoordinates.Y:N3} ({msg})";
+            this.Text = $"X={mouseCoordinates.X:N3}, Y={mouseCoordinates.Y:N3}";
             CH.Position = mouseCoordinates;
-            CH.TextX = $"{mouseCoordinates.X:N3}";
-            CH.TextY = $"{mouseCoordinates.Y:N3}";
+            CH.VerticalLine.Text = $"{mouseCoordinates.X:N3}";
+            CH.HorizontalLine.Text = $"{mouseCoordinates.Y:N3}";
             formsPlot1.Refresh();
         };
 

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/MouseTracker.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/MouseTracker.cs
@@ -26,6 +26,8 @@ public partial class MouseTracker : Form, IDemoWindow
             string msg = e.Button == MouseButtons.Left ? "dragging" : "hovering";
             Text = $"X={mouseCoordinates.X:N3}, Y={mouseCoordinates.Y:N3} ({msg})";
             CH.Position = mouseCoordinates;
+            CH.TextX = $"{mouseCoordinates.X:N3}";
+            CH.TextY = $"{mouseCoordinates.Y:N3}";
             formsPlot1.Refresh();
         };
 

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/ShowValueOnHoverMultiple.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/ShowValueOnHoverMultiple.cs
@@ -92,7 +92,7 @@ public partial class ShowValueOnHoverMultiple : Form, IDemoWindow
 
                 MyCrosshair.IsVisible = true;
                 MyCrosshair.Position = point.Coordinates;
-                MyCrosshair.LineStyle.Color = scatter.MarkerStyle.Fill.Color;
+                MyCrosshair.LineColor = scatter.MarkerStyle.Fill.Color;
 
                 MyHighlightMarker.IsVisible = true;
                 MyHighlightMarker.Location = point.Coordinates;

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Program.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Program.cs
@@ -12,7 +12,7 @@ static class Program
         // use this to quickly launch a test Form while developing
         if (true && Environment.MachineName == "DESKTOP-L7MMAB7")
         {
-            Demos.SignalXYDrag window = new() { StartPosition = FormStartPosition.CenterScreen };
+            Demos.MouseTracker window = new() { StartPosition = FormStartPosition.CenterScreen };
             Application.Run(window);
             Application.Run(new MainMenuForm());
         }

--- a/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/AxisLineTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/RenderTests/Plottable/AxisLineTests.cs
@@ -44,7 +44,7 @@ internal class AxisLineTests
         var hl = plot.Add.HorizontalLine(0.5);
         hl.Text = "HLine";
         hl.FontSize = 10;
-        hl.FontColor = Colors.Yellow;
+        hl.TextColor = Colors.Yellow;
 
         var vl = plot.Add.VerticalLine(0.5);
         vl.Text = "VLine";

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -163,8 +163,9 @@ public class PlottableAdder(Plot plot)
         {
             Position = new(x, y)
         };
-        ch.LineStyle.Color = GetNextColor();
-        ch.FontColor = ch.LineStyle.Color;
+        Color color = GetNextColor();
+        ch.LineColor = color;
+        ch.TextColor = color;
         Plot.PlottableList.Add(ch);
         return ch;
     }

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -164,6 +164,7 @@ public class PlottableAdder(Plot plot)
             Position = new(x, y)
         };
         ch.LineStyle.Color = GetNextColor();
+        ch.FontColor = ch.LineStyle.Color;
         Plot.PlottableList.Add(ch);
         return ch;
     }

--- a/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
@@ -10,7 +10,11 @@ public abstract class AxisLine : IPlottable, IRenderLast
     public float FontSize { get => Label.FontSize; set => Label.FontSize = value; }
     public bool FontBold { get => Label.Bold; set => Label.Bold = value; }
     public string FontName { get => Label.FontName; set => Label.FontName = value; }
-    public Color FontColor { get => Label.ForeColor; set => Label.ForeColor = value; }
+
+    [Obsolete("Use TextColor", true)]
+    public Color FontColor => TextColor;
+    public Color TextColor { get => Label.ForeColor; set => Label.ForeColor = value; }
+    public Color TextBackgroundColor { get => Label.BackColor; set => Label.BackColor = value; }
     public string Text { get => Label.Text; set => Label.Text = value; }
 
     public LineStyle LineStyle { get; set; } = new();

--- a/src/ScottPlot5/ScottPlot5/Plottables/Crosshair.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Crosshair.cs
@@ -1,41 +1,175 @@
 ﻿namespace ScottPlot.Plottables;
 
-public class Crosshair : IPlottable
+public class Crosshair : IPlottable, IRenderLast
 {
     public bool IsVisible { get; set; } = true;
 
-    public IAxes Axes { get; set; } = new Axes();
+    private IAxes axes = new Axes();
+    public IAxes Axes
+    {
+        get
+        {
+            return axes;
+        }
+        set
+        {
+            axes = value;
+            horizontalLine.Axes = value;
+            verticalLine.Axes = value;
+        }
+    }
 
-    public IEnumerable<LegendItem> LegendItems { get; } = Array.Empty<LegendItem>();
+    public IEnumerable<LegendItem> LegendItems
+    {
+        get
+        {
+            return horizontalLine.LegendItems.Concat(verticalLine.LegendItems);
+        }
+    }
 
     public AxisLimits GetAxisLimits() => new(X, X, Y, Y);
 
+    private readonly HorizontalLine horizontalLine = new();
+    private readonly VerticalLine verticalLine = new ();
+
     public Coordinates Position { get => new(X, Y); set { X = value.X; Y = value.Y; } }
-    public double X { get; set; }
-    public double Y { get; set; }
 
-    public bool VerticalLineIsVisible { get; set; } = true;
+    public double X
+    {
+        get
+        {
+            return verticalLine.X;
+        }
+        set
+        {
+            verticalLine.X = value;
+        }
+    }
 
-    public bool HorizontalLineIsVisible { get; set; } = true;
+    public double Y
+    {
+        get
+        {
+            return horizontalLine.Y;
+        }
+        set
+        {
+            horizontalLine.Y = value;
+        }
+    }
+
+    public bool VerticalLineIsVisible
+    {
+        get
+        {
+            return verticalLine.IsVisible;
+        }
+        set
+        {
+            verticalLine.IsVisible = value;
+        }
+    }
+
+    public bool HorizontalLineIsVisible
+    {
+        get
+        {
+            return horizontalLine.IsVisible;
+        }
+        set
+        {
+            horizontalLine.IsVisible = value;
+        }
+    }
+
     public readonly LineStyle LineStyle = new();
+
+    private float fontSize;
+    public float FontSize
+    {
+        get
+        {
+            return fontSize;
+        }
+        set
+        {
+            fontSize = value;
+            horizontalLine.FontSize = value;
+            verticalLine.FontSize = value;
+        }
+    }
+
+    private bool fontBold;
+    public bool FontBold
+    {
+        get
+        {
+            return fontBold;
+        }
+        set
+        {
+            fontBold = value;
+            horizontalLine.FontBold = value;
+            verticalLine.FontBold = value;
+        }
+    }
+
+    private string fontName;
+    public string FontName
+    {
+        get
+        {
+            return fontName;
+        }
+        set
+        {
+            fontName = value;
+            horizontalLine.FontName = value;
+            verticalLine.FontName = value;
+        }
+    }
+
+    private Color fontColor;
+    public Color FontColor
+    {
+        get
+        {
+            return fontColor;
+        }
+        set
+        {
+            fontColor = value;
+            horizontalLine.FontColor = value;
+            verticalLine.FontColor = value;
+        }
+    }
+
+    public string TextX { get => verticalLine.Text; set => verticalLine.Text = value; }
+    public string TextY { get => horizontalLine.Text; set => horizontalLine.Text = value; }
+
+    public Crosshair()
+    {
+        horizontalLine.Axes = Axes;
+        verticalLine.Axes = Axes;
+        horizontalLine.LineStyle = LineStyle;
+        verticalLine.LineStyle = LineStyle;
+    }
 
     public void Render(RenderPack rp)
     {
-        PixelRect dataArea = rp.Canvas.LocalClipBounds.ToPixelRect();
-        Pixel px = Axes.GetPixel(Position);
+        if (!IsVisible)
+            return;
 
-        using SKPaint paint = new();
+        horizontalLine.Render(rp);
+        verticalLine.Render(rp);
+    }
 
-        LineStyle.ApplyToPaint(paint);
+    public void RenderLast(RenderPack rp)
+    {
+        if (!IsVisible)
+            return;
 
-        if (VerticalLineIsVisible)
-        {
-            rp.Canvas.DrawLine(px.X, dataArea.Top, px.X, dataArea.Bottom, paint);
-        }
-
-        if (HorizontalLineIsVisible)
-        {
-            rp.Canvas.DrawLine(dataArea.Left, px.Y, dataArea.Right, px.Y, paint);
-        }
+        horizontalLine.RenderLast(rp);
+        verticalLine.RenderLast(rp);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/Crosshair.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Crosshair.cs
@@ -2,166 +2,44 @@
 
 public class Crosshair : IPlottable, IRenderLast
 {
-    public bool IsVisible { get; set; } = true;
-
-    private IAxes axes = new Axes();
-    public IAxes Axes
-    {
-        get
-        {
-            return axes;
-        }
-        set
-        {
-            axes = value;
-            horizontalLine.Axes = value;
-            verticalLine.Axes = value;
-        }
-    }
-
-    public IEnumerable<LegendItem> LegendItems
-    {
-        get
-        {
-            return horizontalLine.LegendItems.Concat(verticalLine.LegendItems);
-        }
-    }
-
-    public AxisLimits GetAxisLimits() => new(X, X, Y, Y);
-
-    private readonly HorizontalLine horizontalLine = new();
-    private readonly VerticalLine verticalLine = new ();
+    public HorizontalLine HorizontalLine { get; } = new();
+    public VerticalLine VerticalLine { get; } = new();
 
     public Coordinates Position { get => new(X, Y); set { X = value.X; Y = value.Y; } }
+    public double X { get => VerticalLine.X; set => VerticalLine.X = value; }
+    public double Y { get => HorizontalLine.Y; set => HorizontalLine.Y = value; }
 
-    public double X
-    {
-        get
-        {
-            return verticalLine.X;
-        }
-        set
-        {
-            verticalLine.X = value;
-        }
-    }
+    // These properties set styling for both axis lines at once
+    public float FontSize { set { HorizontalLine.FontSize = value; VerticalLine.FontSize = value; } }
+    public bool FontBold { set { HorizontalLine.FontBold = value; VerticalLine.FontBold = value; } }
+    public string FontName { set { HorizontalLine.FontName = value; VerticalLine.FontName = value; } }
+    public Color TextColor { set { HorizontalLine.TextColor = value; VerticalLine.TextColor = value; } }
+    public Color TextBackgroundColor { set { HorizontalLine.TextBackgroundColor = value; VerticalLine.TextBackgroundColor = value; } }
+    public Color LineColor { set { HorizontalLine.LineColor = value; VerticalLine.LineColor = value; } }
+    public float LineWidth { set { HorizontalLine.LineWidth = value; VerticalLine.LineWidth = value; } }
+    public LinePattern LinePattern { set { HorizontalLine.LinePattern = value; VerticalLine.LinePattern = value; } }
 
-    public double Y
-    {
-        get
-        {
-            return horizontalLine.Y;
-        }
-        set
-        {
-            horizontalLine.Y = value;
-        }
-    }
+    [Obsolete("Assign values to Color, LineWidth, or LinePattern properties to set style for both lines. " +
+        "HorizontalLine.LineStyle and VerticalLine.LineStyle are individually available as well.", true)]
+    public LineStyle LineStyle { get; set; } = new();
+    [Obsolete("Use TextColor and TextBackgroundColor instead", true)]
+    public Color FontColor;
 
-    public bool VerticalLineIsVisible
-    {
-        get
-        {
-            return verticalLine.IsVisible;
-        }
-        set
-        {
-            verticalLine.IsVisible = value;
-        }
-    }
-
-    public bool HorizontalLineIsVisible
-    {
-        get
-        {
-            return horizontalLine.IsVisible;
-        }
-        set
-        {
-            horizontalLine.IsVisible = value;
-        }
-    }
-
-    public readonly LineStyle LineStyle = new();
-
-    private float fontSize;
-    public float FontSize
-    {
-        get
-        {
-            return fontSize;
-        }
-        set
-        {
-            fontSize = value;
-            horizontalLine.FontSize = value;
-            verticalLine.FontSize = value;
-        }
-    }
-
-    private bool fontBold;
-    public bool FontBold
-    {
-        get
-        {
-            return fontBold;
-        }
-        set
-        {
-            fontBold = value;
-            horizontalLine.FontBold = value;
-            verticalLine.FontBold = value;
-        }
-    }
-
-    private string fontName;
-    public string FontName
-    {
-        get
-        {
-            return fontName;
-        }
-        set
-        {
-            fontName = value;
-            horizontalLine.FontName = value;
-            verticalLine.FontName = value;
-        }
-    }
-
-    private Color fontColor;
-    public Color FontColor
-    {
-        get
-        {
-            return fontColor;
-        }
-        set
-        {
-            fontColor = value;
-            horizontalLine.FontColor = value;
-            verticalLine.FontColor = value;
-        }
-    }
-
-    public string TextX { get => verticalLine.Text; set => verticalLine.Text = value; }
-    public string TextY { get => horizontalLine.Text; set => horizontalLine.Text = value; }
-
-    public Crosshair()
-    {
-        horizontalLine.Axes = Axes;
-        verticalLine.Axes = Axes;
-        horizontalLine.LineStyle = LineStyle;
-        verticalLine.LineStyle = LineStyle;
-    }
+    public bool IsVisible { get; set; } = true;
+    public IAxes Axes { get; set; } = new Axes();
+    public IEnumerable<LegendItem> LegendItems => HorizontalLine.LegendItems.Concat(VerticalLine.LegendItems);
+    public AxisLimits GetAxisLimits() => new(X, X, Y, Y);
 
     public void Render(RenderPack rp)
     {
         if (!IsVisible)
             return;
 
-        horizontalLine.Render(rp);
-        verticalLine.Render(rp);
+        HorizontalLine.Axes = Axes;
+        HorizontalLine.Render(rp);
+
+        VerticalLine.Axes = Axes;
+        VerticalLine.Render(rp);
     }
 
     public void RenderLast(RenderPack rp)
@@ -169,7 +47,10 @@ public class Crosshair : IPlottable, IRenderLast
         if (!IsVisible)
             return;
 
-        horizontalLine.RenderLast(rp);
-        verticalLine.RenderLast(rp);
+        HorizontalLine.Axes = Axes;
+        HorizontalLine.RenderLast(rp);
+
+        VerticalLine.Axes = Axes;
+        VerticalLine.RenderLast(rp);
     }
 }


### PR DESCRIPTION
Used two AxisLines as Crosshair. This allows more flexible reusage of their features like the Text.

MouseTracker Demo:
![Croshair](https://github.com/ScottPlot/ScottPlot/assets/29866610/0db087c7-d506-46e7-9323-39b9655c8146)
