### PR TITLE
Polar Axis: convert from an IPlottable to an IGrid

### DIFF
--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -535,6 +535,15 @@ public class AxisManager
     {
         ExpandingAxisLimits expandingLimits = new();
 
+        foreach (IGrid grid in Plot.Axes.AllGrids)
+        {
+            if (grid.XAxis != xAxis || grid.YAxis != yAxis ||
+                grid is not PolarAxis polar)
+                continue;
+
+            expandingLimits.Expand(polar.GetAxisLimits());
+        }
+
         foreach (IPlottable plottable in Plot.PlottableList)
         {
             if (plottable.Axes.XAxis != xAxis || plottable.Axes.YAxis != yAxis)

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -578,7 +578,7 @@ public class AxisManager
         ReplaceNullAxesWithDefaults();
         AutoScaler.InvertedX = invertX ?? AutoScaler.InvertedX;
         AutoScaler.InvertedY = invertY ?? AutoScaler.InvertedY;
-        AutoScaler.AutoScaleAll(Plot.PlottableList);
+        AutoScaler.AutoScaleAll(Plot.PlottableList, AllGrids);
     }
 
     /// <summary>

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -615,26 +615,6 @@ public class PlottableAdder(Plot plot)
         return plottable;
     }
 
-    public PolarAxis PolarAxis(double maximumRadius = 1, bool hideCartesianAxesAndGrids = true)
-    {
-        PolarAxis pol = new()
-        {
-            MaximumRadius = maximumRadius,
-        };
-
-        pol.RegenerateCircles();
-        pol.RegenerateSpokes();
-
-        Plot.PlottableList.Add(pol);
-
-        if (hideCartesianAxesAndGrids)
-        {
-            Plot.HideAxesAndGrid();
-        }
-
-        return pol;
-    }
-
     public Polygon Polygon(Coordinates[] coordinates)
     {
         Color color = GetNextColor();

--- a/src/ScottPlot5/ScottPlot5/Primitives/IAutoScaler.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/IAutoScaler.cs
@@ -16,7 +16,7 @@ public interface IAutoScaler
     /// <summary>
     /// Autoscale every unset axis used by plottables.
     /// </summary>
-    public void AutoScaleAll(IEnumerable<IPlottable> plottables);
+    public void AutoScaleAll(IEnumerable<IPlottable> plottables, IEnumerable<IGrid>? grids);
 
     // TODO: axis-specific autoscaling can be moved out of the control class and placed somewhere in here
 


### PR DESCRIPTION
resolve #4105

In this PR, I have adjusted certain interfaces to address the rendering area and zoom issues. However, I am not completely satisfied with these modifications, as they were made directly based on the needs of the Polar Axis without extensive consideration.

- [AxisManager: fixed PolarAxis rendering on wrong data limit](https://github.com/ScottPlot/ScottPlot/commit/de0fd11a91c99ea16a8a7ccfc807772ec2ce95b1)
- [AxisManager: fixed auto scale of PolarAxis](https://github.com/ScottPlot/ScottPlot/commit/31b6c8bd617d231325851ea1bb58d9737400a220)

The key issue lies in the Polar Axis, where the rendering restrictions do not necessarily align with the IPlottable interface. To achieve a more consistent and accurate rendering, it may be necessary for the IGrid interface to participate in the chart rendering or data range decision-making process, similar to the IPlottable interface.

## result image
![image](https://github.com/user-attachments/assets/ef85acf1-310d-4a10-964b-e366adedc5f3)
## sample code
```cs
ScottPlot.Plot myPlot = new();
myPlot.Axes.Rules.Add(new SquareZoomOut(
    myPlot.Axes.Bottom, myPlot.Axes.Left));
PolarAxis polarAxis = new(
    formsPlot1.Plot.Axes.DefaultGrid.XAxis,
    formsPlot1.Plot.Axes.DefaultGrid.YAxis)
{
    MaximumRadius = 30,
};
polarAxis.RegenerateCircles(count: 10);
polarAxis.RegenerateSpokes(count: 4);
myPlot.Axes.CustomGrids.Add(polarAxis);

var points = new PolarCoordinates[] {
    new(10, Angle.FromDegrees(15)),
    new(20, Angle.FromDegrees(120)),
    new(30, Angle.FromDegrees(240)),
};

IPalette palette = new ScottPlot.Palettes.Category10();
Coordinates center = polarAxis.GetCoordinates(0, 0);
for (int i = 0; i < points.Length; i++)
{
    Coordinates tip = polarAxis.GetCoordinates(points[i]);
    var arrow = myPlot.Add.Arrow(center, tip);
    arrow.ArrowLineWidth = 0;
    arrow.ArrowFillColor = palette.GetColor(i).WithAlpha(.7);
}
```