### PR TITLE
Repeat render if changes are made in invoked events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _Not yet on NuGet..._
 * Population: Added a new Population plot type for displaying collections of values (#3944, #3676)
 * IAxisLimitManager: Separated `GetAxisLimits()` into `GetRangeX()` and `GetRangeY()` for improved customization and performance (#3946) @drolevar
 * Experimental: Added `Plottables.Experimental.DataStreamer2` plot type for displaying streaming data in a circular buffer (#3946) @drolevar
+* Rendering: Automatically re-render if a render invokes an event that requests it (#3952) @BrianAtZetica
 
 ## ScottPlot 5.0.35
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-10_

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -246,7 +246,12 @@ public class Plot : IDisposable
         lock (Sync)
         {
             RenderManager.Render(canvas, rect);
-            if (RenderManager.NeedsAnotherRender) RenderManager.Render(canvas, rect);
+            int counter = 0;
+            while (RenderManager.NeedsAnotherRender & counter < 5)
+            {
+                RenderManager.Render(canvas, rect);
+                counter++;
+            }
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -246,6 +246,7 @@ public class Plot : IDisposable
         lock (Sync)
         {
             RenderManager.Render(canvas, rect);
+            if (RenderManager.NeedsAnotherRender) RenderManager.Render(canvas, rect);
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -247,7 +247,7 @@ public class Plot : IDisposable
         {
             RenderManager.Render(canvas, rect);
             int counter = 0;
-            while (RenderManager.NeedsAnotherRender & counter < 5)
+            while (RenderManager.NeedsAnotherRender && counter < 5)
             {
                 RenderManager.Render(canvas, rect);
                 counter++;

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -246,12 +246,6 @@ public class Plot : IDisposable
         lock (Sync)
         {
             RenderManager.Render(canvas, rect);
-            int counter = 0;
-            while (RenderManager.NeedsAnotherRender && counter < 5)
-            {
-                RenderManager.Render(canvas, rect);
-                counter++;
-            }
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
@@ -149,9 +149,10 @@ public class RenderManager(Plot plot)
             {
                 AxisLimitsChanged.Invoke(Plot, LastRender);
             }
+            
+            NeedsAnotherRender = CheckAxesChangedByEvents();
         }
 
-        NeedsAnotherRender = CheckAxesChangedByEvents();
         DisableAxisLimitsChangedEventOnNextRender = false;
 
         // TODO: event for when layout changes

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
@@ -132,7 +132,7 @@ public class RenderManager(Plot plot)
         RenderCount += 1;
         IsRendering = false;
 
-        if (EnableEvents & !NeedsAnotherRender)
+        if (EnableEvents)
         {
             RenderFinished.Invoke(Plot, LastRender);
 

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
@@ -87,7 +87,11 @@ public class RenderManager(Plot plot)
 
     public bool ClearCanvasBeforeEachRender { get; set; } = true;
 
-    public bool NeedsAnotherRender { get; set; } = false;
+    /// <summary>
+    /// If changes to axis limits are detected following invoked events, this will be set to true to indicate another render is required to update the plot
+    /// </summary>
+    public bool NeedsAnotherRender { get; private set; } = false;
+
     private Plot Plot { get; } = plot;
 
     /// <summary>
@@ -162,7 +166,7 @@ public class RenderManager(Plot plot)
 
             CoordinateRangeMutable rangeNow = axis.Range;
             CoordinateRange rangeBefore = LastRender.AxisLimitsByAxis[axis];
-            if (rangeNow.Min != rangeBefore.Min | rangeNow.Max != rangeBefore.Max)
+            if (rangeNow.Min != rangeBefore.Min || rangeNow.Max != rangeBefore.Max)
                 return true;
         }
         return false;

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
@@ -165,6 +165,9 @@ public class RenderManager(Plot plot)
             if (axis is null)
                 continue;
 
+            if (Double.IsNaN(axis.Range.Span))
+                continue;
+
             CoordinateRangeMutable rangeNow = axis.Range;
             CoordinateRange rangeBefore = LastRender.AxisLimitsByAxis[axis];
             if (rangeNow.Min != rangeBefore.Min || rangeNow.Max != rangeBefore.Max)


### PR DESCRIPTION
I had a requirement to synchronise two vertical axes (representing depth and elevation), but:

- Their values would be offset by a user specificed value (i.e. the ground surface elevation)
- The depth axis (only) is snapping to tick intervals (using the SnapToTicksY axis rule). 

I was finding that if the user changed either vertical axis the other axis would update using the invoked AxisLimitsChanged event, but the render was already in progress, so the change was not seen until the next render occurred. This meant the two axes did not have the correct synchronisation.

The solution implemented in this PR is to test for changes made to axis limits by invoked events, and set a flag in the RenderManager to indicate that a repeat render is required. 

However, my scenario was even more complex due to the depth axis snapping to tick values. When the user changed (zoomed/panned) the elevation axis, my AxisLimitsChanged event would change the depth axis. But on the repeat render, the depth axis then snaps to tick intervals and needs to invoke the AxisLimtisChanged event a second time. With the Depth axis now changed, I update the elevation axis, and I need to render a 3rd time to see this change. 

I've set the rendering to repeat as long as it detects an axis change during invoked events, but have put a maximum limit of 5 repeat renders (to avoid an endless loop) - this could be made into a parameter in the future perhaps. 
