### PR TITLE
Label.Typeface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Style: Added `Plot.GetStyle()` and `Plot.SetStyle()` for applying and customizing styles in the `ScottPlot.PlotStyles` namespace (#4025, #3955, #4037) @StendProg @kebox7
 * AxisLimits: Improved accuracy and performance of `WithZoom()` (#4041) @idotta
 * Documentation: Added automatically generated API documentation to the website (#4040, #3822)
+* Label: Added nullable `Typeface` which allows users to supply their own typefaces for rendering text in labels and legend items (#3830, #3825) @lasooch
 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/Paths.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/Paths.cs
@@ -37,4 +37,10 @@ public static class Paths
 
         throw new InvalidOperationException($"repository folder not found in any folder above {defaultFolder}");
     }
+
+    public static string[] GetTtfFilePaths()
+    {
+        string ttfFolder = Path.Combine(RepoFolder, @"src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Fonts");
+        return Directory.GetFiles(ttfFolder, "*.ttf", SearchOption.AllDirectories);
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/LegendTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/LegendTests.cs
@@ -1,4 +1,6 @@
-﻿namespace ScottPlotTests.RenderTests;
+﻿using SkiaSharp;
+
+namespace ScottPlotTests.RenderTests;
 
 internal class LegendTests
 {
@@ -399,5 +401,39 @@ internal class LegendTests
         plt.Axes.AddPanel(pan);
 
         plt.SaveTestImage();
+    }
+
+    [Test]
+    public void Test_CustomTypeface_InLegend()
+    {
+        string ttfFilePath = Paths.GetTtfFilePaths().First();
+        SKTypeface customTypeface = SKTypeface.FromFile(ttfFilePath);
+
+        // create a plot with data
+        Plot plot = new();
+        var sig = plot.Add.Signal(Generate.Sin());
+        sig.LegendText = "Sine Wave";
+
+        // axis label custom typeface
+        plot.XLabel("Horizontal Axis Label");
+        plot.Axes.Bottom.Label.ForeColor = Colors.Red;
+        plot.Axes.Bottom.Label.FontSize = 26;
+        plot.Axes.Bottom.Label.Typeface = customTypeface;
+
+        // automatic legend items custom typeface (overwrites manual item customizations)
+        //plot.Legend.FontColor = Colors.Green;
+        //plot.Legend.FontSize = 26;
+        //plot.Legend.Typeface = customTypeface;
+
+        // manual legend items custom typeface
+        plot.Legend.ManualItems.Add(new LegendItem()
+        {
+            LabelText = "Manual Item",
+            LabelFontColor = Colors.Blue,
+            LabelFontSize = 26,
+            LabelTypeface = customTypeface,
+        });
+
+        plot.SaveTestImage();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Label.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Label.cs
@@ -1,6 +1,6 @@
 ﻿namespace ScottPlot;
 
-public class Label
+public class Label // TODO: rename LabelStyle
 {
     public bool IsVisible { get; set; } = true;
     public string Text { get; set; } = string.Empty;
@@ -36,6 +36,7 @@ public class Label
     public string FontName { get; set; } = Fonts.Default;
     public float FontSize { get; set; } = 12;
     public bool Bold { get; set; } = false;
+    public SKTypeface? Typeface { get; set; } = null;
 
     /// <summary>
     /// Manually defined line height in pixels.
@@ -75,6 +76,7 @@ public class Label
     /// </summary>
     public void SetBestFont()
     {
+        Typeface = null;
         FontName = Fonts.Detect(Text);
     }
 
@@ -117,7 +119,7 @@ public class Label
     {
         paint.TextAlign = SKTextAlign.Left;
         paint.IsStroke = false;
-        paint.Typeface = Fonts.GetTypeface(FontName, Bold, Italic);
+        paint.Typeface = Typeface ?? Fonts.GetTypeface(FontName, Bold, Italic);
         paint.TextSize = FontSize;
         paint.Color = ForeColor.ToSKColor();
         paint.IsAntialias = AntiAliasText;

--- a/src/ScottPlot5/ScottPlot5/Primitives/LabelStyleProperties.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LabelStyleProperties.cs
@@ -20,6 +20,7 @@ public abstract class LabelStyleProperties : IHasLabel
 
     public string LabelFontName { get => LabelStyle.FontName; set => LabelStyle.FontName = value; }
     public float LabelFontSize { get => LabelStyle.FontSize; set => LabelStyle.FontSize = value; }
+    public SKTypeface? LabelTypeface { get => LabelStyle.Typeface; set => LabelStyle.Typeface = value; }
     public float? LabelLineSpacing { get => LabelStyle.LineSpacing; set => LabelStyle.LineSpacing = value; }
     public bool LabelItalic { get => LabelStyle.Italic; set => LabelStyle.Italic = value; }
     public bool LabelBold { get => LabelStyle.Bold; set => LabelStyle.Bold = value; }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
@@ -79,6 +79,11 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
     /// <summary>
     /// If set, this overrides the value in the LegendItem's FontStyle
     /// </summary>
+    public SKTypeface Typeface { get; set; } = null;
+
+    /// <summary>
+    /// If set, this overrides the value in the LegendItem's FontStyle
+    /// </summary>
     public Color? FontColor { get; set; } = null;
 
     [Obsolete("Assign FontSize, FontName, or FontColor to control appearance of all legend items", true)]
@@ -148,6 +153,8 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
                 item.LabelFontSize = FontSize.Value;
             if (FontName is not null)
                 item.LabelFontName = FontName;
+            if (Typeface is not null)
+                item.LabelTypeface = Typeface;
             if (FontColor is not null)
                 item.LabelFontColor = FontColor.Value;
         }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
@@ -79,7 +79,7 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
     /// <summary>
     /// If set, this overrides the value in the LegendItem's FontStyle
     /// </summary>
-    public SKTypeface Typeface { get; set; } = null;
+    public SKTypeface? Typeface { get; set; } = null;
 
     /// <summary>
     /// If set, this overrides the value in the LegendItem's FontStyle


### PR DESCRIPTION
Adds `SKTypeface? Typeface` property to `Label`, `LabelStyle`, and `Legend` allowing objects with text to be supplied a custom typeface. This strategy works for automatically generated and manually added legend items too. 

* Resolves #3825
* Resolves #3830

```cs
SKTypeface customTypeface = SKTypeface.FromFile(ttfFilePath);

plot.Legend.ManualItems.Add(new LegendItem()
{
    LabelText = "Manual Item",
    LabelFontColor = Colors.Blue,
    LabelFontSize = 26,
    LabelTypeface = customTypeface,
});
```

![image](https://github.com/ScottPlot/ScottPlot/assets/4165489/08bc1ec0-8407-49c6-b6f3-a56ce28a3160)
