### PR TITLE
adding console write file name function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _Not yet on NuGet..._
 * SVG: File encoding now supports text containing UTF8 characters (#3956, #3957) @aespitia
 * Documentation: Added a sandbox .NET API project and quickstart section to the website (#3959, #3824) @aespitia
 * Color: Added `ToColor()` and `FromColor()` to simplify conversion between `ScottPlot.Color` and `System.Drawing.Color` (#3964, ##3953) @aespitia
+* Console: Saved image path can be displayed by calling `myPlot.SavePng('demo.png', 600, 400).ConsoleWritePath()` (#3965, #3943) @aespitia
 
 ## ScottPlot 5.0.35
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-10_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotExtensions.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotExtensions.cs
@@ -47,4 +47,10 @@ public static class FormsPlotExtensions
         using MemoryStream ms = new(img.GetImageBytes(ImageFormat.Bmp));
         return new Bitmap(ms);
     }
+
+    public static void CopyToClipboard(this SavedImageInfo info)
+    {
+        System.Drawing.Bitmap bmp = new(info.Path);
+        Clipboard.SetImage(bmp);
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.Console/Program.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.Console/Program.cs
@@ -6,3 +6,5 @@ plt.Add.Signal(Generate.Cos());
 
 plt.SavePng("test.png", 600, 300).LaunchFile();
 plt.SavePng("test.png", 600, 300).LaunchInBrowser();
+plt.SavePng("test.png", 600, 300).ConsoleWriteFilename();
+

--- a/src/ScottPlot5/ScottPlot5/Primitives/SavedImageInfo.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/SavedImageInfo.cs
@@ -1,4 +1,5 @@
-﻿namespace ScottPlot;
+﻿
+namespace ScottPlot;
 
 public class SavedImageInfo
 {
@@ -19,6 +20,8 @@ public class SavedImageInfo
     }
 
     public void LaunchFile() => Platform.LaunchFile(Path);
+
+    public void ConsoleWriteFilename() => Console.WriteLine(Path);
 
     public void LaunchInBrowser(double refresh = 3)
     {

--- a/src/ScottPlot5/ScottPlot5/Primitives/SavedImageInfo.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/SavedImageInfo.cs
@@ -21,7 +21,7 @@ public class SavedImageInfo
 
     public void LaunchFile() => Platform.LaunchFile(Path);
 
-    public void ConsoleWriteFilename() => Console.WriteLine(Path);
+    public void ConsoleWritePath() => Console.WriteLine(Path);
 
     public void LaunchInBrowser(double refresh = 3)
     {


### PR DESCRIPTION
adding requested functionality for writing the file path to the console, briefly looked at the clipboard request too, but it may be a little more involved for different systems, or have to introduce another library to abstract the clipboard, so, i didn't want to introduce a new dependency.  

#3943

```cs
using ScottPlot;

Plot plt = new();
plt.Add.Signal(Generate.Sin());
plt.Add.Signal(Generate.Cos());

plt.SavePng("test.png", 600, 300).ConsoleWriteFilename();
```