### PR TITLE
LineStyle.Hairline: Option for single pixel line widths regardless of scale factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ _Not yet on NuGet..._
 * CoordinateLine: Added additional constructors for creating lines given a point and slope (#3987, #3986) @aalgrou
 * DataLogger: Added `Clear()` and `ResetMinAndMaxValues()` to the data logger source class (#3993, #3969) @jpgarza93
 * Controls: Improved behavior of middle-click-drag zooming over axis panels for plots using DPI scaling (#3994) @bforlgreen
+* Style: Added `Plot.Axes.Hairline()` to enable axis frames, tick marks, and grid lines to render 1px wide regardless of scale factor (#3995) @bforlgreen
 
 ## ScottPlot 5.0.35
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-10_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
@@ -160,7 +160,7 @@ public class Styling : ICategory
 
     public class Scaling : RecipeBase
     {
-        public override string Name => "Scaling";
+        public override string Name => "Scale Factor";
         public override string Description => "All components of an image can be scaled up or down in size " +
             "by adjusting the ScaleFactor property. This is very useful for creating images that look nice " +
             "on high DPI displays with display scaling enabled.";
@@ -171,6 +171,24 @@ public class Styling : ICategory
             myPlot.ScaleFactor = 2;
             myPlot.Add.Signal(Generate.Sin());
             myPlot.Add.Signal(Generate.Cos());
+        }
+    }
+
+    public class Hairline : RecipeBase
+    {
+        public override string Name => "Hairline Mode";
+        public override string Description => "Hairline mode allows axis frames, tick marks, and grid lines " +
+            "to always be rendered a single pixel wide regardless of scale factor. Enable hairline mode to allow " +
+            "interactive plots to feel smoother when a large scale factor is in use.";
+
+        [Test]
+        public override void Execute()
+        {
+            myPlot.ScaleFactor = 2;
+            myPlot.Add.Signal(Generate.Sin());
+            myPlot.Add.Signal(Generate.Cos());
+
+            myPlot.Axes.Hairline(true);
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -882,28 +882,19 @@ public class AxisManager
     }
 
     /// <summary>
-    /// Set hairline for axis frames, tick marks, and grid lines
-    /// You only need to do this if <see cref="Plot.ScaleFactor"/> is more than 1
+    /// Hairline mode causes lines to always render exactly 1 pixel wide regardless of <see cref="Plot.ScaleFactor"/>.
+    /// This function controls hairline behavior for all axis frames. tick marks, and grid lines.
     /// </summary>
-    /// <param name="enable">Whether to enable or disable hairline</param>
-    /// <param name="width">The width to use when hair line is NOT enabled</param>
-    public void Hairline(bool enable, float width = 0)
+    public void Hairline(bool enable)
     {
-        if (enable && width != 0)
-            throw new InvalidOperationException("If enabling hairline, the width should be 0!");
-
         foreach (AxisBase axis in GetAxes().OfType<AxisBase>())
         {
             // frames
             axis.FrameLineStyle.Hairline = enable;
-            axis.FrameLineStyle.Width = width;
 
             // tick marks
             axis.MajorTickStyle.Hairline = enable;
             axis.MinorTickStyle.Hairline = enable;
-
-            axis.MajorTickStyle.Width = width;
-            axis.MinorTickStyle.Width = width;
         }
 
         // grid lines
@@ -911,10 +902,5 @@ public class AxisManager
         Plot.Grid.XAxisStyle.MinorLineStyle.Hairline = enable;
         Plot.Grid.YAxisStyle.MajorLineStyle.Hairline = enable;
         Plot.Grid.YAxisStyle.MinorLineStyle.Hairline = enable;
-
-        Plot.Grid.XAxisStyle.MajorLineStyle.Width = width;
-        Plot.Grid.XAxisStyle.MinorLineStyle.Width = width;
-        Plot.Grid.YAxisStyle.MajorLineStyle.Width = width;
-        Plot.Grid.YAxisStyle.MinorLineStyle.Width = width;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -880,4 +880,41 @@ public class AxisManager
         Plot.Grid.YAxisStyle.MajorLineStyle.AntiAlias = enable;
         Plot.Grid.YAxisStyle.MinorLineStyle.AntiAlias = enable;
     }
+
+    /// <summary>
+    /// Set hairline for axis frames, tick marks, and grid lines
+    /// You only need to do this if <see cref="Plot.ScaleFactor"/> is more than 1
+    /// </summary>
+    /// <param name="enable">Whether to enable or disable hairline</param>
+    /// <param name="width">The width to use when hair line is NOT enabled</param>
+    public void Hairline(bool enable, float width = 0)
+    {
+        if (enable && width != 0)
+            throw new InvalidOperationException("If enabling hairline, the width should be 0!");
+
+        foreach (AxisBase axis in GetAxes().OfType<AxisBase>())
+        {
+            // frames
+            axis.FrameLineStyle.Hairline = enable;
+            axis.FrameLineStyle.Width = width;
+
+            // tick marks
+            axis.MajorTickStyle.Hairline = enable;
+            axis.MinorTickStyle.Hairline = enable;
+
+            axis.MajorTickStyle.Width = width;
+            axis.MinorTickStyle.Width = width;
+        }
+
+        // grid lines
+        Plot.Grid.XAxisStyle.MajorLineStyle.Hairline = enable;
+        Plot.Grid.XAxisStyle.MinorLineStyle.Hairline = enable;
+        Plot.Grid.YAxisStyle.MajorLineStyle.Hairline = enable;
+        Plot.Grid.YAxisStyle.MinorLineStyle.Hairline = enable;
+
+        Plot.Grid.XAxisStyle.MajorLineStyle.Width = width;
+        Plot.Grid.XAxisStyle.MinorLineStyle.Width = width;
+        Plot.Grid.YAxisStyle.MajorLineStyle.Width = width;
+        Plot.Grid.YAxisStyle.MinorLineStyle.Width = width;
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
@@ -134,7 +134,7 @@ public abstract class AxisBase : LabelStyleProperties
             float y = axis.Edge == Edge.Bottom ? panelRect.Top : panelRect.Bottom;
             float yEdge = axis.Edge == Edge.Bottom ? y + tickLength : y - tickLength;
             PixelLine pxLine = new(xPx, y, xPx, yEdge);
-            Drawing.DrawLine(rp.Canvas, paint, pxLine);
+            Drawing.DrawLine(rp.Canvas, paint, pxLine, tick.IsMajor ? majorStyle.Hairline : minorStyle.Hairline);
 
             // draw label
             if (string.IsNullOrWhiteSpace(tick.Label) || !label.IsVisible)
@@ -170,7 +170,7 @@ public abstract class AxisBase : LabelStyleProperties
             float x = axis.Edge == Edge.Left ? panelRect.Right : panelRect.Left;
             float xEdge = axis.Edge == Edge.Left ? x - tickLength : x + tickLength;
             PixelLine pxLine = new(x, yPx, xEdge, yPx);
-            Drawing.DrawLine(rp.Canvas, paint, pxLine);
+            Drawing.DrawLine(rp.Canvas, paint, pxLine, tick.IsMajor ? majorStyle.Hairline : minorStyle.Hairline);
 
             // draw label
             if (string.IsNullOrWhiteSpace(tick.Label) || !label.IsVisible)

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
@@ -134,7 +134,8 @@ public abstract class AxisBase : LabelStyleProperties
             float y = axis.Edge == Edge.Bottom ? panelRect.Top : panelRect.Bottom;
             float yEdge = axis.Edge == Edge.Bottom ? y + tickLength : y - tickLength;
             PixelLine pxLine = new(xPx, y, xPx, yEdge);
-            Drawing.DrawLine(rp.Canvas, paint, pxLine, tick.IsMajor ? majorStyle.Hairline : minorStyle.Hairline);
+            var lineStyle = tick.IsMajor ? majorStyle : minorStyle;
+            lineStyle.Render(rp.Canvas, paint, pxLine);
 
             // draw label
             if (string.IsNullOrWhiteSpace(tick.Label) || !label.IsVisible)
@@ -170,7 +171,8 @@ public abstract class AxisBase : LabelStyleProperties
             float x = axis.Edge == Edge.Left ? panelRect.Right : panelRect.Left;
             float xEdge = axis.Edge == Edge.Left ? x - tickLength : x + tickLength;
             PixelLine pxLine = new(x, yPx, xEdge, yPx);
-            Drawing.DrawLine(rp.Canvas, paint, pxLine, tick.IsMajor ? majorStyle.Hairline : minorStyle.Hairline);
+            var lineStyle = tick.IsMajor ? majorStyle : minorStyle;
+            lineStyle.Render(rp.Canvas, paint, pxLine);
 
             // draw label
             if (string.IsNullOrWhiteSpace(tick.Label) || !label.IsVisible)

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -9,14 +9,14 @@ namespace ScottPlot;
 /// </summary>
 public static class Drawing
 {
-    public static void DrawLine(SKCanvas canvas, SKPaint paint, PixelLine pixelLine)
+    public static void DrawLine(SKCanvas canvas, SKPaint paint, PixelLine pixelLine, bool hairline)
     {
-        DrawLine(canvas, paint, pixelLine.Pixel1, pixelLine.Pixel2);
+        DrawLine(canvas, paint, pixelLine.Pixel1, pixelLine.Pixel2, hairline);
     }
 
-    public static void DrawLine(SKCanvas canvas, SKPaint paint, Pixel pt1, Pixel pt2)
+    public static void DrawLine(SKCanvas canvas, SKPaint paint, Pixel pt1, Pixel pt2, bool hairline)
     {
-        if (paint.StrokeWidth == 0)
+        if (paint.StrokeWidth == 0 && !hairline)
             return;
 
         canvas.DrawLine(pt1.ToSKPoint(), pt2.ToSKPoint(), paint);
@@ -37,7 +37,7 @@ public static class Drawing
 
     public static void DrawLine(SKCanvas canvas, SKPaint paint, Pixel pt1, Pixel pt2, LineStyle lineStyle)
     {
-        if (lineStyle.Width == 0 || lineStyle.Color.Alpha == 0 || lineStyle.IsVisible == false || lineStyle.Color == Colors.Transparent)
+        if (!lineStyle.IsWidthVisible || lineStyle.Color.Alpha == 0 || lineStyle.IsVisible == false || lineStyle.Color == Colors.Transparent)
             return;
 
         lineStyle.ApplyToPaint(paint);
@@ -59,9 +59,9 @@ public static class Drawing
         canvas.DrawLine(pt1.ToSKPoint(), pt2.ToSKPoint(), paint);
     }
 
-    public static void DrawLines(SKCanvas canvas, Pixel[] starts, Pixel[] ends, Color color, float width = 1, bool antiAlias = true, LinePattern pattern = LinePattern.Solid)
+    public static void DrawLines(SKCanvas canvas, Pixel[] starts, Pixel[] ends, Color color, float width = 1, bool antiAlias = true, bool hairline = false, LinePattern pattern = LinePattern.Solid)
     {
-        if (width == 0)
+        if (width == 0 && !hairline)
             return;
 
         if (starts.Length != ends.Length)
@@ -87,22 +87,9 @@ public static class Drawing
         canvas.DrawPath(path, paint);
     }
 
-    public static void DrawLines(SKCanvas canvas, SKPaint paint, IEnumerable<Pixel> pixels, Color color, float width = 1, bool antiAlias = true, LinePattern pattern = LinePattern.Solid)
-    {
-        LineStyle ls = new()
-        {
-            Color = color,
-            AntiAlias = antiAlias,
-            Width = width,
-            Pattern = pattern,
-        };
-
-        DrawLines(canvas, paint, pixels, ls);
-    }
-
     public static void DrawPath(SKCanvas canvas, SKPaint paint, IEnumerable<Pixel> pixels, LineStyle lineStyle)
     {
-        if (lineStyle.IsVisible == false || lineStyle.Width == 0 || lineStyle.Color == Colors.Transparent)
+        if (!lineStyle.IsVisible || !lineStyle.IsWidthVisible || lineStyle.Color == Colors.Transparent)
             return;
 
         using SKPath path = new();
@@ -141,7 +128,7 @@ public static class Drawing
 
     public static void DrawPath(SKCanvas canvas, SKPaint paint, SKPath path, LineStyle lineStyle)
     {
-        if (lineStyle.IsVisible == false || lineStyle.Width == 0 || lineStyle.Color == Colors.Transparent)
+        if (!lineStyle.IsVisible || !lineStyle.IsWidthVisible || lineStyle.Color == Colors.Transparent)
             return;
 
         lineStyle.ApplyToPaint(paint);
@@ -161,7 +148,7 @@ public static class Drawing
 
     public static void DrawLines(SKCanvas canvas, SKPaint paint, IEnumerable<Pixel> pixels, LineStyle lineStyle)
     {
-        if (lineStyle.Width == 0 || lineStyle.IsVisible == false || pixels.Take(2).Count() < 2)
+        if (!lineStyle.IsWidthVisible || lineStyle.IsVisible == false || pixels.Take(2).Count() < 2)
             return;
 
         lineStyle.ApplyToPaint(paint);
@@ -172,7 +159,7 @@ public static class Drawing
 
     public static void DrawLines(SKCanvas canvas, SKPaint paint, SKPath path, LineStyle lineStyle)
     {
-        if (lineStyle.Width == 0 || lineStyle.IsVisible == false)
+        if (!lineStyle.IsWidthVisible || lineStyle.IsVisible == false)
             return;
 
         lineStyle.ApplyToPaint(paint);
@@ -208,7 +195,7 @@ public static class Drawing
     public static void DrawRectangle(SKCanvas canvas, PixelRect rect, SKPaint paint, LineStyle lineStyle)
     {
         if (!lineStyle.IsVisible) return;
-        if (lineStyle.Width == 0) return;
+        if (!lineStyle.IsWidthVisible) return;
         if (lineStyle.Color == Colors.Transparent) return;
 
         lineStyle.ApplyToPaint(paint);
@@ -272,7 +259,7 @@ public static class Drawing
     public static void DrawCircle(SKCanvas canvas, Pixel center, float radius, LineStyle lineStyle, SKPaint paint)
     {
         if (!lineStyle.IsVisible) return;
-        if (lineStyle.Width == 0) return;
+        if (!lineStyle.IsWidthVisible) return;
         if (lineStyle.Color == Colors.Transparent) return;
 
         lineStyle.ApplyToPaint(paint);
@@ -292,7 +279,7 @@ public static class Drawing
     public static void DrawOval(SKCanvas canvas, SKPaint paint, LineStyle lineStyle, PixelRect rect)
     {
         if (!lineStyle.IsVisible) return;
-        if (lineStyle.Width == 0) return;
+        if (!lineStyle.IsWidthVisible) return;
         if (lineStyle.Color == Colors.Transparent) return;
 
         lineStyle.ApplyToPaint(paint);

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -4,21 +4,20 @@ namespace ScottPlot;
 
 // TODO: obsolete methods in this class that create paints. Pass paints in to minimize allocations at render time.
 
+// TODO: obsolete methods that don't take Style objects
+
 /// <summary>
 /// Common operations using the default rendering system.
 /// </summary>
 public static class Drawing
 {
-    public static void DrawLine(SKCanvas canvas, SKPaint paint, PixelLine pixelLine, bool hairline)
+    public static void DrawLine(SKCanvas canvas, SKPaint paint, PixelLine pixelLine)
     {
-        DrawLine(canvas, paint, pixelLine.Pixel1, pixelLine.Pixel2, hairline);
+        DrawLine(canvas, paint, pixelLine.Pixel1, pixelLine.Pixel2);
     }
 
-    public static void DrawLine(SKCanvas canvas, SKPaint paint, Pixel pt1, Pixel pt2, bool hairline)
+    public static void DrawLine(SKCanvas canvas, SKPaint paint, Pixel pt1, Pixel pt2)
     {
-        if (paint.StrokeWidth == 0 && !hairline)
-            return;
-
         canvas.DrawLine(pt1.ToSKPoint(), pt2.ToSKPoint(), paint);
     }
 
@@ -37,10 +36,16 @@ public static class Drawing
 
     public static void DrawLine(SKCanvas canvas, SKPaint paint, Pixel pt1, Pixel pt2, LineStyle lineStyle)
     {
-        if (!lineStyle.IsWidthVisible || lineStyle.Color.Alpha == 0 || lineStyle.IsVisible == false || lineStyle.Color == Colors.Transparent)
+        if (lineStyle.IsVisible == false) return;
+        if (lineStyle.Color.Alpha == 0) return;
+        if (lineStyle.Color == Colors.Transparent) return;
+        if (lineStyle.Width == 0 & lineStyle.Hairline == false)
             return;
 
         lineStyle.ApplyToPaint(paint);
+        if (lineStyle.Hairline)
+            paint.StrokeWidth = 1f / canvas.TotalMatrix.ScaleX;
+
         canvas.DrawLine(pt1.ToSKPoint(), pt2.ToSKPoint(), paint);
     }
 
@@ -54,42 +59,13 @@ public static class Drawing
         paint.IsAntialias = antiAlias;
         paint.StrokeWidth = width;
         paint.PathEffect = pattern.GetPathEffect();
-        if (paint.StrokeWidth == 0)
-            return;
+
         canvas.DrawLine(pt1.ToSKPoint(), pt2.ToSKPoint(), paint);
-    }
-
-    public static void DrawLines(SKCanvas canvas, Pixel[] starts, Pixel[] ends, Color color, float width = 1, bool antiAlias = true, bool hairline = false, LinePattern pattern = LinePattern.Solid)
-    {
-        if (width == 0 && !hairline)
-            return;
-
-        if (starts.Length != ends.Length)
-            throw new ArgumentException($"{nameof(starts)} and {nameof(ends)} must have same length");
-
-        using SKPaint paint = new()
-        {
-            Color = color.ToSKColor(),
-            IsStroke = true,
-            IsAntialias = antiAlias,
-            StrokeWidth = width,
-            PathEffect = pattern.GetPathEffect(),
-        };
-
-        using SKPath path = new();
-
-        for (int i = 0; i < starts.Length; i++)
-        {
-            path.MoveTo(starts[i].X, starts[i].Y);
-            path.LineTo(ends[i].X, ends[i].Y);
-        }
-
-        canvas.DrawPath(path, paint);
     }
 
     public static void DrawPath(SKCanvas canvas, SKPaint paint, IEnumerable<Pixel> pixels, LineStyle lineStyle)
     {
-        if (!lineStyle.IsVisible || !lineStyle.IsWidthVisible || lineStyle.Color == Colors.Transparent)
+        if (!lineStyle.IsVisible || !lineStyle.RenderedLineHasWidth || lineStyle.Color == Colors.Transparent)
             return;
 
         using SKPath path = new();
@@ -128,10 +104,13 @@ public static class Drawing
 
     public static void DrawPath(SKCanvas canvas, SKPaint paint, SKPath path, LineStyle lineStyle)
     {
-        if (!lineStyle.IsVisible || !lineStyle.IsWidthVisible || lineStyle.Color == Colors.Transparent)
+        if (!lineStyle.IsVisible || !lineStyle.RenderedLineHasWidth || lineStyle.Color == Colors.Transparent)
             return;
 
         lineStyle.ApplyToPaint(paint);
+        if (lineStyle.Hairline)
+            paint.StrokeWidth = 1f / canvas.TotalMatrix.ScaleX;
+
         canvas.DrawPath(path, paint);
     }
 
@@ -148,10 +127,12 @@ public static class Drawing
 
     public static void DrawLines(SKCanvas canvas, SKPaint paint, IEnumerable<Pixel> pixels, LineStyle lineStyle)
     {
-        if (!lineStyle.IsWidthVisible || lineStyle.IsVisible == false || pixels.Take(2).Count() < 2)
+        if (!lineStyle.RenderedLineHasWidth || lineStyle.IsVisible == false || pixels.Take(2).Count() < 2)
             return;
 
         lineStyle.ApplyToPaint(paint);
+        if (lineStyle.Hairline)
+            paint.StrokeWidth = 1f / canvas.TotalMatrix.ScaleX;
 
         using SKPath path = StraightLineStrategy.GetPath(pixels);
         canvas.DrawPath(path, paint);
@@ -159,10 +140,13 @@ public static class Drawing
 
     public static void DrawLines(SKCanvas canvas, SKPaint paint, SKPath path, LineStyle lineStyle)
     {
-        if (!lineStyle.IsWidthVisible || lineStyle.IsVisible == false)
+        if (!lineStyle.RenderedLineHasWidth || lineStyle.IsVisible == false)
             return;
 
         lineStyle.ApplyToPaint(paint);
+        if (lineStyle.Hairline)
+            paint.StrokeWidth = 1f / canvas.TotalMatrix.ScaleX;
+
         canvas.DrawPath(path, paint);
     }
 
@@ -195,10 +179,13 @@ public static class Drawing
     public static void DrawRectangle(SKCanvas canvas, PixelRect rect, SKPaint paint, LineStyle lineStyle)
     {
         if (!lineStyle.IsVisible) return;
-        if (!lineStyle.IsWidthVisible) return;
+        if (!lineStyle.RenderedLineHasWidth) return;
         if (lineStyle.Color == Colors.Transparent) return;
 
         lineStyle.ApplyToPaint(paint);
+        if (lineStyle.Hairline)
+            paint.StrokeWidth = 1f / canvas.TotalMatrix.ScaleX;
+
         canvas.DrawRect(rect.ToSKRect(), paint);
     }
 
@@ -259,10 +246,13 @@ public static class Drawing
     public static void DrawCircle(SKCanvas canvas, Pixel center, float radius, LineStyle lineStyle, SKPaint paint)
     {
         if (!lineStyle.IsVisible) return;
-        if (!lineStyle.IsWidthVisible) return;
+        if (!lineStyle.RenderedLineHasWidth) return;
         if (lineStyle.Color == Colors.Transparent) return;
 
         lineStyle.ApplyToPaint(paint);
+        if (lineStyle.Hairline)
+            paint.StrokeWidth = 1f / canvas.TotalMatrix.ScaleX;
+
         canvas.DrawCircle(center.ToSKPoint(), radius, paint);
     }
 
@@ -279,10 +269,13 @@ public static class Drawing
     public static void DrawOval(SKCanvas canvas, SKPaint paint, LineStyle lineStyle, PixelRect rect)
     {
         if (!lineStyle.IsVisible) return;
-        if (!lineStyle.IsWidthVisible) return;
+        if (!lineStyle.RenderedLineHasWidth) return;
         if (lineStyle.Color == Colors.Transparent) return;
 
         lineStyle.ApplyToPaint(paint);
+        if (lineStyle.Hairline)
+            paint.StrokeWidth = 1f / canvas.TotalMatrix.ScaleX;
+
         canvas.DrawOval(rect.ToSKRect(), paint);
     }
 

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -20,7 +20,7 @@ public class Plot : IDisposable
 
     public IZoomRectangle ZoomRectangle { get; set; }
     public double ScaleFactor { get => ScaleFactorF; set => ScaleFactorF = (float)value; }
-    internal float ScaleFactorF = 1.0f;
+    internal float ScaleFactorF { get; private set; } = 1.0f;
 
     public AxisManager Axes { get; }
     public PlotStyler Style { get; }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Box.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Box.cs
@@ -70,29 +70,29 @@ public class Box : IHasFill, IHasLine
         {
             CoordinateLine lineMid = new(bodyRect.Left, BoxMiddle.Value, bodyRect.Right, BoxMiddle.Value);
             PixelLine lineMidPx = axes.GetPixelLine(lineMid);
-            Drawing.DrawLine(rp.Canvas, paint, lineMidPx);
+            Drawing.DrawLine(rp.Canvas, paint, lineMidPx, LineStyle.Hairline);
         }
 
         if (WhiskerMax.HasValue)
         {
             CoordinateLine lineMax = new(Position, BoxMax, Position, WhiskerMax.Value);
             PixelLine lineMaxPx = axes.GetPixelLine(lineMax);
-            Drawing.DrawLine(rp.Canvas, paint, lineMaxPx);
+            Drawing.DrawLine(rp.Canvas, paint, lineMaxPx, LineStyle.Hairline);
 
             CoordinateLine lineMaxAcross = new(Position - WhiskerSize / 2, WhiskerMax.Value, Position + WhiskerSize / 2, WhiskerMax.Value);
             PixelLine lineMaxAcrossPx = axes.GetPixelLine(lineMaxAcross);
-            Drawing.DrawLine(rp.Canvas, paint, lineMaxAcrossPx);
+            Drawing.DrawLine(rp.Canvas, paint, lineMaxAcrossPx, LineStyle.Hairline);
         }
 
         if (WhiskerMin.HasValue)
         {
             CoordinateLine lineMin = new(Position, BoxMin, Position, WhiskerMin.Value);
             PixelLine lineMinPx = axes.GetPixelLine(lineMin);
-            Drawing.DrawLine(rp.Canvas, paint, lineMinPx);
+            Drawing.DrawLine(rp.Canvas, paint, lineMinPx, LineStyle.Hairline);
 
             CoordinateLine lineMinAcross = new(Position - WhiskerSize / 2, WhiskerMin.Value, Position + WhiskerSize / 2, WhiskerMin.Value);
             PixelLine lineMinAcrossPx = axes.GetPixelLine(lineMinAcross);
-            Drawing.DrawLine(rp.Canvas, paint, lineMinAcrossPx);
+            Drawing.DrawLine(rp.Canvas, paint, lineMinAcrossPx, LineStyle.Hairline);
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Box.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Box.cs
@@ -70,29 +70,29 @@ public class Box : IHasFill, IHasLine
         {
             CoordinateLine lineMid = new(bodyRect.Left, BoxMiddle.Value, bodyRect.Right, BoxMiddle.Value);
             PixelLine lineMidPx = axes.GetPixelLine(lineMid);
-            Drawing.DrawLine(rp.Canvas, paint, lineMidPx, LineStyle.Hairline);
+            LineStyle.Render(rp.Canvas, lineMidPx, paint);
         }
 
         if (WhiskerMax.HasValue)
         {
             CoordinateLine lineMax = new(Position, BoxMax, Position, WhiskerMax.Value);
             PixelLine lineMaxPx = axes.GetPixelLine(lineMax);
-            Drawing.DrawLine(rp.Canvas, paint, lineMaxPx, LineStyle.Hairline);
+            LineStyle.Render(rp.Canvas, lineMaxPx, paint);
 
             CoordinateLine lineMaxAcross = new(Position - WhiskerSize / 2, WhiskerMax.Value, Position + WhiskerSize / 2, WhiskerMax.Value);
             PixelLine lineMaxAcrossPx = axes.GetPixelLine(lineMaxAcross);
-            Drawing.DrawLine(rp.Canvas, paint, lineMaxAcrossPx, LineStyle.Hairline);
+            LineStyle.Render(rp.Canvas, lineMaxAcrossPx, paint);
         }
 
         if (WhiskerMin.HasValue)
         {
             CoordinateLine lineMin = new(Position, BoxMin, Position, WhiskerMin.Value);
             PixelLine lineMinPx = axes.GetPixelLine(lineMin);
-            Drawing.DrawLine(rp.Canvas, paint, lineMinPx, LineStyle.Hairline);
+            LineStyle.Render(rp.Canvas, lineMinPx, paint);
 
             CoordinateLine lineMinAcross = new(Position - WhiskerSize / 2, WhiskerMin.Value, Position + WhiskerSize / 2, WhiskerMin.Value);
             PixelLine lineMinAcrossPx = axes.GetPixelLine(lineMinAcross);
-            Drawing.DrawLine(rp.Canvas, paint, lineMinAcrossPx, LineStyle.Hairline);
+            LineStyle.Render(rp.Canvas, lineMinAcrossPx, paint);
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/GridStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/GridStyle.cs
@@ -13,7 +13,8 @@ public class GridStyle
 
     public LineStyle MinorLineStyle { get; set; } = new()
     {
-        Width = 0,
+        Width = 1,
+        IsVisible = false,
         Color = Colors.Black.WithOpacity(.05),
         AntiAlias = false,
     };
@@ -26,7 +27,7 @@ public class GridStyle
         if (!IsVisible)
             return;
 
-        if (MinorLineStyle.IsVisible && MinorLineStyle.Width > 0)
+        if (MinorLineStyle.IsVisible && MinorLineStyle.IsWidthVisible)
         {
             float[] xTicksMinor = ticks
                 .Where(x => !x.IsMajor)
@@ -37,7 +38,7 @@ public class GridStyle
             RenderGridLines(rp, xTicksMinor, axis.Edge, MinorLineStyle);
         }
 
-        if (MajorLineStyle.IsVisible && MajorLineStyle.Width > 0)
+        if (MajorLineStyle.IsVisible && MajorLineStyle.IsWidthVisible)
         {
             float[] xTicksMajor = ticks
                 .Where(x => x.IsMajor)
@@ -67,6 +68,6 @@ public class GridStyle
                 : new Pixel(rp.DataRect.Right, px);
         }
 
-        Drawing.DrawLines(rp.Canvas, starts, ends, lineStyle.Color, lineStyle.Width, lineStyle.AntiAlias, lineStyle.Pattern);
+        Drawing.DrawLines(rp.Canvas, starts, ends, lineStyle.Color, lineStyle.Width, lineStyle.AntiAlias, lineStyle.Hairline, lineStyle.Pattern);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/GridStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/GridStyle.cs
@@ -27,7 +27,7 @@ public class GridStyle
         if (!IsVisible)
             return;
 
-        if (MinorLineStyle.IsVisible && MinorLineStyle.IsWidthVisible)
+        if (MinorLineStyle.IsVisible && MinorLineStyle.RenderedLineHasWidth)
         {
             float[] xTicksMinor = ticks
                 .Where(x => !x.IsMajor)
@@ -38,7 +38,7 @@ public class GridStyle
             RenderGridLines(rp, xTicksMinor, axis.Edge, MinorLineStyle);
         }
 
-        if (MajorLineStyle.IsVisible && MajorLineStyle.IsWidthVisible)
+        if (MajorLineStyle.IsVisible && MajorLineStyle.RenderedLineHasWidth)
         {
             float[] xTicksMajor = ticks
                 .Where(x => x.IsMajor)
@@ -68,6 +68,7 @@ public class GridStyle
                 : new Pixel(rp.DataRect.Right, px);
         }
 
-        Drawing.DrawLines(rp.Canvas, starts, ends, lineStyle.Color, lineStyle.Width, lineStyle.AntiAlias, lineStyle.Hairline, lineStyle.Pattern);
+        using SKPaint paint = new();
+        lineStyle.Render(rp.Canvas, starts, ends, paint);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/LineStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LineStyle.cs
@@ -13,6 +13,14 @@ public class LineStyle
     public bool IsVisible { get; set; } = true;
     public bool AntiAlias { get; set; } = true;
 
+    /// <summary>
+    /// When true and the Width is 0, this will instruct skia to render a 1px width line,
+    /// no matter what the scaling is on the target machine. 
+    /// </summary>
+    public bool Hairline { get; set; } = false;
+
+    public bool IsWidthVisible => Width > 0 || Hairline;
+
     public bool Rounded
     {
         get => StrokeCap == SKStrokeCap.Round;

--- a/src/ScottPlot5/ScottPlot5/Primitives/LineStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LineStyle.cs
@@ -6,35 +6,67 @@
 /// </summary>
 public class LineStyle
 {
+    /// <summary>
+    /// Width of the line (in pixels)
+    /// </summary>
     public float Width { get; set; } = 0;
+
+    /// <summary>
+    /// If enabled, <see cref="Width"/> is ignored and lines are rendered as a single pixel (regardless of scale factor)
+    /// </summary>
+    public bool Hairline { get; set; } = false;
+
+    /// <summary>
+    /// Returns true if <see cref="Width"/> is >0 or <see cref="Hairline"/> is true
+    /// </summary>
+    public bool RenderedLineHasWidth => Width > 0 || Hairline;
+
     public Color Color { get; set; } = Colors.Black;
+
     public LinePattern Pattern { get; set; } = LinePattern.Solid;
 
     public bool IsVisible { get; set; } = true;
     public bool AntiAlias { get; set; } = true;
-
-    /// <summary>
-    /// When true and the Width is 0, this will instruct skia to render a 1px width line,
-    /// no matter what the scaling is on the target machine. 
-    /// </summary>
-    public bool Hairline { get; set; } = false;
-
-    public bool IsWidthVisible => Width > 0 || Hairline;
 
     public bool Rounded
     {
         get => StrokeCap == SKStrokeCap.Round;
         set { StrokeCap = SKStrokeCap.Round; StrokeJoin = SKStrokeJoin.Round; }
     }
-    public SKStrokeCap StrokeCap = SKStrokeCap.Butt;
-    public SKStrokeJoin StrokeJoin = SKStrokeJoin.Miter;
-
-    public float StrokeMiter = 4;
-
-    [Obsolete("Use explicit logic", true)]
-    public bool CanBeRendered => IsVisible && Width > 0 && Color.Alpha > 0;
+    public SKStrokeCap StrokeCap { get; set; } = SKStrokeCap.Butt;
+    public SKStrokeJoin StrokeJoin { get; set; } = SKStrokeJoin.Miter;
+    public float StrokeMiter { get; set; } = 4;
 
     public static LineStyle None => new() { Width = 0 };
+
+    public void Render(SKCanvas canvas, Pixel[] starts, Pixel[] ends, SKPaint paint)
+    {
+        if (starts.Length != ends.Length)
+            throw new ArgumentException($"{nameof(starts)} and {nameof(ends)} must have equal length");
+
+        using SKPath path = new();
+
+        for (int i = 0; i < starts.Length; i++)
+        {
+            path.MoveTo(starts[i].X, starts[i].Y);
+            path.LineTo(ends[i].X, ends[i].Y);
+        }
+
+        Drawing.DrawPath(canvas, paint, path, this);
+    }
+
+    public void Render(SKCanvas canvas, PixelLine[] lines, SKPaint paint)
+    {
+        using SKPath path = new();
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            path.MoveTo(lines[i].X1, lines[i].Y1);
+            path.LineTo(lines[i].X2, lines[i].Y2);
+        }
+
+        Drawing.DrawPath(canvas, paint, path, this);
+    }
 
     public void Render(SKCanvas canvas, PixelLine line, SKPaint paint)
     {
@@ -83,7 +115,7 @@ public class LineStyle
         paint.Shader = null;
         paint.IsStroke = true;
         paint.Color = Color.ToSKColor();
-        paint.StrokeWidth = Width;
+        paint.StrokeWidth = Hairline ? 1 : Width;
         paint.PathEffect = Pattern.GetPathEffect();
         paint.IsAntialias = AntiAlias;
         paint.StrokeCap = StrokeCap;

--- a/src/ScottPlot5/ScottPlot5/Primitives/TickMarkStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/TickMarkStyle.cs
@@ -4,12 +4,24 @@ public class TickMarkStyle
 {
     public float Length;
     public float Width;
+    public bool Hairline;
     public Color Color;
     public bool AntiAlias;
 
-    /// <summary>
-    /// When true and the Width is 0, this will instruct skia to render a 1px width line,
-    /// no matter what the scaling is on the target machine. 
-    /// </summary>
-    public bool Hairline;
+    public void Render(SKCanvas canvas, SKPaint paint, PixelLine pxLine)
+    {
+        ApplyToPaint(paint);
+        if (Hairline)
+            paint.StrokeWidth = 1f / canvas.TotalMatrix.ScaleX;
+
+        Drawing.DrawLine(canvas, paint, pxLine);
+    }
+
+    public void ApplyToPaint(SKPaint paint)
+    {
+        paint.IsAntialias = AntiAlias;
+        paint.IsStroke = true;
+        paint.Color = Color.ToSKColor();
+        paint.StrokeWidth = Hairline ? 1 : Width;
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/TickMarkStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/TickMarkStyle.cs
@@ -6,4 +6,10 @@ public class TickMarkStyle
     public float Width;
     public Color Color;
     public bool AntiAlias;
+
+    /// <summary>
+    /// When true and the Width is 0, this will instruct skia to render a 1px width line,
+    /// no matter what the scaling is on the target machine. 
+    /// </summary>
+    public bool Hairline;
 }


### PR DESCRIPTION
This PR is in relation to https://github.com/ScottPlot/ScottPlot/issues/3977

`Hairline` is only applicable when `ScaleFactor` is greater than 1. If the `ScaleFactor` is 1, you won't see the visual artefacts mentioned below.

When `Hairline` is set to true, and the `Width` is 0, it will instruct Skia to render a single pixel line no matter the scaling factor.

The first image shows a scaling of 1.5, without `Hairline`, and `AntiAliasing` disabled on the second Box
Notice the lines are inconsistent in their width. Its more evident if you resize the window.

![NoHairline](https://github.com/ScottPlot/ScottPlot/assets/7289277/ae78c222-cb54-4b71-ad97-f496055ce5cf)

The second image shows the same setup, with `Hairline` enabled on both the Grid and second Box

![Hairline](https://github.com/ScottPlot/ScottPlot/assets/7289277/8303a6b7-3d01-4318-82a6-f6d6f3068599)

I have made `Hairline` available on both GridStyles and LineStyles, and it is OptIn - so the current behaviour is not changed.
I have also added a helper method to `AxisManager` to enable `Hairline` for all this line drawing.


```
public MainWindow()
 {
     InitializeComponent();

     WpfPlot1.Plot.ScaleFactor = 1.5;
     WpfPlot1.Plot.Axes.Hairline(true);

     ScottPlot.Box box = new()
     {
         Position = 4.5,
         BoxMin = 81,
         BoxMax = 93,
         WhiskerMin = 76,
         WhiskerMax = 107,
         BoxMiddle = 84,
     };

     WpfPlot1.Plot.Add.Box(box);

     box = new()
     {
         Position = 5.5,
         BoxMin = 81,
         BoxMax = 93,
         WhiskerMin = 76,
         WhiskerMax = 107,
         BoxMiddle = 84,
     };

     box.LineStyle.Width = 0;
     box.LineStyle.AntiAlias = false;
     box.LineStyle.Hairline = true;

     WpfPlot1.Plot.Add.Box(box);

     WpfPlot1.Plot.Axes.SetLimits(0, 10, 70, 110);




     WpfPlot1.Refresh();
 }
```