### PR TITLE
SignalConst: evaluate performance of double-only array type

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPlotTypes.Designer.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPlotTypes.Designer.cs
@@ -32,6 +32,7 @@ partial class SignalPlotTypes
         formsPlot1 = new ScottPlot.WinForms.FormsPlot();
         formsPlot2 = new ScottPlot.WinForms.FormsPlot();
         formsPlot3 = new ScottPlot.WinForms.FormsPlot();
+        formsPlot4 = new ScottPlot.WinForms.FormsPlot();
         tableLayoutPanel1.SuspendLayout();
         SuspendLayout();
         // 
@@ -42,13 +43,15 @@ partial class SignalPlotTypes
         tableLayoutPanel1.Controls.Add(formsPlot1, 0, 0);
         tableLayoutPanel1.Controls.Add(formsPlot2, 0, 1);
         tableLayoutPanel1.Controls.Add(formsPlot3, 0, 2);
+        tableLayoutPanel1.Controls.Add(formsPlot4, 0, 3);
         tableLayoutPanel1.Dock = DockStyle.Fill;
         tableLayoutPanel1.Location = new Point(0, 0);
         tableLayoutPanel1.Name = "tableLayoutPanel1";
-        tableLayoutPanel1.RowCount = 3;
-        tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Percent, 33.3333321F));
-        tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Percent, 33.3333321F));
-        tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Percent, 33.3333321F));
+        tableLayoutPanel1.RowCount = 4;
+        tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Percent, 25F));
+        tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Percent, 25F));
+        tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Percent, 25F));
+        tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Percent, 25F));
         tableLayoutPanel1.Size = new Size(914, 777);
         tableLayoutPanel1.TabIndex = 0;
         // 
@@ -58,26 +61,35 @@ partial class SignalPlotTypes
         formsPlot1.Dock = DockStyle.Fill;
         formsPlot1.Location = new Point(3, 3);
         formsPlot1.Name = "formsPlot1";
-        formsPlot1.Size = new Size(908, 252);
+        formsPlot1.Size = new Size(908, 188);
         formsPlot1.TabIndex = 0;
         // 
         // formsPlot2
         // 
         formsPlot2.DisplayScale = 1F;
         formsPlot2.Dock = DockStyle.Fill;
-        formsPlot2.Location = new Point(3, 261);
+        formsPlot2.Location = new Point(3, 197);
         formsPlot2.Name = "formsPlot2";
-        formsPlot2.Size = new Size(908, 252);
+        formsPlot2.Size = new Size(908, 188);
         formsPlot2.TabIndex = 1;
         // 
         // formsPlot3
         // 
         formsPlot3.DisplayScale = 1F;
         formsPlot3.Dock = DockStyle.Fill;
-        formsPlot3.Location = new Point(3, 519);
+        formsPlot3.Location = new Point(3, 391);
         formsPlot3.Name = "formsPlot3";
-        formsPlot3.Size = new Size(908, 255);
+        formsPlot3.Size = new Size(908, 188);
         formsPlot3.TabIndex = 2;
+        // 
+        // formsPlot4
+        // 
+        formsPlot4.DisplayScale = 1F;
+        formsPlot4.Dock = DockStyle.Fill;
+        formsPlot4.Location = new Point(3, 585);
+        formsPlot4.Name = "formsPlot4";
+        formsPlot4.Size = new Size(908, 189);
+        formsPlot4.TabIndex = 3;
         // 
         // SignalPlotTypes
         // 
@@ -97,4 +109,5 @@ partial class SignalPlotTypes
     private ScottPlot.WinForms.FormsPlot formsPlot1;
     private ScottPlot.WinForms.FormsPlot formsPlot2;
     private ScottPlot.WinForms.FormsPlot formsPlot3;
+    private ScottPlot.WinForms.FormsPlot formsPlot4;
 }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPlotTypes.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalPlotTypes.cs
@@ -15,8 +15,9 @@ public partial class SignalPlotTypes : Form, IDemoWindow
 
         double[] data = Generate.RandomWalk(10_000_000);
         SetupSignal(formsPlot1, data);
-        SetupSignalConst(formsPlot2, data);
-        SetupSignalBinned(formsPlot3, data);
+        SetupSignalConstGeneric(formsPlot2, data);
+        SetupSignalConstDouble(formsPlot3, data);
+        SetupSignalBinned(formsPlot4, data);
     }
 
     private static void SetupSignal(IPlotControl formsPlot, double[] data)
@@ -26,9 +27,16 @@ public partial class SignalPlotTypes : Form, IDemoWindow
         formsPlot.Plot.Add.Signal(data);
     }
 
-    private static void SetupSignalConst(IPlotControl formsPlot, double[] data)
+    private static void SetupSignalConstGeneric(IPlotControl formsPlot, double[] data)
     {
-        formsPlot.Plot.Title("SignalConst with 10 million points");
+        formsPlot.Plot.Title("SignalConst (Generic) with 10 million points");
+        formsPlot.Plot.Benchmark.IsVisible = true;
+        formsPlot.Plot.Add.SignalConst<double>(data);
+    }
+
+    private static void SetupSignalConstDouble(IPlotControl formsPlot, double[] data)
+    {
+        formsPlot.Plot.Title("SignalConst (double) with 10 million points");
         formsPlot.Plot.Benchmark.IsVisible = true;
         formsPlot.Plot.Add.SignalConst(data);
     }

--- a/src/ScottPlot5/ScottPlot5/DataSources/SegmentedTreeGeneric.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SegmentedTreeGeneric.cs
@@ -1,0 +1,313 @@
+﻿using System.Threading.Tasks;
+
+namespace ScottPlot.DataSources;
+
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
+#pragma warning disable CS8604 // Possible null reference argument.
+
+public class SegmentedTreeGeneric<T> where T : struct, IComparable
+{
+    private T[] sourceArray;
+
+    private T[] TreeMin;
+    private T[] TreeMax;
+    private int n = 0; // size of each Tree
+    public bool TreesReady = false;
+
+    // precompiled lambda expressions for fast math on generic
+    private static Func<T, T, T> MinExp;
+    private static Func<T, T, T> MaxExp;
+    private static Func<T, T, bool> EqualExp;
+    private static Func<T> MaxValue;
+    private static Func<T> MinValue;
+    private static Func<T, T, bool> LessThanExp;
+    private static Func<T, T, bool> GreaterThanExp;
+
+    public T[] SourceArray
+    {
+        get => sourceArray;
+        set
+        {
+            sourceArray = value ?? throw new Exception("Source Array cannot be null");
+            UpdateTrees();
+        }
+    }
+
+    public SegmentedTreeGeneric()
+    {
+        try // runtime check
+        {
+            var v = new T();
+            NumericConversion.GenericToDouble(ref v);
+        }
+        catch
+        {
+            throw new ArgumentOutOfRangeException("Unsupported data type, provide convertable to double data types");
+        }
+        InitExp();
+    }
+
+    public async Task SetSourceAsync(T[] data)
+    {
+        sourceArray = data ?? throw new ArgumentNullException("Data cannot be null");
+        await Task.Run(() => UpdateTrees());
+    }
+
+    private void InitExp()
+    {
+        ParameterExpression paramA = Expression.Parameter(typeof(T), "a");
+        ParameterExpression paramB = Expression.Parameter(typeof(T), "b");
+        // add the parameters together
+        ConditionalExpression bodyMin = Expression.Condition(Expression.LessThanOrEqual(paramA, paramB), paramA, paramB);
+        ConditionalExpression bodyMax = Expression.Condition(Expression.GreaterThanOrEqual(paramA, paramB), paramA, paramB);
+        BinaryExpression bodyEqual = Expression.Equal(paramA, paramB);
+        MemberExpression bodyMaxValue = Expression.MakeMemberAccess(null, typeof(T).GetField("MaxValue"));
+        MemberExpression bodyMinValue = Expression.MakeMemberAccess(null, typeof(T).GetField("MinValue"));
+        BinaryExpression bodyLessThan = Expression.LessThan(paramA, paramB);
+        BinaryExpression bodyGreaterThan = Expression.GreaterThan(paramA, paramB);
+        // compile it
+        MinExp = Expression.Lambda<Func<T, T, T>>(bodyMin, paramA, paramB).Compile();
+        MaxExp = Expression.Lambda<Func<T, T, T>>(bodyMax, paramA, paramB).Compile();
+        EqualExp = Expression.Lambda<Func<T, T, bool>>(bodyEqual, paramA, paramB).Compile();
+        MaxValue = Expression.Lambda<Func<T>>(bodyMaxValue).Compile();
+        MinValue = Expression.Lambda<Func<T>>(bodyMinValue).Compile();
+        LessThanExp = Expression.Lambda<Func<T, T, bool>>(bodyLessThan, paramA, paramB).Compile();
+        GreaterThanExp = Expression.Lambda<Func<T, T, bool>>(bodyGreaterThan, paramA, paramB).Compile();
+    }
+
+    public void updateElement(int index, T newValue)
+    {
+        sourceArray[index] = newValue;
+        // Update Tree, can be optimized            
+        if (index == sourceArray.Length - 1) // last elem haven't pair
+        {
+            TreeMin[n / 2 + index / 2] = sourceArray[index];
+            TreeMax[n / 2 + index / 2] = sourceArray[index];
+        }
+        else if (index % 2 == 0) // even elem have right pair
+        {
+            TreeMin[n / 2 + index / 2] = MinExp(sourceArray[index], sourceArray[index + 1]);
+            TreeMax[n / 2 + index / 2] = MaxExp(sourceArray[index], sourceArray[index + 1]);
+        }
+        else // odd elem have left pair
+        {
+            TreeMin[n / 2 + index / 2] = MinExp(sourceArray[index], sourceArray[index - 1]);
+            TreeMax[n / 2 + index / 2] = MaxExp(sourceArray[index], sourceArray[index - 1]);
+        }
+
+        T candidate;
+        for (int i = (n / 2 + index / 2) / 2; i > 0; i /= 2)
+        {
+            candidate = MinExp(TreeMin[i * 2], TreeMin[i * 2 + 1]);
+            if (EqualExp(TreeMin[i], candidate)) // if node same then new value don't need to recalc all upper
+                break;
+            TreeMin[i] = candidate;
+        }
+        for (int i = (n / 2 + index / 2) / 2; i > 0; i /= 2)
+        {
+            candidate = MaxExp(TreeMax[i * 2], TreeMax[i * 2 + 1]);
+            if (EqualExp(TreeMax[i], candidate)) // if node same then new value don't need to recalc all upper
+                break;
+            TreeMax[i] = candidate;
+        }
+    }
+
+    public void updateRange(int from, int to, T[] newData, int fromData = 0) // RangeUpdate
+    {
+        //update source signal
+        for (int i = from; i < to; i++)
+        {
+            sourceArray[i] = newData[i - from + fromData];
+        }
+
+        for (int i = n / 2 + from / 2; i < n / 2 + to / 2; i++)
+        {
+            TreeMin[i] = MinExp(sourceArray[i * 2 - n], sourceArray[i * 2 + 1 - n]);
+            TreeMax[i] = MaxExp(sourceArray[i * 2 - n], sourceArray[i * 2 + 1 - n]);
+        }
+        if (to == sourceArray.Length) // last elem haven't pair
+        {
+            TreeMin[n / 2 + to / 2] = sourceArray[to - 1];
+            TreeMax[n / 2 + to / 2] = sourceArray[to - 1];
+        }
+        else if (to % 2 == 1) //last elem even(to-1) and not last
+        {
+            TreeMin[n / 2 + to / 2] = MinExp(sourceArray[to - 1], sourceArray[to]);
+            TreeMax[n / 2 + to / 2] = MaxExp(sourceArray[to - 1], sourceArray[to]);
+        }
+
+        from = (n / 2 + from / 2) / 2;
+        to = (n / 2 + to / 2) / 2;
+
+        T candidate;
+        while (from != 0) // up to root elem, that is [1], [0] - is free elem
+        {
+            if (from != to)
+            {
+                for (int i = from; i <= to; i++) // Recalc all level nodes in range 
+                {
+                    TreeMin[i] = MinExp(TreeMin[i * 2], TreeMin[i * 2 + 1]);
+                    TreeMax[i] = MaxExp(TreeMax[i * 2], TreeMax[i * 2 + 1]);
+                }
+            }
+            else
+            {
+                // left == rigth, so no need more from to loop
+                for (int i = from; i > 0; i /= 2) // up to root node
+                {
+                    candidate = MinExp(TreeMin[i * 2], TreeMin[i * 2 + 1]);
+                    if (EqualExp(TreeMin[i], candidate)) // if node same then new value don't need to recalc all upper
+                        break;
+                    TreeMin[i] = candidate;
+                }
+
+                for (int i = from; i > 0; i /= 2) // up to root node
+                {
+                    candidate = MaxExp(TreeMax[i * 2], TreeMax[i * 2 + 1]);
+                    if (EqualExp(TreeMax[i], candidate)) // if node same then new value don't need to recalc all upper
+                        break;
+                    TreeMax[i] = candidate;
+                }
+                // all work done exit while loop
+                break;
+            }
+            // level up
+            from = from / 2;
+            to = to / 2;
+        }
+    }
+
+    public void updateData(int from, T[] newData)
+    {
+        updateRange(from, newData.Length, newData);
+    }
+
+    public void updateData(T[] newData)
+    {
+        updateRange(0, newData.Length, newData);
+    }
+
+    public void UpdateTreesInBackground()
+    {
+        Task.Run(() => { UpdateTrees(); });
+    }
+
+    public void UpdateTrees()
+    {
+        // O(n) to build trees
+        TreesReady = false;
+        try
+        {
+            if (sourceArray.Length == 0)
+                throw new ArgumentOutOfRangeException($"Array cant't be empty");
+            // Size up to pow2
+            if (sourceArray.Length > 0x40_00_00_00) // pow 2 must be more then int.MaxValue
+                throw new ArgumentOutOfRangeException($"Array higher than {0x40_00_00_00} not supported by SignalConst");
+            int pow2 = 1;
+            while (pow2 < 0x40_00_00_00 && pow2 < sourceArray.Length)
+                pow2 <<= 1;
+            n = pow2;
+            TreeMin = new T[n];
+            TreeMax = new T[n];
+            T maxValue = MaxValue();
+            T minValue = MinValue();
+
+            // fill bottom layer of tree
+            for (int i = 0; i < sourceArray.Length / 2; i++) // with source array pairs min/max
+            {
+                TreeMin[n / 2 + i] = MinExp(sourceArray[i * 2], sourceArray[i * 2 + 1]);
+                TreeMax[n / 2 + i] = MaxExp(sourceArray[i * 2], sourceArray[i * 2 + 1]);
+            }
+            if (sourceArray.Length % 2 == 1) // if array size odd, last element haven't pair to compare
+            {
+                TreeMin[n / 2 + sourceArray.Length / 2] = sourceArray[sourceArray.Length - 1];
+                TreeMax[n / 2 + sourceArray.Length / 2] = sourceArray[sourceArray.Length - 1];
+            }
+            for (int i = n / 2 + (sourceArray.Length + 1) / 2; i < n; i++) // min/max for pairs of nonexistent elements
+            {
+                TreeMin[i] = minValue;
+                TreeMax[i] = maxValue;
+            }
+            // fill other layers
+            for (int i = n / 2 - 1; i > 0; i--)
+            {
+                TreeMin[i] = MinExp(TreeMin[2 * i], TreeMin[2 * i + 1]);
+                TreeMax[i] = MaxExp(TreeMax[2 * i], TreeMax[2 * i + 1]);
+            }
+            TreesReady = true;
+        }
+        catch (OutOfMemoryException)
+        {
+            TreeMin = null;
+            TreeMax = null;
+            TreesReady = false;
+            return;
+        }
+    }
+
+    //  O(log(n)) for each range min/max query
+    public void MinMaxRangeQuery(int l, int r, out double lowestValue, out double highestValue)
+    {
+        T lowestValueT;
+        T highestValueT;
+        // if the tree calculation isn't finished or if it crashed
+        if (!TreesReady)
+        {
+            // use the original (slower) min/max calculated method
+            lowestValueT = sourceArray[l];
+            highestValueT = sourceArray[l];
+            for (int i = l; i < r; i++)
+            {
+                if (LessThanExp(sourceArray[i], lowestValueT))
+                    lowestValueT = sourceArray[i];
+                if (GreaterThanExp(sourceArray[i], highestValueT))
+                    highestValueT = sourceArray[i];
+            }
+            lowestValue = NumericConversion.GenericToDouble(ref lowestValueT);
+            highestValue = NumericConversion.GenericToDouble(ref highestValueT);
+            return;
+        }
+
+        lowestValueT = MaxValue();
+        highestValueT = MinValue();
+        if (l == r)
+        {
+            lowestValue = highestValue = NumericConversion.GenericToDouble(ref sourceArray[l]);
+            return;
+        }
+        // first iteration on source array that virtualy bottom of tree
+        if ((l & 1) == 1) // l is right child
+        {
+            lowestValueT = MinExp(lowestValueT, sourceArray[l]);
+            highestValueT = MaxExp(highestValueT, sourceArray[l]);
+        }
+        if ((r & 1) != 1) // r is left child
+        {
+            lowestValueT = MinExp(lowestValueT, sourceArray[r]);
+            highestValueT = MaxExp(highestValueT, sourceArray[r]);
+        }
+        // go up from array to bottom of Tree
+        l = (l + n + 1) / 2;
+        r = (r + n - 1) / 2;
+        // next iterations on tree
+        while (l <= r)
+        {
+            if ((l & 1) == 1) // l is right child
+            {
+                lowestValueT = MinExp(lowestValueT, TreeMin[l]);
+                highestValueT = MaxExp(highestValueT, TreeMax[l]);
+            }
+            if ((r & 1) != 1) // r is left child
+            {
+                lowestValueT = MinExp(lowestValueT, TreeMin[r]);
+                highestValueT = MaxExp(highestValueT, TreeMax[r]);
+            }
+            // go up one level
+            l = (l + 1) / 2;
+            r = (r - 1) / 2;
+        }
+        lowestValue = NumericConversion.GenericToDouble(ref lowestValueT);
+        highestValue = NumericConversion.GenericToDouble(ref highestValueT);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalConstDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalConstDoubleArray.cs
@@ -1,0 +1,104 @@
+﻿namespace ScottPlot.DataSources;
+
+public class SignalConstSourceDoubleArray
+{
+    public readonly SegmentedTreeGeneric<double> SegmentedTree = new();
+
+    public readonly double[] Ys;
+    public readonly double Period;
+
+    public double XOffset = 0;
+    public double YOffset = 0;
+    public int MinRenderIndex = 0;
+    public int MaxRenderIndex = int.MaxValue;
+
+    public SignalConstSourceDoubleArray(double[] ys, double period)
+    {
+        Ys = ys;
+        Period = period;
+        SegmentedTree.SourceArray = ys;
+        MaxRenderIndex = ys.Length - 1;
+    }
+
+    public AxisLimits GetAxisLimits()
+    {
+        SegmentedTree.MinMaxRangeQuery(0, Ys.Length - 1, out double low, out double high);
+        return new AxisLimits(0, Ys.Length * Period, low, high);
+    }
+
+    public int GetIndex(double x, bool visibleDataOnly)
+    {
+        int i = (int)((x - XOffset) / Period);
+
+        if (visibleDataOnly)
+        {
+            i = Math.Max(i, MinRenderIndex);
+            i = Math.Min(i, MaxRenderIndex);
+        }
+
+        return i;
+    }
+
+    public bool RangeContainsSignal(double xMin, double xMax)
+    {
+        int xMinIndex = GetIndex(xMin, false);
+        int xMaxIndex = GetIndex(xMax, false);
+        return xMaxIndex >= MinRenderIndex && xMinIndex <= MaxRenderIndex;
+    }
+
+    public SignalRangeY GetLimitsY(int firstIndex, int lastIndex)
+    {
+        double min = double.PositiveInfinity;
+        double max = double.NegativeInfinity;
+
+        for (int i = firstIndex; i <= lastIndex; i++)
+        {
+            double value = NumericConversion.GenericToDouble(Ys, i);
+            min = Math.Min(min, value);
+            max = Math.Max(max, value);
+        }
+
+        return new SignalRangeY(min, max);
+    }
+
+    public List<PixelColumn> GetPixelColumns(IAxes axes)
+    {
+        List<PixelColumn> cols = new();
+
+        // ensure the same i1 isn't sampled twice
+        int latIndex1 = int.MinValue;
+        for (int xPixelIndex = 0; xPixelIndex < (int)axes.DataRect.Width; xPixelIndex++)
+        {
+            float xPixel = axes.DataRect.Left + xPixelIndex;
+            double xRangeMin = axes.GetCoordinateX(xPixel);
+            float xUnitsPerPixel = (float)(axes.XAxis.Width / axes.DataRect.Width);
+            double xRangeMax = xRangeMin + xUnitsPerPixel;
+
+            // off the edge of the data
+            if (RangeContainsSignal(xRangeMin, xRangeMax) == false)
+                continue;
+
+            // determine column limits horizontally
+            int i1 = GetIndex(xRangeMin, true);
+            int i2 = GetIndex(xRangeMax, true);
+            if (i1 == latIndex1)
+                continue;
+            latIndex1 = i1;
+
+            // first and last Y vales for this column
+            double y1 = NumericConversion.GenericToDouble(Ys, i1);
+            double y2 = NumericConversion.GenericToDouble(Ys, i2);
+            float yEnter = axes.GetPixelY(y1 + YOffset);
+            float yExit = axes.GetPixelY(y2 + YOffset);
+
+            // column min and max
+            SignalRangeY rangeY = GetLimitsY(i1, i2);
+            float yBottom = axes.GetPixelY(rangeY.Min + YOffset);
+            float yTop = axes.GetPixelY(rangeY.Max + YOffset);
+
+            cols.Add(new PixelColumn(xPixel, yEnter, yExit, yBottom, yTop));
+        }
+
+        return cols;
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalConstSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalConstSourceGenericArray.cs
@@ -1,9 +1,9 @@
 ﻿namespace ScottPlot.DataSources;
 
-public class SignalConstSourceDoubleArray<T>
+public class SignalConstSourceGenericArray<T>
     where T : struct, IComparable
 {
-    public readonly SegmentedTree<T> SegmentedTree = new();
+    public readonly SegmentedTreeGeneric<T> SegmentedTree = new();
 
     public readonly T[] Ys;
     public readonly double Period;
@@ -13,7 +13,7 @@ public class SignalConstSourceDoubleArray<T>
     public int MinRenderIndex = 0;
     public int MaxRenderIndex = int.MaxValue;
 
-    public SignalConstSourceDoubleArray(T[] ys, double period)
+    public SignalConstSourceGenericArray(T[] ys, double period)
     {
         Ys = ys;
         Period = period;

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -777,10 +777,22 @@ public class PlottableAdder(Plot plot)
         return Signal(source, color);
     }
 
-    public SignalConst<T> SignalConst<T>(T[] ys, double period = 1, Color? color = null)
+    public SignalConstDoubleArray SignalConst(double[] ys, double period = 1, Color? color = null)
+    {
+        SignalConstDoubleArray sig = new(ys, period)
+        {
+            Color = color ?? GetNextColor()
+        };
+
+        Plot.PlottableList.Add(sig);
+
+        return sig;
+    }
+
+    public SignalConstGenericArray<T> SignalConst<T>(T[] ys, double period = 1, Color? color = null)
         where T : struct, IComparable
     {
-        SignalConst<T> sig = new(ys, period)
+        SignalConstGenericArray<T> sig = new(ys, period)
         {
             Color = color ?? GetNextColor()
         };

--- a/src/ScottPlot5/ScottPlot5/Plottables/SignalConstBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/SignalConstBase.cs
@@ -1,12 +1,7 @@
-﻿using ScottPlot.DataSources;
+﻿namespace ScottPlot.Plottables;
 
-namespace ScottPlot.Plottables;
-
-public class SignalConst<T>(T[] ys, double period) : IPlottable, IHasLine, IHasMarker, IHasLegendText
-    where T : struct, IComparable
+public abstract class SignalConstBase : IHasLine, IHasMarker, IHasLegendText
 {
-    readonly SignalConstSourceDoubleArray<T> Data = new(ys, period);
-
     public MarkerStyle MarkerStyle { get; set; } = new();
     public MarkerShape MarkerShape { get => MarkerStyle.Shape; set => MarkerStyle.Shape = value; }
     public float MarkerSize { get => MarkerStyle.Size; set => MarkerStyle.Size = value; }
@@ -37,19 +32,14 @@ public class SignalConst<T>(T[] ys, double period) : IPlottable, IHasLine, IHasM
 
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = ScottPlot.Axes.Default;
-
     public IEnumerable<LegendItem> LegendItems => LegendItem.None;
 
-    public AxisLimits GetAxisLimits() => Data.GetAxisLimits();
-
-    public virtual void Render(RenderPack rp)
+    public void Render(RenderPack rp, List<PixelColumn> cols)
     {
         using SKPaint paint = new();
         LineStyle.ApplyToPaint(paint);
 
-        List<PixelColumn> cols = Data.GetPixelColumns(Axes);
-
-        if (!cols.Any())
+        if (cols.Count == 0)
             return;
 
         using SKPath path = new();

--- a/src/ScottPlot5/ScottPlot5/Plottables/SignalConstDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/SignalConstDoubleArray.cs
@@ -1,0 +1,16 @@
+﻿using ScottPlot.DataSources;
+
+namespace ScottPlot.Plottables;
+
+public class SignalConstDoubleArray(double[] ys, double period) : SignalConstBase, IPlottable
+{
+    readonly SignalConstSourceDoubleArray Data = new(ys, period);
+
+    public AxisLimits GetAxisLimits() => Data.GetAxisLimits();
+
+    public virtual void Render(RenderPack rp)
+    {
+        List<PixelColumn> cols = Data.GetPixelColumns(Axes);
+        Render(rp, cols);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/SignalConstGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/SignalConstGenericArray.cs
@@ -1,0 +1,17 @@
+﻿using ScottPlot.DataSources;
+
+namespace ScottPlot.Plottables;
+
+public class SignalConstGenericArray<T>(T[] ys, double period) : SignalConstBase, IPlottable
+    where T : struct, IComparable
+{
+    readonly SignalConstSourceGenericArray<T> Data = new(ys, period);
+
+    public AxisLimits GetAxisLimits() => Data.GetAxisLimits();
+
+    public virtual void Render(RenderPack rp)
+    {
+        List<PixelColumn> cols = Data.GetPixelColumns(Axes);
+        Render(rp, cols);
+    }
+}


### PR DESCRIPTION
discovered performance isn't really any better, so I will not be merging this in

![image](https://github.com/ScottPlot/ScottPlot/assets/4165489/257cc7a0-abe3-46e6-a392-7de9c7bce9de)
