### PR TITLE
Add override support for axis lock keys in InputBindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Scatter: Improve appearance when `FillY` is enabled and all data is on one side of `FillYValue` (#3791) @BendRocks
 * Axes: Added `SetTicks()` shortcut for quickly switching to a manual tick generator pre-loaded with the given tick positions and labels (#3831) @Giviruk
 * Legend: Clip the legend area so it does not flow outside the data area on extremely small plots (#3833) @drolevar
+* Controls: Made axis locking methods `virtual` inside `InputBindings` to facilitate custom behavior (#3838) @JinjieZhao
 
 ## ScottPlot 5.0.34
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-05-05_

--- a/src/ScottPlot5/ScottPlot5/Control/InputBindings.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/InputBindings.cs
@@ -26,7 +26,7 @@ public class InputBindings
     /// <summary>
     /// Returns <see langword="true"/> if <paramref name="keys"/> contains the key which locks the X axis
     /// </summary>
-    public bool ShouldLockX(IEnumerable<Key> keys)
+    public virtual bool ShouldLockX(IEnumerable<Key> keys, MouseButton? button = null)
     {
         return LockHorizontalAxisKey.HasValue ? keys.Contains(LockHorizontalAxisKey.Value) : false;
     }
@@ -34,7 +34,7 @@ public class InputBindings
     /// <summary>
     /// Returns <see langword="true"/> if <paramref name="keys"/> contains the key which locks the Y axis
     /// </summary>
-    public bool ShouldLockY(IEnumerable<Key> keys)
+    public virtual bool ShouldLockY(IEnumerable<Key> keys, MouseButton? button = null)
     {
         return LockVerticalAxisKey.HasValue ? keys.Contains(LockVerticalAxisKey.Value) : false;
     }
@@ -42,7 +42,7 @@ public class InputBindings
     /// <summary>
     /// Returns <see langword="true"/> if the combination of pressed buttons and keys results in a click-drag zoom rectangle
     /// </summary>
-    public bool ShouldZoomRectangle(MouseButton button, IEnumerable<Key> keys)
+    public virtual bool ShouldZoomRectangle(MouseButton button, IEnumerable<Key> keys)
     {
         if (button == DragZoomRectangleButton)
         {

--- a/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
@@ -86,8 +86,8 @@ public class Interaction(IPlotControl control) : IPlotInteraction
 
     protected virtual void MouseDrag(Pixel from, Pixel to, MouseButton button, IEnumerable<Key> keys, MultiAxisLimitManager start)
     {
-        bool lockY = Inputs.ShouldLockY(keys);
-        bool lockX = Inputs.ShouldLockX(keys);
+        bool lockY = Inputs.ShouldLockY(keys, button);
+        bool lockX = Inputs.ShouldLockX(keys, button);
         LockedAxes locks = new(lockX, lockY);
 
         MouseDrag drag = new(start, from, to);
@@ -103,7 +103,6 @@ public class Interaction(IPlotControl control) : IPlotInteraction
         }
         else if (button == Inputs.DragZoomButton)
         {
-
             Actions.DragZoom(PlotControl, drag, locks);
         }
     }


### PR DESCRIPTION
Allow users to customize the lock logic for X and Y axes. 

In my use case, the mouse wheel only zooms X. 
If the right mouse button is pressed, the logic remains consistent with previous behavior.

This is due to the fact that under typical circumstances, I am examining signal data and don't need to zoom the Y-axis.

Here is my code
```
public override bool ShouldLockY(IEnumerable<Key> keys, MouseButton? button = null)
    {
        if (button == DragZoomButton)
        {
            return base.ShouldLockY(keys);
        }

        return !base.ShouldLockY(keys);
    }
```