### PR TITLE
Ticks: Allow `NumericFixedInterval` interval to be a `double`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 * Label: `ScottPlot.Label` has been renamed to `ScottPlot.LabelStyle` to better signal its purpose is to hold styling information rather than store text
 * Label: Improved support for custom horizontal alignment in multiline strings (#4045, #3958, #3859) @karlipl
 * Fonts: Improve performance when automatic best font detection is enabled (#4049) @zxy874175242
-
+* TickGenerators : `NumericFixedInterval` now accepts `double` intervals and supports the passing of a LabelFormatter @epegeot
+ 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_
 * Fonts: Made typeface caching thread-safe to improve support for multi-threaded environments (#3940) @Hawkwind250

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/LabelFormatters.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/LabelFormatters.cs
@@ -1,0 +1,35 @@
+﻿namespace ScottPlot.TickGenerators;
+
+// TODO: Consider creating a `LabelFormatter` type or `ILabelFormatter` because we use this pattern in a lot of places.
+
+/* Maybe something like this?
+
+public interface ILabelFormatter
+{
+    public string GetLabel<T>(T value);
+}
+*/
+
+/// <summary>
+/// A collection of methods which contain logic for choosing how a value is representing with text
+/// </summary>
+public class LabelFormatters
+{
+    public static string Numeric(double value)
+    {
+        // use system culture
+        // https://github.com/ScottPlot/ScottPlot/issues/3688
+
+        // if the number is round or large, use the numeric format
+        // https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#the-numeric-n-format-specifier
+        bool isRoundNumber = (int)value == value;
+        bool isLargeNumber = Math.Abs(value) > 1000;
+        if (isRoundNumber || isLargeNumber)
+            return value.ToString("N0");
+
+        // otherwise the number is probably small or very precise to use the general format (with slight rounding)
+        // https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#the-general-g-format-specifier
+        string label = Math.Round(value, 10).ToString("G");
+        return label == "-0" ? "0" : label;
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/NumericAutomatic.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/NumericAutomatic.cs
@@ -1,26 +1,5 @@
 ﻿namespace ScottPlot.TickGenerators;
 
-public static class LabelFormatterHelper
-{
-    public static string DefaultLabelFormatter(double value)
-    {
-        // use system culture
-        // https://github.com/ScottPlot/ScottPlot/issues/3688
-
-        // if the number is round or large, use the numeric format
-        // https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#the-numeric-n-format-specifier
-        bool isRoundNumber = (int)value == value;
-        bool isLargeNumber = Math.Abs(value) > 1000;
-        if (isRoundNumber || isLargeNumber)
-            return value.ToString("N0");
-
-        // otherwise the number is probably small or very precise to use the general format (with slight rounding)
-        // https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#the-general-g-format-specifier
-        string label = Math.Round(value, 10).ToString("G");
-        return label == "-0" ? "0" : label;
-    }
-}
-
 public class NumericAutomatic : ITickGenerator
 {
     public Tick[] Ticks { get; set; } = [];
@@ -33,7 +12,7 @@ public class NumericAutomatic : ITickGenerator
 
     public bool IntegerTicksOnly { get; set; } = false;
 
-    public Func<double, string> LabelFormatter { get; set; } = LabelFormatterHelper.DefaultLabelFormatter;
+    public Func<double, string> LabelFormatter { get; set; } = LabelFormatters.Numeric;
 
     public IMinorTickGenerator MinorTickGenerator { get; set; } = new EvenlySpacedMinorTickGenerator(5);
 

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/NumericAutomatic.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/NumericAutomatic.cs
@@ -1,26 +1,7 @@
 ﻿namespace ScottPlot.TickGenerators;
 
-public class NumericAutomatic : ITickGenerator
+public static class LabelFormatterHelper
 {
-    public Tick[] Ticks { get; set; } = [];
-
-    public int MaxTickCount
-    {
-        get => TickSpacingCalculator.MaximumTickCount;
-        set => TickSpacingCalculator.MaximumTickCount = value;
-    }
-
-    public bool IntegerTicksOnly { get; set; } = false;
-
-    public Func<double, string> LabelFormatter { get; set; } = DefaultLabelFormatter;
-
-    public IMinorTickGenerator MinorTickGenerator { get; set; } = new EvenlySpacedMinorTickGenerator(5);
-
-    public DecimalTickSpacingCalculator TickSpacingCalculator = new();
-    public float MinimumTickSpacing { get; set; } = 0;
-    public double TickDensity { get; set; } = 1.0; // TODO: consider adding logic to make this a fraction of the width in pixels
-    public int? TargetTickCount = null;
-
     public static string DefaultLabelFormatter(double value)
     {
         // use system culture
@@ -38,6 +19,28 @@ public class NumericAutomatic : ITickGenerator
         string label = Math.Round(value, 10).ToString("G");
         return label == "-0" ? "0" : label;
     }
+}
+
+public class NumericAutomatic : ITickGenerator
+{
+    public Tick[] Ticks { get; set; } = [];
+
+    public int MaxTickCount
+    {
+        get => TickSpacingCalculator.MaximumTickCount;
+        set => TickSpacingCalculator.MaximumTickCount = value;
+    }
+
+    public bool IntegerTicksOnly { get; set; } = false;
+
+    public Func<double, string> LabelFormatter { get; set; } = LabelFormatterHelper.DefaultLabelFormatter;
+
+    public IMinorTickGenerator MinorTickGenerator { get; set; } = new EvenlySpacedMinorTickGenerator(5);
+
+    public DecimalTickSpacingCalculator TickSpacingCalculator = new();
+    public float MinimumTickSpacing { get; set; } = 0;
+    public double TickDensity { get; set; } = 1.0; // TODO: consider adding logic to make this a fraction of the width in pixels
+    public int? TargetTickCount = null;
 
     public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, LabelStyle labelStyle)
     {

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
@@ -3,6 +3,8 @@
 public class NumericFixedInterval(int interval = 1) : ITickGenerator
 {
     public double Interval { get; set; } = interval;
+    
+    public Func<double, string> LabelFormatter { get; set; } = LabelFormatterHelper.DefaultLabelFormatter;
 
     public Tick[] Ticks { get; set; } = [];
 

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
@@ -1,6 +1,6 @@
 ﻿namespace ScottPlot.TickGenerators;
 
-public class NumericFixedInterval(int interval = 1) : ITickGenerator
+public class NumericFixedInterval(double interval = 1) : ITickGenerator
 {
     public double Interval { get; set; } = interval;
     

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
@@ -25,7 +25,7 @@ public class NumericFixedInterval(int interval = 1) : ITickGenerator
                 ? lowest + i * Interval
                 : highest - i * Interval;
 
-            string label = position.ToString();
+            string label = LabelFormatter(position);
             Tick tick = new(position, label, true);
             ticks.Add(tick);
         }

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/NumericFixedInterval.cs
@@ -4,7 +4,7 @@ public class NumericFixedInterval(double interval = 1) : ITickGenerator
 {
     public double Interval { get; set; } = interval;
     
-    public Func<double, string> LabelFormatter { get; set; } = LabelFormatterHelper.DefaultLabelFormatter;
+    public Func<double, string> LabelFormatter { get; set; } = LabelFormatters.Numeric;
 
     public Tick[] Ticks { get; set; } = [];
 


### PR DESCRIPTION
`NumericFixedInterval` is now able to be instanciated using doubles instead of just integers, without changing the logic behind. 
`NumericFixedInterval`  now has a property `LabelFormatter` like `NumericAutomatic`.

This PR creates a static class `DefaultFormatterHelper` to extract the `DefaultLabelFormatter` from `NumericAutomatic` so that it can be also used in `NumericFixedInterval`.

The modification from int to double in the constructor is not a breaking change, as illustrated by this code extract:

```cs
public class Test(double t = 1.0f)
{
    public double T { get; set; } = t;
}

public static class Program
{
    public static void Main()
    {
        int v = 12;  
        Test t = new(v);
        Console.WriteLine(t.T); // -> 12
    }
}
```