### PR TITLE
Signal: improve support for IReadOnlyList<T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _Not yet on NuGet..._
 * Color: Added `ToColor()` and `FromColor()` to simplify conversion between `ScottPlot.Color` and `System.Drawing.Color` (#3964, ##3953) @aespitia
 * Console: Saved image path can be displayed by calling `myPlot.SavePng('demo.png', 600, 400).ConsoleWritePath()` (#3965, #3943) @aespitia
 * Rendering: Improved sharpness of axis frames, tick marks, and grid lines by disabling anti-aliasing by default and added `Plot.Axes.AntiAlias()` so users can customize this behavior (#3976) @bforlgreen
+* Signal: Added support for generic data sources in read-only lists (#3978, #3942) @sdpenner
 
 ## ScottPlot 5.0.35
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-10_

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.Console/Program.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.Console/Program.cs
@@ -6,5 +6,4 @@ plt.Add.Signal(Generate.Cos());
 
 plt.SavePng("test.png", 600, 300).LaunchFile();
 plt.SavePng("test.png", 600, 300).LaunchInBrowser();
-plt.SavePng("test.png", 600, 300).ConsoleWriteFilename();
-
+plt.SavePng("test.png", 600, 300).ConsoleWritePath();

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/Plottable/SignalTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/Plottable/SignalTests.cs
@@ -1,4 +1,6 @@
-﻿namespace ScottPlotTests.RenderTests.Plottable;
+﻿using ScottPlot.DataSources;
+
+namespace ScottPlotTests.RenderTests.Plottable;
 
 internal class SignalTests
 {
@@ -187,6 +189,23 @@ internal class SignalTests
 
         // single plot with single point
         double[] ys = [0];
+        plt.Add.Signal(ys);
+
+        // signal plot is outside the data area
+        plt.Axes.SetLimits(1, 2, 1, 2);
+
+        plt.Should().RenderInMemoryWithoutThrowing();
+    }
+
+    [Test]
+    public void Test_Signal_ReadOnlyList()
+    {
+        // https://github.com/ScottPlot/ScottPlot/pull/3978
+
+        ScottPlot.Plot plt = new();
+
+        // single plot with single point
+        IReadOnlyList<float> ys = [1, 4, 9];
         plt.Add.Signal(ys);
 
         // signal plot is outside the data area

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericList.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericList.cs
@@ -2,10 +2,10 @@
 
 public class SignalSourceGenericList<T> : SignalSourceBase, ISignalSource
 {
-    private readonly List<T> Ys;
+    private readonly IReadOnlyList<T> Ys;
     public override int Length => Ys.Count;
 
-    public SignalSourceGenericList(List<T> ys, double period)
+    public SignalSourceGenericList(IReadOnlyList<T> ys, double period)
     {
         Ys = ys;
         Period = period;

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -857,15 +857,9 @@ public class PlottableAdder(Plot plot)
         return Signal(source, color);
     }
 
-    public Signal Signal<T>(List<T> ys, double period = 1, Color? color = null)
-    {
-        SignalSourceGenericList<T> source = new(ys, period);
-        return Signal(source, color);
-    }
-
     public Signal Signal<T>(IReadOnlyList<T> ys, double period = 1, Color? color = null)
     {
-        SignalSourceGenericList<T> source = new(ys.ToList(), period);
+        SignalSourceGenericList<T> source = new(ys, period);
         return Signal(source, color);
     }
 

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -849,6 +849,12 @@ public class PlottableAdder(Plot plot)
         return Signal(source, color);
     }
 
+    public Signal Signal<T>(IReadOnlyList<T> ys, double period = 1, Color? color = null)
+    {
+        SignalSourceGenericList<T> source = new(ys.ToList(), period);
+        return Signal(source, color);
+    }
+
     public SignalConst<T> SignalConst<T>(T[] ys, double period = 1, Color? color = null)
         where T : struct, IComparable
     {


### PR DESCRIPTION
Added IReadOnlyList adder for creating a new signal.  Just creates a generic list from the read only one.

Not sure this makes sense, as users could easily do the ToList() themselves...

closes #3942

```cs
   public Signal Signal<T>(IReadOnlyList<T> ys, double period = 1, Color? color = null)
   {
       SignalSourceGenericList<T> source = new(ys.ToList(), period);
       return Signal(source, color);
   }
```