### PR TITLE
LabelStyle: improve horizontal alignment for multiline strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Documentation: Added automatically generated API documentation to the website (#4040, #3822)
 * Label: Added nullable `Typeface` which allows users to supply their own typefaces for rendering text in labels and legend items (#3830, #3825) @lasooch
 * Label: `ScottPlot.Label` has been renamed to `ScottPlot.LabelStyle` to better signal its purpose is to hold styling information rather than store text
+* Label: Improved support for custom horizontal alignment in multiline strings (#4045, #3958, #3859) @karlipl
 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/LabelTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/LabelTests.cs
@@ -339,4 +339,28 @@ internal class LabelTests
             }
         }
     }
+
+    [Test]
+    public static void Test_Label_MultilineAlignment()
+    {
+        Plot plot = new();
+
+        var txt1 = plot.Add.Text($"aaa\nbbbbbbbbbbb\nccc", 0, 0);
+        txt1.Alignment = Alignment.MiddleLeft;
+        txt1.LabelBackgroundColor = Colors.SkyBlue;
+
+
+        var txt2 = plot.Add.Text($"aaa\nbbbbbbbbbbb\nccc", 1, 1);
+        txt2.Alignment = Alignment.MiddleCenter;
+        txt2.LabelBackgroundColor = Colors.SkyBlue;
+
+
+        var txt3 = plot.Add.Text($"aaa\nbbbbbbbbbbb\nccc", 2, 2);
+        txt3.Alignment = Alignment.MiddleRight;
+        txt3.LabelBackgroundColor = Colors.SkyBlue;
+
+        plot.Axes.SetLimits(-1, 3, -1, 3);
+
+        plot.SaveTestImage();
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/MeasuredText.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/MeasuredText.cs
@@ -16,16 +16,36 @@ public readonly struct MeasuredText
     public float LineHeight { get; init; }
 
     /// <summary>
+    /// Width of each line of text in pixel units.
+    /// </summary>
+    public float[] LineWidths { get; init; }
+
+    /// <summary>
     /// Recommended vertical offset when calling SKCanvas.DrawText().
     /// See https://github.com/ScottPlot/ScottPlot/issues/3700 for details.
     /// </summary>
     public required float VerticalOffset { get; init; }
 
+    /// <summary>
+    /// Distance below the baseline the rendered font may occupy.
+    /// </summary>
     public required float Bottom { get; init; }
 
+    /// <summary>
+    /// Width of the entire text. 
+    /// Equals the length of the widest line.
+    /// </summary>
     public float Width => Size.Width;
+
+    /// <summary>
+    /// Height of the entire text.
+    /// </summary>
     public float Height => Size.Height;
 
+    /// <summary>
+    /// Return a rectangle representing the bounding box of the entire text
+    /// with the alignment point centered at the origin.
+    /// </summary>
     public PixelRect Rect(Alignment alignment)
     {
         float xOffset = Width * alignment.HorizontalFraction();


### PR DESCRIPTION
* resolves #3859
* resolves #3958

```cs
Plot plot = new();

var txt1 = plot.Add.Text($"aaa\nbbbbbbbbbbb\nccc", 0, 0);
txt1.Alignment = Alignment.MiddleLeft;
txt1.LabelBackgroundColor = Colors.SkyBlue;


var txt2 = plot.Add.Text($"aaa\nbbbbbbbbbbb\nccc", 1, 1);
txt2.Alignment = Alignment.MiddleCenter;
txt2.LabelBackgroundColor = Colors.SkyBlue;


var txt3 = plot.Add.Text($"aaa\nbbbbbbbbbbb\nccc", 2, 2);
txt3.Alignment = Alignment.MiddleRight;
txt3.LabelBackgroundColor = Colors.SkyBlue;
```

![image](https://github.com/ScottPlot/ScottPlot/assets/4165489/ef3f114a-0ae1-4755-a613-a546cb966f9e)
