### PR TITLE
Axes: improve sharpness of axis lines, tick marks, and grid lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ _Not yet on NuGet..._
 * Documentation: Added a sandbox .NET API project and quickstart section to the website (#3959, #3824) @aespitia
 * Color: Added `ToColor()` and `FromColor()` to simplify conversion between `ScottPlot.Color` and `System.Drawing.Color` (#3964, ##3953) @aespitia
 * Console: Saved image path can be displayed by calling `myPlot.SavePng('demo.png', 600, 400).ConsoleWritePath()` (#3965, #3943) @aespitia
-* Axis: Axis frames, tick marks, and grid lines are non-anti-aliased by default, but `Plot.Axes.AntiAlias()` can re-enable it (#3976) @bforlgreen
+* Rendering: Improved sharpness of axis frames, tick marks, and grid lines by disabling anti-aliasing by default and added `Plot.Axes.AntiAlias()` so users can customize this behavior (#3976) @bforlgreen
 
 ## ScottPlot 5.0.35
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-10_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _Not yet on NuGet..._
 * Documentation: Added a sandbox .NET API project and quickstart section to the website (#3959, #3824) @aespitia
 * Color: Added `ToColor()` and `FromColor()` to simplify conversion between `ScottPlot.Color` and `System.Drawing.Color` (#3964, ##3953) @aespitia
 * Console: Saved image path can be displayed by calling `myPlot.SavePng('demo.png', 600, 400).ConsoleWritePath()` (#3965, #3943) @aespitia
+* Axis: Axis frames, tick marks, and grid lines are non-anti-aliased by default, but `Plot.Axes.AntiAlias()` can re-enable it (#3976) @bforlgreen
 
 ## ScottPlot 5.0.35
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-10_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/AdvancedAxis.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Axis/AdvancedAxis.cs
@@ -91,4 +91,22 @@ public class AdvancedAxis : ICategory
             myPlot.Axes.AddLeftAxis(customAxisY);
         }
     }
+
+    public class AxisAntiAliasing : RecipeBase
+    {
+        public override string Name => "Axis AntiAliasing";
+        public override string Description => "To improve crispness of straight vertical and horizontal lines, " +
+            "Anti-aliasing is disabled by default for axis frames, tick marks, and grid lines. Anti-aliasing " +
+            "can be enabled for all these objects by calling the AntiAlias helper method.";
+
+        [Test]
+        public override void Execute()
+        {
+            double[] dataX = { 1, 2, 3, 4, 5 };
+            double[] dataY = { 1, 4, 9, 16, 25 };
+            myPlot.Add.Scatter(dataX, dataY);
+
+            myPlot.Axes.AntiAlias(true);
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -857,4 +857,27 @@ public class AxisManager
         YAxes.ForEach(x => x.IsVisible = false);
         Title.IsVisible = false;
     }
+
+    /// <summary>
+    /// Set anti-aliasing for axis frames, tick marks, and grid lines
+    /// </summary>
+    /// <param name="enable"></param>
+    public void AntiAlias(bool enable)
+    {
+        foreach (AxisBase axis in GetAxes().OfType<AxisBase>())
+        {
+            // frames
+            axis.FrameLineStyle.AntiAlias = enable;
+
+            // tick marks
+            axis.MajorTickStyle.AntiAlias = enable;
+            axis.MinorTickStyle.AntiAlias = enable;
+        }
+
+        // grid lines
+        Plot.Grid.XAxisStyle.MajorLineStyle.AntiAlias = enable;
+        Plot.Grid.XAxisStyle.MinorLineStyle.AntiAlias = enable;
+        Plot.Grid.YAxisStyle.MajorLineStyle.AntiAlias = enable;
+        Plot.Grid.YAxisStyle.MinorLineStyle.AntiAlias = enable;
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
@@ -102,6 +102,14 @@ public abstract class AxisBase : LabelStyleProperties
             _ => throw new NotImplementedException(edge.ToString()),
         };
 
+        if (edge == Edge.Top && !lineStyle.AntiAlias)
+        {
+            // move the top frame line slightly down so the vertical pixel snaps
+            // to the same level as the top of the left and right frame lines
+            // https://github.com/ScottPlot/ScottPlot/pull/3976
+            pxLine = pxLine.WithDelta(0, .1f);
+        }
+
         using SKPaint paint = new();
         Drawing.DrawLine(rp.Canvas, paint, pxLine, lineStyle);
     }

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
@@ -113,6 +113,7 @@ public abstract class AxisBase : LabelStyleProperties
             // draw tick
             paint.Color = tick.IsMajor ? majorStyle.Color.ToSKColor() : minorStyle.Color.ToSKColor();
             paint.StrokeWidth = tick.IsMajor ? majorStyle.Width : minorStyle.Width;
+            paint.IsAntialias = tick.IsMajor ? majorStyle.IsAntialias : minorStyle.IsAntialias;
             float tickLength = tick.IsMajor ? majorStyle.Length : minorStyle.Length;
             float xPx = axis.GetPixel(tick.Position, panelRect);
             float y = axis.Edge == Edge.Bottom ? panelRect.Top : panelRect.Bottom;
@@ -148,6 +149,7 @@ public abstract class AxisBase : LabelStyleProperties
             // draw tick
             paint.Color = tick.IsMajor ? majorStyle.Color.ToSKColor() : minorStyle.Color.ToSKColor();
             paint.StrokeWidth = tick.IsMajor ? majorStyle.Width : minorStyle.Width;
+            paint.IsAntialias = tick.IsMajor ? majorStyle.IsAntialias : minorStyle.IsAntialias;
             float tickLength = tick.IsMajor ? majorStyle.Length : minorStyle.Length;
             float yPx = axis.GetPixel(tick.Position, panelRect);
             float x = axis.Edge == Edge.Left ? panelRect.Right : panelRect.Left;

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
@@ -48,20 +48,27 @@ public abstract class AxisBase : LabelStyleProperties
 
     public bool ShowDebugInformation { get; set; } = false;
 
-    public LineStyle FrameLineStyle { get; } = new() { Width = 1 };
+    public LineStyle FrameLineStyle { get; } = new()
+    {
+        Width = 1,
+        Color = Colors.Black,
+        AntiAlias = false,
+    };
 
     public TickMarkStyle MajorTickStyle { get; set; } = new()
     {
         Length = 4,
         Width = 1,
-        Color = Colors.Black
+        Color = Colors.Black,
+        AntiAlias = false,
     };
 
     public TickMarkStyle MinorTickStyle { get; set; } = new()
     {
         Length = 2,
         Width = 1,
-        Color = Colors.Black
+        Color = Colors.Black,
+        AntiAlias = false,
     };
 
     public Label TickLabelStyle { get; set; } = new()
@@ -113,7 +120,7 @@ public abstract class AxisBase : LabelStyleProperties
             // draw tick
             paint.Color = tick.IsMajor ? majorStyle.Color.ToSKColor() : minorStyle.Color.ToSKColor();
             paint.StrokeWidth = tick.IsMajor ? majorStyle.Width : minorStyle.Width;
-            paint.IsAntialias = tick.IsMajor ? majorStyle.IsAntialias : minorStyle.IsAntialias;
+            paint.IsAntialias = tick.IsMajor ? majorStyle.AntiAlias : minorStyle.AntiAlias;
             float tickLength = tick.IsMajor ? majorStyle.Length : minorStyle.Length;
             float xPx = axis.GetPixel(tick.Position, panelRect);
             float y = axis.Edge == Edge.Bottom ? panelRect.Top : panelRect.Bottom;
@@ -149,7 +156,7 @@ public abstract class AxisBase : LabelStyleProperties
             // draw tick
             paint.Color = tick.IsMajor ? majorStyle.Color.ToSKColor() : minorStyle.Color.ToSKColor();
             paint.StrokeWidth = tick.IsMajor ? majorStyle.Width : minorStyle.Width;
-            paint.IsAntialias = tick.IsMajor ? majorStyle.IsAntialias : minorStyle.IsAntialias;
+            paint.IsAntialias = tick.IsMajor ? majorStyle.AntiAlias : minorStyle.AntiAlias;
             float tickLength = tick.IsMajor ? majorStyle.Length : minorStyle.Length;
             float yPx = axis.GetPixel(tick.Position, panelRect);
             float x = axis.Edge == Edge.Left ? panelRect.Right : panelRect.Left;

--- a/src/ScottPlot5/ScottPlot5/Primitives/GridStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/GridStyle.cs
@@ -65,6 +65,6 @@ public class GridStyle
                 : new Pixel(rp.DataRect.Right, px);
         }
 
-        Drawing.DrawLines(rp.Canvas, starts, ends, lineStyle.Color, lineStyle.Width, antiAlias: true, lineStyle.Pattern);
+        Drawing.DrawLines(rp.Canvas, starts, ends, lineStyle.Color, lineStyle.Width, lineStyle.AntiAlias, lineStyle.Pattern);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/GridStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/GridStyle.cs
@@ -7,13 +7,15 @@ public class GridStyle
     public LineStyle MajorLineStyle { get; set; } = new()
     {
         Width = 1,
-        Color = Colors.Black.WithOpacity(.1)
+        Color = Colors.Black.WithOpacity(.1),
+        AntiAlias = false,
     };
 
     public LineStyle MinorLineStyle { get; set; } = new()
     {
         Width = 0,
-        Color = Colors.Black.WithOpacity(.05)
+        Color = Colors.Black.WithOpacity(.05),
+        AntiAlias = false,
     };
 
     public int MaximumNumberOfGridLines { get; set; } = 1_000;

--- a/src/ScottPlot5/ScottPlot5/Primitives/TickMarkStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/TickMarkStyle.cs
@@ -5,4 +5,5 @@ public class TickMarkStyle
     public float Length;
     public float Width;
     public Color Color;
+    public bool IsAntialias = true;
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/TickMarkStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/TickMarkStyle.cs
@@ -5,5 +5,5 @@ public class TickMarkStyle
     public float Length;
     public float Width;
     public Color Color;
-    public bool IsAntialias = true;
+    public bool AntiAlias;
 }


### PR DESCRIPTION
Allow users to be able to disable antialiasing on grid lines and ticks, which to my mind creates a more pleasing graph as the aa lines look blurry. The defaults have been left as they were, so this is an "opt into" change.

Before
![AntiAlliased](https://github.com/ScottPlot/ScottPlot/assets/7289277/c5812842-f865-4758-9c65-69000bca21cc)


After (with the configuration code below)
![Aliased](https://github.com/ScottPlot/ScottPlot/assets/7289277/1c5a57fd-f32a-4bbf-a487-a58ada8cad17)

```
     WpfPlot1.Plot.Axes.Left.FrameLineStyle.AntiAlias = false;
     WpfPlot1.Plot.Axes.Top.FrameLineStyle.AntiAlias = false;
     WpfPlot1.Plot.Axes.Right.FrameLineStyle.AntiAlias = false;
     WpfPlot1.Plot.Axes.Bottom.FrameLineStyle.AntiAlias = false;

     WpfPlot1.Plot.Grid.XAxisStyle.MajorLineStyle.AntiAlias = false;
     WpfPlot1.Plot.Grid.YAxisStyle.MajorLineStyle.AntiAlias = false;

     WpfPlot1.Plot.Axes.Left.MajorTickStyle.IsAntialias = false;
     WpfPlot1.Plot.Axes.Left.MinorTickStyle.IsAntialias = false;

     WpfPlot1.Plot.Axes.Bottom.MajorTickStyle.IsAntialias = false;
     WpfPlot1.Plot.Axes.Bottom.MinorTickStyle.IsAntialias = false;
```

I highly recommend the ZoomIt app for being able to investigate these kinds of issues.
https://learn.microsoft.com/en-us/sysinternals/downloads/zoomit