### PR TITLE
Avoid excessive memory allocation in Markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-## ScottPlot 5.0.32
+## ScottPlot 5.0.33
 _Not yet on NuGet..._
+* Markers: Reduced memory allocations and improved performance during rendering (#3767) @drolevar
+
+## ScottPlot 5.0.32
+_Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-05-01_
 * Image: Added support support conversion to/from pixel value arrays to facilitate differential image analysis and testing (#3748, #3727)
 * Layout: Improve measurement of vertical axis tick labels (#3736) @ebarnard
 * Annotation: Improved positioning of annotations containing many lines (#3749, #3700) @LerkLin

--- a/src/ScottPlot5/ScottPlot5/Plottables/Markers.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Markers.cs
@@ -34,14 +34,12 @@ public class Markers(IScatterSource data) : IPlottable, IHasMarker, IHasLegendTe
 
     public virtual void Render(RenderPack rp)
     {
-        if (this.MarkerStyle == MarkerStyle.None)
+        IReadOnlyList<Coordinates> points = Data.GetScatterPoints();
+
+        if (this.MarkerStyle == MarkerStyle.None || points.Count == 0)
             return;
 
-        // TODO: can this be more efficient by moving this logic into the DataSource to avoid copying?
-        Pixel[] markerPixels = Data.GetScatterPoints().Select(Axes.GetPixel).ToArray();
-
-        if (!markerPixels.Any())
-            return;
+        IEnumerable<Pixel> markerPixels = Data.GetScatterPoints().Select(Axes.GetPixel);
 
         using SKPaint paint = new();
         Drawing.DrawMarkers(rp.Canvas, paint, markerPixels, MarkerStyle);


### PR DESCRIPTION
Calling ToArray() causes extra memory allocation, as specified in TODO:

```
Large Object Heap: code that allocates a lot of memory in LOH
Allocated object type: Coordinates[]
Last observation: 2024-04-24 11:59 MyApp.exe
  Allocated size: 4 278,4 MB

at Enumerable+ListPartition<Coordinates>.ToList()
at Markers.Render(RenderPack) in /_/src/ScottPlot5/ScottPlot5/Plottables/Markers.cs:line 38 column 13
at RenderPlottables.Render(RenderPack) in /_/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/RenderPlottables.cs:line 22 column 17
```

Use lazy Linq query instead.