### PR TITLE
SignalConst: Enable `LegendText`, increase default marker size, and fix first point position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ _Not yet on NuGet..._
 * Controls: Added autoscale to default context menu (#4053)
 * Axes: A polar plot axis can now be added with `myPlot.Add.PolarAxis()` and customized as seen in the cookbook (#4055, #3939) @CoderPM2011
 * Axis lines and spans: Added `EnableAutoscale` flag to allow plottables to be ignored when `Plot.Axes.AutoScale()` is called (#4069, #4067) @KroMignon @andresod
+* SignalConst: Improved support for custom legend text (#4081, #4082) @KroMignon @fanshuxian
+* SignalConst: Improve accuracy of the first point in low density mode (#4082, #4083, #4086) @KroMignon
+* SignalConst: Allowed markers to become visible by setting their shape without requiring users to define a non-zero size (#4082) @KroMignon
 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalConstSource.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalConstSource.cs
@@ -28,7 +28,8 @@ public class SignalConstSource<T>
 
     public int GetIndex(double x, bool visibleDataOnly)
     {
-        int i = (int)((x - XOffset) / Period);
+        // using Math.Floor to fix rounding issue with first point (https://github.com/ScottPlot/ScottPlot/issues/4083)
+        int i = (int)Math.Floor((x - XOffset) / Period);
 
         if (visibleDataOnly)
         {

--- a/src/ScottPlot5/ScottPlot5/Plottables/SignalConst.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/SignalConst.cs
@@ -14,6 +14,11 @@ public class SignalConst<T>(T[] ys, double period) : IPlottable, IHasLine, IHasM
     public Color MarkerLineColor { get => MarkerStyle.LineColor; set => MarkerStyle.LineColor = value; }
     public Color MarkerColor { get => MarkerStyle.MarkerColor; set => MarkerStyle.MarkerColor = value; }
     public float MarkerLineWidth { get => MarkerStyle.LineWidth; set => MarkerStyle.LineWidth = value; }
+    /// <summary>
+    /// Maximum size of the marker (in pixels) to display
+    /// at each data point when the plot is zoomed far in.
+    /// </summary>
+    public float MaximumMarkerSize { get; set; } = 4;
 
     public LineStyle LineStyle { get; set; } = new() { Width = 1 };
     public float LineWidth { get => LineStyle.Width; set => LineStyle.Width = value; }
@@ -54,6 +59,8 @@ public class SignalConst<T>(T[] ys, double period) : IPlottable, IHasLine, IHasM
         LineStyle.ApplyToPaint(paint);
 
         List<PixelColumn> cols = Data.GetPixelColumns(Axes);
+        List<Pixel> points = [];
+        var pointsPerPx = PointsPerPixel();
 
         if (!cols.Any())
             return;
@@ -70,8 +77,34 @@ public class SignalConst<T>(T[] ys, double period) : IPlottable, IHasLine, IHasM
                 path.LineTo(col.X, col.Top);
                 path.MoveTo(col.X, col.Exit);
             }
+            if(pointsPerPx < 1)
+            {
+                points.Add(new(col.X, col.Enter));
+            }
         }
 
         rp.Canvas.DrawPath(path, paint);
+        /// Zoomed in enough that no pixel could contain two points.
+        if (pointsPerPx < 1)
+        {
+            paint.IsStroke = false;
+            float radius = (float)Math.Min(Math.Sqrt(.2 / pointsPerPx), MaximumMarkerSize);
+            MarkerSize = radius * MaximumMarkerSize * .2f;
+            Drawing.DrawMarkers(rp.Canvas, paint, points, MarkerStyle);
+        }
+
+    }
+    private CoordinateRange GetVisibleXRange(PixelRect dataRect)
+    {
+        // TODO: put GetRange in axis translator
+        double xViewLeft = Axes.GetCoordinateX(dataRect.Left);
+        double xViewRight = Axes.GetCoordinateX(dataRect.Right);
+        return (xViewLeft <= xViewRight)
+            ? new CoordinateRange(xViewLeft, xViewRight)
+            : new CoordinateRange(xViewRight, xViewLeft);
+    }
+    private double PointsPerPixel()
+    {
+        return GetVisibleXRange(Axes.DataRect).Span / Axes.DataRect.Width / Data.Period;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/SignalConst.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/SignalConst.cs
@@ -15,7 +15,7 @@ public class SignalConst<T>(T[] ys, double period) : IPlottable, IHasLine, IHasM
     public Color MarkerColor { get => MarkerStyle.MarkerColor; set => MarkerStyle.MarkerColor = value; }
     public float MarkerLineWidth { get => MarkerStyle.LineWidth; set => MarkerStyle.LineWidth = value; }
 
-    public LineStyle LineStyle { get; set; } = new();
+    public LineStyle LineStyle { get; set; } = new() { Width = 1 };
     public float LineWidth { get => LineStyle.Width; set => LineStyle.Width = value; }
     public LinePattern LinePattern { get => LineStyle.Pattern; set => LineStyle.Pattern = value; }
     public Color LineColor { get => LineStyle.Color; set => LineStyle.Color = value; }
@@ -41,7 +41,7 @@ public class SignalConst<T>(T[] ys, double period) : IPlottable, IHasLine, IHasM
     public bool IsVisible { get; set; } = true;
     public IAxes Axes { get; set; } = ScottPlot.Axes.Default;
 
-    public IEnumerable<LegendItem> LegendItems => LegendItem.None;
+    public IEnumerable<LegendItem> LegendItems => LegendItem.Single(LegendText, MarkerStyle, LineStyle);
 
     public AxisLimits GetAxisLimits() => Data.GetAxisLimits();
 


### PR DESCRIPTION
`SignalConst` has as `LegendText` field but did not defines `LegendItems`!

Also change `LineStyle` initialization for set `Width` to 1.

This should fix issue #4081.

Doing this, I found a bug in `SignalConst` rendering for first points:
```cs
ScottPlot.Plot myPlot = new();

var sign = myPlot.Add.SignalConst(Generate.Sin(phase:Math.PI));
sign.LegendText = "My fabulous SignalConst LegendText";
var sign2 = myPlot.Add.Signal(Generate.Sin());
sign2.LegendText = "My fabulous Signal LegendText";
myPlot.ShowLegend();
myPlot.SavePng("bug_4081.png", 800, 600);
```
![bug_4081](https://github.com/user-attachments/assets/4dad52bd-5f53-4376-b26d-753c804411e0)
