### PR TITLE
Plot: SavedImageInfo.ToString()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _Not yet on NuGet..._
 * Colormap: Added `Colormap.GetImage()` to generate a gradient image using a given colormap
 * Coordinates: Added `Position` and `Coordinates` properties (#4185) @blouflashdb
 * Signal: Added `AlwaysUseLowDensityMode` for improved anti-aliased rendering in static plots (#4153)
+* Plot: Improved default `ToString()` implementation for the object returned when saving image files (#4154)
 
 ## ScottPlot 5.0.37
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-07-29_

--- a/src/ScottPlot5/ScottPlot5/Primitives/SavedImageInfo.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/SavedImageInfo.cs
@@ -1,16 +1,18 @@
 ﻿
 namespace ScottPlot;
 
-public class SavedImageInfo
+public class SavedImageInfo(string path, int fileSize)
 {
-    public string Path { get; }
-    public int FileSize { get; }
+    public string Path { get; } = System.IO.Path.GetFullPath(path);
+    public int FileSize { get; } = fileSize;
     private RenderDetails RenderDetails;
 
-    public SavedImageInfo(string path, int fileSize)
+    public override string ToString()
     {
-        Path = System.IO.Path.GetFullPath(path);
-        FileSize = fileSize;
+        return $"Saved Image " +
+            $"[{RenderDetails.FigureRect.Width}x{RenderDetails.FigureRect.Height}] " +
+            $"({FileSize * .001} kB) " +
+            $"{Path}";
     }
 
     public SavedImageInfo WithRenderDetails(RenderDetails renderDetails)


### PR DESCRIPTION
Plot: Improved default `ToString()` implementation for the object returned when saving image files. Resolves #4154.