### PR TITLE
Signal: AlwaysUseLowDensityMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _Not yet on NuGet..._
 * Colormap: Added `Colormap.GetColormaps()` to allow iterating over all available colormaps
 * Colormap: Added `Colormap.GetImage()` to generate a gradient image using a given colormap
 * Coordinates: Added `Position` and `Coordinates` properties (#4185) @blouflashdb
+* Signal: Added `AlwaysUseLowDensityMode` for improved anti-aliased rendering in static plots (#4153)
 
 ## ScottPlot 5.0.37
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-07-29_

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -33,6 +33,14 @@ public class Signal(ISignalSource data) : IPlottable, IHasLine, IHasMarker, IHas
     /// </summary>
     public float MaximumMarkerSize { get; set; } = 4;
 
+    /// <summary>
+    /// Setting this flag causes lines to be drawn between every visible point
+    /// (similar to scatter plots) to improve anti-aliasing in static images.
+    /// Setting this will decrease performance for large datasets 
+    /// and is not recommended for interactive environments.
+    /// </summary>
+    public bool AlwaysUseLowDensityMode { get; set; } = false;
+
     public Color Color
     {
         get => LineColor;
@@ -70,7 +78,7 @@ public class Signal(ISignalSource data) : IPlottable, IHasLine, IHasMarker, IHas
             return;
         }
 
-        if (PointsPerPixel() < 1)
+        if (PointsPerPixel() < 1 || AlwaysUseLowDensityMode)
         {
             RenderLowDensity(rp);
         }


### PR DESCRIPTION
opt-in flag for improved anti-aliased rendering in static plots. Resolves #4153