### PR TITLE
Added ResetMinAndMaxValues() to DataLoggerSource.cs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _Not yet on NuGet..._
 * LinearRegression: Added overload that accepts `IEnumerable<Coordinates>` (#3982, #3981) @ANGADJEET @CoderPM2011
 * Colormap: Added `GetColors()` for generating a given number of colors evenly spaced along a colormap (#3983, #3947) @CoderPM2011
 * CoordinateLine: Added additional constructors for creating lines given a point and slope (#3987, #3986) @aalgrou
+* DataLogger: Added `Clear()` and `ResetMinAndMaxValues()` to the data logger source class (#3993, #3969) @jpgarza93
 
 ## ScottPlot 5.0.35
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-10_

--- a/src/ScottPlot5/ScottPlot5/DataSources/DataLoggerSource.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/DataLoggerSource.cs
@@ -48,14 +48,18 @@ public class DataLoggerSource
         }
     }
 
-    public void Clear()
+    public void ResetMinAndMaxValues()
     {
-        Coordinates.Clear();
-
         YMin = double.NaN;
         YMax = double.NaN;
         XMin = double.NaN;
         XMax = double.NaN;
+    }
+
+    public void Clear()
+    {
+        Coordinates.Clear();
+        ResetMinAndMaxValues();
     }
 
     public AxisLimits GetAxisLimits()


### PR DESCRIPTION
This is a small PR to add a way to reset Min/Max values in the DataLoggerSource class.

Mentioned here: https://github.com/ScottPlot/ScottPlot/issues/3969