### PR TITLE
PlottablerAdder: make `Plot` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ _Not yet on NuGet..._
 * DataStreamer: Improved support for rotated plots (#4093, #4085) @drolevar @KroMignon @Jofstera
 * Security: Removed outdated reference to `System.Text.Json` which contained CVE-2024-30105 (#4095, #4063) @SerTetora
 * Phaser: New plot type for displaying arrows to points in polar space (#4096, #3939) @CoderPM2011 @nilsakesson
+* PlottableAdder: Exposed `Plot` so users can create methods that extend `Plot.Add` which have access to the `Plot` itself (#4109, #4107) @DDiggs91
 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -9,7 +9,7 @@ namespace ScottPlot;
 /// </summary>
 public class PlottableAdder(Plot plot)
 {
-    private readonly Plot Plot = plot;
+    public Plot Plot { get; } = plot;
 
     /// <summary>
     /// Color set used for adding new plottables


### PR DESCRIPTION
Access modified change
Exposing PlottableAdder.Plot as requested in #4107 
