### PR TITLE
SignalXY: Improvements to rending and handling of rotated plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ _Not yet on NuGet..._
 * PlottableAdder: Exposed `Plot` so users can create methods that extend `Plot.Add` which have access to the `Plot` itself (#4109, #4107) @DDiggs91
 * AxisManager: Improve `AutoScale()` support for inverted axes (#4110) @BrianAtZetica
 * Scatter: Added `ColorPositions` to allow placement of colors at specific X positions when using filled scatter plots (#4111) @CoderPM2011
+* SignalXY: Improved support for rotated plots and added support for `XScale` to compliment `YScale` (#4112, #4102) @BrianAtZetica
 
 ## ScottPlot 5.0.36
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-06-29_

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
@@ -256,7 +256,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
         }
 
         if (pointsInRange > 1)
-        { 
+        {
             yield return new Pixel(axes.GetPixelX(Ys[lastIndex] * YScale + YOffset), yPixel); // exit
         }
     }

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
@@ -1,4 +1,6 @@
-﻿namespace ScottPlot.DataSources;
+﻿using System;
+
+namespace ScottPlot.DataSources;
 
 public class SignalXYSourceDoubleArray : ISignalXYSource
 {
@@ -62,20 +64,15 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
             .Select(pxColumn => GetColumnPixelsX(pxColumn, visibleRange, rp, axes))
             .SelectMany(x => x);
 
-        // duplicate the last point to ensure it is always rendered
-        // https://github.com/ScottPlot/ScottPlot/issues/3812
-        Pixel lastPoint = axes.GetPixel(new Coordinates(Xs[dataIndexLast] + XOffset, Ys[dataIndexLast] * YScale + YOffset));
-
         Pixel[] leftOutsidePoint = PointBefore, rightOutsidePoint = PointAfter;
         if (axes.XAxis.Range.Span < 0)
         {
             leftOutsidePoint = PointAfter;
             rightOutsidePoint = PointBefore;
-            lastPoint = axes.GetPixel(new Coordinates(Xs[dataIndexFirst] + XOffset, Ys[dataIndexFirst] * YScale + YOffset));
         }
 
         // combine with one extra point before and after
-        Pixel[] points = [.. leftOutsidePoint, .. VisiblePoints, .. rightOutsidePoint, lastPoint];
+        Pixel[] points = [.. leftOutsidePoint, .. VisiblePoints, .. rightOutsidePoint];
 
         // use interpolation at the edges to prevent points from going way off the screen
         if (leftOutsidePoint.Length > 0)
@@ -99,21 +96,16 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
             .Select(pxRow => GetColumnPixelsY(pxRow, visibleRange, rp, axes))
             .SelectMany(x => x);
 
-        // duplicate the last point to ensure it is always rendered
-        // https://github.com/ScottPlot/ScottPlot/issues/3812
-        Pixel lastPoint = axes.GetPixel(new Coordinates(Ys[dataIndexLast], Xs[dataIndexLast]));
-
         Pixel[] bottomOutsidePoint = PointBefore, topOutsidePoint = PointAfter;
         if (axes.YAxis.Range.Span < 0)
         {
             bottomOutsidePoint = PointAfter;
             topOutsidePoint = PointBefore;
-            lastPoint = axes.GetPixel(new Coordinates(Ys[dataIndexFirst], Xs[dataIndexFirst]));
         }
 
 
         // combine with one extra point before and after
-        Pixel[] points = [.. bottomOutsidePoint, .. VisiblePoints, .. topOutsidePoint, lastPoint];
+        Pixel[] points = [.. bottomOutsidePoint, .. VisiblePoints, .. topOutsidePoint];
 
         // use interpolation at the edges to prevent points from going way off the screen
         if (bottomOutsidePoint.Length > 0)
@@ -181,23 +173,36 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
         double overlap = unitsPerPixelX * .01;
         end += overlap;
 
-        var (startPosition, startIndex) = SearchIndex(start, rng);
-        var (endPosition, endIndex) = SearchIndex(end, rng);
-        int pointsInRange = Math.Abs(endPosition - startPosition);
+        var (startIndex, _) = SearchIndex(start, rng);
+        var (endIndex, _) = SearchIndex(end, rng);
+        int pointsInRange = Math.Abs(endIndex - startIndex);
 
         if (pointsInRange == 0)
         {
             yield break;
         }
 
-        yield return new Pixel(xPixel, axes.GetPixelY(Ys[Math.Min(startIndex, endIndex)] * YScale + YOffset)); // enter
+        int firstIndex = startIndex < endIndex ? startIndex : startIndex - 1;
+        int lastIndex = startIndex < endIndex ? endIndex - 1 : endIndex;
+        yield return new Pixel(xPixel, axes.GetPixelY(Ys[firstIndex] * YScale + YOffset)); // enter
+
+        if (pointsInRange > 2)
+        {
+            CoordinateRange yRange = GetRangeY(startIndex, lastIndex); //YOffset is added in GetRangeY
+            if (Ys[firstIndex] > Ys[lastIndex])
+            { //signal amplitude is decreasing, so we'll return the maximum before the minimum
+                yield return new Pixel(xPixel, axes.GetPixelY(yRange.Max)); // max
+                yield return new Pixel(xPixel, axes.GetPixelY(yRange.Min)); // min
+            }
+            else
+            { //signal amplitude is increasing, so we'll return the minimum before the maximum
+                yield return new Pixel(xPixel, axes.GetPixelY(yRange.Min)); // min
+                yield return new Pixel(xPixel, axes.GetPixelY(yRange.Max)); // max
+            }
+        }
 
         if (pointsInRange > 1)
         {
-            int lastIndex = startIndex < endIndex ? endIndex - 1 : endIndex + 1;
-            CoordinateRange yRange = GetRangeY(startIndex, lastIndex); //YOffset is added in GetRangeY
-            yield return new Pixel(xPixel, axes.GetPixelY(yRange.Min)); // min
-            yield return new Pixel(xPixel, axes.GetPixelY(yRange.Max)); // max
             yield return new Pixel(xPixel, axes.GetPixelY(Ys[lastIndex] * YScale + YOffset)); // exit
         }
     }
@@ -210,28 +215,48 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     /// </summary>
     private IEnumerable<Pixel> GetColumnPixelsY(int rowColumnIndex, IndexRange rng, RenderPack rp, IAxes axes)
     {
+        // here rowColumnIndex will count upwards from the bottom, but pixels are measured from the top of the plot
         float yPixel = rp.DataRect.Bottom - rowColumnIndex;
         double unitsPerPixelY = axes.YAxis.Height / rp.DataRect.Height;
         double start = axes.YAxis.Min + unitsPerPixelY * rowColumnIndex;
         double end = start + unitsPerPixelY;
-        var (startPosition, startIndex) = SearchIndex(start, rng);
-        var (endPosition, endIndex) = SearchIndex(end, rng);
-        int pointsInRange = Math.Abs(endPosition - startPosition);
+
+        // add slight overlap to prevent floating point errors from missing points
+        // https://github.com/ScottPlot/ScottPlot/issues/3665
+        double overlap = unitsPerPixelY * .01;
+        end += overlap;
+
+        var (startIndex, _) = SearchIndex(start, rng);
+        var (endIndex, _) = SearchIndex(end, rng);
+        int pointsInRange = Math.Abs(endIndex - startIndex);
 
         if (pointsInRange == 0)
         {
             yield break;
         }
 
-        yield return new Pixel(axes.GetPixelX(Ys[Math.Min(startIndex, endIndex)] + XOffset), yPixel); // enter
+        int firstIndex = startIndex < endIndex ? startIndex : startIndex - 1;
+        int lastIndex = startIndex < endIndex ? endIndex - 1 : endIndex;
+        yield return new Pixel(axes.GetPixelX(Ys[firstIndex] * YScale + YOffset), yPixel); // enter
+
+        if (pointsInRange > 2)
+        {
+            CoordinateRange yRange = GetRangeY(firstIndex, lastIndex);
+            if (Ys[firstIndex] > Ys[lastIndex])
+            { //signal amplitude is decreasing, so we'll return the maximum before the minimum
+                yield return new Pixel(axes.GetPixelX(yRange.Max), yPixel); // max
+                yield return new Pixel(axes.GetPixelX(yRange.Min), yPixel); // min
+            }
+            else
+            { //signal amplitude is increasing, so we'll return the minimum before the maximum
+                yield return new Pixel(axes.GetPixelX(yRange.Min), yPixel); // min
+                yield return new Pixel(axes.GetPixelX(yRange.Max), yPixel); // max
+            }
+        }
 
         if (pointsInRange > 1)
-        {
-            int lastIndex = startIndex < endIndex ? endIndex - 1 : endIndex + 1;
-            CoordinateRange yRange = GetRangeY(startIndex, lastIndex);
-            yield return new Pixel(axes.GetPixelX(yRange.Min), yPixel); // min
-            yield return new Pixel(axes.GetPixelX(yRange.Max), yPixel); // max
-            yield return new Pixel(axes.GetPixelX(Ys[lastIndex] + XOffset), yPixel); // exit
+        { 
+            yield return new Pixel(axes.GetPixelX(Ys[lastIndex] * YScale + YOffset), yPixel); // exit
         }
     }
 
@@ -239,14 +264,14 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     /// If data is off to the screen to the left, 
     /// returns information about the closest point off the screen
     /// </summary>
-    private (Pixel[] pointsBefore, int firstIndex) GetFirstPointX(IAxes axes)
+    private (Pixel[] pointBefore, int firstIndex) GetFirstPointX(IAxes axes)
     {
         if (Xs.Length == 1)
             return ([], MinimumIndex);
 
-        var (firstPointPosition, firstPointIndex) = SearchIndex(axes.XAxis.Range.Span > 0 ? axes.XAxis.Min : axes.XAxis.Max); // if axis is reversed first index will on the right limit of the plot
+        var (firstPointIndex, _) = SearchIndex(axes.XAxis.Range.Span > 0 ? axes.XAxis.Min : axes.XAxis.Max); // if axis is reversed first index will on the right limit of the plot
 
-        if (firstPointPosition > MinimumIndex)
+        if (firstPointIndex > MinimumIndex)
         {
             float beforeX = axes.GetPixelX(Xs[firstPointIndex - 1] + XOffset);
             float beforeY = axes.GetPixelY(Ys[firstPointIndex - 1] * YScale + YOffset);
@@ -263,14 +288,14 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     /// If data is off to the screen to the bottom, 
     /// returns information about the closest point off the screen
     /// </summary>
-    private (Pixel[] pointsBefore, int firstIndex) GetFirstPointY(IAxes axes)
+    private (Pixel[] pointBefore, int firstIndex) GetFirstPointY(IAxes axes)
     {
         if (Xs.Length == 1)
             return ([], MinimumIndex);
 
-        var (firstPointPosition, firstPointIndex) = SearchIndex(axes.YAxis.Range.Span > 0 ? axes.YAxis.Min : axes.YAxis.Max); // if axis is reversed first index will on the top limit of the plot
+        var (firstPointIndex, _) = SearchIndex(axes.YAxis.Range.Span > 0 ? axes.YAxis.Min : axes.YAxis.Max); // if axis is reversed first index will on the top limit of the plot
 
-        if (firstPointPosition > MinimumIndex)
+        if (firstPointIndex > MinimumIndex)
         {
             float beforeY = axes.GetPixelY(Xs[firstPointIndex - 1] + XOffset);
             float beforeX = axes.GetPixelX(Ys[firstPointIndex - 1] * YScale + YOffset);
@@ -287,19 +312,19 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     /// If data is off to the screen to the right, 
     /// returns information about the closest point off the screen
     /// </summary>
-    private (Pixel[] pointsAfter, int lastIndex) GetLastPointX(IAxes axes)
+    private (Pixel[] pointAfter, int lastIndex) GetLastPointX(IAxes axes)
     {
         if (Xs.Length == 1)
             return ([], MaximumIndex);
 
-        var (lastPointPosition, lastPointIndex) = SearchIndex(axes.XAxis.Range.Span > 0 ? axes.XAxis.Max : axes.XAxis.Min); // if axis is reversed last index will on the left limit of the plot
+        var (lastPointIndex, _) = SearchIndex(axes.XAxis.Range.Span > 0 ? axes.XAxis.Max : axes.XAxis.Min); // if axis is reversed last index will on the left limit of the plot
 
-        if (lastPointPosition <= MaximumIndex)
+        if (lastPointIndex <= MaximumIndex)
         {
             float afterX = axes.GetPixelX(Xs[lastPointIndex] + XOffset);
             float afterY = axes.GetPixelY(Ys[lastPointIndex] * YScale + YOffset);
             Pixel afterPoint = new(afterX, afterY);
-            return ([afterPoint], lastPointIndex);
+            return ([afterPoint], lastPointIndex - 1);
         }
         else
         {
@@ -311,19 +336,19 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
     /// If data is off to the screen to the top, 
     /// returns information about the closest point off the screen
     /// </summary>
-    private (Pixel[] pointsAfter, int lastIndex) GetLastPointY(IAxes axes)
+    private (Pixel[] pointAfter, int lastIndex) GetLastPointY(IAxes axes)
     {
         if (Xs.Length == 1)
             return ([], MaximumIndex);
 
-        var (lastPointPosition, lastPointIndex) = SearchIndex(axes.YAxis.Range.Span > 0 ? axes.YAxis.Max : axes.YAxis.Min); // if axis is reversed last index will on the bottom limit of the plot
+        var (lastPointIndex, _) = SearchIndex(axes.YAxis.Range.Span > 0 ? axes.YAxis.Max : axes.YAxis.Min); // if axis is reversed last index will on the bottom limit of the plot
 
-        if (lastPointPosition <= MaximumIndex)
+        if (lastPointIndex <= MaximumIndex)
         {
             float afterY = axes.GetPixelY(Xs[lastPointIndex] + XOffset);
             float afterX = axes.GetPixelX(Ys[lastPointIndex] * YScale + YOffset);
             Pixel afterPoint = new(afterX, afterY);
-            return ([afterPoint], lastPointIndex);
+            return ([afterPoint], lastPointIndex - 1);
         }
         else
         {
@@ -369,15 +394,26 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
 
         for (int i = 0; i < Xs.Length; i++)
         {
-            double dX = (Xs[i] + XOffset - mouseLocation.X) * renderInfo.PxPerUnitX;
-            double dY = (Ys[i] * YScale + YOffset - mouseLocation.Y) * renderInfo.PxPerUnitY;
+            double dX = Rotated ?
+                 (Ys[i] * YScale + YOffset - mouseLocation.X) * renderInfo.PxPerUnitX :
+                 (Xs[i] + XOffset - mouseLocation.X) * renderInfo.PxPerUnitX;
+            double dY = Rotated ?
+                (Xs[i] + XOffset - mouseLocation.Y) * renderInfo.PxPerUnitY :
+                (Ys[i] * YScale + YOffset - mouseLocation.Y) * renderInfo.PxPerUnitY;
+
             double distanceSquared = dX * dX + dY * dY;
 
             if (distanceSquared <= closestDistanceSquared)
             {
                 closestDistanceSquared = distanceSquared;
-                closestX = Xs[i] + XOffset;
-                closestY = Ys[i] * YScale + YOffset;
+
+                closestX = Rotated ?
+                    Ys[i] * YScale + YOffset :
+                    Xs[i] + XOffset;
+                closestY = Rotated ?
+                    Xs[i] + XOffset :
+                    Ys[i] * YScale + YOffset;
+
                 closestIndex = i;
             }
         }
@@ -389,10 +425,16 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
 
     public DataPoint GetNearestX(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
     {
-        int i = GetIndex(mouseLocation.X); // TODO: check the index after too?
-        double distance = (Xs[i] + XOffset - mouseLocation.X) * renderInfo.PxPerUnitX;
+        var MousePosition = Rotated ? mouseLocation.Y : mouseLocation.X;
+        int i = GetIndex(MousePosition); // TODO: check the index after too?
+        var PxPerPositionUnit = Rotated ? renderInfo.PxPerUnitY : renderInfo.PxPerUnitX;
+
+        double distance = (Xs[i] + XOffset - MousePosition) * PxPerPositionUnit;
+        var closestX = Rotated ? Ys[i] * YScale + YOffset : Xs[i] + XOffset;
+        var closestY = Rotated ? Xs[i] + XOffset : Ys[i] * YScale + YOffset;
+
         return Math.Abs(distance) <= maxDistance
-            ? new DataPoint(Xs[i], Ys[i], i)
+            ? new DataPoint(closestX, closestY, i)
             : DataPoint.None;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
@@ -183,7 +183,7 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
         int lastIndex = startIndex < endIndex ? endIndex - 1 : endIndex;
         double yStart = NumericConversion.GenericToDouble(Ys, firstIndex) * YScale + YOffset;
         double yEnd = NumericConversion.GenericToDouble(Ys, lastIndex) * YScale + YOffset;
-        
+
         yield return new Pixel(xPixel, axes.GetPixelY(yStart)); // enter
 
         if (pointsInRange > 2)

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
@@ -6,11 +6,7 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
     public TY[] Ys { get; set; }
     public int Count => Xs.Length;
 
-    public bool Rotated
-    {
-        get => false;
-        set => throw new NotImplementedException("rotation is not yet supported for generic SignalXY plots (try using doubles)");
-    }
+    public bool Rotated { get; set; } = false;
 
     public double XOffset { get; set; } = 0;
     public double YOffset { get; set; } = 0;
@@ -47,14 +43,21 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
 
     public Pixel[] GetPixelsToDraw(RenderPack rp, IAxes axes, ConnectStyle connectStyle)
     {
+        return Rotated
+            ? GetPixelsToDrawVertically(rp, axes, connectStyle)
+            : GetPixelsToDrawHorizontally(rp, axes, connectStyle);
+    }
+
+    public Pixel[] GetPixelsToDrawHorizontally(RenderPack rp, IAxes axes, ConnectStyle connectStyle)
+    {
         // determine the range of data in view
-        (Pixel[] PointBefore, int dataIndexFirst) = GetFirstPoint(axes);
-        (Pixel[] PointAfter, int dataIndexLast) = GetLastPoint(axes);
-        IndexRange columnIndexRange = new(dataIndexFirst, dataIndexLast);
+        (Pixel[] PointBefore, int dataIndexFirst) = GetFirstPointX(axes);
+        (Pixel[] PointAfter, int dataIndexLast) = GetLastPointX(axes);
+        IndexRange visibleRange = new(dataIndexFirst, dataIndexLast);
 
         // get all points in view
         IEnumerable<Pixel> VisiblePoints = Enumerable.Range(0, (int)Math.Ceiling(rp.DataRect.Width))
-            .Select(pixelColumnIndex => GetColumnPixels(pixelColumnIndex, columnIndexRange, rp, axes))
+            .Select(pixelColumnIndex => GetColumnPixelsX(pixelColumnIndex, visibleRange, rp, axes))
             .SelectMany(x => x);
 
         Pixel[] leftOutsidePoint = PointBefore, rightOutsidePoint = PointAfter;
@@ -64,14 +67,8 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
             rightOutsidePoint = PointBefore;
         }
 
-        // duplicate the last point to ensure it is always rendered
-        // https://github.com/ScottPlot/ScottPlot/issues/3812
-        double lastX = NumericConversion.GenericToDouble(Xs, dataIndexLast) + XOffset;
-        double lastY = NumericConversion.GenericToDouble(Ys, dataIndexLast) * YScale + XOffset;
-        Pixel lastPoint = axes.GetPixel(new Coordinates(lastX, lastY));
-
         // combine with one extra point before and after
-        Pixel[] points = [.. leftOutsidePoint, .. VisiblePoints, .. rightOutsidePoint, lastPoint];
+        Pixel[] points = [.. leftOutsidePoint, .. VisiblePoints, .. rightOutsidePoint];
 
         // use interpolation at the edges to prevent points from going way off the screen
         if (leftOutsidePoint.Length > 0)
@@ -79,6 +76,38 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
 
         if (rightOutsidePoint.Length > 0)
             SignalInterpolation.InterpolateAfterX(rp, points, connectStyle);
+
+        return points;
+    }
+
+    public Pixel[] GetPixelsToDrawVertically(RenderPack rp, IAxes axes, ConnectStyle connectStyle)
+    {
+        // determine the range of data in view
+        (Pixel[] PointBefore, int dataIndexFirst) = GetFirstPointY(axes);
+        (Pixel[] PointAfter, int dataIndexLast) = GetLastPointY(axes);
+        IndexRange visibleRange = new(dataIndexFirst, dataIndexLast);
+
+        // get all points in view
+        IEnumerable<Pixel> VisiblePoints = Enumerable.Range(0, (int)Math.Ceiling(rp.DataRect.Height))
+            .Select(pixelRowIndex => GetColumnPixelsY(pixelRowIndex, visibleRange, rp, axes))
+            .SelectMany(x => x);
+
+        Pixel[] bottomOutsidePoint = PointBefore, topOutsidePoint = PointAfter;
+        if (axes.YAxis.Range.Span < 0)
+        {
+            bottomOutsidePoint = PointAfter;
+            topOutsidePoint = PointBefore;
+        }
+
+        // combine with one extra point before and after
+        Pixel[] points = [.. bottomOutsidePoint, .. VisiblePoints, .. topOutsidePoint];
+
+        // use interpolation at the edges to prevent points from going way off the screen
+        if (bottomOutsidePoint.Length > 0)
+            SignalInterpolation.InterpolateBeforeY(rp, points, connectStyle);
+
+        if (topOutsidePoint.Length > 0)
+            SignalInterpolation.InterpolateAfterY(rp, points, connectStyle);
 
         return points;
     }
@@ -107,7 +136,7 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
     /// <summary>
     /// Get the index associated with the given X position
     /// </summary>
-    public int GetIndexX(double x)
+    public int GetIndex(double x)
     {
         IndexRange range = new(MinimumIndex, MaximumIndex);
         return GetIndex(x, range);
@@ -128,7 +157,7 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
     /// If the column contains one point, return that one pixel.
     /// If the column contains multiple points, return 4 pixels: enter, min, max, and exit
     /// </summary>
-    public IEnumerable<Pixel> GetColumnPixels(int pixelColumnIndex, IndexRange rng, RenderPack rp, IAxes axes)
+    public IEnumerable<Pixel> GetColumnPixelsX(int pixelColumnIndex, IndexRange rng, RenderPack rp, IAxes axes)
     {
         float xPixel = pixelColumnIndex + rp.DataRect.Left;
         double unitsPerPixelX = axes.XAxis.Width / rp.DataRect.Width;
@@ -140,26 +169,98 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
         double overlap = unitsPerPixelX * .01;
         end += overlap;
 
-        var (startPosition, startIndex) = SearchIndex(start, rng);
-        var (endPosition, endIndex) = SearchIndex(end, rng);
-        int pointsInRange = Math.Abs(endPosition - startPosition);
+        var (startIndex, _) = SearchIndex(start, rng);
+        var (endIndex, _) = SearchIndex(end, rng);
+        int pointsInRange = Math.Abs(endIndex - startIndex);
 
         if (pointsInRange == 0)
         {
             yield break;
         }
 
-        double yStart = NumericConversion.GenericToDouble(Ys, startIndex) * YScale + YOffset;
+        int firstIndex = startIndex < endIndex ? startIndex : startIndex - 1;
+        int lastIndex = startIndex < endIndex ? endIndex - 1 : endIndex;
+        double yStart = NumericConversion.GenericToDouble(Ys, firstIndex) * YScale + YOffset;
+        double yEnd = NumericConversion.GenericToDouble(Ys, lastIndex) * YScale + YOffset;
+        
         yield return new Pixel(xPixel, axes.GetPixelY(yStart)); // enter
+
+        if (pointsInRange > 2)
+        {
+            CoordinateRange yRange = GetRangeY(firstIndex, lastIndex); //YOffset is added in GetRangeY
+
+            if (yStart > yEnd)
+            { //signal amplitude is decreasing, so we'll return the maximum before the minimum
+                yield return new Pixel(xPixel, axes.GetPixelY(yRange.Max)); // max
+                yield return new Pixel(xPixel, axes.GetPixelY(yRange.Min)); // min
+            }
+            else
+            { //signal amplitude is increasing, so we'll return the minimum before the maximum
+                yield return new Pixel(xPixel, axes.GetPixelY(yRange.Min)); // min
+                yield return new Pixel(xPixel, axes.GetPixelY(yRange.Max)); // max
+            }
+        }
 
         if (pointsInRange > 1)
         {
-            int lastIndex = startIndex < endIndex ? endIndex - 1 : endIndex + 1;
-            double yEnd = NumericConversion.GenericToDouble(Ys, lastIndex) * YScale + YOffset;
-            CoordinateRange yRange = GetRangeY(startIndex, lastIndex); //YOffset is added in GetRangeY
-            yield return new Pixel(xPixel, axes.GetPixelY(yRange.Min)); // min
-            yield return new Pixel(xPixel, axes.GetPixelY(yRange.Max)); // max
             yield return new Pixel(xPixel, axes.GetPixelY(yEnd)); // exit
+        }
+    }
+
+    /// <summary>
+    /// Given a pixel column, return the pixels to render its line.
+    /// If the column contains no data, no pixels are returned.
+    /// If the column contains one point, return that one pixel.
+    /// If the column contains multiple points, return 4 pixels: enter, min, max, and exit
+    /// </summary>
+    public IEnumerable<Pixel> GetColumnPixelsY(int pixelColumnIndex, IndexRange rng, RenderPack rp, IAxes axes)
+    {
+        // here rowColumnIndex will count upwards from the bottom, but pixels are measured from the top of the plot
+        float yPixel = rp.DataRect.Bottom - pixelColumnIndex;
+        double unitsPerPixelY = axes.YAxis.Height / rp.DataRect.Height;
+        double start = axes.YAxis.Min + unitsPerPixelY * pixelColumnIndex;
+        double end = start + unitsPerPixelY;
+
+        // add slight overlap to prevent floating point errors from missing points
+        // https://github.com/ScottPlot/ScottPlot/issues/3665
+        double overlap = unitsPerPixelY * .01;
+        end += overlap;
+
+        var (startIndex, _) = SearchIndex(start, rng);
+        var (endIndex, _) = SearchIndex(end, rng);
+        int pointsInRange = Math.Abs(endIndex - startIndex);
+
+        if (pointsInRange == 0)
+        {
+            yield break;
+        }
+
+        int firstIndex = startIndex < endIndex ? startIndex : startIndex - 1;
+        int lastIndex = startIndex < endIndex ? endIndex - 1 : endIndex;
+        double yStart = NumericConversion.GenericToDouble(Ys, firstIndex) * YScale + YOffset;
+        double yEnd = NumericConversion.GenericToDouble(Ys, lastIndex) * YScale + YOffset;
+
+        yield return new Pixel(axes.GetPixelX(yStart), yPixel); // enter
+
+        if (pointsInRange > 2)
+        {
+            CoordinateRange yRange = GetRangeY(firstIndex, lastIndex); //YOffset is added in GetRangeY
+
+            if (yStart > yEnd)
+            { //signal amplitude is decreasing, so we'll return the maximum before the minimum
+                yield return new Pixel(axes.GetPixelX(yRange.Max), yPixel); // max
+                yield return new Pixel(axes.GetPixelX(yRange.Min), yPixel); // min
+            }
+            else
+            { //signal amplitude is increasing, so we'll return the minimum before the maximum
+                yield return new Pixel(axes.GetPixelX(yRange.Min), yPixel); // min
+                yield return new Pixel(axes.GetPixelX(yRange.Max), yPixel); // max
+            }
+        }
+
+        if (pointsInRange > 1)
+        {
+            yield return new Pixel(axes.GetPixelX(yEnd), yPixel); // exit
         }
     }
 
@@ -167,11 +268,14 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
     /// If data is off to the screen to the left, 
     /// returns information about the closest point off the screen
     /// </summary>
-    private (Pixel[] pointsBefore, int firstIndex) GetFirstPoint(IAxes axes)
+    private (Pixel[] pointBefore, int firstIndex) GetFirstPointX(IAxes axes)
     {
-        var (firstPointPosition, firstPointIndex) = SearchIndex(axes.XAxis.Range.Span > 0 ? axes.XAxis.Min : axes.XAxis.Max); // if axis is reversed first index will on the right limit of the plot
+        if (Xs.Length == 1)
+            return ([], MinimumIndex);
 
-        if (firstPointPosition > MinimumIndex)
+        var (firstPointIndex, _) = SearchIndex(axes.XAxis.Range.Span > 0 ? axes.XAxis.Min : axes.XAxis.Max); // if axis is reversed first index will on the right limit of the plot
+
+        if (firstPointIndex > MinimumIndex)
         {
             double x = NumericConversion.GenericToDouble(Xs, firstPointIndex - 1) + XOffset;
             double y = NumericConversion.GenericToDouble(Ys, firstPointIndex - 1) * YScale + YOffset;
@@ -187,21 +291,76 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
     }
 
     /// <summary>
+    /// If data is off to the screen to the bottom, 
+    /// returns information about the closest point off the screen
+    /// </summary>
+    private (Pixel[] pointBefore, int firstIndex) GetFirstPointY(IAxes axes)
+    {
+        if (Xs.Length == 1)
+            return ([], MinimumIndex);
+
+        var (firstPointIndex, _) = SearchIndex(axes.YAxis.Range.Span > 0 ? axes.YAxis.Min : axes.YAxis.Max); // if axis is reversed first index will on the top limit of the plot
+
+        if (firstPointIndex > MinimumIndex)
+        {
+            double x = NumericConversion.GenericToDouble(Xs, firstPointIndex - 1) + XOffset;
+            double y = NumericConversion.GenericToDouble(Ys, firstPointIndex - 1) * YScale + YOffset;
+            float beforeX = axes.GetPixelX(y);
+            float beforeY = axes.GetPixelY(x);
+            Pixel beforePoint = new(beforeX, beforeY);
+            return ([beforePoint], firstPointIndex);
+        }
+        else
+        {
+            return ([], MinimumIndex);
+        }
+    }
+
+    /// <summary>
     /// If data is off to the screen to the right, 
     /// returns information about the closest point off the screen
     /// </summary>
-    private (Pixel[] pointsAfter, int lastIndex) GetLastPoint(IAxes axes)
+    private (Pixel[] pointAfter, int lastIndex) GetLastPointX(IAxes axes)
     {
-        var (lastPointPosition, lastPointIndex) = SearchIndex(axes.XAxis.Range.Span > 0 ? axes.XAxis.Max : axes.XAxis.Min); // if axis is reversed last index will on the left limit of the plot
+        if (Xs.Length == 1)
+            return ([], MaximumIndex);
 
-        if (lastPointPosition <= MaximumIndex)
+        var (lastPointIndex, _) = SearchIndex(axes.XAxis.Range.Span > 0 ? axes.XAxis.Max : axes.XAxis.Min); // if axis is reversed last index will on the left limit of the plot
+
+        if (lastPointIndex <= MaximumIndex)
         {
             double x = NumericConversion.GenericToDouble(Xs, lastPointIndex) + XOffset;
             double y = NumericConversion.GenericToDouble(Ys, lastPointIndex) * YScale + YOffset;
             float afterX = axes.GetPixelX(x);
             float afterY = axes.GetPixelY(y);
             Pixel afterPoint = new(afterX, afterY);
-            return ([afterPoint], lastPointIndex);
+            return ([afterPoint], lastPointIndex - 1);
+        }
+        else
+        {
+            return ([], MaximumIndex);
+        }
+    }
+
+    /// <summary>
+    /// If data is off to the screen to the top, 
+    /// returns information about the closest point off the screen
+    /// </summary>
+    private (Pixel[] pointAfter, int lastIndex) GetLastPointY(IAxes axes)
+    {
+        if (Xs.Length == 1)
+            return ([], MaximumIndex);
+
+        var (lastPointIndex, _) = SearchIndex(axes.YAxis.Range.Span > 0 ? axes.YAxis.Max : axes.YAxis.Min); // if axis is reversed last index will on the bottom limit of the plot
+
+        if (lastPointIndex <= MaximumIndex)
+        {
+            double x = NumericConversion.GenericToDouble(Xs, lastPointIndex) + XOffset;
+            double y = NumericConversion.GenericToDouble(Ys, lastPointIndex) * YScale + YOffset;
+            float afterX = axes.GetPixelX(y);
+            float afterY = axes.GetPixelY(x);
+            Pixel afterPoint = new(afterX, afterY);
+            return ([afterPoint], lastPointIndex - 1);
         }
         else
         {
@@ -248,15 +407,25 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
 
         for (int i = 0; i < Xs.Length; i++)
         {
-            double dX = (NumericConversion.GenericToDouble(Xs, i) + XOffset - mouseLocation.X) * renderInfo.PxPerUnitX;
-            double dY = (NumericConversion.GenericToDouble(Ys, i) * YScale + YOffset - mouseLocation.Y) * renderInfo.PxPerUnitY;
+            double dX = Rotated ?
+                 (NumericConversion.GenericToDouble(Ys, i) * YScale + YOffset - mouseLocation.X) * renderInfo.PxPerUnitX :
+                 (NumericConversion.GenericToDouble(Xs, i) + XOffset - mouseLocation.X) * renderInfo.PxPerUnitX;
+            double dY = Rotated ?
+                (NumericConversion.GenericToDouble(Xs, i) + XOffset - mouseLocation.Y) * renderInfo.PxPerUnitY :
+                (NumericConversion.GenericToDouble(Ys, i) * YScale + YOffset - mouseLocation.Y) * renderInfo.PxPerUnitY;
             double distanceSquared = dX * dX + dY * dY;
 
             if (distanceSquared <= closestDistanceSquared)
             {
                 closestDistanceSquared = distanceSquared;
-                closestX = NumericConversion.GenericToDouble(Xs, i) + XOffset;
-                closestY = NumericConversion.GenericToDouble(Ys, i) * YScale + YOffset;
+
+                closestX = Rotated ?
+                    NumericConversion.GenericToDouble(Ys, i) * YScale + YOffset :
+                    NumericConversion.GenericToDouble(Xs, i) + XOffset;
+                closestY = Rotated ?
+                    NumericConversion.GenericToDouble(Xs, i) + XOffset :
+                    NumericConversion.GenericToDouble(Ys, i) * YScale + YOffset;
+
                 closestIndex = i;
             }
         }
@@ -268,12 +437,18 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
 
     public DataPoint GetNearestX(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
     {
-        int i = GetIndexX(mouseLocation.X); // TODO: check the index after too?
+        var MousePosition = Rotated ? mouseLocation.Y : mouseLocation.X;
+        int i = GetIndex(MousePosition); // TODO: check the index after too?
+        var PxPerPositionUnit = Rotated ? renderInfo.PxPerUnitY : renderInfo.PxPerUnitX;
         double x = NumericConversion.GenericToDouble(Xs, i);
         double y = NumericConversion.GenericToDouble(Ys, i);
-        double distance = (x + XOffset - mouseLocation.X) * renderInfo.PxPerUnitX;
+        double distance = (x + XOffset - MousePosition) * PxPerPositionUnit;
+
+        var closestX = Rotated ? y * YScale + YOffset : x + XOffset;
+        var closestY = Rotated ? x + XOffset : y * YScale + YOffset;
+
         return Math.Abs(distance) <= maxDistance
-            ? new DataPoint(x, y, i)
+            ? new DataPoint(closestX, closestY, i)
             : DataPoint.None;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Interfaces/ISignalXYSource.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/ISignalXYSource.cs
@@ -23,6 +23,11 @@ public interface ISignalXYSource
     public double YScale { get; set; }
 
     /// <summary>
+    /// Multiply X values by this scale factor (before applying offset)
+    /// </summary>
+    public double XScale { get; set; }
+
+    /// <summary>
     /// Do not display data below this index
     /// </summary>
     public int MinimumIndex { get; set; }


### PR DESCRIPTION
This PR resolves some minor and some major rendering artefacts that were occurrign in Rotated SignalXY plots.
This incorporates changes made in a prevfious PR (#4102 ) that also attempted to refactor the plottable type to remove confusion between X and Y data types and X and Y axis directions.

The main artefact was best illustrated when plotting a rotated signal on inverted axes

```cs
        var size = 500;
        var cycles = 1;
        double[] xs = Generate.Consecutive(size);
        double[] ys = Generate.Sin(count: xs.Length, oscillations: cycles);

        var sig1 = WpfPlot1.Plot.Add.SignalXY(xs, ys);
        sig1.Data.Rotated = true;
        WpfPlot1.Plot.Axes.InvertX();
        WpfPlot1.Plot.Axes.InvertY();

```

![RotatedSignalXY_InvertedBefore](https://github.com/user-attachments/assets/eb2da70b-df76-4e41-ba0d-28e0b91e1cfe)
After this PR the same code produces a smooth sinusoid:
![RotatedSignalXY_InvertedAfter](https://github.com/user-attachments/assets/2870ac6a-b9fe-4220-8a94-2a2ae464e2c2)

The other artefacts demonstrated in #4102 are also resolved.

The PR also:
- implements Rotated plots in the generic data type variant of SIgnal XY
- Introduces an XOffset parameter (this is an offset along the uniform dimension of the  SignalXY).