### PR TITLE
Fix label text position when offset specified

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/LabelTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/LabelTests.cs
@@ -286,4 +286,57 @@ internal class LabelTests
 
         bmp.SaveTestImage();
     }
+
+
+    [Test]
+    public void Test_Label_Offset()
+    {
+        SKBitmap bmp = new(500, 500);
+        Test_Label_Offset(bmp, "X:{0}, Y:{1}");
+        bmp.SaveTestImage();
+    }
+
+    [Test]
+    public void Test_Label_MultiLineOffset()
+    {
+        SKBitmap bmp = new(500, 500);
+        Test_Label_Offset(bmp, "X:{0}\nY:{1}");
+        bmp.SaveTestImage();
+    }
+
+    private static void Test_Label_Offset(SKBitmap bmp, string format)
+    {
+        using SKCanvas canvas = new(bmp);
+        canvas.Clear(SKColors.Navy);
+
+        using SKPaint paint = new();
+
+        Pixel center = new(bmp.Width / 2, bmp.Height / 2);
+        float offset = 150f;
+
+        for (int y = -1; y < 2; y++)
+        {
+            for (int x = -1; x < 2; x++)
+            {
+                float offsetX = offset * x;
+                float offsetY = offset * y;
+
+                Label lbl = new()
+                {
+                    Text = string.Format(format, offsetX, offsetY),
+                    Alignment = Alignment.MiddleCenter,
+                    FontSize = 24,
+                    ForeColor = Colors.White.WithOpacity(.5),
+                    PointSize = 5,
+                    BorderColor = Colors.Yellow,
+                    PointColor = Colors.White,
+                    BorderWidth = 1,
+                    OffsetX = offsetX,
+                    OffsetY = offsetY,
+                };
+
+                lbl.Render(canvas, center, paint);
+            }
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Label.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Label.cs
@@ -261,8 +261,8 @@ public class Label
         }
         else
         {
-            float xPx = textRect.Left + OffsetX;
-            float yPx = textRect.Bottom + OffsetY + dV;
+            float xPx = textRect.Left;
+            float yPx = textRect.Bottom + dV;
             canvas.DrawText(Text, xPx, yPx, paint);
         }
     }


### PR DESCRIPTION
This is just the patch from #3836 pushed to a new branch, as the creator of that PR closed it.


```cs
var plot = AvaPlot.Plot;
var color = Colors.Cyan;

var vLine = plot.Add.VerticalLine(1000, 1, color, LinePattern.Dashed);
vLine.LabelFontColor = Color.FromARGB(0xC0000000);
vLine.LabelBorderColor = color;
vLine.LabelBackgroundColor = Colors.Transparent;
vLine.LabelText = $"{Math.Round(1000f, 3)}Hz"; // Label the line with its position
vLine.LabelRotation = -90;
vLine.LabelAlignment = Alignment.MiddleRight;
vLine.LabelOffsetX = -20;
vLine.LabelOffsetY = -250;
```

Before:
![image](https://github.com/ScottPlot/ScottPlot/assets/8635304/19d26311-a07e-492a-a950-b3059f83e89e)

After:
![image](https://github.com/ScottPlot/ScottPlot/assets/8635304/7967c5a1-a212-437d-9cde-89270bc47c6d)
