### PR TITLE
Controls: Improve alt-left click to draw zoom region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ _Not yet on NuGet..._
 * Controls: Improved `Plot.Interactions.Disable()` behavior so interactivity can be restored with `Plot.Interactions.Enable()` (#3879) @StendProg @KroMignon
 * Controls: Improved mouse zoom behavior for plots with custom scale factors (#3887, #3886) @BrianAtZetica
 * Text: Improve support for text objects containing null strings (#3892, #3861) @sdpenner
+* Controls: Improve behavior of Alt + Left-Click-Drag zoom rectangle (#3896, #3845) @MCF
 
 ## ScottPlot 5.0.34
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-05-05_

--- a/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/Interaction.cs
@@ -92,7 +92,7 @@ public class Interaction(IPlotControl control) : IPlotInteraction
 
         MouseDrag drag = new(start, from, to);
 
-        if (Inputs.ShouldZoomRectangle(button, keys))
+        if (Inputs.ShouldZoomRectangle(button, keys) || IsZoomingRectangle)
         {
             Actions.DragZoomRectangle(PlotControl, drag, locks);
             IsZoomingRectangle = true;
@@ -125,11 +125,7 @@ public class Interaction(IPlotControl control) : IPlotInteraction
     public virtual void MouseUp(Pixel position, MouseButton button)
     {
         bool isDragging = Mouse.IsDragging(position);
-
-        bool droppedZoomRectangle =
-            isDragging &&
-            Inputs.ShouldZoomRectangle(button, Keyboard.PressedKeys) &&
-            IsZoomingRectangle;
+        bool droppedZoomRectangle = isDragging && IsZoomingRectangle;
 
         if (droppedZoomRectangle)
         {


### PR DESCRIPTION
Alt-left click now used to start drawing the rectangle only.  Alt key is ignored for the remainder of the region's rectangle draw and The zoom occurs upon left click button release only.

Resolves #3845