### PR TITLE
Grid: eliminate allocations for ticks of invisible axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ _Not yet on NuGet..._
 * SignalConst: Improved support for custom legend text (#4081, #4082) @KroMignon @fanshuxian
 * SignalConst: Improve accuracy of the first point in low density mode (#4082, #4083, #4086) @KroMignon
 * SignalConst: Allowed markers to become visible by setting their shape without requiring users to define a non-zero size (#4082) @KroMignon
+* Grid: Improved performance by reducing unnecessary allocations for ticks of invisible axes (#4087) @kebox7
 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_

--- a/src/ScottPlot5/ScottPlot5/Grids/DefaultGrid.cs
+++ b/src/ScottPlot5/ScottPlot5/Grids/DefaultGrid.cs
@@ -51,15 +51,20 @@ public class DefaultGrid(IXAxis xAxis, IYAxis yAxis) : IGrid
         if (!IsVisible)
             return;
 
-        var minX = Math.Min(XAxis.Min, XAxis.Max);
-        var maxX = Math.Max(XAxis.Min, XAxis.Max);
-        var minY = Math.Min(YAxis.Min, YAxis.Max);
-        var maxY = Math.Max(YAxis.Min, YAxis.Max);
+        if (XAxisStyle.IsVisible)
+        {
+            var minX = Math.Min(XAxis.Min, XAxis.Max);
+            var maxX = Math.Max(XAxis.Min, XAxis.Max);
+            var xTicks = XAxis.TickGenerator.Ticks.Where(x => x.Position >= minX && x.Position <= maxX);
+            XAxisStyle.Render(rp, XAxis, xTicks);
+        }
 
-        var xTicks = XAxis.TickGenerator.Ticks.Where(x => x.Position >= minX && x.Position <= maxX);
-        var yTicks = YAxis.TickGenerator.Ticks.Where(x => x.Position >= minY && x.Position <= maxY);
-
-        XAxisStyle.Render(rp, XAxis, xTicks);
-        YAxisStyle.Render(rp, YAxis, yTicks);
+        if (YAxisStyle.IsVisible)
+        {
+            var minY = Math.Min(YAxis.Min, YAxis.Max);
+            var maxY = Math.Max(YAxis.Min, YAxis.Max);
+            var yTicks = YAxis.TickGenerator.Ticks.Where(x => x.Position >= minY && x.Position <= maxY);
+            YAxisStyle.Render(rp, YAxis, yTicks);
+        }
     }
 }


### PR DESCRIPTION
Grid rendering micro-optimization that eliminates unnecessary calculations if the vertical (X) or horizontal (Y) grid is invisible.