### PR TITLE
GetAxis now uses a scaled pixel (allows for ScaleFactor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ _Not yet on NuGet..._
 * Fonts: Improved support for true-type font files and custom typefaces (#3841) @kebox7 @bclehmann
 * Axis: Simplified strategy for achieving shared axis limits between multiple controls as seen in the demo application (#3873) @StendProg
 * Controls: Improved `Plot.Interactions.Disable()` behavior so interactivity can be restored with `Plot.Interactions.Enable()` (#3879) @StendProg @KroMignon
-* Axes: `Plot.GetAxis()` now offers improved support for custom scale factors (#3887, #3886) @BrianAtZetica
+* Controls: Improved mouse zoom behavior for plots with custom scale factors (#3887, #3886) @BrianAtZetica
 
 ## ScottPlot 5.0.34
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-05-05_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _Not yet on NuGet..._
 * Fonts: Improved support for true-type font files and custom typefaces (#3841) @kebox7 @bclehmann
 * Axis: Simplified strategy for achieving shared axis limits between multiple controls as seen in the demo application (#3873) @StendProg
 * Controls: Improved `Plot.Interactions.Disable()` behavior so interactivity can be restored with `Plot.Interactions.Enable()` (#3879) @StendProg @KroMignon
+* Axes: `Plot.GetAxis()` now offers improved support for custom scale factors (#3887, #3886) @BrianAtZetica
 
 ## ScottPlot 5.0.34
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-05-05_

--- a/src/ScottPlot5/ScottPlot5/Control/StandardActions.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/StandardActions.cs
@@ -310,35 +310,35 @@ public static class StandardActions
 
     private static void MouseZoom(Plot plot, double fracX, double fracY, Pixel pixel, bool ChangeOpposingAxesTogether)
     {
+        Pixel scaledPixel = new(pixel.X / plot.ScaleFactorF, pixel.Y / plot.ScaleFactorF);
         MultiAxisLimitManager originalLimits = new(plot);
         PixelRect dataRect = plot.RenderManager.LastRender.DataRect;
 
         // restore MouseDown limits
         originalLimits.Apply(plot);
 
-        var axisUnderMouse = plot.GetAxis(pixel);
+        var axisUnderMouse = plot.GetAxis(scaledPixel);
 
         if (axisUnderMouse is not null)
         {
             if (ChangeOpposingAxesTogether && axisUnderMouse.IsHorizontal())
             {
-                plot.Axes.XAxes.ForEach(xAxis => xAxis.Range.ZoomFrac(fracX, xAxis.GetCoordinate(pixel.X / plot.ScaleFactorF, dataRect)));
+                plot.Axes.XAxes.ForEach(xAxis => xAxis.Range.ZoomFrac(fracX, xAxis.GetCoordinate(scaledPixel.X, dataRect)));
             }
             if (ChangeOpposingAxesTogether && axisUnderMouse.IsVertical())
             {
-                plot.Axes.YAxes.ForEach(yAxis => yAxis.Range.ZoomFrac(fracY, yAxis.GetCoordinate(pixel.Y / plot.ScaleFactorF, dataRect)));
+                plot.Axes.YAxes.ForEach(yAxis => yAxis.Range.ZoomFrac(fracY, yAxis.GetCoordinate(scaledPixel.Y, dataRect)));
             }
             else
             {
                 double frac = axisUnderMouse.IsHorizontal() ? fracX : fracY;
-                float scaledCoord = (axisUnderMouse.IsHorizontal() ? pixel.X : pixel.Y) / plot.ScaleFactorF;
+                float scaledCoord = (axisUnderMouse.IsHorizontal() ? scaledPixel.X : scaledPixel.Y);
                 axisUnderMouse.Range.ZoomFrac(frac, axisUnderMouse.GetCoordinate(scaledCoord, dataRect));
             }
         }
         else
         {
             // modify all axes
-            Pixel scaledPixel = new(pixel.X / plot.ScaleFactor, pixel.Y / plot.ScaleFactor);
             plot.Axes.XAxes.ForEach(xAxis => xAxis.Range.ZoomFrac(fracX, xAxis.GetCoordinate(scaledPixel.X, dataRect)));
             plot.Axes.YAxes.ForEach(yAxis => yAxis.Range.ZoomFrac(fracY, yAxis.GetCoordinate(scaledPixel.Y, dataRect)));
         }


### PR DESCRIPTION
Addresses #3886 

Moves the line calcualtign a scaled pixel coordinate to the top of the function, then uses the scaled pixel (instead of the passed in pixel) when testing for axisUnderMouse

bug fix verified using same code as described in bug report:

```cs
using System.Windows;
using ScottPlot;

namespace Sandbox.WPF;

public partial class MainWindow : Window
{
    public MainWindow()
    {
        InitializeComponent();
        WpfPlot1.Plot.Add.Signal(Generate.Sin());
        WpfPlot1.Plot.Add.Signal(Generate.Cos());
        WpfPlot1.Plot.ScaleFactor = 2.5;
    }
}
```