### PR TITLE
AxisManager: Improve `AutoScale()` support for inverted axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ _Not yet on NuGet..._
 * Security: Removed outdated reference to `System.Text.Json` which contained CVE-2024-30105 (#4095, #4063) @SerTetora
 * Phaser: New plot type for displaying arrows to points in polar space (#4096, #3939) @CoderPM2011 @nilsakesson
 * PlottableAdder: Exposed `Plot` so users can create methods that extend `Plot.Add` which have access to the `Plot` itself (#4109, #4107) @DDiggs91
+* AxisManager: Improve `AutoScale()` support for inverted axes (#4110) @BrianAtZetica
 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -564,7 +564,7 @@ public class AxisManager
     /// <summary>
     /// Automatically scale all axes to fit the data in all plottables
     /// </summary>
-    public void AutoScale(bool? invertX = false, bool? invertY = false)
+    public void AutoScale(bool? invertX = null, bool? invertY = null)
     {
         ReplaceNullAxesWithDefaults();
         AutoScaler.InvertedX = invertX ?? AutoScaler.InvertedX;


### PR DESCRIPTION
When axes are set to inverted and then an AutoScale is initiated (i.e. middle mouse button) the plot was restoring the axes back to normal directions. 

This was caused by the optional parameters on AutoScale being defaulted to false instead of null. 
The subsequent use of the null-coalescing operator '??' was therefore having no purpose. 

Now the default is null, so if no local parameters are provided AutoScaler parameters are used to decide on axis direction
