### PR TITLE
Default text rendering to use subpixel rendering

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Primitives/Label.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Label.cs
@@ -31,6 +31,7 @@ public class Label
 
     public bool AntiAliasBackground { get; set; } = true;
     public bool AntiAliasText { get; set; } = true;
+    public bool SubpixelText { get; set; } = true;
 
     public string FontName { get; set; } = Fonts.Default;
     public float FontSize { get; set; } = 12;
@@ -120,6 +121,7 @@ public class Label
         paint.TextSize = FontSize;
         paint.Color = ForeColor.ToSKColor();
         paint.IsAntialias = AntiAliasText;
+        paint.SubpixelText = SubpixelText;
         paint.Shader = null;
     }
 


### PR DESCRIPTION
I noticed that the font spacing between characters was not consistent. This resulted in spacing between characters that almost looks like white space, as can be seen in the image below : 

![image](https://github.com/ScottPlot/ScottPlot/assets/7289277/9156a9d4-55a2-4188-95c8-5e7017d2c9de)

To correct this, there is a property on the skia Paint object that enables subpixel text rendering. Enabling this results in much more consistent spacing between characters.

In the image below, the lines with the '!' at the end have `SubpixelText` set to true.
It's very subtle, but notice how they have a consistent 1 pixel gap between the characters?
Where as the ones below (without the '!', with `SubpixelText` set to false) have either a 2 pixel gap, 1 pixel gap or no pixel gap.

![image](https://github.com/ScottPlot/ScottPlot/assets/7289277/a8cf5955-e204-4712-aa6b-c8d4c2d20b32)

I have added this property to the `Label` class with the default being set to true.
