### PR TITLE
Scatter: Added X-axis gradient fill area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ _Not yet on NuGet..._
 * DataStreamer: Improved support for rotated plots (#4093, #4085) @drolevar @KroMignon @Jofstera
 * Security: Removed outdated reference to `System.Text.Json` which contained CVE-2024-30105 (#4095, #4063) @SerTetora
 * Phaser: New plot type for displaying arrows to points in polar space (#4096, #3939) @CoderPM2011 @nilsakesson
+* Scatter: Added `ColorPositions` to allow placement of colors at specific X positions when using filled scatter plots (#4111) @CoderPM2011
 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Scatter.cs
@@ -422,6 +422,30 @@ public class Scatter : ICategory
         }
     }
 
+    public class ScatterFillGradient : RecipeBase
+    {
+        public override string Name => "Scatter Plot with Gradient Fill";
+        public override string Description => "The area beneath a scatter plot can be " +
+            "filled with a custom gradient of colors.";
+
+        [Test]
+        public override void Execute()
+        {
+            double[] xs = Generate.Consecutive(51);
+            double[] ys = Generate.Sin(51);
+
+            var poly = myPlot.Add.ScatterLine(xs, ys);
+
+            poly.FillY = true;
+            poly.ColorPositions.Add(new(Colors.Red, 0));
+            poly.ColorPositions.Add(new(Colors.Orange, 10));
+            poly.ColorPositions.Add(new(Colors.Yellow, 20));
+            poly.ColorPositions.Add(new(Colors.Green, 30));
+            poly.ColorPositions.Add(new(Colors.Blue, 40));
+            poly.ColorPositions.Add(new(Colors.Violet, 50));
+        }
+    }
+
     public class ScatterScaleAndOffset : RecipeBase
     {
         public override string Name => "Scatter Scale and Offset";


### PR DESCRIPTION
Add X-direction gradient fill to `Scatter` plot.
User can set stop points and corresponding colors.

Like Microsoft word - Create a custom gradient
https://support.microsoft.com/en-us/topic/add-a-gradient-color-to-a-shape-11cf6392-723c-4be8-840a-b2dab4b2ba3e

For example the following picture is the spectrum of an LED.
![image](https://github.com/user-attachments/assets/5c69f812-4d4c-45da-838b-752ec480cb0f)

## How I implement it
**When `FillX` is set, it will be used instead of the setting of `FillYColor` for rendering.** 

In `Render()`, I set the `Hatch` property in `FillStyle`.
And calculate the `ColorPositions` and `Colors` of `Gradient` based on the current chart position.

- Since in `Gradient`, the range of `ColorPositions` is 0~1, so a conversion calculation has to be done on this.
- When a graph is cut off by an edge, the colors must be interpolated in order to get the correct cutoff point color.

---

## result image
After scaling or moving, the color corresponding to the X-axis can be displayed correctly.
![temp](https://github.com/user-attachments/assets/897d883a-b777-4ebb-b8ce-8cb726f116cc)

## sample code
```cs
 Coordinates[] points =
 {
     new (350, 1),
     new (380, 2),
     new (555, 3),
     new (780, 1),
     new (950, 2),
 };

 var poly = formsPlot1.Plot.Add.Scatter(points);

 poly.MarkerStyle.IsVisible = false;
 poly.FillY = true;
 poly.FillXPoints = new float[] {
     380.0F,
     440.0F,
     490.0F,
     510.0F,
     580.0F,
     650.0F,
 };
 poly.FillXColors = new Color[] {
     Color.FromHex("#610061"),
     Color.FromHex("#0000FF"),
     Color.FromHex("#00FFFF"),
     Color.FromHex("#00FF00"),
     Color.FromHex("#FFFF00"),
     Color.FromHex("#FF0000"),
 };
```