### PR TITLE
Prevent exception when no ticks have been generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## ScottPlot 5.0.33
 _Not yet on NuGet..._
 * Markers: Reduced memory allocations and improved performance during rendering (#3767) @drolevar
+* Axes: Prevent exceptions for conditions where tick generation produces no ticks (#3768) @drolevar
 
 ## ScottPlot 5.0.32
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-05-01_

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/XAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/XAxisBase.cs
@@ -14,7 +14,7 @@ public abstract class XAxisBase : AxisBase, IXAxis
         if (!IsVisible)
             return 0;
 
-        if (!Range.HasBeenSet)
+        if (!Range.HasBeenSet || TickGenerator.Ticks.Length == 0)
             return SizeWhenNoData;
 
         using SKPaint paint = new();

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
@@ -25,13 +25,11 @@ public abstract class YAxisBase : AxisBase, IYAxis
         if (!IsVisible)
             return 0;
 
-        if (!Range.HasBeenSet)
+        if (!Range.HasBeenSet || TickGenerator.Ticks.Length == 0)
             return SizeWhenNoData;
 
         using SKPaint paint = new();
         float maxTickLabelWidth = TickGenerator.Ticks.Select(x => TickLabelStyle.Measure(x.Label, paint).Width).Max();
-
-        string ticks = string.Join(", ", TickGenerator.Ticks.Select(x => x.Label));
 
         float axisLabelHeight = string.IsNullOrEmpty(LabelStyle.Text)
             ? EmptyLabelPadding.Horizontal


### PR DESCRIPTION
If the zoom level is too big, no ticks are generated an Measure methods throw an exception.