### PR TITLE
Fix avalonia performance on Linux

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Primitives/Label.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Label.cs
@@ -77,6 +77,19 @@ public class Label
         FontName = Fonts.Detect(Text);
     }
 
+    private SKTypeface? CachedTypeface = null;
+
+    private SKTypeface Typeface
+    {
+        get
+        {
+            if (CachedTypeface is null)
+            {
+                CachedTypeface = Fonts.GetTypeface(FontName, Bold, Italic);
+            }
+            return CachedTypeface;
+        }
+    }
 
     private void ApplyPointPaint(SKPaint paint)
     {


### PR DESCRIPTION
Thanks to @zii-dmg for finding the solution for the issue with unset CachedTypeface causing very slow performance under Avalonia in Linux.

Tested on RaspberryPi 5 under DRM, performance improvement from 1-3FPS to 40-80FPS rendering speed on large data set.

Fixes #3439 