### PR TITLE
Colormap: shortcut to get a range of colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ _Not yet on NuGet..._
 * Rendering: Improved sharpness of axis frames, tick marks, and grid lines by disabling anti-aliasing by default and added `Plot.Axes.AntiAlias()` so users can customize this behavior (#3976) @bforlgreen
 * Signal: Added support for generic data sources in read-only lists (#3978, #3942) @sdpenner
 * LinearRegression: Added overload that accepts `IEnumerable<Coordinates>` (#3982, #3981) @ANGADJEET @CoderPM2011
+* Colormap: Added `GetColors()` for generating a given number of colors evenly spaced along a colormap (#3983, #3947) @CoderPM2011
 
 ## ScottPlot 5.0.35
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-10_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
@@ -213,5 +213,32 @@ public class Styling : ICategory
         }
     }
 
+    public class ColormapColorSteps : RecipeBase
+    {
+        public override string Name => "Colormap Steps";
+        public override string Description => "Colormaps can be used to generate " +
+            "a collection of discrete colors that can be applied to plottable objects.";
 
+        [Test]
+        public override void Execute()
+        {
+            IColormap colormap = new ScottPlot.Colormaps.Turbo();
+
+            for (int count = 1; count < 10; count++)
+            {
+                double[] xs = Generate.Consecutive(count);
+                double[] ys = Generate.Repeating(count, count);
+                Color[] colors = colormap.GetColors(count);
+
+                for (int i = 0; i < count; i++)
+                {
+                    var circle = myPlot.Add.Circle(xs[i], ys[i], 0.45);
+                    circle.FillColor = colors[i];
+                    circle.LineWidth = 0;
+                }
+            }
+
+            myPlot.YLabel("number of colors");
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IColormap.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IColormap.cs
@@ -43,4 +43,65 @@ public static class IColormapExtensions
 
         return bmp;
     }
+
+    /// <summary>
+    /// Returns a collection of colors in the specified range on this colormap according to the given range and quantity.
+    /// </summary>
+    /// <param name="count">The number of colors to get from the colormap.</param>
+    /// <param name="start">The starting point in the colormap range from which to begin extracting colors (normalized to [0, 1]).</param>
+    /// <param name="end">The ending point in the colormap range at which to stop extracting colors (normalized to [0, 1]).</param>
+    /// <returns>An <see cref="IEnumerable{Color}"/> collection of colors within the specified range.</returns>
+    /// <remarks>
+    /// If the <paramref name="count"/> is greater than the number of distinct colors in the range,
+    /// duplicate colors may be included in the returned collection,
+    /// depending on the implementation of <see cref="IColormap.GetColor(double)"/>.
+    /// </remarks>
+    /// <seealso cref="IColormap"/>
+    public static IEnumerable<Color> GetColors(
+        this IColormap colormap, int count, double start = 0, double end = 1)
+    {
+        #region Assert
+
+        if (count < 2)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(count), $"Argument ${nameof(count)} must be greater than or equal to 2.");
+        }
+
+        if (double.IsInfinity(start) || double.IsNaN(start))
+        {
+            throw new ArgumentException(
+                $"{nameof(start)} must be a real number", nameof(start));
+        }
+
+        if (double.IsInfinity(end) || double.IsNaN(end))
+        {
+            throw new ArgumentException(
+                $"{nameof(end)} must be a real number", nameof(end));
+        }
+
+        if (start < 0 || start > 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(start), $"{nameof(start)} must be within the range of 0 to 1.");
+        }
+
+        if (end < 0 || end > 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(start), $"{nameof(end)} must be within the range of 0 to 1.");
+        }
+
+        if (start > end)
+        {
+            throw new ArgumentException(
+                $"Argument ${nameof(start)} must be less than or equal to ${nameof(end)}.");
+        }
+
+        #endregion // Assert
+
+        double step = (end - start) / (count - 1);
+        return Enumerable.Range(0, count)
+            .Select(i => colormap.GetColor(i * step + start));
+    }
 }


### PR DESCRIPTION
I implemented a slightly different version of the `GetColors` method in `IColormapExtensions` based on #3947.
I'm not sure if this meets the requirements of #3947, so feel free to make changes.