### PR TITLE
Disable() double call fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _Not yet on NuGet..._
 * Controls: Made axis locking methods `virtual` inside `InputBindings` to facilitate custom behavior (#3838) @JinjieZhao
 * Fonts: Improved support for true-type font files and custom typefaces (#3841) @kebox7 @bclehmann
 * Axis: Simplified strategy for achieving shared axis limits between multiple controls as seen in the demo application (#3873) @StendProg
+* Controls: Improved `Plot.Interactions.Disable()` behavior so interactivity can be restored with `Plot.Interactions.Enable()` (#3879) @StendProg @KroMignon
 
 ## ScottPlot 5.0.34
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-05-05_

--- a/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
@@ -11,6 +11,11 @@ public class Interaction(IPlotControl control) : IPlotInteraction
     public IPlotControl PlotControl { get; private set; } = control;
 
     /// <summary>
+    /// Indicates whether interactions have been disabled.
+    /// </summary>
+    public bool Disabled { get; private set; } = false;
+
+    /// <summary>
     /// Buttons and keys in this object can be overwritten to customize actions for specific user input events.
     /// (e.g., make left-click-drag zoom instead of pan)
     /// </summary>
@@ -41,6 +46,10 @@ public class Interaction(IPlotControl control) : IPlotInteraction
     /// </summary>
     public void Disable()
     {
+        if (Disabled)
+            return;
+
+        Disabled = true;
         ActionsWhenDisabled = Actions;
         Actions = PlotActions.NonInteractive();
     }
@@ -51,6 +60,7 @@ public class Interaction(IPlotControl control) : IPlotInteraction
     public void Enable()
     {
         Actions = ActionsWhenDisabled;
+        Disabled = false;
     }
 
     /// <summary>
@@ -59,6 +69,7 @@ public class Interaction(IPlotControl control) : IPlotInteraction
     public void Enable(PlotActions customActions)
     {
         Actions = customActions;
+        Disabled = false;
     }
 
     /// <summary>

--- a/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
@@ -59,7 +59,9 @@ public class Interaction(IPlotControl control) : IPlotInteraction
     /// </summary>
     public void Enable()
     {
-        Actions = ActionsWhenDisabled;
+        if (Disabled)
+            Actions = ActionsWhenDisabled;
+
         Disabled = false;
     }
 


### PR DESCRIPTION
A double call to `Interactions.Disable()` resulted in the fact that interactions could not be restored with `Enable()` afterwards.

In this PR a special flag `Disabled` was introduced. It is now possible to call `Disable()` many times and then restore interactions with `Enable()` afterwards.