### PR TITLE
Fix WithZoom in AxisLimits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * Signal and SignalXY: Improve data source `GetNearestX()` accuracy (#4019) @StendProg
 * Maui: Created a `ScottPlot.Maui.MauiPlot` control to provide interactive plots in .NET Maui applications (#4013) @ByteSore
 * Style: Added `Plot.GetStyle()` and `Plot.SetStyle()` for applying and customizing styles in the `ScottPlot.PlotStyles` namespace (#4025, #3955, #4037) @StendProg @kebox7
-* AxisLimits: Improved accuracy and performance of `WidthLimits()` (#4041) @idotta
+* AxisLimits: Improved accuracy and performance of `WidthZoom()` (#4041) @idotta
 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Signal and SignalXY: Improve data source `GetNearestX()` accuracy (#4019) @StendProg
 * Maui: Created a `ScottPlot.Maui.MauiPlot` control to provide interactive plots in .NET Maui applications (#4013) @ByteSore
 * Style: Added `Plot.GetStyle()` and `Plot.SetStyle()` for applying and customizing styles in the `ScottPlot.PlotStyles` namespace (#4025, #3955, #4037) @StendProg @kebox7
+* AxisLimits: Improved accuracy and performance of `WidthLimits()` (#4041) @idotta
 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * Signal and SignalXY: Improve data source `GetNearestX()` accuracy (#4019) @StendProg
 * Maui: Created a `ScottPlot.Maui.MauiPlot` control to provide interactive plots in .NET Maui applications (#4013) @ByteSore
 * Style: Added `Plot.GetStyle()` and `Plot.SetStyle()` for applying and customizing styles in the `ScottPlot.PlotStyles` namespace (#4025, #3955, #4037) @StendProg @kebox7
-* AxisLimits: Improved accuracy and performance of `WidthZoom()` (#4041) @idotta
+* AxisLimits: Improved accuracy and performance of `WithZoom()` (#4041) @idotta
 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/AxisLimitTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/AxisLimitTests.cs
@@ -70,4 +70,26 @@ internal class AxisLimitTests
         limits.Bottom.Should().BeApproximately(-1, .2);
         limits.Top.Should().BeApproximately(1, .2);
     }
+
+    [Test]
+    public void Test_AxisLimits_WithZoom()
+    {
+        AxisLimits limits1 = new(5, 10, 25, 50);
+        AxisLimits limits2 = limits1.WithZoom(0.5, 0.25);
+        limits2.Left.Should().Be(2.5);
+        limits2.Right.Should().Be(12.5);
+        limits2.Bottom.Should().Be(-12.5);
+        limits2.Top.Should().Be(87.5);
+    }
+
+    [Test]
+    public void Test_AxisLimits_WithZoomTo()
+    {
+        AxisLimits limits1 = new(-20, 20, -40, 40);
+        AxisLimits limits2 = limits1.WithZoom(0.5, 0.5, 10, 20);
+        limits2.Left.Should().Be(-50);
+        limits2.Right.Should().Be(30);
+        limits2.Bottom.Should().Be(-100);
+        limits2.Top.Should().Be(60);
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/AxisLimits.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/AxisLimits.cs
@@ -162,15 +162,15 @@ public readonly struct AxisLimits : IEquatable<AxisLimits>
 
     public AxisLimits WithZoom(double fracX, double fracY, double zoomToX, double zoomToY)
     {
-        var xMin = Left;
-        var xMax = Right;
+        double xMin = Left;
+        double xMax = Right;
         double spanLeft = zoomToX - xMin;
         double spanRight = xMax - zoomToX;
         xMin = zoomToX - spanLeft / fracX;
         xMax = zoomToX + spanRight / fracX;
 
-        var yMin = Bottom;
-        var yMax = Top;
+        double yMin = Bottom;
+        double yMax = Top;
         double spanBottom = zoomToY - yMin;
         double spanTop = yMax - zoomToY;
         yMin = zoomToY - spanBottom / fracY;

--- a/src/ScottPlot5/ScottPlot5/Primitives/AxisLimits.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/AxisLimits.cs
@@ -162,15 +162,21 @@ public readonly struct AxisLimits : IEquatable<AxisLimits>
 
     public AxisLimits WithZoom(double fracX, double fracY, double zoomToX, double zoomToY)
     {
-        // TODO: do this without heap allocations
+        var xMin = Left;
+        var xMax = Right;
+        double spanLeft = zoomToX - xMin;
+        double spanRight = xMax - zoomToX;
+        xMin = zoomToX - spanLeft / fracX;
+        xMax = zoomToX + spanRight / fracX;
 
-        CoordinateRangeMutable xRange = new(Rect.Left, Rect.Right);
-        xRange.ZoomFrac(fracX, zoomToX);
+        var yMin = Bottom;
+        var yMax = Top;
+        double spanBottom = zoomToY - yMin;
+        double spanTop = yMax - zoomToY;
+        yMin = zoomToY - spanBottom / fracY;
+        yMax = zoomToY + spanTop / fracY;
 
-        CoordinateRangeMutable yRange = new(Rect.Bottom, Rect.Top);
-        yRange.ZoomFrac(fracY, zoomToY);
-
-        return new(XRange.Min, XRange.Max, yRange.Min, yRange.Max);
+        return new(xMin, xMax, yMin, yMax);
     }
 
     public bool Equals(AxisLimits other)


### PR DESCRIPTION
`WithZoom` was using property `XRange` instead of local variable `xRange`. Also avoiding heap allocations.