### PR TITLE
Added a constructor overload that accepts List<Coordinates>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _Not yet on NuGet..._
 * Console: Saved image path can be displayed by calling `myPlot.SavePng('demo.png', 600, 400).ConsoleWritePath()` (#3965, #3943) @aespitia
 * Rendering: Improved sharpness of axis frames, tick marks, and grid lines by disabling anti-aliasing by default and added `Plot.Axes.AntiAlias()` so users can customize this behavior (#3976) @bforlgreen
 * Signal: Added support for generic data sources in read-only lists (#3978, #3942) @sdpenner
+* LinearRegression: Added overload that accepts `IEnumerable<Coordinates>` (#3982, #3981) @ANGADJEET @CoderPM2011
 
 ## ScottPlot 5.0.35
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-10_

--- a/src/ScottPlot5/ScottPlot5/Statistics/LinearRegression.cs
+++ b/src/ScottPlot5/ScottPlot5/Statistics/LinearRegression.cs
@@ -24,6 +24,22 @@ public readonly struct LinearRegression
     }
 
     /// <summary>
+    /// Calculate the linear regression from a collection of X/Y coordinates
+    /// Accepts a List of Coordinates.
+    /// </summary>     
+    public LinearRegression(List<Coordinates> coordinates)
+    {
+        if (coordinates == null || coordinates.Count < 2)
+        {
+            throw new ArgumentException($"{nameof(coordinates)} must have at least 2 points");
+        }
+
+        double[] xs = coordinates.Select(c => c.X).ToArray();
+        double[] ys = coordinates.Select(c => c.Y).ToArray();
+        (Slope, Offset, Rsquared) = GetCoefficients(xs, ys);
+    }
+    
+    /// <summary>
     /// Calculate the linear regression a paired collection of X and Y points
     /// </summary>
     public LinearRegression(double[] xs, double[] ys)

--- a/src/ScottPlot5/ScottPlot5/Statistics/LinearRegression.cs
+++ b/src/ScottPlot5/ScottPlot5/Statistics/LinearRegression.cs
@@ -25,11 +25,10 @@ public readonly struct LinearRegression
 
     /// <summary>
     /// Calculate the linear regression from a collection of X/Y coordinates
-    /// Accepts a List of Coordinates.
     /// </summary>     
-    public LinearRegression(List<Coordinates> coordinates)
+    public LinearRegression(IEnumerable<Coordinates> coordinates)
     {
-        if (coordinates == null || coordinates.Count < 2)
+        if (coordinates == null || coordinates.Count() < 2)
         {
             throw new ArgumentException($"{nameof(coordinates)} must have at least 2 points");
         }
@@ -38,7 +37,7 @@ public readonly struct LinearRegression
         double[] ys = coordinates.Select(c => c.Y).ToArray();
         (Slope, Offset, Rsquared) = GetCoefficients(xs, ys);
     }
-    
+
     /// <summary>
     /// Calculate the linear regression a paired collection of X and Y points
     /// </summary>


### PR DESCRIPTION
### Pull Request Description

#### Overview
This pull request adds a new constructor to the `LinearRegression` struct that accepts a `List<Coordinates>`. It simplifies creating a `LinearRegression` instance from a collection of coordinates.

#### Changes Made
- Added a constructor overload for `LinearRegression` that accepts `List<Coordinates>`.

![os](https://github.com/ScottPlot/ScottPlot/assets/119041931/80a6185e-63f6-4bb7-bcb7-0c4032ff776c)
