### PR TITLE
AvaPlot: Set InputElement.Focusable to receive key events

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
@@ -29,6 +29,7 @@ public class AvaPlot : Controls.Control, IPlotControl
         DisplayScale = DetectDisplayScale();
         Interaction = new Interaction(this);
         Menu = new AvaPlotMenu(this);
+        Focusable = true; // Required for keyboard events
         Refresh();
     }
 


### PR DESCRIPTION
Previously AvaPlot did not receive key events. Now it does.