### PR TITLE
ScottPlot.Label → ScottPlot.LabelStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * AxisLimits: Improved accuracy and performance of `WithZoom()` (#4041) @idotta
 * Documentation: Added automatically generated API documentation to the website (#4040, #3822)
 * Label: Added nullable `Typeface` which allows users to supply their own typefaces for rendering text in labels and legend items (#3830, #3825) @lasooch
+* Label: `ScottPlot.Label` has been renamed to `ScottPlot.LabelStyle` to better signal its purpose is to hold styling information rather than store text
 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Radar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Radar.cs
@@ -28,7 +28,7 @@ public class Radar : ICategory
 
             // customize radar axis labels (5 axes because each RadarSeries has 5 values)
             radar.Labels = new string[] { "Axis 1", "Axis 2", "Axis 3", "Axis 4", "Axis 5" }
-                .Select(s => new Label() { Text = s, Alignment = Alignment.MiddleCenter })
+                .Select(s => new LabelStyle() { Text = s, Alignment = Alignment.MiddleCenter })
                 .ToArray();
 
             myPlot.Axes.Frameless();

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/CustomAxis.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/CustomAxis.cs
@@ -40,7 +40,7 @@ public partial class CustomAxis : Form, IDemoWindow
     {
         public string SubLabelText { get => SubLabelStyle.Text; set => SubLabelStyle.Text = value; }
 
-        public ScottPlot.Label SubLabelStyle { get; set; } = new() { Rotation = -90, };
+        public ScottPlot.LabelStyle SubLabelStyle { get; set; } = new() { Rotation = -90, };
 
         public override Edge Edge => Edge.Left;
 

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/LabelDemo.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/LabelDemo.cs
@@ -30,7 +30,7 @@ public partial class LabelDemo : Form, IDemoWindow
         SKCanvas canvas = surface.Canvas;
         canvas.Clear(SKColors.White);
 
-        ScottPlot.Label label = new()
+        ScottPlot.LabelStyle label = new()
         {
             ForeColor = Colors.Black,
             BorderColor = Colors.Gray,

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Plottables3D/Axis3D.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms3D/Plottables3D/Axis3D.cs
@@ -5,7 +5,7 @@ namespace Sandbox.WinForms3D.Plottables3D;
 
 public class Axis3D : IPlottable3D
 {
-    readonly ScottPlot.Label LabelStyle = new()
+    readonly ScottPlot.LabelStyle LabelStyle = new()
     {
         FontSize = 15,
         Bold = true,

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/CodeTests/ForbiddenCodeTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/CodeTests/ForbiddenCodeTests.cs
@@ -107,7 +107,7 @@ internal class ForbiddenCodeTests
         StringBuilder errorMessages = new();
         foreach (string filePath in SourceFilePaths)
         {
-            if (Path.GetFileName(filePath) == "Label.cs")
+            if (Path.GetFileName(filePath) == "LabelStyle.cs")
                 continue;
 
             string[] lines = File.ReadAllLines(filePath);

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/CodeTests/ForbiddenCodeTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/CodeTests/ForbiddenCodeTests.cs
@@ -70,7 +70,7 @@ internal class ForbiddenCodeTests
         StringBuilder errorMessages = new();
         foreach (string filePath in SourceFilePaths)
         {
-            if (Path.GetFileName(filePath) == "Label.cs")
+            if (Path.GetFileName(filePath) == "LabelStyle.cs")
                 continue;
 
             if (Path.GetFileName(filePath) == "MeasuredText.cs")

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/CodeTests/ForbiddenCodeTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/CodeTests/ForbiddenCodeTests.cs
@@ -128,7 +128,7 @@ internal class ForbiddenCodeTests
 
         offences.Should().Be(0,
             $"SKPaint.FontSpacing must never be accessed." +
-            $"Create a Label, style it as desired, use its Measeure() method." +
+            $"Create a Label, style it as desired, use its Measure() method." +
             $"{offences} offences:\n" +
             $"{errorMessages}");
     }

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/LabelTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/LabelTests.cs
@@ -18,7 +18,7 @@ internal class LabelTests
         foreach (Alignment alignment in Enum.GetValues(typeof(Alignment)))
         {
             Pixel pixel = new(250, 20 + y);
-            Label lbl = new()
+            LabelStyle lbl = new()
             {
                 Text = alignment.ToString(),
                 Alignment = alignment,
@@ -55,7 +55,7 @@ internal class LabelTests
             float y = (float)Math.Sin(i * Math.PI / 180) * radius;
             Pixel center = new(bmp.Width / 2 + x, bmp.Height / 2 + y);
 
-            Label lbl = new()
+            LabelStyle lbl = new()
             {
                 Text = $"R{i}",
                 FontSize = 32,
@@ -87,7 +87,7 @@ internal class LabelTests
         foreach (Alignment alignment in Enum.GetValues(typeof(Alignment)))
         {
             Pixel pixel = new(250, 20 + y);
-            Label lbl = new()
+            LabelStyle lbl = new()
             {
                 Text = alignment.ToString(),
                 Alignment = alignment,
@@ -127,7 +127,7 @@ internal class LabelTests
                 Alignment alignment = alignmentMatrix[y, x];
 
                 Pixel pixel = new(100 + x * 200, 100 + y * 200);
-                Label label = new()
+                LabelStyle label = new()
                 {
                     Text = alignment.ToString()
                         .Replace("Upper", "Upper\n")
@@ -164,7 +164,7 @@ internal class LabelTests
         float yOffset = 20;
         foreach (string font in fonts)
         {
-            Label lbl = new()
+            LabelStyle lbl = new()
             {
                 Text = "Hello, World",
                 FontName = font,
@@ -192,7 +192,7 @@ internal class LabelTests
         canvas.Clear(SKColors.Navy);
         using SKPaint paint = new();
 
-        Label lbl = new()
+        LabelStyle lbl = new()
         {
             Text = "One\nTwo",
             ForeColor = Colors.White.WithAlpha(.5),
@@ -220,7 +220,7 @@ internal class LabelTests
         canvas.Clear(SKColors.Navy);
         using SKPaint paint = new();
 
-        Label lbl = new()
+        LabelStyle lbl = new()
         {
             Text = $"Hello",
             FontSize = 32,
@@ -245,7 +245,7 @@ internal class LabelTests
         canvas.Clear(SKColors.White);
         using SKPaint paint = new();
 
-        Label lbl1 = new()
+        LabelStyle lbl1 = new()
         {
             Text = $"Default",
             BorderColor = Colors.Black,
@@ -256,7 +256,7 @@ internal class LabelTests
             BackgroundColor = Colors.White,
         };
 
-        Label lbl2 = new()
+        LabelStyle lbl2 = new()
         {
             Text = $"AntiAliasBackground = false",
             BorderColor = Colors.Black,
@@ -268,7 +268,7 @@ internal class LabelTests
             AntiAliasBackground = false,
         };
 
-        Label lbl3 = new()
+        LabelStyle lbl3 = new()
         {
             Text = $"AntiAliasText = false",
             BorderColor = Colors.Black,
@@ -321,7 +321,7 @@ internal class LabelTests
                 float offsetX = offset * x;
                 float offsetY = offset * y;
 
-                Label lbl = new()
+                LabelStyle lbl = new()
                 {
                     Text = string.Format(format, offsetX, offsetY),
                     Alignment = Alignment.MiddleCenter,

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/TickGenerators/DateTimeFixedIntervalsTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/TickGenerators/DateTimeFixedIntervalsTests.cs
@@ -20,7 +20,7 @@ public class DateTimeFixedIntervalsTests
             NumericConversion.ToNumber(endRange)
         );
 
-        gen.Regenerate(range, Edge.Bottom, new PixelLength(1), new SKPaint(), new Label());
+        gen.Regenerate(range, Edge.Bottom, new PixelLength(1), new SKPaint(), new LabelStyle());
 
         gen.Ticks.Skip(1).First().Position.Should().Be(NumericConversion.ToNumber(startRange.AddHours(1)));
     }
@@ -38,7 +38,7 @@ public class DateTimeFixedIntervalsTests
             NumericConversion.ToNumber(endRange)
         );
 
-        gen.Regenerate(range, Edge.Bottom, new PixelLength(1), new SKPaint(), new Label());
+        gen.Regenerate(range, Edge.Bottom, new PixelLength(1), new SKPaint(), new LabelStyle());
 
         // 1st major tick is start
         gen.Ticks.First(t => t.IsMajor).Position.Should().Be(NumericConversion.ToNumber(startRange));
@@ -62,7 +62,7 @@ public class DateTimeFixedIntervalsTests
             NumericConversion.ToNumber(endRange)
         );
 
-        gen.Regenerate(range, Edge.Bottom, new PixelLength(1), new SKPaint(), new Label());
+        gen.Regenerate(range, Edge.Bottom, new PixelLength(1), new SKPaint(), new LabelStyle());
 
         // 1st major tick is start
         gen.Ticks.First(t => t.IsMajor).Position.Should().Be(NumericConversion.ToNumber(startRange));
@@ -88,7 +88,7 @@ public class DateTimeFixedIntervalsTests
             NumericConversion.ToNumber(endRange)
         );
 
-        gen.Regenerate(range, Edge.Bottom, new PixelLength(1), new SKPaint(), new Label());
+        gen.Regenerate(range, Edge.Bottom, new PixelLength(1), new SKPaint(), new LabelStyle());
 
         // 1st minor tick is 3am, 45minutes after range start.
         gen.Ticks.First(t => !t.IsMajor).Position.Should().Be(NumericConversion.ToNumber(startRange.AddMinutes(45)));

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
@@ -36,9 +36,9 @@ public abstract class AxisBase : LabelStyleProperties
     public virtual ITickGenerator TickGenerator { get; set; } = null!;
 
     [Obsolete("use LabelText, LabelFontColor, LabelFontSize, LabelFontName, etc. or properties of LabelStyle", false)]
-    public Label Label => LabelStyle;
+    public LabelStyle Label => LabelStyle;
 
-    public override Label LabelStyle { get; set; } = new()
+    public override LabelStyle LabelStyle { get; set; } = new()
     {
         Text = string.Empty,
         FontSize = 16,
@@ -71,7 +71,7 @@ public abstract class AxisBase : LabelStyleProperties
         AntiAlias = false,
     };
 
-    public Label TickLabelStyle { get; set; } = new()
+    public LabelStyle TickLabelStyle { get; set; } = new()
     {
         Alignment = Alignment.MiddleCenter
     };
@@ -114,7 +114,7 @@ public abstract class AxisBase : LabelStyleProperties
         Drawing.DrawLine(rp.Canvas, paint, pxLine, lineStyle);
     }
 
-    private static void DrawTicksHorizontalAxis(RenderPack rp, Label label, PixelRect panelRect, IEnumerable<Tick> ticks, IAxis axis, TickMarkStyle majorStyle, TickMarkStyle minorStyle)
+    private static void DrawTicksHorizontalAxis(RenderPack rp, LabelStyle label, PixelRect panelRect, IEnumerable<Tick> ticks, IAxis axis, TickMarkStyle majorStyle, TickMarkStyle minorStyle)
     {
         if (axis.Edge != Edge.Bottom && axis.Edge != Edge.Top)
         {
@@ -151,7 +151,7 @@ public abstract class AxisBase : LabelStyleProperties
         }
     }
 
-    private static void DrawTicksVerticalAxis(RenderPack rp, Label label, PixelRect panelRect, IEnumerable<Tick> ticks, IAxis axis, TickMarkStyle majorStyle, TickMarkStyle minorStyle)
+    private static void DrawTicksVerticalAxis(RenderPack rp, LabelStyle label, PixelRect panelRect, IEnumerable<Tick> ticks, IAxis axis, TickMarkStyle majorStyle, TickMarkStyle minorStyle)
     {
         if (axis.Edge != Edge.Left && axis.Edge != Edge.Right)
         {
@@ -187,7 +187,7 @@ public abstract class AxisBase : LabelStyleProperties
         }
     }
 
-    public static void DrawTicks(RenderPack rp, Label label, PixelRect panelRect, IEnumerable<Tick> ticks, IAxis axis, TickMarkStyle majorStyle, TickMarkStyle minorStyle)
+    public static void DrawTicks(RenderPack rp, LabelStyle label, PixelRect panelRect, IEnumerable<Tick> ticks, IAxis axis, TickMarkStyle majorStyle, TickMarkStyle minorStyle)
     {
         if (axis.Edge.IsVertical())
             DrawTicksVerticalAxis(rp, label, panelRect, ticks, axis, majorStyle, minorStyle);

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/Experimental/LeftAxisWithSubtitle.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/Experimental/LeftAxisWithSubtitle.cs
@@ -10,7 +10,7 @@ public class LeftAxisWithSubtitle : YAxisBase
 {
     public string SubLabelText { get => SubLabelStyle.Text; set => SubLabelStyle.Text = value; }
 
-    public Label SubLabelStyle { get; set; } = new() { Rotation = -90, };
+    public LabelStyle SubLabelStyle { get; set; } = new() { Rotation = -90, };
 
     public override Edge Edge => Edge.Left;
 

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IAxis.cs
@@ -60,13 +60,13 @@ public interface IAxis : IPanel
     /// <summary>
     /// The label is the text displayed distal to the ticks
     /// </summary>
-    Label Label { get; }
+    LabelStyle Label { get; }
 
     TickMarkStyle MajorTickStyle { get; set; }
 
     TickMarkStyle MinorTickStyle { get; set; }
 
-    Label TickLabelStyle { get; set; }
+    LabelStyle TickLabelStyle { get; set; }
 
     LineStyle FrameLineStyle { get; }
 }

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IHasLabel.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IHasLabel.cs
@@ -2,7 +2,7 @@
 
 interface IHasLabel
 {
-    Label LabelStyle { get; }
+    LabelStyle LabelStyle { get; }
 
     float LabelOffsetX { get; set; }
     float LabelOffsetY { get; set; }

--- a/src/ScottPlot5/ScottPlot5/Interfaces/ITickGenerator.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/ITickGenerator.cs
@@ -17,5 +17,5 @@ public interface ITickGenerator
     /// <summary>
     /// Generate ticks based on the current settings and store the result in <see cref="Ticks"/>
     /// </summary>
-    void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, Label labelStyle);
+    void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, LabelStyle labelStyle);
 }

--- a/src/ScottPlot5/ScottPlot5/Panels/ColorBar.cs
+++ b/src/ScottPlot5/ScottPlot5/Panels/ColorBar.cs
@@ -42,7 +42,7 @@ public class ColorBar(IHasColorAxis source, Edge edge = Edge.Right) : IPanel
     /// <summary>
     /// Title for the colorbar, displayed outside the ticks.
     /// </summary>
-    public Label LabelStyle => Axis.Label;
+    public LabelStyle LabelStyle => Axis.Label;
 
     public bool ShowDebugInformation { get; set; } = false;
     public float MinimumSize { get; set; } = 0;

--- a/src/ScottPlot5/ScottPlot5/Panels/TitlePanel.cs
+++ b/src/ScottPlot5/ScottPlot5/Panels/TitlePanel.cs
@@ -15,7 +15,7 @@ public class TitlePanel : IPanel
         Label.Rotation = 0;
     }
 
-    public Label Label { get; } = new()
+    public LabelStyle Label { get; } = new()
     {
         Text = string.Empty,
         FontSize = 16,

--- a/src/ScottPlot5/ScottPlot5/Plottables/Annotation.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Annotation.cs
@@ -6,10 +6,10 @@ public class Annotation : LabelStyleProperties, IPlottable, IHasLabel
     public IAxes Axes { get; set; } = new Axes();
     public IEnumerable<LegendItem> LegendItems => LegendItem.None;
 
-    public override Label LabelStyle { get; set; } = new() { ShadowColor = Colors.Black.WithAlpha(.2) };
+    public override LabelStyle LabelStyle { get; set; } = new() { ShadowColor = Colors.Black.WithAlpha(.2) };
 
     [Obsolete("Interact properties in this class (e.g., LabelFontColor) or properties of LabelStyle")]
-    public Label Label { get => LabelStyle; set => LabelStyle = value; }
+    public LabelStyle Label { get => LabelStyle; set => LabelStyle = value; }
 
     public string Text { get => LabelText; set => LabelText = value; }
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
@@ -10,7 +10,7 @@ public abstract class AxisLine : LabelStyleProperties, IPlottable, IRenderLast, 
     public LinePattern LinePattern { get => LineStyle.Pattern; set => LineStyle.Pattern = value; }
     public Color LineColor { get => LineStyle.Color; set => LineStyle.Color = value; }
 
-    public override Label LabelStyle { get; set; } = new();
+    public override LabelStyle LabelStyle { get; set; } = new();
     public string Text { get => LabelText; set => LabelText = value; }
     public string LegendText { get; set; } = string.Empty;
 
@@ -22,7 +22,7 @@ public abstract class AxisLine : LabelStyleProperties, IPlottable, IRenderLast, 
     public Alignment? TextAlignment { get => ManualLabelAlignment; set => ManualLabelAlignment = value; }
 
     [Obsolete("Set LabelFontSize, LabelBold, LabelFontColor, or properties of the LabelStyle object.")]
-    public Label Label { get => LabelStyle; set => LabelStyle = value; }
+    public LabelStyle Label { get => LabelStyle; set => LabelStyle = value; }
 
     [Obsolete("Use LabelFontSize")]
     public float FontSize { get => LabelFontSize; set => LabelFontSize = value; }

--- a/src/ScottPlot5/ScottPlot5/Plottables/AxisSpan.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/AxisSpan.cs
@@ -7,8 +7,8 @@ public abstract class AxisSpan : IPlottable, IHasLine, IHasFill, IHasLegendText
 
 
     [Obsolete("set LegendText")]
-    public Label Label { get => ObsoleteLabel; set => LegendText = value.Text; }
-    private readonly Label ObsoleteLabel = new();
+    public LabelStyle Label { get => ObsoleteLabel; set => LegendText = value.Text; }
+    private readonly LabelStyle ObsoleteLabel = new();
 
     public string LegendText { get; set; } = string.Empty;
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/BarPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/BarPlot.cs
@@ -14,7 +14,7 @@ public class BarPlot : IPlottable, IHasLegendText
 
     public IEnumerable<Bar> Bars { get; set; } // TODO: bars data source
 
-    public Label ValueLabelStyle { get; set; } = new()
+    public LabelStyle ValueLabelStyle { get; set; } = new()
     {
         Alignment = Alignment.LowerCenter,
     };

--- a/src/ScottPlot5/ScottPlot5/Plottables/Benchmark.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Benchmark.cs
@@ -10,7 +10,7 @@ public class Benchmark : LabelStyleProperties, IPlottable
 
     public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
 
-    public override Label LabelStyle { get; set; } = new()
+    public override LabelStyle LabelStyle { get; set; } = new()
     {
         FontName = Fonts.Monospace,
         Alignment = Alignment.LowerLeft,

--- a/src/ScottPlot5/ScottPlot5/Plottables/Callout.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Callout.cs
@@ -4,7 +4,7 @@ public class Callout : LabelStyleProperties, IPlottable, IHasArrow, IHasLabel
 {
     public Text LabelPlottable { get; } = new() { LabelPadding = 5 };
     public Arrow ArrowPlottable { get; } = new();
-    public override Label LabelStyle { get => LabelPlottable.LabelStyle; set => LabelPlottable.LabelStyle = value; }
+    public override LabelStyle LabelStyle { get => LabelPlottable.LabelStyle; set => LabelPlottable.LabelStyle = value; }
     public string Text { get => LabelStyle.Text; set => LabelStyle.Text = value; }
 
     public ArrowStyle ArrowStyle { get => ArrowPlottable.ArrowStyle; set => ArrowPlottable.ArrowStyle = value; }

--- a/src/ScottPlot5/ScottPlot5/Plottables/IsoLines.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/IsoLines.cs
@@ -6,7 +6,7 @@ public class IsoLines : IPlottable, IHasLine
     public IAxes Axes { get; set; } = new Axes();
     public IEnumerable<LegendItem> LegendItems => LegendItem.None;
     public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
-    public Label TickLabelStyle = new();
+    public LabelStyle TickLabelStyle = new();
     public bool RotateLabels { get; set; } = true;
 
     public readonly List<(double, string)> ManualPositions = [];

--- a/src/ScottPlot5/ScottPlot5/Plottables/PopulationSymbol.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/PopulationSymbol.cs
@@ -25,7 +25,7 @@ public class PopulationSymbol(Population population) : IPlottable
     public Box Box { get; set; } = new() { IsVisible = false };
     public Marker Marker { get; set; } = new() { Size = 10, Shape = MarkerShape.OpenCircle };
 
-    private Label _EmptyLabel = new() { IsVisible = false };
+    private LabelStyle _EmptyLabel = new() { IsVisible = false };
 
     public Func<Box, Population, Population> BoxValueConfig { get; set; } = BoxValueConfigurator_MedianQuantileExtrema;
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/Radar.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Radar.cs
@@ -22,7 +22,7 @@ public class Radar(IReadOnlyList<RadarSeries> series) : IPlottable, IHasLine
     public IReadOnlyList<RadarSeries> Series { get; set; } = series;
     public double Padding { get; set; } = 0.2;
     public double LabelDistance { get; set; } = 1.2;
-    public IReadOnlyList<Label>? Labels { get; set; }
+    public IReadOnlyList<LabelStyle>? Labels { get; set; }
 
     public AxisLimits GetAxisLimits()
     {

--- a/src/ScottPlot5/ScottPlot5/Plottables/Text.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Text.cs
@@ -6,7 +6,7 @@ public class Text : LabelStyleProperties, IPlottable
     public float OffsetX { get; set; }
     public float OffsetY { get; set; }
 
-    public override Label LabelStyle { get; set; } = new() { FontSize = 14 };
+    public override LabelStyle LabelStyle { get; set; } = new() { FontSize = 14 };
     public Alignment Alignment { get => LabelAlignment; set => LabelAlignment = value; }
 
     public bool IsVisible { get; set; } = true;
@@ -16,7 +16,7 @@ public class Text : LabelStyleProperties, IPlottable
     #region obsolete
 
     [Obsolete("Interact properties in this class (e.g., LabelFontColor) or properties of LabelStyle", true)]
-    public readonly Label Label = null!;
+    public readonly LabelStyle Label = null!;
 
     [Obsolete("Use LabelFontColor")]
     public Color Color { get => LabelFontColor; set => LabelFontColor = value; }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Bar.cs
@@ -89,7 +89,7 @@ public class Bar
         }
     }
 
-    public void Render(RenderPack rp, IAxes axes, SKPaint paint, Label labelStyle)
+    public void Render(RenderPack rp, IAxes axes, SKPaint paint, LabelStyle labelStyle)
     {
         if (!IsVisible)
             return;

--- a/src/ScottPlot5/ScottPlot5/Primitives/LabelStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LabelStyle.cs
@@ -1,8 +1,13 @@
 ﻿namespace ScottPlot;
 
-public class Label // TODO: rename LabelStyle
+[Obsolete("Label has been renamed to LabelStyle", true)]
+public class Label : LabelStyle { }
+
+public class LabelStyle
 {
     public bool IsVisible { get; set; } = true;
+
+    // TODO: deprecate this and pass text into the render method
     public string Text { get; set; } = string.Empty;
 
     public Alignment Alignment { get; set; } = Alignment.UpperLeft;
@@ -213,6 +218,7 @@ public class Label // TODO: rename LabelStyle
         return new Pixel(x, y);
     }
 
+    // TODO: deprecate this and require a string to be passed in
     public void Render(SKCanvas canvas, Pixel px, SKPaint paint, bool bottom = true)
     {
         if (!IsVisible)

--- a/src/ScottPlot5/ScottPlot5/Primitives/LabelStyleProperties.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LabelStyleProperties.cs
@@ -6,7 +6,7 @@
 /// </summary>
 public abstract class LabelStyleProperties : IHasLabel
 {
-    public abstract Label LabelStyle { get; set; }
+    public abstract LabelStyle LabelStyle { get; set; }
 
     public float LabelOffsetX { get => LabelStyle.OffsetX; set => LabelStyle.OffsetX = value; }
     public float LabelOffsetY { get => LabelStyle.OffsetY; set => LabelStyle.OffsetY = value; }

--- a/src/ScottPlot5/ScottPlot5/Primitives/LegendItem.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LegendItem.cs
@@ -3,7 +3,7 @@
 public class LegendItem : LabelStyleProperties, IHasMarker, IHasLine, IHasFill, IHasArrow, IHasLabel
 {
     public bool IsVisible { get; set; } = true;
-    public override Label LabelStyle { get; set; } = new() { Alignment = Alignment.MiddleLeft };
+    public override LabelStyle LabelStyle { get; set; } = new() { Alignment = Alignment.MiddleLeft };
 
     public LineStyle LineStyle { get; set; } = new() { Width = 0 };
     public float LineWidth { get => LineStyle.Width; set => LineStyle.Width = value; }

--- a/src/ScottPlot5/ScottPlot5/Primitives/PieSlice.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/PieSlice.cs
@@ -6,7 +6,7 @@ public class PieSlice : LabelStyleProperties, IHasLegendText, IHasLabel
     public string LegendText { get => LabelStyle.Text; set => LabelStyle.Text = value; }
     public double Value { get; set; }
     public FillStyle Fill { get; set; } = new();
-    public override Label LabelStyle { get; set; } = new() { Alignment = Alignment.MiddleCenter };
+    public override LabelStyle LabelStyle { get; set; } = new() { Alignment = Alignment.MiddleCenter };
     public Color FillColor { get => Fill.Color; set => Fill.Color = value; }
 
     public PieSlice() { }

--- a/src/ScottPlot5/ScottPlot5/Primitives/RadarSeries.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/RadarSeries.cs
@@ -6,7 +6,7 @@ public class RadarSeries : LabelStyleProperties, IHasLabel, IHasLegendText
     public string Label { get => LegendText; set => LegendText = value; }
     public string LegendText { get => LabelStyle.Text; set => LabelStyle.Text = value; }
     public FillStyle Fill { get; set; } = new();
-    public override Label LabelStyle { get; set; } = new() { Alignment = Alignment.MiddleCenter };
+    public override LabelStyle LabelStyle { get; set; } = new() { Alignment = Alignment.MiddleCenter };
     public Color FillColor { get => Fill.Color; set => Fill.Color = value; }
 
     public IReadOnlyList<double> Values { get; set; } = [];

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/DateTimeAutomatic.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/DateTimeAutomatic.cs
@@ -63,7 +63,7 @@ public class DateTimeAutomatic : IDateTimeTickGenerator
         return null;
     }
 
-    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, Label labelStyle)
+    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, LabelStyle labelStyle)
     {
         if (range.Span >= TimeSpan.MaxValue.Days || double.IsNaN(range.Span) || double.IsInfinity(range.Span))
         {
@@ -125,7 +125,7 @@ public class DateTimeAutomatic : IDateTimeTickGenerator
     /// If all labels fit within the bounds, the list of ticks is returned.
     /// If a label doesn't fit in the bounds, the list is null and the size of the large tick label is returned.
     /// </summary>
-    private (List<Tick>? Positions, PixelSize? PixelSize) GenerateTicks(CoordinateRange range, ITimeUnit unit, int increment, PixelSize tickLabelBounds, SKPaint paint, Label labelStyle)
+    private (List<Tick>? Positions, PixelSize? PixelSize) GenerateTicks(CoordinateRange range, ITimeUnit unit, int increment, PixelSize tickLabelBounds, SKPaint paint, LabelStyle labelStyle)
     {
         DateTime rangeMin = NumericConversion.ToDateTime(range.Min);
         DateTime rangeMax = NumericConversion.ToDateTime(range.Max);

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/DateTimeFixedInterval.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/DateTimeFixedInterval.cs
@@ -79,7 +79,7 @@ namespace ScottPlot.TickGenerators
             return dates.Select(NumericConversion.ToNumber);
         }
 
-        public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, Label labelStyle)
+        public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, LabelStyle labelStyle)
         {
             List<Tick> ticks = new();
             HashSet<DateTime> timesWithTicks = new(); // Avoid having minor and major ticks at same time

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/EmptyTickGenerator.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/EmptyTickGenerator.cs
@@ -10,7 +10,7 @@ public class EmptyTickGenerator : ITickGenerator
     {
     }
 
-    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, Label labelStyle)
+    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, LabelStyle labelStyle)
     {
     }
 }

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/NumericAutomatic.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/NumericAutomatic.cs
@@ -39,14 +39,14 @@ public class NumericAutomatic : ITickGenerator
         return label == "-0" ? "0" : label;
     }
 
-    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, Label labelStyle)
+    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, LabelStyle labelStyle)
     {
         Ticks = GenerateTicks(range, edge, size, new PixelLength(12), paint, labelStyle)
             .Where(x => range.Contains(x.Position))
             .ToArray();
     }
 
-    private Tick[] GenerateTicks(CoordinateRange range, Edge edge, PixelLength axisLength, PixelLength maxLabelLength, SKPaint paint, Label labelStyle, int depth = 0)
+    private Tick[] GenerateTicks(CoordinateRange range, Edge edge, PixelLength axisLength, PixelLength maxLabelLength, SKPaint paint, LabelStyle labelStyle, int depth = 0)
     {
         if (depth > 3)
             Debug.WriteLine($"Warning: Tick recursion depth = {depth}");

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
@@ -8,7 +8,7 @@ public class NumericFixedInterval(int interval = 1) : ITickGenerator
 
     public int MaxTickCount { get; set; } = 10_000;
 
-    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, Label labelStyle)
+    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, LabelStyle labelStyle)
     {
         List<Tick> ticks = [];
 

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/NumericManual.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/NumericManual.cs
@@ -28,7 +28,7 @@ public class NumericManual : ITickGenerator
         }
     }
 
-    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, Label labelStyle)
+    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, LabelStyle labelStyle)
     {
         Ticks = TickList.Where(x => range.Contains(x.Position)).ToArray();
     }


### PR DESCRIPTION
Rename this class to better signal that its purpose is to store state related to label styling rather than store string contents of a label itself. In practice the text is frequently changed in loops (e.g., as axis ticks are drawn).

The original class name has been left in place and marked with an `Obsolete` attribute to guide users who may depend on it what the new name is.