### PR TITLE
Axis line and span: Add `EnableAutoscale` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _Not yet on NuGet..._
 * Fonts: Improve performance when automatic best font detection is enabled (#4049) @zxy874175242
 * Controls: Added autoscale to default context menu (#4053)
 * Axes: A polar plot axis can now be added with `myPlot.Add.PolarAxis()` and customized as seen in the cookbook (#4055, #3939) @CoderPM2011
+* Axis lines and spans: Added `EnableAutoscale` flag to allow plottables to be ignored when `Plot.Axes.AutoScale()` is called (#4069, #4067) @KroMignon @andresod
 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/AxisLines.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/AxisLines.cs
@@ -153,4 +153,27 @@ public class AxisLines : ICategory
             myPlot.ShowLegend();
         }
     }
+
+    public class AxisLineIgnoreLimits: RecipeBase
+    {
+        public override string Name => "Ignore Axis Limits";
+        public override string Description => "Calling Plot.AxisAuto (or middle-clicking the plot) will set the axis limits " +
+            "automatically to fit the data on the plot. By default the position of axis lines and spans are " +
+            "included in automatic axis limit calculations, but setting the 'IgnoreAxisAuto' flag can disable this behavior.";
+
+        [Test]
+        public override void Execute()
+        {
+            myPlot.Add.Signal(Generate.Sin(51));
+            myPlot.Add.Signal(Generate.Cos(51));
+
+            var hline = myPlot.Add.HorizontalLine(0.23);
+            hline.IsDraggable = true;
+            hline.IgnoreAxisAuto = true;
+
+            var hSpan = myPlot.Add.HorizontalSpan(-10, 20);
+            hSpan.IsDraggable = true;
+            hSpan.IgnoreAxisAuto = true;
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/AxisLines.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/AxisLines.cs
@@ -156,10 +156,10 @@ public class AxisLines : ICategory
 
     public class AxisLineIgnoreLimits: RecipeBase
     {
-        public override string Name => "Ignore Axis Limits";
-        public override string Description => "Calling Plot.AxisAuto (or middle-clicking the plot) will set the axis limits " +
-            "automatically to fit the data on the plot. By default the position of axis lines and spans are " +
-            "included in automatic axis limit calculations, but setting the 'IgnoreAxisAuto' flag can disable this behavior.";
+        public override string Name => "Ignore When Autoscaling";
+        public override string Description => "Calling Plot.Axes.AutoScale() or middle-clicking the plot will set the axis limits " +
+            "to fit the data. By default the position of axis lines and spans are included in automatic axis limit calculations, " +
+            "but a flag can be set to ignore certain plottables when automatically scaling the plot.";
 
         [Test]
         public override void Execute()
@@ -169,11 +169,11 @@ public class AxisLines : ICategory
 
             var hline = myPlot.Add.HorizontalLine(0.23);
             hline.IsDraggable = true;
-            hline.IgnoreAxisAuto = true;
+            hline.EnableAutoscale = false;
 
             var hSpan = myPlot.Add.HorizontalSpan(-10, 20);
             hSpan.IsDraggable = true;
-            hSpan.IgnoreAxisAuto = true;
+            hSpan.EnableAutoscale = false;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
@@ -53,10 +53,8 @@ public abstract class AxisLine : LabelStyleProperties, IPlottable, IRenderLast, 
     public bool LabelOppositeAxis { get; set; } = false;
     public bool IsDraggable { get; set; } = false;
     public bool ExcludeFromLegend { get; set; } = false;
-    /// <summary>
-    /// If true, AxisAuto() will ignore the position of this line when determining axis limits
-    /// </summary>
-    public bool IgnoreAxisAuto { get; set; } = false;
+
+    public bool EnableAutoscale { get; set; } = true;
 
     public Color Color
     {

--- a/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/AxisLine.cs
@@ -53,6 +53,10 @@ public abstract class AxisLine : LabelStyleProperties, IPlottable, IRenderLast, 
     public bool LabelOppositeAxis { get; set; } = false;
     public bool IsDraggable { get; set; } = false;
     public bool ExcludeFromLegend { get; set; } = false;
+    /// <summary>
+    /// If true, AxisAuto() will ignore the position of this line when determining axis limits
+    /// </summary>
+    public bool IgnoreAxisAuto { get; set; } = false;
 
     public Color Color
     {

--- a/src/ScottPlot5/ScottPlot5/Plottables/AxisSpan.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/AxisSpan.cs
@@ -24,6 +24,10 @@ public abstract class AxisSpan : IPlottable, IHasLine, IHasFill, IHasLegendText
     public IHatch? FillHatch { get => FillStyle.Hatch; set => FillStyle.Hatch = value; }
 
     public IEnumerable<LegendItem> LegendItems => LegendItem.Single(LegendText, FillStyle);
+    /// <summary>
+    /// If true, AxisAuto() will ignore the position of this line when determining axis limits
+    /// </summary>
+    public bool IgnoreAxisAuto { get; set; } = false;
 
     public abstract AxisLimits GetAxisLimits();
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/AxisSpan.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/AxisSpan.cs
@@ -24,10 +24,8 @@ public abstract class AxisSpan : IPlottable, IHasLine, IHasFill, IHasLegendText
     public IHatch? FillHatch { get => FillStyle.Hatch; set => FillStyle.Hatch = value; }
 
     public IEnumerable<LegendItem> LegendItems => LegendItem.Single(LegendText, FillStyle);
-    /// <summary>
-    /// If true, AxisAuto() will ignore the position of this line when determining axis limits
-    /// </summary>
-    public bool IgnoreAxisAuto { get; set; } = false;
+
+    public bool EnableAutoscale { get; set; } = true;
 
     public abstract AxisLimits GetAxisLimits();
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/Crosshair.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Crosshair.cs
@@ -35,14 +35,11 @@ public class Crosshair : IPlottable, IRenderLast, IHasMarker
     [Obsolete("Use TextColor and TextBackgroundColor instead", true)]
     public Color FontColor;
 
-    /// <summary>
-    /// If true, AxisAuto() will ignore the position of this line when determining axis limits
-    /// </summary>
-    public bool IgnoreAxisAuto { get; set; } = false;
+    public bool EnableAutoscale { get; set; } = false;
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = new Axes();
     public IEnumerable<LegendItem> LegendItems => HorizontalLine.LegendItems.Concat(VerticalLine.LegendItems);
-    public AxisLimits GetAxisLimits() => IgnoreAxisAuto ? AxisLimits.NoLimits : new(X, X, Y, Y);
+    public AxisLimits GetAxisLimits() => EnableAutoscale ? new(X, X, Y, Y) : AxisLimits.NoLimits;
 
     public virtual void Render(RenderPack rp)
     {

--- a/src/ScottPlot5/ScottPlot5/Plottables/Crosshair.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Crosshair.cs
@@ -35,10 +35,14 @@ public class Crosshair : IPlottable, IRenderLast, IHasMarker
     [Obsolete("Use TextColor and TextBackgroundColor instead", true)]
     public Color FontColor;
 
+    /// <summary>
+    /// If true, AxisAuto() will ignore the position of this line when determining axis limits
+    /// </summary>
+    public bool IgnoreAxisAuto { get; set; } = false;
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = new Axes();
     public IEnumerable<LegendItem> LegendItems => HorizontalLine.LegendItems.Concat(VerticalLine.LegendItems);
-    public AxisLimits GetAxisLimits() => new(X, X, Y, Y);
+    public AxisLimits GetAxisLimits() => IgnoreAxisAuto ? AxisLimits.NoLimits : new(X, X, Y, Y);
 
     public virtual void Render(RenderPack rp)
     {

--- a/src/ScottPlot5/ScottPlot5/Plottables/HorizontalLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/HorizontalLine.cs
@@ -25,7 +25,7 @@ public class HorizontalLine : AxisLine
 
     public override AxisLimits GetAxisLimits()
     {
-        return AxisLimits.VerticalOnly(Y, Y);
+        return IgnoreAxisAuto ? AxisLimits.NoLimits : AxisLimits.VerticalOnly(Y, Y);
     }
 
     public override void Render(RenderPack rp)

--- a/src/ScottPlot5/ScottPlot5/Plottables/HorizontalLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/HorizontalLine.cs
@@ -25,7 +25,7 @@ public class HorizontalLine : AxisLine
 
     public override AxisLimits GetAxisLimits()
     {
-        return IgnoreAxisAuto ? AxisLimits.NoLimits : AxisLimits.VerticalOnly(Y, Y);
+        return EnableAutoscale ? AxisLimits.VerticalOnly(Y, Y) : AxisLimits.NoLimits;
     }
 
     public override void Render(RenderPack rp)

--- a/src/ScottPlot5/ScottPlot5/Plottables/HorizontalSpan.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/HorizontalSpan.cs
@@ -23,7 +23,7 @@ public class HorizontalSpan : AxisSpan, IPlottable
 
     public override AxisLimits GetAxisLimits()
     {
-        return AxisLimits.HorizontalOnly(Left, Right);
+        return IgnoreAxisAuto ? AxisLimits.NoLimits : AxisLimits.HorizontalOnly(Left, Right);
     }
 
     public override void Render(RenderPack rp)

--- a/src/ScottPlot5/ScottPlot5/Plottables/HorizontalSpan.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/HorizontalSpan.cs
@@ -23,7 +23,7 @@ public class HorizontalSpan : AxisSpan, IPlottable
 
     public override AxisLimits GetAxisLimits()
     {
-        return IgnoreAxisAuto ? AxisLimits.NoLimits : AxisLimits.HorizontalOnly(Left, Right);
+        return EnableAutoscale ? AxisLimits.HorizontalOnly(Left, Right) : AxisLimits.NoLimits;
     }
 
     public override void Render(RenderPack rp)

--- a/src/ScottPlot5/ScottPlot5/Plottables/VerticalLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/VerticalLine.cs
@@ -23,7 +23,7 @@ public class VerticalLine : AxisLine
 
     public override AxisLimits GetAxisLimits()
     {
-        return AxisLimits.HorizontalOnly(X, X);
+        return IgnoreAxisAuto ? AxisLimits.NoLimits : AxisLimits.HorizontalOnly(X, X);
     }
 
     public override void Render(RenderPack rp)

--- a/src/ScottPlot5/ScottPlot5/Plottables/VerticalLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/VerticalLine.cs
@@ -23,7 +23,7 @@ public class VerticalLine : AxisLine
 
     public override AxisLimits GetAxisLimits()
     {
-        return IgnoreAxisAuto ? AxisLimits.NoLimits : AxisLimits.HorizontalOnly(X, X);
+        return EnableAutoscale ? AxisLimits.HorizontalOnly(X, X) : AxisLimits.NoLimits;
     }
 
     public override void Render(RenderPack rp)

--- a/src/ScottPlot5/ScottPlot5/Plottables/VerticalSpan.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/VerticalSpan.cs
@@ -23,7 +23,7 @@ public class VerticalSpan : AxisSpan, IPlottable
 
     public override AxisLimits GetAxisLimits()
     {
-        return IgnoreAxisAuto ? AxisLimits.NoLimits : AxisLimits.VerticalOnly(Bottom, Top);
+        return EnableAutoscale ? AxisLimits.VerticalOnly(Bottom, Top) : AxisLimits.NoLimits;
     }
 
     public override void Render(RenderPack rp)

--- a/src/ScottPlot5/ScottPlot5/Plottables/VerticalSpan.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/VerticalSpan.cs
@@ -23,7 +23,7 @@ public class VerticalSpan : AxisSpan, IPlottable
 
     public override AxisLimits GetAxisLimits()
     {
-        return AxisLimits.VerticalOnly(Bottom, Top);
+        return IgnoreAxisAuto ? AxisLimits.NoLimits : AxisLimits.VerticalOnly(Bottom, Top);
     }
 
     public override void Render(RenderPack rp)


### PR DESCRIPTION
Port `IgnoreAxisAuto` feature from `ScottPlot` 4.1 to 5.0

Add support for `Crosshair`, `HorizontalLine`, `VerticalLine`, `HorizonzalSpan` and `VerticalSpan`.

Port Recipe.

This should fix issue #4067.