### PR TITLE
Fix interaction of axis panels when scale factor is more than 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _Not yet on NuGet..._
 * Colormap: Added `GetColors()` for generating a given number of colors evenly spaced along a colormap (#3983, #3947) @CoderPM2011
 * CoordinateLine: Added additional constructors for creating lines given a point and slope (#3987, #3986) @aalgrou
 * DataLogger: Added `Clear()` and `ResetMinAndMaxValues()` to the data logger source class (#3993, #3969) @jpgarza93
+* Controls: Improved behavior of middle-click-drag zooming over axis panels for plots using DPI scaling (#3994) @bforlgreen
 
 ## ScottPlot 5.0.35
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-10_

--- a/src/ScottPlot5/ScottPlot5/Control/StandardActions.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/StandardActions.cs
@@ -235,7 +235,9 @@ public static class StandardActions
             control.Plot.ZoomRectangle.VerticalSpan = locked.X;
             control.Plot.ZoomRectangle.HorizontalSpan = locked.Y;
 
-            IAxis? axisUnderMouse = control.Plot.GetAxis(drag.From);
+            float scaleFactor = control.Plot.ScaleFactorF;
+
+            IAxis? axisUnderMouse = control.Plot.GetAxis(drag.From.Divide(scaleFactor));
             if (axisUnderMouse is not null)
             {
                 // Do not respond if the axis under the mouse has no data
@@ -252,9 +254,8 @@ public static class StandardActions
                 control.Plot.ZoomRectangle.HorizontalSpan = axisUnderMouse.IsVertical();
             }
 
-            double scaleFactor = control.Plot.ScaleFactor;
-            control.Plot.ZoomRectangle.MouseDown = new(drag.From.X / scaleFactor, drag.From.Y / scaleFactor);
-            control.Plot.ZoomRectangle.MouseUp = new(drag.To.X / scaleFactor, drag.To.Y / scaleFactor);
+            control.Plot.ZoomRectangle.MouseDown = drag.From.Divide(scaleFactor);
+            control.Plot.ZoomRectangle.MouseUp = drag.To.Divide(scaleFactor);
             control.Plot.ZoomRectangle.IsVisible = true;
             control.Refresh();
         }
@@ -318,7 +319,7 @@ public static class StandardActions
 
     private static void MouseZoom(Plot plot, double fracX, double fracY, Pixel pixel, bool ChangeOpposingAxesTogether)
     {
-        Pixel scaledPixel = new(pixel.X / plot.ScaleFactorF, pixel.Y / plot.ScaleFactorF);
+        Pixel scaledPixel = pixel.Divide(plot.ScaleFactorF);
         MultiAxisLimitManager originalLimits = new(plot);
         PixelRect dataRect = plot.RenderManager.LastRender.DataRect;
 

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -74,13 +74,7 @@ public class Plot : IDisposable
         float xPixel = xAxis.GetPixel(coordinates.X, RenderManager.LastRender.DataRect);
         float yPixel = yAxis.GetPixel(coordinates.Y, RenderManager.LastRender.DataRect);
 
-        if (ScaleFactor != 1)
-        {
-            xPixel *= ScaleFactorF;
-            yPixel *= ScaleFactorF;
-        }
-
-        return new Pixel(xPixel, yPixel);
+        return new Pixel(xPixel, yPixel).Multiply(ScaleFactorF);
     }
 
     /// <summary>
@@ -88,7 +82,7 @@ public class Plot : IDisposable
     /// </summary>
     public Coordinates GetCoordinates(Pixel pixel, IXAxis? xAxis = null, IYAxis? yAxis = null)
     {
-        Pixel scaledPx = new(pixel.X / ScaleFactor, pixel.Y / ScaleFactor);
+        Pixel scaledPx = pixel.Divide(ScaleFactorF);
         PixelRect dataRect = RenderManager.LastRender.DataRect;
         double x = (xAxis ?? Axes.Bottom).GetCoordinate(scaledPx.X, dataRect);
         double y = (yAxis ?? Axes.Left).GetCoordinate(scaledPx.Y, dataRect);
@@ -114,18 +108,10 @@ public class Plot : IDisposable
     /// </summary>
     public CoordinateRect GetCoordinateRect(float x, float y, float radius = 10, IXAxis? xAxis = null, IYAxis? yAxis = null)
     {
-        float leftPx = (x - radius);
-        float rightPx = (x + radius);
-        float topPx = (y - radius);
-        float bottomPx = (y + radius);
-
-        if (ScaleFactor != 1)
-        {
-            leftPx /= ScaleFactorF;
-            rightPx /= ScaleFactorF;
-            topPx /= ScaleFactorF;
-            bottomPx /= ScaleFactorF;
-        }
+        float leftPx = (x - radius) / ScaleFactorF;
+        float rightPx = (x + radius) / ScaleFactorF;
+        float topPx = (y - radius) / ScaleFactorF;
+        float bottomPx = (y + radius) / ScaleFactorF;
 
         PixelRect dataRect = RenderManager.LastRender.DataRect;
         double x1 = (xAxis ?? Axes.Bottom).GetCoordinate(leftPx, dataRect);
@@ -165,10 +151,7 @@ public class Plot : IDisposable
     /// </summary>
     public CoordinateRect GetCoordinateRect(Coordinates coordinates, float radius = 10, IXAxis? xAxis = null, IYAxis? yAxis = null)
     {
-        if (ScaleFactor != 1)
-        {
-            radius /= ScaleFactorF;
-        }
+        radius /= ScaleFactorF;
 
         PixelRect dataRect = RenderManager.LastRender.DataRect;
         double radiusX = (xAxis ?? Axes.Bottom).GetCoordinateDistance(radius, dataRect);

--- a/src/ScottPlot5/ScottPlot5/Primitives/Pixel.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Pixel.cs
@@ -124,4 +124,10 @@ public struct Pixel : IEquatable<Pixel>
     {
         return new Pixel(X + offset.X, Y + offset.Y);
     }
+
+    public readonly Pixel Divide(float v) => new Pixel(X / v, Y / v);
+    public readonly Pixel Divide(float x, float y) => new Pixel(X / x, Y / y);
+
+    public readonly Pixel Multiply(float v) => new Pixel(X * v, Y * v);
+    public readonly Pixel Multiply(float x, float y) => new Pixel(X * x, Y * y);
 }


### PR DESCRIPTION
If you set the ScaleFactor to a value greater than 1, then interaction with the Axis Panels (mouse interactions) was incorrect.

To repro the issue (without these changes), set the scale factor to something like 1.5 and then try to perform a marquee select in the **YAxis only** in the area pointed to by the arrow. You'll notice it doesn't work.

![image](https://github.com/ScottPlot/ScottPlot/assets/7289277/16a33d41-d3d5-4280-ae28-551800541acf)

These changes scale the mouse pos like we do with all the other functions.

I have also cleaned up some of the Scale factor code

- removed unnecessary checks of Scale factor == 1 (multiply or divide by 1 wont change anything)
- added helper methods to reduce some of the duplicate code. 
