### PR TITLE
 Fix : NumericFixedInterval lowest tick was not included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Label: `ScottPlot.Label` has been renamed to `ScottPlot.LabelStyle` to better signal its purpose is to hold styling information rather than store text
 * Label: Improved support for custom horizontal alignment in multiline strings (#4045, #3958, #3859) @karlipl
 * Fonts: Improve performance when automatic best font detection is enabled (#4049) @zxy874175242
+* TickGenerator : Fixed a bug on the generation of the lowest tick in `NumericalFixedInterval` @epegeot
 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ _Not yet on NuGet..._
 * Label: Improved support for custom horizontal alignment in multiline strings (#4045, #3958, #3859) @karlipl
 * Fonts: Improve performance when automatic best font detection is enabled (#4049) @zxy874175242
 * Controls: Added autoscale to default context menu (#4053)
-* TickGenerator : Fixed a bug on the generation of the lowest tick in `NumericalFixedInterval` @epegeot
+* Ticks: Improved behavior of `NumericalFixedInterval` to ensure the correct lowest tick is always rendered (#4089) @epegeot
 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
@@ -12,7 +12,7 @@ public class NumericFixedInterval(int interval = 1) : ITickGenerator
     {
         List<Tick> ticks = [];
 
-        double lowest = range.TrueMin - range.TrueMin % Interval;
+        double lowest = range.TrueMin - range.TrueMin % Interval - Interval;
         double highest = range.TrueMax - range.TrueMax % Interval + Interval;
         int tickCount = (int)((highest - lowest) / Interval);
         tickCount = Math.Min(tickCount, MaxTickCount);


### PR DESCRIPTION
This commit fixes a bug where the first tick of a NumericalFixedInterval was not generated.

Adds a simple `- Interval` in the calculation for the lowest bound to generate the lowest tick.