### PR TITLE
FillY bug fixes: Update poly coordinates instead of creating a new po…

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Plottables/FillY.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/FillY.cs
@@ -17,7 +17,7 @@ public class FillY : IPlottable, IHasLine, IHasFill, IHasMarker, IHasLegendText
     public Color FillHatchColor { get => FillStyle.HatchColor; set => FillStyle.HatchColor = value; }
     public IHatch? FillHatch { get => FillStyle.Hatch; set => FillStyle.Hatch = value; }
 
-    public LineStyle LineStyle { get; set; } = new() { Width = 1 };
+    public LineStyle LineStyle { get => Poly.LineStyle; set => Poly.LineStyle = value; }
     public float LineWidth { get => LineStyle.Width; set => LineStyle.Width = value; }
     public LinePattern LinePattern { get => LineStyle.Pattern; set => LineStyle.Pattern = value; }
     public Color LineColor { get => LineStyle.Color; set => LineStyle.Color = value; }
@@ -69,7 +69,7 @@ public class FillY : IPlottable, IHasLine, IHasFill, IHasMarker, IHasLegendText
             i++;
         }
 
-        Poly = new Polygon(all);
+        Poly.UpdateCoordinates(all);
     }
 
     public void SetDataSource<T>(ICollection<T> items, Func<T, (double X, double Top, double Bottom)> coordinateSolver)
@@ -90,7 +90,7 @@ public class FillY : IPlottable, IHasLine, IHasFill, IHasMarker, IHasLegendText
             i++;
         }
 
-        Poly = new Polygon(all);
+        Poly.UpdateCoordinates(all);
     }
 
     public AxisLimits GetAxisLimits()


### PR DESCRIPTION
…lygon to prevent loss of all set properties (marker, line and fill styles) when setting (updating) data source. Redirect LineStyle property to Poly to actually apply it.

Use this space to describe what this pull request accomplishes. 
FillY bug fixes: Update poly coordinates instead of creating a new polygon to prevent loss of all set properties (marker, line and fill styles) when setting (updating) data source. Redirect LineStyle property to Poly to actually apply it.
Refer to open issues by their number to help link them with this pull request.
should fix #3720 and #3723