### PR TITLE
BugFixes to Rotated SignalXY plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,13 +32,14 @@ _Not yet on NuGet..._
 * Scatter: Added `GetNearestX()` to the data source to help locate the point closest to the cursor's X position (#3807) @MatKinPro
 * Controls: Disable middle-click-drag zooming on axes which have no data (#3810, #3897) @MCF
 * DataLogger: Create `Add()` overloads which accept fixed-length arrays (#3555) @h25019871990
-* SignalXY: Ensure the final point is always drawn in high density mode (#3812)
+* SignalXY: Ensure the final point is always drawn in high density mode (#3812, #3812)
 * Axes: Improved exception messages when calling `Zoom()` methods with invalid scale factors (#3813) @KennyTK
 * WinForms: Exposed `SKControl` so users may bind to its events (#3819) @CD-SailingPerf
 * Scatter: Added support for `Scale` and `Offset` properties (#3835) @bukkideme
 * Axis Lines: Separated `LegendText` from `LabelText` so items may be configured separately
 * Heatmap: Exposed `CellWidth` and `CellHeight` as an alternative sizing strategy to setting `Extent` (#3869) @alexisvrignaud
 * ImageRect: New plot type that places an image inside a defined rectangle on the plot (#3870) @sdpenner
+* SignalXY: Improved appearance of rotated plots when low density mode is in use (#3921) @BrianAtZetica
 
 ## ScottPlot 5.0.34
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-05-05_

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
@@ -258,8 +258,8 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
 
         if (firstPointPosition > MinimumIndex)
         {
-            float beforeX = axes.GetPixelX(Xs[firstPointIndex - 1] + XOffset);
-            float beforeY = axes.GetPixelY(Ys[firstPointIndex - 1] * YScale + YOffset);
+            float beforeY = axes.GetPixelY(Xs[firstPointIndex - 1] + XOffset);
+            float beforeX = axes.GetPixelX(Ys[firstPointIndex - 1] * YScale + YOffset);
             Pixel beforePoint = new(beforeX, beforeY);
             return ([beforePoint], firstPointIndex);
         }
@@ -300,8 +300,8 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
 
         if (lastPointPosition <= MaximumIndex)
         {
-            float afterX = axes.GetPixelX(Xs[lastPointIndex] + XOffset);
-            float afterY = axes.GetPixelY(Ys[lastPointIndex] * YScale + YOffset);
+            float afterY = axes.GetPixelY(Xs[lastPointIndex] + XOffset);
+            float afterX = axes.GetPixelX(Ys[lastPointIndex] * YScale + YOffset);
             Pixel afterPoint = new(afterX, afterY);
             return ([afterPoint], lastPointIndex);
         }

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
@@ -57,16 +57,17 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
             .Select(pxColumn => GetColumnPixelsX(pxColumn, visibileRange, rp, axes))
             .SelectMany(x => x);
 
+        // duplicate the last point to ensure it is always rendered
+        // https://github.com/ScottPlot/ScottPlot/issues/3812
+        Pixel lastPoint = axes.GetPixel(new Coordinates(Xs[dataIndexLast], Ys[dataIndexLast]));
+
         Pixel[] leftOutsidePoint = PointBefore, rightOutsidePoint = PointAfter;
         if (axes.XAxis.Range.Span < 0)
         {
             leftOutsidePoint = PointAfter;
             rightOutsidePoint = PointBefore;
+            lastPoint = axes.GetPixel(new Coordinates(Xs[dataIndexFirst], Ys[dataIndexFirst]));
         }
-
-        // duplicate the last point to ensure it is always rendered
-        // https://github.com/ScottPlot/ScottPlot/issues/3812
-        Pixel lastPoint = axes.GetPixel(new Coordinates(Xs[dataIndexLast], Ys[dataIndexLast]));
 
         // combine with one extra point before and after
         Pixel[] points = [.. leftOutsidePoint, .. VisiblePoints, .. rightOutsidePoint, lastPoint];
@@ -93,16 +94,18 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
             .Select(pxRow => GetColumnPixelsY(pxRow, visibleRange, rp, axes))
             .SelectMany(x => x);
 
+        // duplicate the last point to ensure it is always rendered
+        // https://github.com/ScottPlot/ScottPlot/issues/3812
+        Pixel lastPoint = axes.GetPixel(new Coordinates(Ys[dataIndexLast], Xs[dataIndexLast]));
+
         Pixel[] bottomOutsidePoint = PointBefore, topOutsidePoint = PointAfter;
         if (axes.YAxis.Range.Span < 0)
         {
             bottomOutsidePoint = PointAfter;
             topOutsidePoint = PointBefore;
+            lastPoint = axes.GetPixel(new Coordinates(Ys[dataIndexFirst], Xs[dataIndexFirst]));
         }
 
-        // duplicate the last point to ensure it is always rendered
-        // https://github.com/ScottPlot/ScottPlot/issues/3812
-        Pixel lastPoint = axes.GetPixel(new Coordinates(Ys[dataIndexLast], Xs[dataIndexLast]));
 
         // combine with one extra point before and after
         Pixel[] points = [.. bottomOutsidePoint, .. VisiblePoints, .. topOutsidePoint, lastPoint];
@@ -182,7 +185,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
             yield break;
         }
 
-        yield return new Pixel(xPixel, axes.GetPixelY(Ys[startIndex] * YScale + YOffset)); // enter
+        yield return new Pixel(xPixel, axes.GetPixelY(Ys[Math.Min(startIndex, endIndex)] * YScale + YOffset)); // enter
 
         if (pointsInRange > 1)
         {
@@ -215,7 +218,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
             yield break;
         }
 
-        yield return new Pixel(axes.GetPixelX(Ys[startIndex] + XOffset), yPixel); // enter
+        yield return new Pixel(axes.GetPixelX(Ys[Math.Min(startIndex,endIndex)] + XOffset), yPixel); // enter
 
         if (pointsInRange > 1)
         {

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
@@ -102,7 +102,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
 
         // duplicate the last point to ensure it is always rendered
         // https://github.com/ScottPlot/ScottPlot/issues/3812
-        Pixel lastPoint = axes.GetPixel(new Coordinates(Xs[dataIndexLast], Ys[dataIndexLast]));
+        Pixel lastPoint = axes.GetPixel(new Coordinates(Ys[dataIndexLast], Xs[dataIndexLast]));
 
         // combine with one extra point before and after
         Pixel[] points = [.. bottomOutsidePoint, .. VisiblePoints, .. topOutsidePoint, lastPoint];


### PR DESCRIPTION
Reolution for #3812 had introduced an incorrect final pixel location for rotated SignalXY plots.
This was resolved by a swapping of Xs and Ys coordinates when defining the additional "lastPoint" value. 
_Note, we could consider renaming Xs and Ys to something like independentValues and dependentValues respectively. Not sure if that will be intuitove to all developers though._

Using the sample code provided in comment on #3812  the fix provided no longer shows a distored line at top of the plot:
![image](https://github.com/ScottPlot/ScottPlot/assets/119825052/8a9f638f-2c9d-494d-8912-d81cf74da02a)


Second bug was pre-existing, and became apparent when zoomed into the series to observe the final pixel. 
Rotated SignalXY series were performing an incorrect interpolation for the final pixel location (another mix-up of Xs and Ys).

Code to demonstrate this issue is as follows:

```cs

        InitializeComponent();

        double[] X = new double[2];
        double[] Y = new double[2];
        X[0] = -10;
        X[1] = 10;
        Y[0] = 1;
        Y[1] = 2;

        var signal = WpfPlot1.Plot.Add.SignalXY(X, Y, color: ScottPlot.Colors.Black);
        signal.Data.Rotated = false;
        var signalrotated = WpfPlot1.Plot.Add.SignalXY(X, Y, color: ScottPlot.Colors.Black);
        signalrotated.Data.Rotated = true;
```

This plots a normal SignalXY and a rotated SignalXY on the same graph.
Before the bug fix, this becomes distorted when panning the content up or down:

![image](https://github.com/ScottPlot/ScottPlot/assets/119825052/18764652-b4b2-4f8f-bc08-62c3e4154dfe)

After the bug fix the plot keeps its cross shape while scrolling off the page in any direction:
![image](https://github.com/ScottPlot/ScottPlot/assets/119825052/db874073-d8be-4dc9-9ffd-6d9debd0450a)

