### PR TITLE
Add option for clear type text

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Primitives/Label.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Label.cs
@@ -32,6 +32,12 @@ public class Label
     public bool AntiAliasBackground { get; set; } = true;
     public bool AntiAliasText { get; set; } = true;
 
+    /// <summary>
+    /// To make use of ClearType text, you must also set the  SKSurfaceProperties 
+    /// of your SKSurface to be something other than SKPixelGeometry.Unknown
+    /// </summary>
+    public bool SubPixelAntiAliasText { get; set; }
+
     // TODO: use a class for cached typeface management
 
     private SKTypeface? CachedTypeface = null;
@@ -170,6 +176,7 @@ public class Label
         paint.TextSize = FontSize;
         paint.Color = ForeColor.ToSKColor();
         paint.IsAntialias = AntiAliasText;
+        paint.LcdRenderText = SubPixelAntiAliasText;
         paint.Shader = null;
     }
 


### PR DESCRIPTION
Clear type text is a process to make text appear crisper at the same resolution. Whilst basic antialiasing makes text look less pixelated, it can also then make text look more blurry. Clear type is an extension to antialiasing that uses colours to "trick" us into perceiving the text is crisper.  

On the left, no AA, so looks pixelated.
In the middle, AA has been applied (but in certain situations, like with a grey colour, it can look blurry)
On the right, AA with clear type

![image](https://github.com/ScottPlot/ScottPlot/assets/7289277/c29f2114-31c0-484f-b3fd-559cb83d9a3e)

To enable ClearType in Skia, you have to set LcdRenderText on the Paint class to true, which will then enables "SubpixelAntialias". I am not sure why they use the name "LcdRenderText" instead of 'SubpixelAntialias'.

Unfortunately, this is not the only change you have to make to enable ClearType. You also have to set the SkSurfacesProperties within the SKElement class. To achieve this, you kind of have to copy the the SKElement class from the SkiaSharp code base.

Results ( you will need to zoom in)
![image](https://github.com/ScottPlot/ScottPlot/assets/7289277/7199b533-da03-4390-abad-61016dfdacde)


