### PR TITLE
DateTimeAutomatic: Add `LabelFormatter` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Legend: Added `Plot.ShowLegend()` overload that accepts an `Edge` for quickly adding a legend outside the data area (#3672, #3635)
 * Radar Plot: New plot type (also called a spider charts or star charts) for representing multi-axis data as a 2D shape on a circular axis system (#3457, #3780) @bclehmann
 * Coxcomb Plot: New plot type like a pie graph where the angle of slices is constant but the radii are not (#3457, #3780) @bclehmann
+* Axes: Added `LabelFormatter` property to `DateTimeAutomatic` for custom formatting of DateTime tick labels (#3783) @loyvsc
 
 ## ScottPlot 5.0.34
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-05-05_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/CustomizingTicks.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/CustomizingTicks.cs
@@ -1,4 +1,5 @@
-﻿using SkiaSharp;
+﻿using ScottPlot.TickGenerators;
+using SkiaSharp;
 
 namespace ScottPlotCookbook.Recipes.Axis;
 
@@ -41,6 +42,30 @@ public class CustomizingTicks : ICategory
 
             // tell an axis to use the custom tick generator
             myPlot.Axes.Bottom.TickGenerator = myTickGenerator;
+        }
+    }
+    
+    public class DateTimeAutomaticTickFormatter : RecipeBase
+    {
+        public override string Name => "DateTimeAutomatic Tick Formatters";
+        public override string Description => "Users can customize the logic used to create " +
+                                              "datetime tick labels from tick positions. ";
+
+        [Test]
+        public override void Execute()
+        {
+            // create a static function containing the formatting logic
+            string CustomFormatter(DateTime arg)
+            {
+                return arg is { Hour: 0, Minute: 0, Second: 0 } ? arg.ToShortDateString() : arg.ToLongTimeString();
+            }
+
+            // add a datetime ticks to axis, for example to bottom axis
+            myPlot.Axes.DateTimeTicksBottom();
+            // set up a label formatter function
+            ((DateTimeAutomatic)myPlot.Axes.Bottom.TickGenerator).LabelFormatter = CustomFormatter;
+            
+            myPlot.Axes.SetLimitsX(45000, 45003);
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/CustomizingTicks.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/CustomizingTicks.cs
@@ -44,7 +44,7 @@ public class CustomizingTicks : ICategory
             myPlot.Axes.Bottom.TickGenerator = myTickGenerator;
         }
     }
-    
+
     public class DateTimeAutomaticTickFormatter : RecipeBase
     {
         public override string Name => "DateTimeAutomatic Tick Formatters";
@@ -54,18 +54,27 @@ public class CustomizingTicks : ICategory
         [Test]
         public override void Execute()
         {
-            // create a static function containing the formatting logic
-            string CustomFormatter(DateTime arg)
+            // plot data using DateTime values on the horizontal axis
+            DateTime[] xs = Generate.ConsecutiveHours(100);
+            double[] ys = Generate.RandomWalk(100);
+            myPlot.Add.Scatter(xs, ys);
+
+            // setup the bottom axis to use DateTime ticks
+            var axis = myPlot.Axes.DateTimeTicksBottom();
+
+            // create a custom formatter to return a string with
+            // date only when zoomed out and time only when zoomed in
+            static string CustomFormatter(DateTime dt)
             {
-                return arg is { Hour: 0, Minute: 0, Second: 0 } ? arg.ToShortDateString() : arg.ToLongTimeString();
+                bool isMidnight = dt is { Hour: 0, Minute: 0, Second: 0 };
+                return isMidnight
+                    ? DateOnly.FromDateTime(dt).ToString()
+                    : TimeOnly.FromDateTime(dt).ToString();
             }
 
-            // add a datetime ticks to axis, for example to bottom axis
-            myPlot.Axes.DateTimeTicksBottom();
-            // set up a label formatter function
-            ((DateTimeAutomatic)myPlot.Axes.Bottom.TickGenerator).LabelFormatter = CustomFormatter;
-            
-            myPlot.Axes.SetLimitsX(45000, 45003);
+            // apply our custom tick formatter
+            DateTimeAutomatic tickGen = (DateTimeAutomatic)axis.TickGenerator;
+            tickGen.LabelFormatter = CustomFormatter;
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5/Generate.cs
+++ b/src/ScottPlot5/ScottPlot5/Generate.cs
@@ -509,6 +509,12 @@ public static class Generate
         return dates;
     }
 
+    public static System.DateTime[] ConsecutiveHours(int count)
+    {
+        var start = new System.DateTime(2023, 01, 01);
+        return ConsecutiveHours(count, start);
+    }
+
     public static System.DateTime[] ConsecutiveHours(int count, System.DateTime start)
     {
         return Consecutive(count, start, TimeSpan.FromHours(1));


### PR DESCRIPTION
Hi! With this request, I want to add a label formatter for the datetimeautomatic tick generator. At the moment, we cannot set a custom label formatter - we are content with "presets" (timeunits), but with labelformatter we can customize the display of date and time.
For example:
```cs
WpfPlot1.Plot.Axes.DateTimeTicksBottom();
((DateTimeAutomatic)WpfPlot1.Plot.Axes.Bottom.TickGenerator).LabelFormatter = LabelFormatter;

string LabelFormatter(DateTime arg)
{
    return arg is { Hour: 0, Minute: 0, Second: 0 } ? arg.ToShortDateString() : arg.ToLongTimeString();
}
```
I hope I've brought a useful feature.