### PR TITLE
Prevent legend overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Signal and Scatter: Added `MinRenderIndex` and `MaxRenderIndex` properties as shortcuts to those in the `Data` property (#3798)
 * Scatter: Improve appearance when `FillY` is enabled and all data is on one side of `FillYValue` (#3791) @BendRocks
 * Axes: Added `SetTicks()` shortcut for quickly switching to a manual tick generator pre-loaded with the given tick positions and labels (#3831) @Giviruk
+* Legend: Clip the legend area so it does not flow outside the data area on extremely small plots (#3833) @drolevar
 
 ## ScottPlot 5.0.34
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-05-05_

--- a/src/ScottPlot5/ScottPlot5/LegendLayouts/Wrapping.cs
+++ b/src/ScottPlot5/ScottPlot5/LegendLayouts/Wrapping.cs
@@ -6,6 +6,7 @@ public class Wrapping : ILegendLayout
     {
         using SKPaint paint = new();
         PixelSize maxSizeAfterPadding = maxSize.Contracted(legend.Padding);
+        PixelRect maxRectAfterPadding = new(0, maxSizeAfterPadding.Width, maxSizeAfterPadding.Height, 0);
         PixelSize[] labelSizes = items.Select(x => x.LabelStyle.Measure(x.LabelText, paint).Size).ToArray();
         float maxLabelWidth = labelSizes.Select(x => x.Width).Max();
         float maxLabelHeight = labelSizes.Select(x => x.Height).Max();
@@ -40,6 +41,8 @@ public class Wrapping : ILegendLayout
 
             // create rectangles for the item using the current position
             PixelRect itemRect = new(nextPixel, new PixelSize(itemWidth, maxItemHeight));
+            itemRect = itemRect.Intersect(maxRectAfterPadding);
+
             symbolRects[i] = new(itemRect.Left, itemRect.Left + legend.SymbolWidth, itemRect.Bottom, itemRect.Top);
             labelRects[i] = new(
                 left: itemRect.Left + legend.SymbolWidth + legend.SymbolPadding,
@@ -59,8 +62,8 @@ public class Wrapping : ILegendLayout
             }
         }
 
-        float tightWidth = labelRects.Select(x => x.Right).Max();
-        float tightHeight = labelRects.Select(x => x.Bottom).Max();
+        float tightWidth = Math.Min(labelRects.Select(x => x.Right).Max(), maxSizeAfterPadding.Width);
+        float tightHeight = Math.Min(labelRects.Select(x => x.Bottom).Max(), maxSizeAfterPadding.Height);
         PixelRect legendRect = new(0, tightWidth + legend.Padding.Horizontal, tightHeight + legend.Padding.Vertical, 0);
         PixelOffset paddingOffset = new(legend.Padding.Left, legend.Padding.Top);
 

--- a/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
@@ -260,6 +260,13 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
         Drawing.FillRectangle(canvas, layout.LegendRect, paint, BackgroundFillStyle);
         Drawing.DrawRectangle(canvas, layout.LegendRect, paint, OutlineStyle);
 
+        CanvasState canvasState = new(canvas);
+        canvasState.Save();
+
+        PixelRect clipRect = layout.LegendRect.Contract(Padding).Expand(1.0f);
+
+        canvasState.Clip(clipRect);
+
         // render items inside the legend
         for (int i = 0; i < layout.LegendItems.Length; i++)
         {
@@ -284,5 +291,7 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
             item.MarkerStyle.Render(canvas, symbolRect.Center, paint);
             item.ArrowStyle.Render(canvas, symbolLine, paint);
         }
+
+        canvasState.Restore();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/PixelRect.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/PixelRect.cs
@@ -177,6 +177,28 @@ public readonly struct PixelRect : IEquatable<PixelRect>
         return new PixelRect(left, right, bottom, top);
     }
 
+    /// <summary>
+    /// Returns the intersection with another rectangle
+    /// </summary>
+    /// <param name="other">Other rectangle</param>
+    /// <returns>Intersection rectangle</returns>
+    public PixelRect Intersect(PixelRect other)
+    {
+        float left = Math.Max(Left, other.Left);
+        float right = Math.Min(Right, other.Right);
+
+        if (left > right)
+            return NaN;
+
+        float bottom = Math.Min(Bottom, other.Bottom);
+        float top = Math.Max(Top, other.Top);
+
+        if (top > bottom)
+            return NaN;
+
+        return new PixelRect(left, right, bottom, top);
+    }
+
     public PixelRect Expand(PixelPadding pad)
     {
         float left = Left - pad.Left;


### PR DESCRIPTION
Currently the legend overflows the DataRect if the DataRect size is too small:

![image](https://github.com/ScottPlot/ScottPlot/assets/14980349/1d1cd1ef-f664-488a-be7d-eab877b73b0c)

With this change it will fit the DataRect and the contents will be clipped to the LegendRect:

![image](https://github.com/ScottPlot/ScottPlot/assets/14980349/6eba4896-ea14-4824-a4a4-ba41414671ba)
