### PR TITLE
color conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _Not yet on NuGet..._
 * Rendering: Automatically re-render if a render invokes an event that requests it (#3952) @BrianAtZetica
 * SVG: File encoding now supports text containing UTF8 characters (#3956, #3957) @aespitia
 * Documentation: Added a sandbox .NET API project and quickstart section to the website (#3959, #3824) @aespitia
+* Color: Added `ToColor()` and `FromColor()` to simplify conversion between `ScottPlot.Color` and `System.Drawing.Color` (#3964, ##3953) @aespitia
 
 ## ScottPlot 5.0.35
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-10_

--- a/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
@@ -359,4 +359,9 @@ public readonly struct Color
         float luminosity = 0.5f;
         return Color.FromHSL(hue, saturation, luminosity);
     }
+
+    public static System.Drawing.Color ConvertColor(ScottPlot.Color color)
+    {
+        return System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
@@ -360,7 +360,7 @@ public readonly struct Color
         return Color.FromHSL(hue, saturation, luminosity);
     }
 
-    public static System.Drawing.Color ConvertColor(ScottPlot.Color color)
+    public static System.Drawing.Color ToColor(ScottPlot.Color color)
     {
         return System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
     }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Colors.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Colors.cs
@@ -220,4 +220,9 @@ public struct Colors
 
         return colors;
     }
+
+    static ScottPlot.Color ConvertColor(System.Drawing.Color color)
+    {
+        return ScottPlot.Color.FromHex($"#{color.R:X2}{color.G:X2}{color.B:X2}");
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Colors.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Colors.cs
@@ -220,9 +220,4 @@ public struct Colors
 
         return colors;
     }
-
-    static ScottPlot.Color ConvertColor(System.Drawing.Color color)
-    {
-        return ScottPlot.Color.FromHex($"#{color.R:X2}{color.G:X2}{color.B:X2}");
-    }
 }


### PR DESCRIPTION
Adding a method to convert from ScottPlot.Color to System.Drawing.Color.

#3953

function name update to ToColor

sample from linqpad


```cs
var c = ConvertColor(ScottPlot.Color.FromHex("#CCCCCC"));

c.Dump();

static System.Drawing.Color ConvertColor(ScottPlot.Color color)
{
	return System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);	
}
```
 result from dump
 
![image](https://github.com/ScottPlot/ScottPlot/assets/105309364/c20701dc-3ac7-4626-8657-6e95f2c97f7d)

