### PR TITLE
SP5: fix DataLogger scrolling when not using default axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ _Not yet on NuGet..._
 * AxisLine: Improve appearance in of the key displayed in the legend (#3627, #3613) @MCF
 * Crosshair: Expose `VerticalLine` and `HorizontalLine` for to allow axis-specific customization (#3638) @Fruchtzwerg94 @heartacker
 * AxisLine: Added properties for faster styling including an optional `TextAlignment` setting (#3640, #3624) @MCF
+* Axes: Improved autoscaling support behavior for plots where nonstandard axes are in use (#3641, #3637) @KroMignon @jpgarza93
 
 ## ScottPlot 5.0.25
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-04-08_

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DataLogger.Designer.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DataLogger.Designer.cs
@@ -30,89 +30,81 @@ partial class DataLogger
     {
         btnJump = new Button();
         btnFull = new Button();
-        cbManageLimits = new CheckBox();
+        chkManageLimits = new CheckBox();
         formsPlot1 = new ScottPlot.WinForms.FormsPlot();
         btnSlide = new Button();
-        chkRightAxe = new CheckBox();
+        chkRightAxis = new CheckBox();
         SuspendLayout();
         // 
         // btnJump
         // 
-        btnJump.Location = new Point(121, 16);
-        btnJump.Margin = new Padding(3, 4, 3, 4);
+        btnJump.Location = new Point(106, 12);
         btnJump.Name = "btnJump";
-        btnJump.Size = new Size(101, 45);
+        btnJump.Size = new Size(88, 34);
         btnJump.TabIndex = 9;
         btnJump.Text = "Jump";
         btnJump.UseVisualStyleBackColor = true;
         // 
         // btnFull
         // 
-        btnFull.Location = new Point(14, 16);
-        btnFull.Margin = new Padding(3, 4, 3, 4);
+        btnFull.Location = new Point(12, 12);
         btnFull.Name = "btnFull";
-        btnFull.Size = new Size(101, 45);
+        btnFull.Size = new Size(88, 34);
         btnFull.TabIndex = 8;
         btnFull.Text = "Full";
         btnFull.UseVisualStyleBackColor = true;
         // 
         // cbManageLimits
         // 
-        cbManageLimits.AutoSize = true;
-        cbManageLimits.Checked = true;
-        cbManageLimits.CheckState = CheckState.Checked;
-        cbManageLimits.Location = new Point(350, 28);
-        cbManageLimits.Margin = new Padding(3, 4, 3, 4);
-        cbManageLimits.Name = "cbManageLimits";
-        cbManageLimits.Size = new Size(159, 24);
-        cbManageLimits.TabIndex = 7;
-        cbManageLimits.Text = "Manage Axis Limits";
-        cbManageLimits.UseVisualStyleBackColor = true;
+        chkManageLimits.AutoSize = true;
+        chkManageLimits.Checked = true;
+        chkManageLimits.CheckState = CheckState.Checked;
+        chkManageLimits.Location = new Point(306, 21);
+        chkManageLimits.Name = "cbManageLimits";
+        chkManageLimits.Size = new Size(129, 19);
+        chkManageLimits.TabIndex = 7;
+        chkManageLimits.Text = "Manage Axis Limits";
+        chkManageLimits.UseVisualStyleBackColor = true;
         // 
         // formsPlot1
         // 
         formsPlot1.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
         formsPlot1.DisplayScale = 1F;
-        formsPlot1.Location = new Point(14, 69);
-        formsPlot1.Margin = new Padding(3, 4, 3, 4);
+        formsPlot1.Location = new Point(12, 52);
         formsPlot1.Name = "formsPlot1";
-        formsPlot1.Size = new Size(783, 460);
+        formsPlot1.Size = new Size(685, 345);
         formsPlot1.TabIndex = 6;
         // 
         // btnSlide
         // 
-        btnSlide.Location = new Point(229, 16);
-        btnSlide.Margin = new Padding(3, 4, 3, 4);
+        btnSlide.Location = new Point(200, 12);
         btnSlide.Name = "btnSlide";
-        btnSlide.Size = new Size(101, 45);
+        btnSlide.Size = new Size(88, 34);
         btnSlide.TabIndex = 10;
         btnSlide.Text = "Slide";
         btnSlide.UseVisualStyleBackColor = true;
         // 
-        // chkRightAxe
+        // chkRightAxis
         // 
-        chkRightAxe.AutoSize = true;
-        chkRightAxe.Location = new Point(550, 28);
-        chkRightAxe.Margin = new Padding(3, 4, 3, 4);
-        chkRightAxe.Name = "chkRightAxe";
-        chkRightAxe.Size = new Size(119, 24);
-        chkRightAxe.TabIndex = 11;
-        chkRightAxe.Text = "Use right axis";
-        chkRightAxe.UseVisualStyleBackColor = true;
-        chkRightAxe.CheckedChanged += chkRightAxe_CheckedChanged;
+        chkRightAxis.AutoSize = true;
+        chkRightAxis.Location = new Point(454, 21);
+        chkRightAxis.Name = "chkRightAxis";
+        chkRightAxis.Size = new Size(79, 19);
+        chkRightAxis.TabIndex = 11;
+        chkRightAxis.Text = "Right Axis";
+        chkRightAxis.UseVisualStyleBackColor = true;
         // 
         // DataLogger
         // 
-        AutoScaleDimensions = new SizeF(8F, 20F);
+        AutoScaleDimensions = new SizeF(7F, 15F);
         AutoScaleMode = AutoScaleMode.Font;
-        ClientSize = new Size(810, 545);
-        Controls.Add(chkRightAxe);
+        ClientSize = new Size(709, 409);
+        Controls.Add(chkRightAxis);
         Controls.Add(btnSlide);
         Controls.Add(btnJump);
         Controls.Add(btnFull);
-        Controls.Add(cbManageLimits);
+        Controls.Add(chkManageLimits);
         Controls.Add(formsPlot1);
-        Margin = new Padding(3, 4, 3, 4);
         Name = "DataLogger";
         Text = "DataLogger";
         ResumeLayout(false);
@@ -123,8 +115,8 @@ partial class DataLogger
 
     private Button btnJump;
     private Button btnFull;
-    private CheckBox cbManageLimits;
+    private CheckBox chkManageLimits;
     private ScottPlot.WinForms.FormsPlot formsPlot1;
     private Button btnSlide;
-    private CheckBox chkRightAxe;
+    private CheckBox chkRightAxis;
 }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DataLogger.Designer.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DataLogger.Designer.cs
@@ -33,22 +33,25 @@ partial class DataLogger
         cbManageLimits = new CheckBox();
         formsPlot1 = new ScottPlot.WinForms.FormsPlot();
         btnSlide = new Button();
+        chkRightAxe = new CheckBox();
         SuspendLayout();
         // 
         // btnJump
         // 
-        btnJump.Location = new Point(106, 12);
+        btnJump.Location = new Point(121, 16);
+        btnJump.Margin = new Padding(3, 4, 3, 4);
         btnJump.Name = "btnJump";
-        btnJump.Size = new Size(88, 34);
+        btnJump.Size = new Size(101, 45);
         btnJump.TabIndex = 9;
         btnJump.Text = "Jump";
         btnJump.UseVisualStyleBackColor = true;
         // 
         // btnFull
         // 
-        btnFull.Location = new Point(12, 12);
+        btnFull.Location = new Point(14, 16);
+        btnFull.Margin = new Padding(3, 4, 3, 4);
         btnFull.Name = "btnFull";
-        btnFull.Size = new Size(88, 34);
+        btnFull.Size = new Size(101, 45);
         btnFull.TabIndex = 8;
         btnFull.Text = "Full";
         btnFull.UseVisualStyleBackColor = true;
@@ -58,9 +61,10 @@ partial class DataLogger
         cbManageLimits.AutoSize = true;
         cbManageLimits.Checked = true;
         cbManageLimits.CheckState = CheckState.Checked;
-        cbManageLimits.Location = new Point(306, 21);
+        cbManageLimits.Location = new Point(350, 28);
+        cbManageLimits.Margin = new Padding(3, 4, 3, 4);
         cbManageLimits.Name = "cbManageLimits";
-        cbManageLimits.Size = new Size(129, 19);
+        cbManageLimits.Size = new Size(159, 24);
         cbManageLimits.TabIndex = 7;
         cbManageLimits.Text = "Manage Axis Limits";
         cbManageLimits.UseVisualStyleBackColor = true;
@@ -69,30 +73,46 @@ partial class DataLogger
         // 
         formsPlot1.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
         formsPlot1.DisplayScale = 1F;
-        formsPlot1.Location = new Point(12, 52);
+        formsPlot1.Location = new Point(14, 69);
+        formsPlot1.Margin = new Padding(3, 4, 3, 4);
         formsPlot1.Name = "formsPlot1";
-        formsPlot1.Size = new Size(685, 345);
+        formsPlot1.Size = new Size(783, 460);
         formsPlot1.TabIndex = 6;
         // 
         // btnSlide
         // 
-        btnSlide.Location = new Point(200, 12);
+        btnSlide.Location = new Point(229, 16);
+        btnSlide.Margin = new Padding(3, 4, 3, 4);
         btnSlide.Name = "btnSlide";
-        btnSlide.Size = new Size(88, 34);
+        btnSlide.Size = new Size(101, 45);
         btnSlide.TabIndex = 10;
         btnSlide.Text = "Slide";
         btnSlide.UseVisualStyleBackColor = true;
         // 
+        // chkRightAxe
+        // 
+        chkRightAxe.AutoSize = true;
+        chkRightAxe.Location = new Point(550, 28);
+        chkRightAxe.Margin = new Padding(3, 4, 3, 4);
+        chkRightAxe.Name = "chkRightAxe";
+        chkRightAxe.Size = new Size(119, 24);
+        chkRightAxe.TabIndex = 11;
+        chkRightAxe.Text = "Use right axis";
+        chkRightAxe.UseVisualStyleBackColor = true;
+        chkRightAxe.CheckedChanged += chkRightAxe_CheckedChanged;
+        // 
         // DataLogger
         // 
-        AutoScaleDimensions = new SizeF(7F, 15F);
+        AutoScaleDimensions = new SizeF(8F, 20F);
         AutoScaleMode = AutoScaleMode.Font;
-        ClientSize = new Size(709, 409);
+        ClientSize = new Size(810, 545);
+        Controls.Add(chkRightAxe);
         Controls.Add(btnSlide);
         Controls.Add(btnJump);
         Controls.Add(btnFull);
         Controls.Add(cbManageLimits);
         Controls.Add(formsPlot1);
+        Margin = new Padding(3, 4, 3, 4);
         Name = "DataLogger";
         Text = "DataLogger";
         ResumeLayout(false);
@@ -106,4 +126,5 @@ partial class DataLogger
     private CheckBox cbManageLimits;
     private ScottPlot.WinForms.FormsPlot formsPlot1;
     private Button btnSlide;
+    private CheckBox chkRightAxe;
 }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DataLogger.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DataLogger.cs
@@ -19,6 +19,8 @@ public partial class DataLogger : Form, IDemoWindow
         // disable mouse interaction by default
         formsPlot1.Interaction.Disable();
 
+        Logger.Axes.YAxis = chkRightAxe.Checked ? formsPlot1.Plot.Axes.Right : formsPlot1.Plot.Axes.Left;
+
         // setup a timer to add data to the streamer periodically
         AddNewDataTimer.Tick += (s, e) =>
         {
@@ -54,5 +56,13 @@ public partial class DataLogger : Form, IDemoWindow
                 formsPlot1.Interaction.Enable();
             }
         };
+    }
+
+    private void chkRightAxe_CheckedChanged(object sender, EventArgs e)
+    {
+        lock (formsPlot1.Plot.Sync)
+        {
+            Logger.Axes.YAxis = chkRightAxe.Checked ? formsPlot1.Plot.Axes.Right : formsPlot1.Plot.Axes.Left;
+        }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DataLogger.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DataLogger.cs
@@ -19,8 +19,6 @@ public partial class DataLogger : Form, IDemoWindow
         // disable mouse interaction by default
         formsPlot1.Interaction.Disable();
 
-        Logger.Axes.YAxis = chkRightAxe.Checked ? formsPlot1.Plot.Axes.Right : formsPlot1.Plot.Axes.Left;
-
         // setup a timer to add data to the streamer periodically
         AddNewDataTimer.Tick += (s, e) =>
         {
@@ -42,9 +40,11 @@ public partial class DataLogger : Form, IDemoWindow
         btnFull.Click += (s, e) => Logger.ViewFull();
         btnJump.Click += (s, e) => Logger.ViewJump();
         btnSlide.Click += (s, e) => Logger.ViewSlide();
-        cbManageLimits.CheckedChanged += (s, e) =>
+
+        // control automatic axis limit modification behavior
+        chkManageLimits.CheckedChanged += (s, e) =>
         {
-            if (cbManageLimits.Checked)
+            if (chkManageLimits.Checked)
             {
                 Logger.ManageAxisLimits = true;
                 formsPlot1.Interaction.Disable();
@@ -56,13 +56,21 @@ public partial class DataLogger : Form, IDemoWindow
                 formsPlot1.Interaction.Enable();
             }
         };
-    }
 
-    private void chkRightAxe_CheckedChanged(object sender, EventArgs e)
-    {
-        lock (formsPlot1.Plot.Sync)
+        // switch between using primary and secondary Y axes
+        chkRightAxis.CheckedChanged += (s, e) =>
         {
-            Logger.Axes.YAxis = chkRightAxe.Checked ? formsPlot1.Plot.Axes.Right : formsPlot1.Plot.Axes.Left;
-        }
+            lock (formsPlot1.Plot.Sync)
+            {
+                // reset old axis limits so ticks are not displayed on unused axes 
+                formsPlot1.Plot.Axes.Left.Range.Reset();
+                formsPlot1.Plot.Axes.Right.Range.Reset();
+
+                // tell the datalogger which axis to use and modify moving forward
+                Logger.Axes.YAxis = chkRightAxis.Checked
+                    ? formsPlot1.Plot.Axes.Right
+                    : formsPlot1.Plot.Axes.Left;
+            }
+        };
     }
 }

--- a/src/ScottPlot5/ScottPlot5/AutoScalers/FractionalAutoScaler.cs
+++ b/src/ScottPlot5/ScottPlot5/AutoScalers/FractionalAutoScaler.cs
@@ -88,7 +88,7 @@ public class FractionalAutoScaler : IAutoScaler
 
     public AxisLimits GetAxisLimits(Plot plot, IXAxis xAxis, IYAxis yAxis)
     {
-        AxisLimits dataLimits = plot.Axes.GetDataLimits();
+        AxisLimits dataLimits = plot.Axes.GetDataLimits(xAxis, yAxis);
         ExpandingAxisLimits limits = new(dataLimits);
 
         if (!limits.IsRealX)

--- a/src/ScottPlot5/ScottPlot5/Plottables/DataLogger.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/DataLogger.cs
@@ -29,10 +29,6 @@ public class DataLogger : IPlottable, IManagesAxisLimits
         AxisLimits dataLimits = GetAxisLimits();
         AxisLimits newLimits = AxisManager.GetAxisLimits(viewLimits, dataLimits);
 
-        Debug.WriteLine("");
-        Debug.WriteLine(dataLimits);
-        Debug.WriteLine(newLimits);
-
         plot.Axes.SetLimits(newLimits, Axes.XAxis, Axes.YAxis);
 
         if (force)


### PR DESCRIPTION
There was a little bug in `FractionalAutoScaler`, data were always taken from default axes left and bottom and not from the axes given as parameter.

I have changed the Demo application to add a checkbox to toggle between left and right axis for the `DataLogger`.

This should fix issue #3637.