### PR TITLE
CoordinateLine: add constructor overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _Not yet on NuGet..._
 * Signal: Added support for generic data sources in read-only lists (#3978, #3942) @sdpenner
 * LinearRegression: Added overload that accepts `IEnumerable<Coordinates>` (#3982, #3981) @ANGADJEET @CoderPM2011
 * Colormap: Added `GetColors()` for generating a given number of colors evenly spaced along a colormap (#3983, #3947) @CoderPM2011
+* CoordinateLine: Added additional constructors for creating lines given a point and slope (#3987, #3986) @aalgrou
 
 ## ScottPlot 5.0.35
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-10_

--- a/src/ScottPlot5/ScottPlot5/Primitives/CoordinateLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/CoordinateLine.cs
@@ -1,4 +1,6 @@
-﻿namespace ScottPlot;
+﻿using System.Drawing;
+
+namespace ScottPlot;
 
 /// <summary>
 /// Represents a straight line in coordinate space
@@ -36,16 +38,20 @@ public readonly struct CoordinateLine
         Y2 = pt2.Y;
     }
 
-    private static CoordinateLine GetCoordinateLine(double x, double y, double slope)
+    public CoordinateLine(double x, double y, double slope)
     {
-        Coordinates pt1 = new(x, y);
-        return GetCoordinateLine(pt1, slope);
+        X1 = x;
+        Y1 = y;
+        X2 = x + 1;
+        Y2 = y + slope;
     }
 
-    private static CoordinateLine GetCoordinateLine(Coordinates point, double slope)
+    public CoordinateLine(Coordinates point, double slope)
     {
-        Coordinates pt2 = new(point.X + 1, point.Y + slope);
-        return new CoordinateLine(point, pt2);
+        X1 = point.X;
+        Y1 = point.Y;
+        X2 = point.X + 1;
+        Y2 = point.Y + slope;
     }
 
     public override string ToString()

--- a/src/ScottPlot5/ScottPlot5/Primitives/CoordinateLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/CoordinateLine.cs
@@ -36,6 +36,18 @@ public readonly struct CoordinateLine
         Y2 = pt2.Y;
     }
 
+    private static CoordinateLine GetCoordinateLine(double x, double y, double slope)
+    {
+        Coordinates pt1 = new(x, y);
+        return GetCoordinateLine(pt1, slope);
+    }
+
+    private static CoordinateLine GetCoordinateLine(Coordinates point, double slope)
+    {
+        Coordinates pt2 = new(point.X + 1, point.Y + slope);
+        return new CoordinateLine(point, pt2);
+    }
+
     public override string ToString()
     {
         return $"CoordinateLine from ({X1}, {Y1}) to ({X2}, {Y2})";

--- a/src/ScottPlot5/ScottPlot5/Statistics/LinearRegression.cs
+++ b/src/ScottPlot5/ScottPlot5/Statistics/LinearRegression.cs
@@ -11,14 +11,9 @@ public readonly struct LinearRegression
     /// <summary>
     /// Calculate the linear regression from a collection of X/Y coordinates
     /// </summary>
-    public LinearRegression(IEnumerable<Coordinates> coordinates)
+    public LinearRegression(Coordinates[] coordinates)
     {
-        if (coordinates == null)
-        {
-            throw new ArgumentNullException(nameof(coordinates), $"{nameof(coordinates)} cannot be null");
-        }
-
-        if (coordinates.Count() < 2)
+        if (coordinates.Length < 2)
         {
             throw new ArgumentException($"{nameof(coordinates)} must have at least 2 points");
         }

--- a/src/ScottPlot5/ScottPlot5/Statistics/LinearRegression.cs
+++ b/src/ScottPlot5/ScottPlot5/Statistics/LinearRegression.cs
@@ -11,9 +11,14 @@ public readonly struct LinearRegression
     /// <summary>
     /// Calculate the linear regression from a collection of X/Y coordinates
     /// </summary>
-    public LinearRegression(Coordinates[] coordinates)
+    public LinearRegression(IEnumerable<Coordinates> coordinates)
     {
-        if (coordinates.Length < 2)
+        if (coordinates == null)
+        {
+            throw new ArgumentNullException(nameof(coordinates), $"{nameof(coordinates)} cannot be null");
+        }
+
+        if (coordinates.Count() < 2)
         {
             throw new ArgumentException($"{nameof(coordinates)} must have at least 2 points");
         }


### PR DESCRIPTION
I added the required functions based on this issue 
CoordinateLine: add constructor overloads for accepting a point and slope #3986