### PR TITLE
SignalConst: Uses Segment Tree for GetLimitsY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## ScottPlot 5.0.34
 _Not yet on NuGet..._
 * Axes: Added `AutoScale()` overloads that accept user-defined lists of plottables (#3776) @levipara
+* SignalConst: Properly implement range search to achieve extreme performance improvements for large datasets (#3778) @StendProg @bclehmann @Cardroid
 
 ## ScottPlot 5.0.33
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-05-04_

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalConstSource.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalConstSource.cs
@@ -1,6 +1,6 @@
 ﻿namespace ScottPlot.DataSources;
 
-public class SignalConstSourceDoubleArray<T>
+public class SignalConstSource<T>
     where T : struct, IComparable
 {
     public readonly SegmentedTree<T> SegmentedTree = new();
@@ -13,7 +13,7 @@ public class SignalConstSourceDoubleArray<T>
     public int MinRenderIndex = 0;
     public int MaxRenderIndex = int.MaxValue;
 
-    public SignalConstSourceDoubleArray(T[] ys, double period)
+    public SignalConstSource(T[] ys, double period)
     {
         Ys = ys;
         Period = period;

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalConstSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalConstSourceDoubleArray.cs
@@ -48,17 +48,8 @@ public class SignalConstSourceDoubleArray<T>
 
     public SignalRangeY GetLimitsY(int firstIndex, int lastIndex)
     {
-        double min = double.PositiveInfinity;
-        double max = double.NegativeInfinity;
-
-        for (int i = firstIndex; i <= lastIndex; i++)
-        {
-            double value = NumericConversion.GenericToDouble(Ys, i);
-            min = Math.Min(min, value);
-            max = Math.Max(max, value);
-        }
-
-        return new SignalRangeY(min, max);
+        SegmentedTree.MinMaxRangeQuery(firstIndex, lastIndex, out double min, out double max);
+        return new(min, max);
     }
 
     public List<PixelColumn> GetPixelColumns(IAxes axes)

--- a/src/ScottPlot5/ScottPlot5/Plottables/SignalConst.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/SignalConst.cs
@@ -5,7 +5,7 @@ namespace ScottPlot.Plottables;
 public class SignalConst<T>(T[] ys, double period) : IPlottable, IHasLine, IHasMarker, IHasLegendText
     where T : struct, IComparable
 {
-    readonly SignalConstSourceDoubleArray<T> Data = new(ys, period);
+    readonly SignalConstSource<T> Data = new(ys, period);
 
     public MarkerStyle MarkerStyle { get; set; } = new();
     public MarkerShape MarkerShape { get => MarkerStyle.Shape; set => MarkerStyle.Shape = value; }


### PR DESCRIPTION
As @StendProg noted in https://github.com/ScottPlot/ScottPlot/pull/3718#issuecomment-2094355113 we were not using the segment tree in `GetLimitsY`, instead falling back to linear search.

This massively improves performance, for me `SignalConst` could actually be slower than `Signal` for very large datasets (though still faster for more moderately-sized ones), possibly because of the memory cost of the tree. With this change `SignalConst` is much faster, and outperforms the new `FastSignalSourceDouble`. Below is a screenshot of the benchmark demo:
![image](https://github.com/ScottPlot/ScottPlot/assets/8635304/d12d5230-e243-4c17-8993-cdd2a96a484f)