### PR TITLE
Add missing maxDistance check for right border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## ScottPlot 5.0.37
-_Not yet on NuGet..._
+* Signal and SignalXY: Improve data source `GetNearestX()` accuracy (#4019) @StendProg
 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
@@ -391,7 +391,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     {
         int i = GetIndex(mouseLocation.X); // TODO: check the index after too?
         double distance = (Xs[i] + XOffset - mouseLocation.X) * renderInfo.PxPerUnitX;
-        return distance <= maxDistance
+        return Math.Abs(distance) <= maxDistance
             ? new DataPoint(Xs[i], Ys[i], i)
             : DataPoint.None;
     }

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
@@ -272,7 +272,7 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
         double x = NumericConversion.GenericToDouble(Xs, i);
         double y = NumericConversion.GenericToDouble(Ys, i);
         double distance = (x + XOffset - mouseLocation.X) * renderInfo.PxPerUnitX;
-        return distance <= maxDistance
+        return Math.Abs(distance) <= maxDistance
             ? new DataPoint(x, y, i)
             : DataPoint.None;
     }


### PR DESCRIPTION
The `SignalXY` `GetNearestX()` maximum distance check is now performed for the right mouse position as well.