### PR TITLE
Added Lollipop plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _Not yet on NuGet..._
 * Signal: Added `AlwaysUseLowDensityMode` for improved anti-aliased rendering in static plots (#4153)
 * Plot: Improved default `ToString()` implementation for the object returned when saving image files (#4154)
 * Coordinates: Added `Coordinates.Zip()` for creating a `Coordinates[]` from distinct `xs[]` and `ys[]` arrays.
-* Lollipop: New plot type that displays values with a stem and a marker similar to a bar graph but with less visual clutter (#4193) @CoderPM2011
+* Lollipop: New plot type that displays values with a stem and a marker similar to a bar graph but with less visual clutter (#4193, #4183) @CoderPM2011
 
 ## ScottPlot 5.0.37
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-07-29_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _Not yet on NuGet..._
 * Signal: Added `AlwaysUseLowDensityMode` for improved anti-aliased rendering in static plots (#4153)
 * Plot: Improved default `ToString()` implementation for the object returned when saving image files (#4154)
 * Coordinates: Added `Coordinates.Zip()` for creating a `Coordinates[]` from distinct `xs[]` and `ys[]` arrays.
+* Lollipop: New plot type that displays values with a stem and a marker similar to a bar graph but with less visual clutter (#4193) @CoderPM2011
 
 ## ScottPlot 5.0.37
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-07-29_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _Not yet on NuGet..._
 * Coordinates: Added `Position` and `Coordinates` properties (#4185) @blouflashdb
 * Signal: Added `AlwaysUseLowDensityMode` for improved anti-aliased rendering in static plots (#4153)
 * Plot: Improved default `ToString()` implementation for the object returned when saving image files (#4154)
+* Coordinates: Added `Coordinates.Zip()` for creating a `Coordinates[]` from distinct `xs[]` and `ys[]` arrays.
 
 ## ScottPlot 5.0.37
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-07-29_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
@@ -349,34 +349,4 @@ public class Bar : ICategory
             myPlot.Axes.Margins(bottom: 0, top: .3);
         }
     }
-
-    public class BarLollipop : RecipeBase
-    {
-        public override string Name => "Lollipop Plot Quickstart";
-        public override string Description => "Lollipop plots convey the same information as Bar plots but have a different appearance.";
-
-        [Test]
-        public override void Execute()
-        {
-            double[] values = { 26, 20, 23, 7, 16 };
-            myPlot.Add.Lollipop(values);
-        }
-    }
-
-    public class BarLollipopCustom : RecipeBase
-    {
-        public override string Name => "Lollipop Plot Customizations";
-        public override string Description => "Lollipop plots can be extensively customized.";
-
-        [Test]
-        public override void Execute()
-        {
-            double[] values = { 26, 20, 23, 7, 16 };
-            double[] positions = { 2, 6, 10, 16, 20 };
-            var lollipop = myPlot.Add.Lollipop(values, positions);
-            lollipop.Orientation = Orientation.Horizontal;
-            lollipop.MarkerColor = Colors.Red;
-            lollipop.MarkerSize = 10;
-        }
-    }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
@@ -349,4 +349,34 @@ public class Bar : ICategory
             myPlot.Axes.Margins(bottom: 0, top: .3);
         }
     }
+
+    public class BarLollipop : RecipeBase
+    {
+        public override string Name => "Lollipop Plot Quickstart";
+        public override string Description => "Lollipop plots convey the same information as Bar plots but have a different appearance.";
+
+        [Test]
+        public override void Execute()
+        {
+            double[] values = { 26, 20, 23, 7, 16 };
+            myPlot.Add.Lollipop(values);
+        }
+    }
+
+    public class BarLollipopCustom : RecipeBase
+    {
+        public override string Name => "Lollipop Plot Customizations";
+        public override string Description => "Lollipop plots can be extensively customized.";
+
+        [Test]
+        public override void Execute()
+        {
+            double[] values = { 26, 20, 23, 7, 16 };
+            double[] positions = { 2, 6, 10, 16, 20 };
+            var lollipop = myPlot.Add.Lollipop(values, positions);
+            lollipop.Orientation = Orientation.Horizontal;
+            lollipop.MarkerColor = Colors.Red;
+            lollipop.MarkerSize = 10;
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Lollipop.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Lollipop.cs
@@ -1,0 +1,76 @@
+﻿namespace ScottPlotCookbook.Recipes.PlotTypes;
+
+public class Lollipop : ICategory
+{
+    public string Chapter => "Plot Types";
+    public string CategoryName => "Lollipop Plot";
+    public string CategoryDescription => "A lollipop chart is a variation of a bar chart that uses a line (stem) " +
+        "extending from a baseline to a marker (head) to represent data points. " +
+        "Lollipop highlight individual data points with less visual clutter than to traditional bar charts.";
+
+    public class LollipopQuickStart : RecipeBase
+    {
+        public override string Name => "Lollipop Plot Quickstart";
+        public override string Description => "Lollipop plots can be created from a sequence of values";
+
+        [Test]
+        public override void Execute()
+        {
+            double[] values = Generate.Sin(25);
+            myPlot.Add.Lollipop(values);
+        }
+    }
+
+    public class LollipopPositions : RecipeBase
+    {
+        public override string Name => "Lollipop Positions";
+        public override string Description => "The position of each lollipop may be defined.";
+
+        [Test]
+        public override void Execute()
+        {
+            double[] xs = Generate.Range(0, 6.28, 0.314);
+            double[] ys = xs.Select(Math.Sin).ToArray();
+            var lollipop = myPlot.Add.Lollipop(ys, xs);
+        }
+    }
+
+    public class BarLollipopCustom : RecipeBase
+    {
+        public override string Name => "Lollipop Plot Customizations";
+        public override string Description => "The stem line and head marker can be extensively customized.";
+
+        [Test]
+        public override void Execute()
+        {
+            double[] values = Generate.Sin(21);
+            var lollipop = myPlot.Add.Lollipop(values);
+
+            lollipop.MarkerColor = Colors.Red;
+            lollipop.MarkerSize = 15;
+            lollipop.MarkerShape = MarkerShape.FilledDiamond;
+
+            lollipop.LineColor = Colors.Green;
+            lollipop.LineWidth = 3;
+            lollipop.LinePattern = LinePattern.Dotted;
+        }
+    }
+
+    public class LollipopHorizontal : RecipeBase
+    {
+        public override string Name => "Horizontal Lollipop Plot";
+        public override string Description => "Change the lollipop plot's Orientation to Horizontal " +
+            "to cause stems to be drawn horizontally instead of vertically.";
+
+        [Test]
+        public override void Execute()
+        {
+            double[] xs = Generate.Sin(21);
+            double[] ys = Generate.Consecutive(21);
+            Coordinates[] coordinates = Coordinates.Zip(xs, ys);
+
+            var lollipop = myPlot.Add.Lollipop(coordinates);
+            lollipop.Orientation = Orientation.Horizontal;
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -472,14 +472,21 @@ public class PlottableAdder(Plot plot)
         return Line(start, end);
     }
 
-    public LollipopPlot Lollipop(double[] values, double[]? positions = null, MarkerShape shape = MarkerShape.FilledCircle, float size = 5, Color? color = null)
+    public LollipopPlot Lollipop(double[] values)
     {
-        var plottable = new LollipopPlot(values, positions)
-        {
-            MarkerShape = shape,
-            MarkerSize = size,
-            Color = color ?? GetNextColor()
-        };
+        var coordinates = Enumerable.Range(0, values.Length).Select(x => new Coordinates(x, values[x]));
+        return Lollipop(coordinates);
+    }
+
+    public LollipopPlot Lollipop(double[] values, double[] positions)
+    {
+        Coordinates[] coordinates = Coordinates.Zip(positions, values);
+        return Lollipop(coordinates);
+    }
+
+    public LollipopPlot Lollipop(IEnumerable<Coordinates> coordinates)
+    {
+        LollipopPlot plottable = new(coordinates) { Color = GetNextColor() };
         Plot.PlottableList.Add(plottable);
         return plottable;
     }

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -1,7 +1,6 @@
 ﻿using ScottPlot.DataSources;
 using ScottPlot.Panels;
 using ScottPlot.Plottables;
-using System.Linq;
 
 namespace ScottPlot;
 
@@ -473,6 +472,17 @@ public class PlottableAdder(Plot plot)
         return Line(start, end);
     }
 
+    public LollipopPlot Lollipop(double[] values, double[]? positions = null, MarkerShape shape = MarkerShape.FilledCircle, float size = 10, Color? color = null)
+    {
+        var plottable = new LollipopPlot(values, positions)
+        {
+            MarkerShape = shape,
+            MarkerSize = size,
+            Color = color ?? GetNextColor()
+        };
+        Plot.PlottableList.Add(plottable);
+        return plottable;
+    }
 
     public Marker Marker(double x, double y, MarkerShape shape = MarkerShape.FilledCircle, float size = 10, Color? color = null)
     {

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -472,7 +472,7 @@ public class PlottableAdder(Plot plot)
         return Line(start, end);
     }
 
-    public LollipopPlot Lollipop(double[] values, double[]? positions = null, MarkerShape shape = MarkerShape.FilledCircle, float size = 10, Color? color = null)
+    public LollipopPlot Lollipop(double[] values, double[]? positions = null, MarkerShape shape = MarkerShape.FilledCircle, float size = 5, Color? color = null)
     {
         var plottable = new LollipopPlot(values, positions)
         {

--- a/src/ScottPlot5/ScottPlot5/Plottables/LollipopPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/LollipopPlot.cs
@@ -1,0 +1,81 @@
+﻿namespace ScottPlot.Plottables;
+
+public class LollipopPlot : IPlottable, IHasLine, IHasMarker
+{
+    public bool IsVisible { get; set; } = true;
+
+    public IAxes Axes { get; set; } = new Axes();
+
+    public string LegendText { get; set; } = string.Empty;
+
+    public IEnumerable<LegendItem> LegendItems => LegendItem.Single(LegendText, LineStyle, MarkerStyle);
+
+    public LineStyle LineStyle { get; set; } = new() { Width = 1 };
+    public float LineWidth { get => LineStyle.Width; set => LineStyle.Width = value; }
+    public LinePattern LinePattern { get => LineStyle.Pattern; set => LineStyle.Pattern = value; }
+    public Color LineColor { get => LineStyle.Color; set => LineStyle.Color = value; }
+
+    public MarkerStyle MarkerStyle { get; set; } = new() { Size = 0 };
+    public MarkerShape MarkerShape { get => MarkerStyle.Shape; set => MarkerStyle.Shape = value; }
+    public float MarkerSize { get => MarkerStyle.Size; set => MarkerStyle.Size = value; }
+    public Color MarkerFillColor { get => MarkerStyle.FillColor; set => MarkerStyle.FillColor = value; }
+    public Color MarkerLineColor { get => MarkerStyle.LineColor; set => MarkerStyle.LineColor = value; }
+    public Color MarkerColor { get => MarkerStyle.MarkerColor; set => MarkerStyle.MarkerColor = value; }
+    public float MarkerLineWidth { get => MarkerStyle.LineWidth; set => MarkerStyle.LineWidth = value; }
+
+    public Color Color
+    {
+        get => LineStyle.Color;
+        set
+        {
+            LineStyle.Color = value;
+            MarkerStyle.FillColor = value;
+        }
+    }
+
+    public double[] Data { get; }
+
+    public double[] Positions { get; }
+
+    public Orientation Orientation { get; set; } = Orientation.Vertical;
+
+    public LollipopPlot(IEnumerable<double> data, IEnumerable<double>? positions = null)
+    {
+        Data = data.ToArray();
+        Positions =
+            (positions ?? Enumerable.Range(0, Data.Length).Select(i => (double)i))
+            .ToArray();
+    }
+
+    public AxisLimits GetAxisLimits()
+    {
+        return Orientation == Orientation.Vertical
+            ? new AxisLimits(Positions.Min(), Positions.Max(), Data.Max(), 0)
+            : new AxisLimits(0, Data.Max(), Positions.Max(), Positions.Min());
+    }
+
+    public virtual void Render(RenderPack rp)
+    {
+        using SKPaint paint = new();
+        for (int i = 0; i < Data.Length; i++)
+        {
+            Coordinates Start;
+            Coordinates End;
+            if (Orientation == Orientation.Vertical)
+            {
+                Start = new(Positions[i], 0);
+                End = new(Positions[i], Data[i]);
+            }
+            else
+            {
+                Start = new(0, Positions[i]);
+                End = new(Data[i], Positions[i]);
+            }
+
+            PixelLine pxLine = Axes.GetPixelLine(new(Start, End));
+
+            Drawing.DrawLine(rp.Canvas, paint, pxLine, LineStyle);
+            Drawing.DrawMarker(rp.Canvas, paint, Axes.GetPixel(End), MarkerStyle);
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Primitives/Coordinates.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Coordinates.cs
@@ -10,10 +10,31 @@ public struct Coordinates : IEquatable<Coordinates>
 
     public bool AreReal => NumericConversion.IsReal(X) && NumericConversion.IsReal(Y);
 
+    /// <summary>
+    /// Define a new coordinate at the given X and Y location (in axis units)
+    /// </summary>
     public Coordinates(double x, double y)
     {
         X = x;
         Y = y;
+    }
+
+    /// <summary>
+    /// Create an array of coordinates from individual arrays of X and Y positions
+    /// </summary>
+    public static Coordinates[] Zip(double[] xs, double[] ys)
+    {
+        if (xs.Length != ys.Length)
+            throw new ArgumentException($"{nameof(xs)} and {nameof(ys)} must have equal length");
+
+        Coordinates[] cs = new Coordinates[xs.Length];
+
+        for (int i = 0; i < cs.Length; i++)
+        {
+            cs[i] = new Coordinates(xs[i], ys[i]);
+        }
+
+        return cs;
     }
 
     public double DistanceSquared(Coordinates pt)
@@ -39,7 +60,10 @@ public struct Coordinates : IEquatable<Coordinates>
 
     public static Coordinates Infinity => new(double.PositiveInfinity, double.PositiveInfinity);
 
-    public Coordinates Rotated => new(Y, X);
+    /// <summary>
+    /// The inverse of the present coordinate. E.g., the point (X, Y) becomes (Y, X).
+    /// </summary>
+    public readonly Coordinates Rotated => new(Y, X);
 
     public bool Equals(Coordinates other)
     {


### PR DESCRIPTION
resolve #4183

Copy the Lollipop Cookbook from scottplot 4 and adjust it slightly.

## sample
from my added cookbook - Lollipop Plot Customizations

### result image
![image](https://github.com/user-attachments/assets/3c13a759-ed94-4884-8e9a-8c4a7f327f74)

### sample code
```cs
double[] values = { 26, 20, 23, 7, 16 };
double[] positions = { 2, 4, 8, 10, 20 };
var lollipop = plt.Add.Lollipop(values, positions);
lollipop.Orientation = ScottPlot.Orientation.Horizontal;
lollipop.MarkerColor = ScottPlot.Colors.Red;
lollipop.MarkerSize = 10;
```