### PR TITLE
Sandbox: 3D plot

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Form1.Designer.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Form1.Designer.cs
@@ -1,0 +1,56 @@
+﻿namespace Sandbox.WinForms3D;
+
+partial class Form1
+{
+    /// <summary>
+    ///  Required designer variable.
+    /// </summary>
+    private System.ComponentModel.IContainer components = null;
+
+    /// <summary>
+    ///  Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && (components != null))
+        {
+            components.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+
+    #region Windows Form Designer generated code
+
+    /// <summary>
+    ///  Required method for Designer support - do not modify
+    ///  the contents of this method with the code editor.
+    /// </summary>
+    private void InitializeComponent()
+    {
+        formsPlot3d1 = new FormsPlot3D();
+        SuspendLayout();
+        // 
+        // formsPlot3d1
+        // 
+        formsPlot3d1.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+        formsPlot3d1.Location = new Point(12, 12);
+        formsPlot3d1.Name = "formsPlot3d1";
+        formsPlot3d1.Size = new Size(758, 495);
+        formsPlot3d1.TabIndex = 0;
+        // 
+        // Form1
+        // 
+        AutoScaleDimensions = new SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
+        ClientSize = new Size(782, 519);
+        Controls.Add(formsPlot3d1);
+        Name = "Form1";
+        Text = "ScottPlot 3D Test";
+        ResumeLayout(false);
+    }
+
+    #endregion
+
+    private FormsPlot3D formsPlot3d1;
+}

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Form1.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Form1.cs
@@ -1,0 +1,13 @@
+namespace Sandbox.WinForms3D;
+
+public partial class Form1 : Form
+{
+    public Form1()
+    {
+        InitializeComponent();
+
+        Plottables3D.Scatter3D scatter = new();
+
+        formsPlot3d1.Plot3D.Plottables.Add(scatter);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Form1.resx
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Form1.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/FormsPlot3D.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/FormsPlot3D.cs
@@ -1,0 +1,72 @@
+﻿using Sandbox.WinForms3D.Primitives3D;
+using SkiaSharp.Views.Desktop;
+using System.Windows.Forms;
+
+namespace Sandbox.WinForms3D;
+
+public class FormsPlot3D : UserControl
+{
+    private SKControl SKControl { get; }
+    public Plot3D Plot3D = new();
+
+    Rotation3D? MouseDownRotation = null;
+    double MouseDownZoom;
+    Point MouseDownPoint;
+    Point3D MouseDownCameraCenter;
+
+    public FormsPlot3D()
+    {
+        SKControl = new() { Dock = DockStyle.Fill };
+        SKControl.PaintSurface += (s, e) => Plot3D.Render(e.Surface);
+        Controls.Add(SKControl);
+
+        SKControl.MouseDown += (s, e) =>
+        {
+            MouseDownRotation = Plot3D.Rotation;
+            MouseDownPoint = e.Location;
+            MouseDownZoom = Plot3D.ZoomFactor;
+            MouseDownCameraCenter = Plot3D.CameraCenter;
+        };
+
+        SKControl.MouseUp += (s, e) =>
+        {
+            MouseDownRotation = null;
+        };
+
+        SKControl.MouseMove += (s, e) =>
+        {
+            if (MouseDownRotation is null)
+                return;
+
+            int dX = e.X - MouseDownPoint.X;
+            int dY = e.Y - MouseDownPoint.Y;
+
+            Plot3D.Rotation = MouseDownRotation.Value;
+            if (e.Button == MouseButtons.Left)
+            {
+                float rotateSensitivity = 0.2f;
+                Plot3D.Rotation.DegreesY += -dX * rotateSensitivity;
+                Plot3D.Rotation.DegreesX += dY * rotateSensitivity;
+            }
+            else if (e.Button == MouseButtons.Middle)
+            {
+                float panSensitivity = 0.005f;
+                Plot3D.CameraCenter.X = MouseDownCameraCenter.X - dX * panSensitivity;
+                Plot3D.CameraCenter.Y = MouseDownCameraCenter.Y + dY * panSensitivity;
+            }
+            else if (e.Button == MouseButtons.Right)
+            {
+                float dMax = Math.Max(dX, -dY);
+                Plot3D.ZoomFactor = MouseDownZoom + dMax;
+            }
+
+            Refresh();
+        };
+    }
+
+    public override void Refresh()
+    {
+        SKControl?.Invalidate();
+        base.Refresh();
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/IPlottable3D.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/IPlottable3D.cs
@@ -1,0 +1,6 @@
+﻿namespace Sandbox.WinForms3D;
+
+public interface IPlottable3D
+{
+    void Render(RenderPack3D rp);
+}

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Plot3D.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Plot3D.cs
@@ -1,0 +1,42 @@
+﻿using Sandbox.WinForms3D.Plottables3D;
+using Sandbox.WinForms3D.Primitives3D;
+using ScottPlot;
+using SkiaSharp;
+
+namespace Sandbox.WinForms3D;
+
+public class Plot3D
+{
+    public double ZoomFactor = 200;
+    public Rotation3D Rotation = new() { DegreesX = 110, DegreesY = 18, DegreesZ = 5 };
+    public Point3D CameraCenter = new();
+    public readonly Axis3D Axis3D = new();
+    public readonly List<IPlottable3D> Plottables = [];
+
+    public Pixel GetPoint2D(Point3D point, Pixel imageCenter)
+    {
+        point = point.WithZoom(ZoomFactor);
+        point = point.Translated(Rotation.CenterPoint, Point3D.Origin);
+        point = point.RotatedX(Rotation.DegreesX);
+        point = point.RotatedY(Rotation.DegreesY);
+        point = point.RotatedZ(Rotation.DegreesZ);
+        point = point.Translated(Point3D.Origin, Rotation.CenterPoint);
+        float x = (float)(point.X - CameraCenter.X * ZoomFactor) + imageCenter.X;
+        float y = (float)(CameraCenter.Y * ZoomFactor - point.Y) + imageCenter.Y;
+        return new Pixel(x, y);
+    }
+
+    public void Render(SKSurface surface)
+    {
+        RenderPack3D rp = new(this, surface);
+
+        Drawing.FillRectangle(rp.Canvas, rp.ImageRect, Colors.White);
+
+        Axis3D.Render(rp);
+
+        foreach (IPlottable3D plottable in Plottables)
+        {
+            plottable.Render(rp);
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Plottables3D/Axis3D.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Plottables3D/Axis3D.cs
@@ -1,0 +1,104 @@
+﻿using Sandbox.WinForms3D.Primitives3D;
+using ScottPlot;
+
+namespace Sandbox.WinForms3D.Plottables3D;
+
+public class Axis3D : IPlottable3D
+{
+    readonly ScottPlot.Label LabelStyle = new()
+    {
+        FontSize = 15,
+        Bold = true,
+        Alignment = Alignment.MiddleCenter
+    };
+
+    public void Render(RenderPack3D rp)
+    {
+        RenderGrid(rp);
+        RenderSpines(rp);
+        RenderAxisLabels(rp);
+    }
+
+    private void RenderGrid(RenderPack3D rp)
+    {
+        int divisions = 10;
+
+        List<Line3D> lines = [];
+
+        for (int xIndex = 0; xIndex <= divisions; xIndex++)
+        {
+            double x = xIndex * 1.0 / divisions;
+            Point3D xStart = new(x, 0, 0);
+            Point3D yEnd = new(x, 1, 0);
+            Point3D zEnd = new(x, 0, 1);
+            lines.Add(new Line3D(xStart, yEnd));
+            lines.Add(new Line3D(xStart, zEnd));
+        }
+
+        for (int yIndex = 0; yIndex <= divisions; yIndex++)
+        {
+            double y = yIndex * 1.0 / divisions;
+            Point3D yStart = new(0, y, 0);
+            Point3D xEnd = new(1, y, 0);
+            Point3D zEnd = new(0, y, 1);
+            lines.Add(new Line3D(yStart, xEnd));
+            lines.Add(new Line3D(yStart, zEnd));
+        }
+
+        for (int zIndex = 0; zIndex <= divisions; zIndex++)
+        {
+            double z = zIndex * 1.0 / divisions;
+            Point3D zStart = new(0, 0, z);
+            Point3D xEnd = new(1, 0, z);
+            Point3D yEnd = new(0, 1, z);
+            lines.Add(new Line3D(zStart, xEnd));
+            lines.Add(new Line3D(zStart, yEnd));
+        }
+
+        foreach (Line3D line in lines)
+        {
+            line.LineStyle.Color = Colors.Black.WithAlpha(.2);
+            line.Render(rp);
+        }
+    }
+
+    private void RenderSpines(RenderPack3D rp)
+    {
+        Point3D origin = new(0, 0, 0);
+        Point3D xUnit = new(1, 0, 0);
+        Point3D yUnit = new(0, 1, 0);
+        Point3D zUnit = new(0, 0, 1);
+
+        List<Line3D> lines2 =
+        [
+            new(origin, xUnit, 2, Colors.Red),
+            new(origin, yUnit, 2, Colors.Green),
+            new(origin, zUnit, 2, Colors.Blue),
+        ];
+
+        foreach (Line3D line in lines2)
+        {
+            line.Render(rp);
+        }
+    }
+
+    private void RenderAxisLabels(RenderPack3D rp)
+    {
+        double padding = .1;
+        Point3D ptX = new(1 + padding, 0, 0);
+        Point3D ptY = new(0, 1 + padding, 0);
+        Point3D ptZ = new(0, 0, 1 + padding);
+
+        LabelStyle.Text = "X";
+        LabelStyle.ForeColor = Colors.Red;
+        LabelStyle.Render(rp.Canvas, rp.GetPixel(ptX), rp.Paint);
+
+        LabelStyle.Text = "Y";
+        LabelStyle.ForeColor = Colors.Green;
+        LabelStyle.Render(rp.Canvas, rp.GetPixel(ptY), rp.Paint);
+
+        LabelStyle.Text = "Z";
+        LabelStyle.ForeColor = Colors.Blue;
+        LabelStyle.Render(rp.Canvas, rp.GetPixel(ptZ), rp.Paint);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Plottables3D/Line3D.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Plottables3D/Line3D.cs
@@ -1,0 +1,30 @@
+﻿using Sandbox.WinForms3D.Primitives3D;
+using ScottPlot;
+
+namespace Sandbox.WinForms3D.Plottables3D;
+
+public struct Line3D : IPlottable3D
+{
+    public Primitives3D.Line3D Line { get; }
+
+    public LineStyle LineStyle { get; }
+
+    public Line3D(Point3D start, Point3D end, float lineWidth = 1, ScottPlot.Color? color = null)
+    {
+        Line = new(start, end);
+
+        LineStyle = new()
+        {
+            Width = lineWidth,
+            Color = color ?? Colors.Black
+        };
+    }
+
+    public void Render(RenderPack3D rp)
+    {
+        Pixel start = rp.GetPixel(Line.Start);
+        Pixel end = rp.GetPixel(Line.End);
+        PixelLine line = new(start, end);
+        Drawing.DrawLine(rp.Canvas, rp.Paint, line, LineStyle);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Plottables3D/Scatter3D.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Plottables3D/Scatter3D.cs
@@ -1,0 +1,41 @@
+﻿using Sandbox.WinForms3D.Primitives3D;
+using ScottPlot;
+
+namespace Sandbox.WinForms3D.Plottables3D;
+
+public class Scatter3D : IPlottable3D
+{
+    public readonly List<Point3D> Points = [];
+
+    public readonly LineStyle LineStyle = new()
+    {
+        Width = 1,
+        Color = Colors.Blue
+    };
+
+    public readonly MarkerStyle MarkerStyle = new()
+    {
+        IsVisible = true,
+        Shape = MarkerShape.FilledCircle,
+        FillColor = Colors.Blue,
+        Size = 5,
+    };
+
+    public Scatter3D()
+    {
+        double m = 10;
+        for (double z = 0; z < 1.0; z += 0.01)
+        {
+            double x = Math.Sin(z * m) / 2 + .5;
+            double y = Math.Cos(z * m) / 2 + .5;
+            Points.Add(new Point3D(x, y, z));
+        }
+    }
+
+    public void Render(RenderPack3D rp)
+    {
+        Pixel[] pixels = Points.Select(rp.GetPixel).ToArray();
+        Drawing.DrawLines(rp.Canvas, rp.Paint, pixels, LineStyle);
+        Drawing.DrawMarkers(rp.Canvas, rp.Paint, pixels, MarkerStyle);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Primitives3D/Line3D.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Primitives3D/Line3D.cs
@@ -1,0 +1,3 @@
+﻿namespace Sandbox.WinForms3D.Primitives3D;
+
+public record struct Line3D(Point3D Start, Point3D End);

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Primitives3D/Point3D.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Primitives3D/Point3D.cs
@@ -1,0 +1,52 @@
+﻿namespace Sandbox.WinForms3D.Primitives3D;
+
+public record struct Point3D(double x, double y, double z)
+{
+    public double X = x;
+    public double Y = y;
+    public double Z = z;
+
+    public readonly static Point3D Origin = new(0, 0, 0);
+
+    public readonly Point3D WithZoom(double zoom) => new(X * zoom, Y * zoom, Z * zoom);
+
+    public readonly Point3D WithPan(double x, double y, double z) => new(X + x, Y + y, Z + z);
+
+    public Point3D Translated(Point3D oldOrigin, Point3D newOrigin)
+    {
+        double dX = newOrigin.X - oldOrigin.X;
+        double dY = newOrigin.Y - oldOrigin.Y;
+        double dZ = newOrigin.Z - oldOrigin.Z;
+        return new(X + dX, Y + dY, Z + dZ);
+    }
+
+    public Point3D RotatedX(double degrees)
+    {
+        double radians = Math.PI * degrees / 180.0f;
+        double cos = Math.Cos(radians);
+        double sin = Math.Sin(radians);
+        double y = Y * cos + Z * sin;
+        double z = Y * -sin + Z * cos;
+        return new Point3D(X, y, z);
+    }
+
+    public Point3D RotatedY(double degrees)
+    {
+        double radians = Math.PI * degrees / 180.0;
+        double cos = Math.Cos(radians);
+        double sin = Math.Sin(radians);
+        double x = X * cos + Z * sin;
+        double z = X * -sin + Z * cos;
+        return new Point3D(x, Y, z);
+    }
+
+    public Point3D RotatedZ(double degrees)
+    {
+        double radians = Math.PI * degrees / 180.0;
+        double cos = Math.Cos(radians);
+        double sin = Math.Sin(radians);
+        double x = X * cos + Y * sin;
+        double y = X * -sin + Y * cos;
+        return new Point3D(x, y, Z);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Primitives3D/Rotation3D.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Primitives3D/Rotation3D.cs
@@ -1,0 +1,12 @@
+﻿namespace Sandbox.WinForms3D.Primitives3D;
+
+public record struct Rotation3D
+{
+    public double DegreesX;
+    public double DegreesY;
+    public double DegreesZ;
+    public double CenterX;
+    public double CenterY;
+    public double CenterZ;
+    public Point3D CenterPoint => new(CenterX, CenterY, CenterZ);
+}

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Program.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Program.cs
@@ -1,0 +1,16 @@
+namespace Sandbox.WinForms3D;
+
+static class Program
+{
+    /// <summary>
+    ///  The main entry point for the application.
+    /// </summary>
+    [STAThread]
+    static void Main()
+    {
+        // To customize application configuration such as set high DPI settings or default font,
+        // see https://aka.ms/applicationconfiguration.
+        ApplicationConfiguration.Initialize();
+        Application.Run(new Form1());
+    }    
+}

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/RenderPack3D.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/RenderPack3D.cs
@@ -1,0 +1,21 @@
+﻿using Sandbox.WinForms3D.Primitives3D;
+using ScottPlot;
+using SkiaSharp;
+
+namespace Sandbox.WinForms3D;
+
+public class RenderPack3D(Plot3D plot3d, SKSurface surface) : IDisposable
+{
+    public Plot3D Plot { get; } = plot3d;
+    public SKCanvas Canvas { get; } = surface.Canvas;
+    public PixelRect ImageRect { get; } = surface.Canvas.LocalClipBounds.ToPixelRect();
+    public SKPaint Paint { get; } = new();
+
+    public Pixel GetPixel(Point3D point) => Plot.GetPoint2D(point, ImageRect.Center);
+
+    public void Dispose()
+    {
+        Paint.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Sandbox.WinForms3D.csproj
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Sandbox.WinForms3D.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>WinExe</OutputType>
+        <TargetFramework>net8.0-windows</TargetFramework>
+        <Nullable>enable</Nullable>
+        <UseWindowsForms>true</UseWindowsForms>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\ScottPlot5 Controls\ScottPlot.WinForms\ScottPlot.WinForms.csproj" />
+      <ProjectReference Include="..\..\ScottPlot5\ScottPlot.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/ScottPlot5/ScottPlot5.sln
+++ b/src/ScottPlot5/ScottPlot5.sln
@@ -59,6 +59,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Graphical Test Runner", "Sc
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ScottPlot Unit Tests", "ScottPlot5 Tests\Unit Tests\ScottPlot Unit Tests.csproj", "{6CED419A-A9F9-4200-80A7-A38AE1295F0A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sandbox.WinForms3D", "ScottPlot5 Sandbox\Sandbox.WinForms3D\Sandbox.WinForms3D.csproj", "{0AE452FC-1D87-45C5-9B09-E645A759FCD5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -161,6 +163,10 @@ Global
 		{6CED419A-A9F9-4200-80A7-A38AE1295F0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6CED419A-A9F9-4200-80A7-A38AE1295F0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6CED419A-A9F9-4200-80A7-A38AE1295F0A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0AE452FC-1D87-45C5-9B09-E645A759FCD5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0AE452FC-1D87-45C5-9B09-E645A759FCD5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0AE452FC-1D87-45C5-9B09-E645A759FCD5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0AE452FC-1D87-45C5-9B09-E645A759FCD5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -187,6 +193,7 @@ Global
 		{0A738D46-7654-4C7D-99BF-C420602965F7} = {9C3D2BEE-76E3-4C99-9D38-07EB5CC162B9}
 		{68FECF4F-9557-4B01-9C87-CCD6FE50CDEF} = {6500EB02-9E5D-4FDF-AAEC-84B831B4E396}
 		{AA39141A-E248-43FB-ABF4-92D7E94F6190} = {B0708928-FFD3-4062-A3AD-3BA9D7CD8A55}
+		{0AE452FC-1D87-45C5-9B09-E645A759FCD5} = {9C3D2BEE-76E3-4C99-9D38-07EB5CC162B9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FBAE082A-173A-4F13-BE31-E6C070513C9C}


### PR DESCRIPTION
This PR adds a `Sandbox.WinForms3D` project to facilitate experimentation with 3D plot types. A MVP control is provided with a few 3D primitives and interfaces, but there is a lot of room for improvement and extension. 

High priority next steps that come to mind include:
* non-orthographic projection perspective (this may be a 2-line modification)
* improved center of rotation
* ability to render flat surfaces in 3D space by creating a polygon from their vertices
* addition of 3D volume primitives like `Rectangle3D` which have a collection of `Line3D` and `Surface3D` objects
* a more carefully thought out UI which allows rotation along specific axes

![3d4](https://github.com/ScottPlot/ScottPlot/assets/4165489/bf6b19e9-83fe-4de0-9940-a4a1153ad022)
