### PR TITLE
Axis span: ensure rendered rectangle is at least 1px wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ _Not yet on NuGet..._
 * Signal: Exposed `Data` property setter so users can replace the `ISignalSource` without resetting the plottable (#3932) @danieljfarrell @bclehmann
 * Heatmap: Exposed `Intensities` setter to allow users to replace heatmap data with a 2D array of a different size (#3941) @sdpenner
 * Axes: Added `Plot.Axes.Link()` to simplify sharing axis limits between multiple plots or plot controls (#4003)
+* Axis Spans: Improved visibility of extremely narrow spans (#4017, #3968) @CoderPM2011
 
 ## ScottPlot 5.0.35
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-10_

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/Plottable/AxisSpanTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/Plottable/AxisSpanTests.cs
@@ -1,0 +1,20 @@
+﻿namespace ScottPlotTests.RenderTests.Plottable;
+
+internal class AxisSpanTests
+{
+    [Test]
+    public void Test_AxisSpan_ExtremelyNarrow()
+    {
+        ScottPlot.Plot plot = new();
+
+        for (int i = 0; i < 10; i++)
+        {
+            double width = 1e-10;
+            plot.Add.VerticalSpan(i, i + width);
+            plot.Add.HorizontalSpan(i, i + width);
+        }
+
+        plot.HideGrid();
+        plot.SaveTestImage();
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/HorizontalSpan.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/HorizontalSpan.cs
@@ -30,6 +30,11 @@ public class HorizontalSpan : AxisSpan, IPlottable
     {
         PixelRangeY vert = new(rp.DataRect.Bottom, rp.DataRect.Top);
         PixelRangeX horiz = new(Axes.GetPixelX(Left), Axes.GetPixelX(Right));
+        if (horiz.Span < 1)
+        {
+            float middle = (horiz.Left + horiz.Right) / 2;
+            horiz = new(middle - 0.5F, middle + 0.5F);
+        }
         PixelRect rect = new(horiz, vert);
         Render(rp, rect);
     }

--- a/src/ScottPlot5/ScottPlot5/Plottables/VerticalSpan.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/VerticalSpan.cs
@@ -29,6 +29,11 @@ public class VerticalSpan : AxisSpan, IPlottable
     public override void Render(RenderPack rp)
     {
         PixelRangeY vert = new(Axes.GetPixelY(Bottom), Axes.GetPixelY(Top));
+        if (vert.Span < 1)
+        {
+            float middle = (vert.Top + vert.Bottom) / 2;
+            vert = new(middle - 0.5F, middle + 0.5F);
+        }
         PixelRangeX horiz = new(rp.DataRect.Left, rp.DataRect.Right);
         PixelRect rect = new(horiz, vert);
         Render(rp, rect);


### PR DESCRIPTION
Just a simple patch. 

When the axis span is less than 1, force the mean value ±0.5 as the new range values.
like this
``` csharp
if (vert.Span < 1)
{
    float middle = (vert.Top + vert.Bottom) / 2;
    vert = new(middle - 0.5F, middle + 0.5F);
}
```

Are there other aspects to consider?

#3968