### PR TITLE
AxisLine: Allow override of automatic label alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _Not yet on NuGet..._
 * Vector Field: Added a new plot type to display a collection of rooted vectors (#3625, #3626, #3632, #3630, #3631) @bclehmann
 * AxisLine: Improve appearance in of the key displayed in the legend (#3627, #3613) @MCF
 * Crosshair: Expose `VerticalLine` and `HorizontalLine` for to allow axis-specific customization (#3638) @Fruchtzwerg94 @heartacker
+* AxisLine: Added properties for faster styling including an optional `TextAlignment` setting (#3640, #3624) @MCF
 
 ## ScottPlot 5.0.25
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-04-08_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/AxisLines.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/AxisLines.cs
@@ -72,15 +72,18 @@ public class AxisLines : ICategory
 
             var axLine1 = myPlot.Add.VerticalLine(42);
             axLine1.Text = "Line 1";
-            axLine1.Label.Rotation = -90;
-            axLine1.UseAutoAlignment = false;   // Disable automatic alignment
-            axLine1.Label.Alignment = Alignment.MiddleRight;
+            axLine1.TextRotation = -90;
+            axLine1.TextAlignment = Alignment.MiddleRight;
 
             var axLine2 = myPlot.Add.HorizontalLine(0.75);
             axLine2.Text = "Line 2";
-            axLine2.Label.Rotation = 0;
-            axLine2.UseAutoAlignment = false;   // Disable automatic alignment
-            axLine2.Label.Alignment = Alignment.MiddleRight;
+            axLine2.TextRotation = 0;
+            axLine2.TextAlignment = Alignment.MiddleRight;
+
+            var axLine3 = myPlot.Add.VerticalLine(20);
+            axLine3.Text = "Line 3";
+            axLine3.TextRotation = -45;
+            axLine3.TextAlignment = Alignment.UpperRight;
 
             // extra padding on the bottom and left for the rotated labels
             myPlot.Axes.Bottom.MinimumSize = 60;
@@ -112,9 +115,9 @@ public class AxisLines : ICategory
             hl2.LineColor = Colors.Navy;
             hl2.LineWidth = 5;
             hl2.Text = "Hello";
-            hl2.Label.FontSize = 24;
-            hl2.Label.BackColor = Colors.Blue;
-            hl2.Label.ForeColor = Colors.Yellow;
+            hl2.TextSize = 24;
+            hl2.TextBackgroundColor = Colors.Blue;
+            hl2.TextColor = Colors.Yellow;
             hl2.LinePattern = LinePattern.DenselyDashed;
         }
     }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/AxisLines.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/AxisLines.cs
@@ -26,7 +26,7 @@ public class AxisLines : ICategory
     {
         public override string Name => "Axis Line Label";
         public override string Description => "Axis lines have labels that can be used " +
-            "to display arbitrary on the axes they are attached to.";
+            "to display arbitrary text on the axes they are attached to.";
 
         [Test]
         public override void Execute()
@@ -55,6 +55,36 @@ public class AxisLines : ICategory
             // extra padding on the right and top ensures labels have room
             myPlot.Axes.Right.MinimumSize = 30;
             myPlot.Axes.Top.MinimumSize = 30;
+        }
+    }
+
+    public class AxisLineLabelPositioning : RecipeBase
+    {
+        public override string Name => "Axis Line Label Positioning";
+        public override string Description => "Axis line labels can have " +
+            "custom positioning, including rotation and alignment.";
+
+        [Test]
+        public override void Execute()
+        {
+            myPlot.Add.Signal(Generate.Sin());
+            myPlot.Add.Signal(Generate.Cos());
+
+            var axLine1 = myPlot.Add.VerticalLine(42);
+            axLine1.Text = "Line 1";
+            axLine1.Label.Rotation = -90;
+            axLine1.UseAutoAlignment = false;   // Disable automatic alignment
+            axLine1.Label.Alignment = Alignment.MiddleRight;
+
+            var axLine2 = myPlot.Add.HorizontalLine(0.75);
+            axLine2.Text = "Line 2";
+            axLine2.Label.Rotation = 0;
+            axLine2.UseAutoAlignment = false;   // Disable automatic alignment
+            axLine2.Label.Alignment = Alignment.MiddleRight;
+
+            // extra padding on the bottom and left for the rotated labels
+            myPlot.Axes.Bottom.MinimumSize = 60;
+            myPlot.Axes.Left.MinimumSize = 60;
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -303,12 +303,16 @@ public class PlottableAdder(Plot plot)
 
     public HorizontalLine HorizontalLine(double y, float width = 2, Color? color = null, LinePattern pattern = LinePattern.Solid)
     {
-        HorizontalLine line = new();
-        line.LineStyle.Width = width;
-        line.LineStyle.Color = color ?? GetNextColor();
-        line.Label.BackColor = line.LineStyle.Color;
-        line.LineStyle.Pattern = pattern;
-        line.Y = y;
+        Color color2 = color ?? GetNextColor();
+        HorizontalLine line = new()
+        {
+            LineWidth = width,
+            LineColor = color2,
+            TextBackgroundColor = color2,
+            TextColor = Colors.White,
+            LinePattern = pattern,
+            Y = y
+        };
         Plot.PlottableList.Add(line);
         return line;
     }
@@ -795,12 +799,15 @@ public class PlottableAdder(Plot plot)
 
     public VerticalLine VerticalLine(double x, float width = 2, Color? color = null, LinePattern pattern = LinePattern.Solid)
     {
-        VerticalLine line = new();
-        line.LineStyle.Width = width;
-        line.LineStyle.Color = color ?? GetNextColor();
-        line.Label.BackColor = line.LineStyle.Color;
-        line.LineStyle.Pattern = pattern;
-        line.X = x;
+        Color color2 = color ?? GetNextColor();
+        VerticalLine line = new()
+        {
+            LineWidth = width,
+            LineColor = color2,
+            TextBackgroundColor = color2,
+            LinePattern = pattern,
+            X = x
+        };
         Plot.PlottableList.Add(line);
         return line;
     }

--- a/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
@@ -6,17 +6,21 @@ public abstract class AxisLine : IPlottable, IRenderLast
 
     public IAxes Axes { get; set; } = new Axes();
 
-    public readonly Label Label = new();
-    public float FontSize { get => Label.FontSize; set => Label.FontSize = value; }
-    public bool FontBold { get => Label.Bold; set => Label.Bold = value; }
-    public string FontName { get => Label.FontName; set => Label.FontName = value; }
-    public bool UseAutoAlignment { get; set; } = true;
+    [Obsolete("Use properties in this class (e.g., TextColor) or reach into LabelStyle and assign properties there.", true)]
+    public Label Label { get; set; } = new();
+    public Label LabelStyle { get; set; } = new();
+    public float FontSize { get => LabelStyle.FontSize; set => LabelStyle.FontSize = value; }
+    public bool FontBold { get => LabelStyle.Bold; set => LabelStyle.Bold = value; }
+    public string FontName { get => LabelStyle.FontName; set => LabelStyle.FontName = value; }
 
     [Obsolete("Use TextColor", true)]
     public Color FontColor => TextColor;
-    public Color TextColor { get => Label.ForeColor; set => Label.ForeColor = value; }
-    public Color TextBackgroundColor { get => Label.BackColor; set => Label.BackColor = value; }
-    public string Text { get => Label.Text; set => Label.Text = value; }
+    public Color TextColor { get => LabelStyle.ForeColor; set => LabelStyle.ForeColor = value; }
+    public Color TextBackgroundColor { get => LabelStyle.BackColor; set => LabelStyle.BackColor = value; }
+    public string Text { get => LabelStyle.Text; set => LabelStyle.Text = value; }
+    public float TextRotation { get => LabelStyle.Rotation; set => LabelStyle.Rotation = value; }
+    public float TextSize { get => LabelStyle.FontSize; set => LabelStyle.FontSize = value; }
+    public Alignment? TextAlignment { get; set; } = null;
 
     public LineStyle LineStyle { get; set; } = new();
     public float LineWidth { get => LineStyle.Width; set => LineStyle.Width = value; }
@@ -35,7 +39,7 @@ public abstract class AxisLine : IPlottable, IRenderLast
         set
         {
             LineStyle.Color = value;
-            Label.BackColor = value;
+            LabelStyle.BackColor = value;
         }
     }
 
@@ -47,7 +51,7 @@ public abstract class AxisLine : IPlottable, IRenderLast
         {
             return LegendItem.Single(new LegendItem()
             {
-                Label = ExcludeFromLegend ? string.Empty : Label.Text,
+                Label = ExcludeFromLegend ? string.Empty : LabelStyle.Text,
                 Line = LineStyle,
                 Marker = MarkerStyle.None,
             });

--- a/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
@@ -10,6 +10,7 @@ public abstract class AxisLine : IPlottable, IRenderLast
     public float FontSize { get => Label.FontSize; set => Label.FontSize = value; }
     public bool FontBold { get => Label.Bold; set => Label.Bold = value; }
     public string FontName { get => Label.FontName; set => Label.FontName = value; }
+    public bool UseAutoAlignment { get; set; } = true;
 
     [Obsolete("Use TextColor", true)]
     public Color FontColor => TextColor;

--- a/src/ScottPlot5/ScottPlot5/Plottables/HorizontalLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/HorizontalLine.cs
@@ -13,12 +13,12 @@ public class HorizontalLine : AxisLine
 
     public HorizontalLine()
     {
-        Label.Rotation = -90;
-        Label.Alignment = Alignment.LowerCenter;
-        Label.FontSize = 14;
-        Label.Bold = true;
-        Label.ForeColor = Colors.White;
-        Label.Padding = 5;
+        LabelStyle.Rotation = -90;
+        LabelStyle.Alignment = Alignment.LowerCenter;
+        LabelStyle.FontSize = 14;
+        LabelStyle.Bold = true;
+        LabelStyle.ForeColor = Colors.White;
+        LabelStyle.Padding = 5;
     }
 
     public override bool IsUnderMouse(CoordinateRect rect) => IsDraggable && rect.ContainsY(Y);
@@ -50,7 +50,7 @@ public class HorizontalLine : AxisLine
 
     public override void RenderLast(RenderPack rp)
     {
-        if (Label.IsVisible == false || string.IsNullOrEmpty(Label.Text))
+        if (LabelStyle.IsVisible == false || string.IsNullOrEmpty(LabelStyle.Text))
             return;
 
         // determine location
@@ -61,20 +61,19 @@ public class HorizontalLine : AxisLine
             return;
 
         float x = LabelOppositeAxis
-            ? rp.DataRect.Right + Label.Padding
-            : rp.DataRect.Left - Label.Padding;
+            ? rp.DataRect.Right + LabelStyle.Padding
+            : rp.DataRect.Left - LabelStyle.Padding;
 
-        if (UseAutoAlignment)
-        {
-            Label.Alignment = LabelOppositeAxis
-                ? Alignment.UpperCenter
-                : Alignment.LowerCenter;
-        }
+        Alignment defaultAlignment = LabelOppositeAxis
+            ? Alignment.UpperCenter
+            : Alignment.LowerCenter;
+
+        LabelStyle.Alignment = TextAlignment ?? defaultAlignment;
 
         // draw label outside the data area
         rp.CanvasState.DisableClipping();
 
         using SKPaint paint = new();
-        Label.Render(rp.Canvas, x, y, paint);
+        LabelStyle.Render(rp.Canvas, x, y, paint);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/HorizontalLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/HorizontalLine.cs
@@ -64,9 +64,12 @@ public class HorizontalLine : AxisLine
             ? rp.DataRect.Right + Label.Padding
             : rp.DataRect.Left - Label.Padding;
 
-        Label.Alignment = LabelOppositeAxis
-            ? Alignment.UpperCenter
-            : Alignment.LowerCenter;
+        if (UseAutoAlignment)
+        {
+            Label.Alignment = LabelOppositeAxis
+                ? Alignment.UpperCenter
+                : Alignment.LowerCenter;
+        }
 
         // draw label outside the data area
         rp.CanvasState.DisableClipping();

--- a/src/ScottPlot5/ScottPlot5/Plottables/VerticalLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/VerticalLine.cs
@@ -63,9 +63,12 @@ public class VerticalLine : AxisLine
             ? rp.DataRect.Top - Label.Padding
             : rp.DataRect.Bottom + Label.Padding;
 
-        Label.Alignment = LabelOppositeAxis
-            ? Alignment.LowerCenter
-            : Alignment.UpperCenter;
+        if (UseAutoAlignment)
+        {
+            Label.Alignment = LabelOppositeAxis
+                ? Alignment.LowerCenter
+                : Alignment.UpperCenter;
+        }
 
         // draw label outside the data area
         rp.CanvasState.DisableClipping();

--- a/src/ScottPlot5/ScottPlot5/Plottables/VerticalLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/VerticalLine.cs
@@ -13,10 +13,10 @@ public class VerticalLine : AxisLine
 
     public VerticalLine()
     {
-        Label.ForeColor = Colors.White;
-        Label.FontSize = 14;
-        Label.Bold = true;
-        Label.Padding = 5;
+        LabelStyle.ForeColor = Colors.White;
+        LabelStyle.FontSize = 14;
+        LabelStyle.Bold = true;
+        LabelStyle.Padding = 5;
     }
 
     public override bool IsUnderMouse(CoordinateRect rect) => IsDraggable && rect.ContainsX(X);
@@ -49,7 +49,7 @@ public class VerticalLine : AxisLine
 
     public override void RenderLast(RenderPack rp)
     {
-        if (Label.IsVisible == false || string.IsNullOrEmpty(Label.Text))
+        if (LabelStyle.IsVisible == false || string.IsNullOrEmpty(LabelStyle.Text))
             return;
 
         // determine location
@@ -60,20 +60,19 @@ public class VerticalLine : AxisLine
             return;
 
         float y = LabelOppositeAxis
-            ? rp.DataRect.Top - Label.Padding
-            : rp.DataRect.Bottom + Label.Padding;
+            ? rp.DataRect.Top - LabelStyle.Padding
+            : rp.DataRect.Bottom + LabelStyle.Padding;
 
-        if (UseAutoAlignment)
-        {
-            Label.Alignment = LabelOppositeAxis
-                ? Alignment.LowerCenter
-                : Alignment.UpperCenter;
-        }
+        Alignment defaultAlignment = LabelOppositeAxis
+            ? Alignment.LowerCenter
+            : Alignment.UpperCenter;
+
+        LabelStyle.Alignment = TextAlignment ?? defaultAlignment;
 
         // draw label outside the data area
         rp.CanvasState.DisableClipping();
 
         using SKPaint paint = new();
-        Label.Render(rp.Canvas, x, y, paint);
+        LabelStyle.Render(rp.Canvas, x, y, paint);
     }
 }


### PR DESCRIPTION
Fixes #3624 

New flag on AxisLine objects called UseAutoAlignment.  Defaults to true, if set to false the Label.Alignment property not set to the AxisLine default.  Gives full control over the label positioning, allowing such things as rotating the label sensibly.

New cookbook recipe is included in the PR.  Recipe is shown below along with the resulting plot below that.

```cs
myPlot.Add.Signal(Generate.Sin());
myPlot.Add.Signal(Generate.Cos());

var axLine1 = myPlot.Add.VerticalLine(42);
axLine1.Text = "Line 1";
axLine1.Label.Rotation = -90;
axLine1.UseAutoAlignment = false;   // Disable automatic alignment
axLine1.Label.Alignment = Alignment.MiddleRight;

var axLine2 = myPlot.Add.HorizontalLine(0.75);
axLine2.Text = "Line 2";
axLine2.Label.Rotation = 0;
axLine2.UseAutoAlignment = false;   // Disable automatic alignment
axLine2.Label.Alignment = Alignment.MiddleRight;

// extra padding on the bottom and left for the rotated labels
myPlot.Axes.Bottom.MinimumSize = 60;
myPlot.Axes.Left.MinimumSize = 60;
```

![AxisLineLabelPositioning](https://github.com/ScottPlot/ScottPlot/assets/223530/1b1c31d3-c97b-46c1-a668-db1130dea289)

