### PR TITLE
Ticks, Tests, Cookbook: Improve DateTimeFixedInterval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 _Not yet on NuGet..._
 * Axes: Added `AutoScale()` overloads that accept user-defined lists of plottables (#3776) @levipara
 * SignalConst: Properly implement range search to achieve extreme performance improvements for large datasets (#3778) @StendProg @bclehmann @Cardroid
+* Ticks: Added options for minor ticks when using DateTime axes (#3779, #3408) @EricEzaM
 
 ## ScottPlot 5.0.33
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-05-04_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/DateTimeAxes.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/DateTimeAxes.cs
@@ -1,4 +1,7 @@
-﻿namespace ScottPlotCookbook.Recipes.Axis;
+﻿using ScottPlot.TickGenerators;
+using ScottPlot.TickGenerators.TimeUnits;
+
+namespace ScottPlotCookbook.Recipes.Axis;
 
 public class DateTimeAxes : ICategory
 {
@@ -87,6 +90,58 @@ public class DateTimeAxes : ICategory
                     DateTime dt = DateTime.FromOADate(ticks[i].Position);
                     string label = $"{dt:MMM} '{dt:yy}";
                     ticks[i] = new Tick(ticks[i].Position, label);
+                }
+            };
+        }
+    }
+    
+    public class DateTimeAxisFixedIntervalTicks : RecipeBase
+    {
+        public override string Name => "DateTime Axis Fixed Interval Ticks";
+        public override string Description => "Make ticks render at fixed intervals. Optionally make the ticks render " +
+            "from a custom start date, rather than using the start date of the plot (e.g. to draw ticks on the hour " +
+            "every hour, or on the first of every month, etc).";
+
+        [Test]
+        public override void Execute()
+        {
+            // Plot 24 hours sample DateTime data (1 point every minute)
+            DateTime[] dates = Generate.ConsecutiveMinutes(24 * 60, new DateTime(2000, 1, 1, 2, 12, 0));
+            double[] ys = Generate.RandomWalk(24 * 60);
+            myPlot.Add.Scatter(dates, ys);
+            var dtAx = myPlot.Axes.DateTimeTicksBottom();
+            
+            // Create fixed-intervals ticks, major ticks every 6 hours, minor ticks every hour
+            dtAx.TickGenerator = new DateTimeFixedInterval(
+                new Hour(), 6,
+                new Hour(), 1, 
+                // Here we provide a delegate to override when the ticks start. In this case, we want the majors to be
+                // 00:00, 06:00, 12:00, etc. and the minors to be on the hour, every hour, so we start at midnight.
+                // If you do not provide this delegate, the ticks will start at whatever the Min on the x-axis is.
+                // The major ticks might end up as 1:30am, 7:30am, etc, and the tick positions will be fixed on the plot
+                // when it is panned around.
+                dt => new DateTime(dt.Year, dt.Month, dt.Day));
+
+            // Customise gridlines to make the ticks easier to see
+            myPlot.Grid.XAxisStyle.MajorLineStyle.Color = Colors.Black.WithOpacity();
+            myPlot.Grid.XAxisStyle.MajorLineStyle.Width = 2;
+
+            myPlot.Grid.XAxisStyle.MinorLineStyle.Color = Colors.Gray.WithOpacity(0.25);
+            myPlot.Grid.XAxisStyle.MinorLineStyle.Width = 1;
+            myPlot.Grid.XAxisStyle.MinorLineStyle.Pattern = LinePattern.DenselyDashed;
+            
+            // Remove labels on minor ticks, otherwise there is a lot of tick label overlap
+            myPlot.RenderManager.RenderStarting += (s, e) =>
+            {
+                Tick[] ticks = myPlot.Axes.Bottom.TickGenerator.Ticks;
+                for (int i = 0; i < ticks.Length; i++)
+                {
+                    if (ticks[i].IsMajor)
+                    {
+                        continue;
+                    }
+                    
+                    ticks[i] = new Tick(ticks[i].Position, "", ticks[i].IsMajor);
                 }
             };
         }

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/TickGenerators/DateTimeFixedIntervalsTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/TickGenerators/DateTimeFixedIntervalsTests.cs
@@ -1,0 +1,99 @@
+﻿using ScottPlot.TickGenerators;
+using ScottPlot.TickGenerators.TimeUnits;
+using SkiaSharp;
+using DateTime = System.DateTime;
+
+namespace ScottPlotTests.UnitTests.TickGenerators;
+
+public class DateTimeFixedIntervalsTests
+{
+    [Test]
+    public void Test_HourlyTicks_GeneratesTicksFromStartTimeOfRange()
+    {
+        DateTimeFixedInterval gen = new(new Hour());
+
+        DateTime startRange = new(2000, 1, 1, 0, 30, 30);
+        DateTime endRange = new(2000, 1, 2, 0, 30, 30);
+        
+        CoordinateRange range = new(
+            NumericConversion.ToNumber(startRange),
+            NumericConversion.ToNumber(endRange)
+        );
+        
+        gen.Regenerate(range, Edge.Bottom, new PixelLength(1), new SKPaint(), new Label());
+        
+        gen.Ticks.Skip(1).First().Position.Should().Be(NumericConversion.ToNumber(startRange.AddHours(1)));
+    }
+
+    [Test]
+    public void Test_DailyTicksWithHourlyMinor_GeneratesTicksFromStartTimeOfRange()
+    {
+        DateTimeFixedInterval gen = new(new Day(), 1, new Hour());
+
+        DateTime startRange = new(2000, 1, 1);
+        DateTime endRange = startRange.AddDays(2);
+        
+        CoordinateRange range = new(
+            NumericConversion.ToNumber(startRange),
+            NumericConversion.ToNumber(endRange)
+        );
+        
+        gen.Regenerate(range, Edge.Bottom, new PixelLength(1), new SKPaint(), new Label());
+        
+        // 1st major tick is start
+        gen.Ticks.First(t => t.IsMajor).Position.Should().Be(NumericConversion.ToNumber(startRange));
+        // 2nd major tick is for the next day
+        gen.Ticks.Where(t => t.IsMajor).Skip(1).First().Position.Should().Be(NumericConversion.ToNumber(startRange.AddDays(1)));
+        
+        // 1st minor tick is 1 hour after start.
+        gen.Ticks.First(t => !t.IsMajor).Position.Should().Be(NumericConversion.ToNumber(startRange.AddHours(1)));
+    }
+    
+    [Test]
+    public void Test_2DaysMajor6HoursMinor_GeneratesTicksFromStartTimeOfRange()
+    {
+        DateTimeFixedInterval gen = new(new Day(), 2, new Hour(), 6);
+
+        DateTime startRange = new(2000, 1, 1);
+        DateTime endRange = startRange.AddDays(6);
+        
+        CoordinateRange range = new(
+            NumericConversion.ToNumber(startRange),
+            NumericConversion.ToNumber(endRange)
+        );
+        
+        gen.Regenerate(range, Edge.Bottom, new PixelLength(1), new SKPaint(), new Label());
+        
+        // 1st major tick is start
+        gen.Ticks.First(t => t.IsMajor).Position.Should().Be(NumericConversion.ToNumber(startRange));
+        // 2nd major tick is for 2 days from start
+        gen.Ticks.Where(t => t.IsMajor).Skip(1).First().Position.Should().Be(NumericConversion.ToNumber(startRange.AddDays(2)));
+        
+        // 1st minor tick is 6 hours after start.
+        gen.Ticks.First(t => !t.IsMajor).Position.Should().Be(NumericConversion.ToNumber(startRange.AddHours(6)));
+    }
+    
+    [Test]
+    public void Test_6HoursMajor1HourMinorStartTicksAtMidnight_GeneratesTicksAtExpectedPoints()
+    {
+        DateTimeFixedInterval gen = new(new Hour(), 6, new Hour(), 1, 
+            dt => new DateTime(dt.Year, dt.Month, dt.Day));
+        
+        // Make start range not coincident with any tick markers
+        DateTime startRange = new(2000, 1, 1, 2, 15, 0);
+        DateTime endRange = startRange.AddDays(1);
+        
+        CoordinateRange range = new(
+            NumericConversion.ToNumber(startRange),
+            NumericConversion.ToNumber(endRange)
+        );
+        
+        gen.Regenerate(range, Edge.Bottom, new PixelLength(1), new SKPaint(), new Label());
+        
+        // 1st minor tick is 3am, 45minutes after range start.
+        gen.Ticks.First(t => !t.IsMajor).Position.Should().Be(NumericConversion.ToNumber(startRange.AddMinutes(45)));
+        
+        // 1st major tick is 6am, 3hrs 45min after range start
+        gen.Ticks.First(t => t.IsMajor).Position.Should().Be(NumericConversion.ToNumber(startRange.AddHours(3).AddMinutes(45)));
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/DateTimeFixedInterval.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/DateTimeFixedInterval.cs
@@ -1,15 +1,68 @@
-﻿namespace ScottPlot.TickGenerators
+﻿using ScottPlot.TickGenerators.TimeUnits;
+
+namespace ScottPlot.TickGenerators
 {
     public class DateTimeFixedInterval : IDateTimeTickGenerator
     {
+        /// <summary>
+        /// The time unit to use for major ticks
+        /// </summary>
         public ITimeUnit Interval { get; set; }
 
-        public int IntervalsPerTick { get; set; } = 1;
+        /// <summary>
+        /// The number of <see cref="Interval"/> units between major ticks (e.g. major ticks every 7 <see cref="Day"/>s)
+        /// </summary>
+        public int IntervalsPerTick { get; set; }
+        
+        /// <summary>
+        /// The time unit to use for minor ticks. If null, no minor ticks are generated.
+        /// </summary>
+        public ITimeUnit? MinorInterval { get; set; }
+        
+        /// <summary>
+        /// The number of <see cref="MinorInterval"/> units between minor ticks.
+        /// </summary>
+        public int MinorIntervalsPerTick { get; set; }
+        
+        /// <summary>
+        /// An optional function to override where the intervals for ticks start. The DateTime argument provided is
+        /// the start range of the axis (i.e. <see cref="IAxis.Min"/>). 
+        /// </summary>
+        /// <remarks>
+        /// If omitted, the ticks will start from <see cref="IAxis.Min"/>. This may have undesirable effects when zooming
+        /// and panning. If provided, the ticks will start from the returned DateTime.
+        /// </remarks>
+        /// <example>
+        /// If the plot contains weekly data, and it is desired to have ticks on the 1st of each month:
+        /// <code>
+        /// dt => new DateTime(dt.Year, dt.Month, 1);
+        /// </code>
+        /// If the plot contains hourly data, and it is desired to have ticks every 6 hours at 00:00, 6:00, 12:00, etc,
+        /// then set <see cref="Interval"/> to <see cref="Hour"/>, <see cref="IntervalsPerTick"/> to 6, and provide the function:
+        /// <code>
+        /// dt => new DateTime(dt.Year, dt.Month, dt.Day);
+        /// </code>
+        /// </example>
+        public Func<DateTime, DateTime>? GetIntervalStartFunc { get; set; }
 
-        public DateTimeFixedInterval(ITimeUnit interval, int intervalsPerTick = 1)
+        /// <summary>
+        /// Creates a new <see cref="DateTimeFixedInterval"/> generator.
+        /// </summary>
+        /// <param name="interval">The time unit to use for major ticks</param>
+        /// <param name="intervalsPerTick">The number of <see cref="Interval"/> units between major ticks</param>
+        /// <param name="minorInterval">The time unit to use for minor ticks. If null, no minor ticks are generated.</param>
+        /// <param name="minorIntervalsPerTick">The number of <see cref="MinorInterval"/> units between minor ticks.</param>
+        /// <param name="getIntervalStartFunc">
+        /// An optional function to override where the intervals for ticks start. The DateTime argument provided is
+        /// the start range of the axis (i.e. <see cref="IAxis.Min"/>).
+        /// </param>
+        public DateTimeFixedInterval(ITimeUnit interval, int intervalsPerTick = 1, ITimeUnit? minorInterval = null, int minorIntervalsPerTick = 1, Func<DateTime, DateTime>? getIntervalStartFunc = null)
         {
             Interval = interval;
             IntervalsPerTick = intervalsPerTick;
+            MinorInterval = minorInterval;
+            MinorIntervalsPerTick = minorIntervalsPerTick;
+            GetIntervalStartFunc = getIntervalStartFunc;
         }
 
         public Tick[] Ticks { get; set; } = Array.Empty<Tick>();
@@ -24,12 +77,30 @@
         public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, Label labelStyle)
         {
             List<Tick> ticks = new();
+            HashSet<DateTime> timesWithTicks = new(); // Avoid having minor and major ticks at same time
 
-            DateTime start = Interval.Next(NumericConversion.ToDateTime(range.Min), -1);
-            DateTime end = Interval.Next(NumericConversion.ToDateTime(range.Max), 1);
+            // Modify the start time of the ticks if a delegate was provided
+            DateTime rangeMin = NumericConversion.ToDateTime(range.Min);
+            DateTime start = GetIntervalStartFunc?.Invoke(rangeMin) ?? Interval.Next(rangeMin, -1 * IntervalsPerTick);
+
+            DateTime end = Interval.Next(NumericConversion.ToDateTime(range.Max));
             for (DateTime dt = start; dt <= end; dt = Interval.Next(dt, IntervalsPerTick))
             {
                 ticks.Add(new Tick(NumericConversion.ToNumber(dt), dt.ToString(Interval.GetDateTimeFormatString()), true));
+                timesWithTicks.Add(dt);
+            }
+
+            if (MinorInterval is not null)
+            {
+                for (DateTime dt = start; dt <= end; dt = MinorInterval.Next(dt, MinorIntervalsPerTick))
+                {
+                    if (timesWithTicks.Contains(dt))
+                    {
+                        continue;
+                    }
+                    
+                    ticks.Add(new Tick(NumericConversion.ToNumber(dt), dt.ToString(Interval.GetDateTimeFormatString()), false));
+                }
             }
 
             Ticks = ticks.Where(x => range.Contains(x.Position)).ToArray();


### PR DESCRIPTION
Fixes #3408
No breaking API changes, only optional params/properties added.

https://github.com/ScottPlot/ScottPlot/assets/41730826/2fbd2061-994a-4b98-a122-f27ff00b0fa2


It would be nice if fixed-width tick labels also had logic to hide when overlap started... but not in this PR.
