### PR TITLE
CoordinateRect: add constructor overload that accepts IAxes

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Primitives/CoordinateRect.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/CoordinateRect.cs
@@ -45,6 +45,10 @@ public struct CoordinateRect : IEquatable<CoordinateRect>
         Top = yRange.Max;
     }
 
+    public CoordinateRect(IAxes axes) : this(axes.XAxis.Range, axes.YAxis.Range)
+    {
+    }
+
     public CoordinateRect(Coordinates pt1, Coordinates pt2)
     {
         Left = Math.Min(pt1.X, pt2.X);


### PR DESCRIPTION
I added `CoordinateRect(IAxes axes)`.
It actually uses `CoordinateRect(CoordinateRange xRange, CoordinateRange yRange)`.
Therefore, I placed it below it.

#3985