### PR TITLE
Pie: add `Rotation` property and improve label alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 _Not yet on NuGet..._
 * Angle: Added support for common arithmetic operators
 * PolarCoordinates: Added `FromCartesian()` and `FromCartesian()` overloads to facilitate conversion between polar and Cartesian space (#4211) @CoderPM2011
+* Pie: Added `Rotation` property (#4211) @CoderPM2011
 
 ## ScottPlot 5.0.38
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-09-02_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## ScottPlot 5.0.39
 _Not yet on NuGet..._
 * Angle: Added support for common arithmetic operators
+* PolarCoordinates: Added `FromCartesian()` and `FromCartesian()` overloads to facilitate conversion between polar and Cartesian space (#4211) @CoderPM2011
 
 ## ScottPlot 5.0.38
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-09-02_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ _Not yet on NuGet..._
 * PolarCoordinates: Added `FromCartesian()` and `FromCartesian()` overloads to facilitate conversion between polar and Cartesian space (#4211) @CoderPM2011
 * Pie: Added `Rotation` property (#4211) @CoderPM2011
 * Pie: Improved label alignment (#4211) @CoderPM2011
+* Pie: First slice now starts vertically (-90 degrees) instead of to the right (0 degrees) (#4211) @CoderPM2011
 
 ## ScottPlot 5.0.38
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-09-02_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## ScottPlot 5.0.39
 _Not yet on NuGet..._
+* Angle: Added support for common arithmetic operators
 
 ## ScottPlot 5.0.38
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-09-02_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ _Not yet on NuGet..._
 * Angle: Added support for common arithmetic operators
 * PolarCoordinates: Added `FromCartesian()` and `FromCartesian()` overloads to facilitate conversion between polar and Cartesian space (#4211) @CoderPM2011
 * Pie: Added `Rotation` property (#4211) @CoderPM2011
+* Pie: Improved label alignment (#4211) @CoderPM2011
 
 ## ScottPlot 5.0.38
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-09-02_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Pie.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Pie.cs
@@ -94,11 +94,12 @@ public class Pie : ICategory
         [Test]
         public override void Execute()
         {
-            PieSlice slice1 = new() { Value = 5, FillColor = Colors.Red, Label = "Red" };
-            PieSlice slice2 = new() { Value = 2, FillColor = Colors.Orange, Label = "Orange" };
-            PieSlice slice3 = new() { Value = 8, FillColor = Colors.Gold, Label = "Yellow" };
-            PieSlice slice4 = new() { Value = 4, FillColor = Colors.Green, Label = "Green" };
-            PieSlice slice5 = new() { Value = 8, FillColor = Colors.Blue, Label = "Blue" };
+            PieSlice slice1 = new() { Value = 5, FillColor = Colors.Red, Label = "alpha" };
+            PieSlice slice2 = new() { Value = 2, FillColor = Colors.Orange, Label = "beta" };
+            PieSlice slice3 = new() { Value = 8, FillColor = Colors.Gold, Label = "gamma" };
+            PieSlice slice4 = new() { Value = 4, FillColor = Colors.Green, Label = "delta" };
+            PieSlice slice5 = new() { Value = 8, FillColor = Colors.Blue, Label = "epsilon" };
+
             List<PieSlice> slices = new() { slice1, slice2, slice3, slice4, slice5 };
 
             // setup the pie to display slice labels
@@ -107,10 +108,13 @@ public class Pie : ICategory
             pie.ShowSliceLabels = true;
             pie.SliceLabelDistance = 1.3;
 
+            // color each label's text to match the slice
+            slices.ForEach(x => x.LabelFontColor = x.FillColor);
+
             // styling can be customized for individual slices
             slice5.LabelStyle.FontSize = 22;
-            slice5.LabelStyle.ForeColor = Colors.Magenta;
             slice5.LabelStyle.Bold = true;
+            slice5.LabelStyle.Italic = true;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Pie.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Pie.cs
@@ -69,6 +69,21 @@ public class Pie : ICategory
         }
     }
 
+    public class PieRotation : RecipeBase
+    {
+        public override string Name => "Pie Chart Rotation";
+        public override string Description => "Pie charts may be rotated to control where the first slice begins.";
+
+        [Test]
+        public override void Execute()
+        {
+            double[] values = { 5, 2, 8, 4, 8 };
+            var pie = myPlot.Add.Pie(values);
+            pie.ExplodeFraction = .1;
+            pie.Rotation = Angle.FromDegrees(90);
+        }
+    }
+
     public class PieSliceLabels : RecipeBase
     {
         public override string Name => "Pie Slice Labels";

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/PrimitiveTests/AngleTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/PrimitiveTests/AngleTests.cs
@@ -1,0 +1,58 @@
+﻿namespace ScottPlotTests.UnitTests.PrimitiveTests;
+
+public class AngleTests
+{
+    [Test]
+    public void Test_Angle_Equality()
+    {
+        Angle.FromDegrees(111).Should().BeEquivalentTo(Angle.FromDegrees(111));
+        Angle.FromDegrees(111).Should().NotBeEquivalentTo(Angle.FromDegrees(222));
+        Angle.FromRadians(1.11).Should().BeEquivalentTo(Angle.FromRadians(1.11));
+        Angle.FromRadians(1.11).Should().NotBeEquivalentTo(Angle.FromRadians(2.22));
+    }
+
+    [Test]
+    [TestCase([0, 0])]
+    [TestCase([90, Math.PI / 2])]
+    [TestCase([-90, -Math.PI / 2])]
+    [TestCase([180, Math.PI])]
+    [TestCase([-180, -Math.PI])]
+    [TestCase([360, Math.PI * 2])]
+    [TestCase([-360, -Math.PI * 2])]
+    public void Test_Angle_DegreesToRadians(double degrees, double radians)
+    {
+        Angle.FromDegrees(degrees).Should().BeEquivalentTo(Angle.FromRadians(radians));
+        Angle.FromRadians(radians).Should().BeEquivalentTo(Angle.FromDegrees(degrees));
+    }
+
+    [Test]
+    public void Test_Angle_Normalization()
+    {
+        Angle.FromDegrees(375).Normalized.Should().BeEquivalentTo(Angle.FromDegrees(15));
+    }
+
+    [Test]
+    public void Test_Angle_Multiply()
+    {
+        (Angle.FromDegrees(10) * 2).Should().BeEquivalentTo(Angle.FromDegrees(20));
+        (Angle.FromDegrees(-10) * 2).Should().BeEquivalentTo(Angle.FromDegrees(-20));
+        (Angle.FromDegrees(100) * 5).Should().BeEquivalentTo(Angle.FromDegrees(500));
+        (Angle.FromDegrees(-100) * 5).Should().BeEquivalentTo(Angle.FromDegrees(-500));
+    }
+
+    [Test]
+    public void Test_Angle_Divide()
+    {
+        (Angle.FromDegrees(20) / 2).Should().BeEquivalentTo(Angle.FromDegrees(10));
+        (Angle.FromDegrees(-20) / 2).Should().BeEquivalentTo(Angle.FromDegrees(-10));
+        (Angle.FromDegrees(500) / 5).Should().BeEquivalentTo(Angle.FromDegrees(100));
+        (Angle.FromDegrees(-500) / 5).Should().BeEquivalentTo(Angle.FromDegrees(-100));
+    }
+
+    [Test]
+    public void Test_Angle_Modulus()
+    {
+        (Angle.FromDegrees(100) % 90).Should().BeEquivalentTo(Angle.FromDegrees(10));
+        (Angle.FromDegrees(-100) % 90).Should().BeEquivalentTo(Angle.FromDegrees(-10));
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/Coxcomb.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Coxcomb.cs
@@ -24,6 +24,13 @@ public class Coxcomb : PieBase
     private double SliceTotal => Slices.Sum(s => s.Value);
     private float[] NormalizedSlices => Slices.Select(x => (float)(x.Value / SliceTotal)).ToArray();
 
+    private static SKPoint GetRotatedPoint(double radius, double angleInDegrees)
+    {
+        // WARNING: this returns pixel units but primitive types suggest coordinate units
+        Coordinates pt = new PolarCoordinates(radius, Angle.FromDegrees(angleInDegrees)).ToCartesian();
+        return new SKPoint((float)pt.X, (float)pt.Y);
+    }
+
     public override void Render(RenderPack rp)
     {
         float startAngle = (float)Rotation.Degrees;

--- a/src/ScottPlot5/ScottPlot5/Plottables/Coxcomb.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Coxcomb.cs
@@ -26,7 +26,7 @@ public class Coxcomb : PieBase
 
     public override void Render(RenderPack rp)
     {
-        const float startAngle = -90;
+        float startAngle = (float)Rotation.Degrees;
 
         var sliceSizes = NormalizedSlices;
         double maxRadius = NormalizedSlices.Max();

--- a/src/ScottPlot5/ScottPlot5/Plottables/Phasor.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Phasor.cs
@@ -59,7 +59,7 @@ public class Phasor : IPlottable, IHasArrow, IHasLegendText
         }
 
         IEnumerable<Coordinates> points = Points
-            .Select(i => i.CartesianCoordinates)
+            .Select(i => i.ToCartesian())
             .Concat([Coordinates.Origin]);
 
         return new AxisLimits(points);
@@ -80,7 +80,7 @@ public class Phasor : IPlottable, IHasArrow, IHasLegendText
         {
             PolarCoordinates point = Points[i];
 
-            Pixel pxTip = Axes.GetPixel(point.CartesianCoordinates);
+            Pixel pxTip = Axes.GetPixel(point.ToCartesian());
             PixelLine pxLine = new(pxBase, pxTip);
             if (ArrowOffset != 0)
             {
@@ -98,7 +98,7 @@ public class Phasor : IPlottable, IHasArrow, IHasLegendText
 
                 double padding = Math.Min(Axes.XAxis.Range.Span, Axes.YAxis.Range.Span) * PaddingFraction;
                 PolarCoordinates labelPoint = new(point.Radius + padding, angle);
-                Pixel labelPixel = Axes.GetPixel(labelPoint.CartesianCoordinates);
+                Pixel labelPixel = Axes.GetPixel(labelPoint.ToCartesian());
                 PixelRect labelRect = LabelStyle.Measure().Rect(Alignment.MiddleCenter);
                 Pixel labelOffset = labelRect.Center - labelRect.TopLeft;
                 labelPixel -= labelOffset;

--- a/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
@@ -55,6 +55,22 @@ public class Pie : PieBase
 
             if (sliceAngle.Degrees == 360)
             {
+                if (DonutFraction > 0)
+                {
+                    // Clip inner oval
+                    // avoid clipping to inner oval line
+                    float innerRadius2 = innerRadius - 1;
+                    path.AddOval(new SKRect(
+                        -innerRadius2, -innerRadius2, innerRadius2, innerRadius2));
+                    rp.Canvas.ClipPath(path, SKClipOperation.Difference);
+                    path.Reset();
+
+                    // Draw inner oval line
+                    path.AddOval(innerRect);
+                    LineStyle.ApplyToPaint(paint);
+                    rp.Canvas.DrawPath(path, paint);
+                }
+
                 path.AddOval(outerRect);
             }
             else

--- a/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
@@ -44,10 +44,9 @@ public class Pie : PieBase
             using SKAutoCanvasRestore _ = new(rp.Canvas);
 
             var sliceAngle = Angle.FromDegrees(slice.Value / totalValue * 360);
-            Angle centerDegrees = totalAngle + sliceAngle / 2;
+            Angle centerAngle = totalAngle + sliceAngle / 2;
 
-            var explosionOffset = Coordinates
-                .FromPolar((float)ExplodeFraction * outerRadius, centerDegrees);
+            Coordinates explosionOffset = new PolarCoordinates(ExplodeFraction * outerRadius, centerAngle).ToCartesian();
             rp.Canvas.Translate(
                 (float)(origin.X + explosionOffset.X),
                 (float)(origin.Y + explosionOffset.Y));
@@ -74,9 +73,9 @@ public class Pie : PieBase
             }
             else
             {
-                var ptInnerHome = Coordinates.FromPolar(innerRadius, totalAngle);
-                var ptOuterHome = Coordinates.FromPolar(outerRadius, totalAngle);
-                var ptInnerRotated = Coordinates.FromPolar(innerRadius, totalAngle + sliceAngle);
+                Coordinates ptInnerHome = new PolarCoordinates(innerRadius, totalAngle).ToCartesian();
+                Coordinates ptOuterHome = new PolarCoordinates(outerRadius, totalAngle).ToCartesian();
+                Coordinates ptInnerRotated = new PolarCoordinates(innerRadius, totalAngle + sliceAngle).ToCartesian();
 
                 path.MoveTo(new SKPoint((float)ptInnerHome.X, (float)ptInnerHome.Y));
                 path.LineTo(new SKPoint((float)ptOuterHome.X, (float)ptOuterHome.Y));
@@ -100,8 +99,7 @@ public class Pie : PieBase
 
             if (ShowSliceLabels)
             {
-                var polar = Coordinates
-                    .FromPolar(1.0 * SliceLabelDistance, centerDegrees);
+                Coordinates polar = new PolarCoordinates(1.0 * SliceLabelDistance, centerAngle).ToCartesian();
                 polar.Y = -polar.Y;
                 Pixel px = Axes.GetPixel(polar) - origin;
                 slice.LabelStyle.Render(rp.Canvas, px, paint);

--- a/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
@@ -17,13 +17,14 @@ public class Pie : PieBase
             : 1 + ExplodeFraction + Padding;
 
         return new AxisLimits(-radius, radius, -radius, radius);
-
     }
 
     public override void Render(RenderPack rp)
     {
         double total = Slices.Sum(s => s.Value);
-        float[] sliceSizeDegrees = Slices.Select(x => (float)(x.Value / total) * 360).ToArray();
+        Angle[] sliceSizeDegrees = Slices
+            .Select(x => Angle.FromDegrees(x.Value / total * 360))
+            .ToArray();
 
         Pixel origin = Axes.GetPixel(Coordinates.Origin);
 
@@ -44,14 +45,14 @@ public class Pie : PieBase
         using SKPath path = new();
         using SKPaint paint = new() { IsAntialias = true };
 
-        // TODO: first slice should be North, not East.        
-        float[] sliceOffsetDegrees = new float[Slices.Count];
+        // TODO: first slice should be North, not East.
+        var sliceOffsetDegrees = new Angle[Slices.Count];
         for (int i = 1; i < Slices.Count; i++)
         {
             sliceOffsetDegrees[i] = sliceOffsetDegrees[i - 1] + sliceSizeDegrees[i - 1];
         }
 
-        float[] sliceCenterDegrees = new float[Slices.Count];
+        var sliceCenterDegrees = new Angle[Slices.Count];
         for (int i = 0; i < Slices.Count; i++)
         {
             sliceCenterDegrees[i] = sliceOffsetDegrees[i] + sliceSizeDegrees[i] / 2;
@@ -61,26 +62,26 @@ public class Pie : PieBase
         {
             using SKAutoCanvasRestore _ = new(rp.Canvas);
 
-            float rotation = sliceOffsetDegrees[i] + sliceSizeDegrees[i] / 2;
+            Angle rotation = sliceOffsetDegrees[i] + sliceSizeDegrees[i] / 2;
             rp.Canvas.Translate(origin.X, origin.Y);
-            rp.Canvas.RotateDegrees(rotation);
+            rp.Canvas.RotateDegrees((float)rotation.Degrees);
             rp.Canvas.Translate(explosionOuterRadius, 0);
 
-            float degrees1 = -sliceSizeDegrees[i] / 2;
-            float degrees2 = sliceSizeDegrees[i] / 2;
+            double degrees1 = -sliceSizeDegrees[i].Degrees / 2;
+            double degrees2 = sliceSizeDegrees[i].Degrees / 2;
 
             SKPoint ptInnerHome = GetRotatedPoint(innerRadius, degrees1);
             SKPoint ptOuterHome = GetRotatedPoint(outerRadius, degrees1);
             SKPoint ptOuterRotated = GetRotatedPoint(outerRadius, degrees2);
             SKPoint ptInnerRotated = GetRotatedPoint(innerRadius, degrees2);
 
-            if (sliceSizeDegrees[i] != 360)
+            if (sliceSizeDegrees[i].Degrees != 360)
             {
                 path.MoveTo(ptInnerHome);
                 path.LineTo(ptOuterHome);
-                path.ArcTo(outerRect, -sliceSizeDegrees[i] / 2, sliceSizeDegrees[i], false);
+                path.ArcTo(outerRect, (float)-sliceSizeDegrees[i].Degrees / 2, (float)sliceSizeDegrees[i].Degrees, false);
                 path.LineTo(ptInnerRotated);
-                path.ArcTo(innerRect, sliceSizeDegrees[i] / 2, -sliceSizeDegrees[i], false);
+                path.ArcTo(innerRect, (float)sliceSizeDegrees[i].Degrees / 2, (float)-sliceSizeDegrees[i].Degrees, false);
                 path.Close();
             }
             else
@@ -89,7 +90,7 @@ public class Pie : PieBase
             }
 
             Slices[i].Fill.ApplyToPaint(paint, new PixelRect(origin, outerRadius));
-            paint.Shader = paint.Shader?.WithLocalMatrix(SKMatrix.CreateRotationDegrees(-rotation));
+            paint.Shader = paint.Shader?.WithLocalMatrix(SKMatrix.CreateRotationDegrees((float)-rotation.Degrees));
             rp.Canvas.DrawPath(path, paint);
 
             LineStyle.ApplyToPaint(paint);
@@ -102,8 +103,8 @@ public class Pie : PieBase
         {
             for (int i = 0; i < Slices.Count; i++)
             {
-                double x = Math.Cos(sliceCenterDegrees[i] * Math.PI / 180) * SliceLabelDistance;
-                double y = -Math.Sin(sliceCenterDegrees[i] * Math.PI / 180) * SliceLabelDistance;
+                double x = Math.Cos(sliceCenterDegrees[i].Radians) * SliceLabelDistance;
+                double y = -Math.Sin(sliceCenterDegrees[i].Radians) * SliceLabelDistance;
                 Pixel px = Axes.GetPixel(new Coordinates(x, y));
                 Slices[i].LabelStyle.Render(rp.Canvas, px, paint);
             }

--- a/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
@@ -37,9 +37,8 @@ public class Pie : PieBase
         float innerRadius = outerRadius * (float)DonutFraction;
         SKRect innerRect = new(-innerRadius, -innerRadius, innerRadius, innerRadius);
 
-        // TODO: first slice should be North, not East.
         double totalValue = Slices.Sum(s => s.Value);
-        var totalAngle = Angle.FromDegrees(0);
+        Angle totalAngle = Rotation;
         foreach (PieSlice slice in Slices)
         {
             using SKAutoCanvasRestore _ = new(rp.Canvas);

--- a/src/ScottPlot5/ScottPlot5/Plottables/PieBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/PieBase.cs
@@ -1,6 +1,6 @@
 ﻿namespace ScottPlot.Plottables;
 
-public abstract class PieBase : IPlottable, IHasLine
+public abstract class PieBase : IPlottable, IManagesAxisLimits, IHasLine
 {
     public IAxes Axes { get; set; } = new Axes();
     public bool IsVisible { get; set; } = true;
@@ -21,12 +21,32 @@ public abstract class PieBase : IPlottable, IHasLine
     public double SliceLabelDistance { get; set; } = 1.2;
     public IList<PieSlice> Slices { get; set; } = [];
 
+    /// <summary>
+    /// Enable this to modify the axis limits at render time to achieve "square axes"
+    /// where the units/px values are equal for horizontal and vertical axes, allowing
+    /// circles to always appear as circles instead of ellipses.
+    /// </summary>
+    public bool ManageAxisLimits { get; set; } = true;
+
     protected static SKPoint GetRotatedPoint(double radius, double angleInDegrees)
     {
         double angleInRadians = angleInDegrees * (Math.PI / 180);
         double x = radius * Math.Cos(angleInRadians);
         double y = radius * Math.Sin(angleInRadians);
         return new SKPoint((float)x, (float)y);
+    }
+
+    public virtual void UpdateAxisLimits(Plot plot)
+    {
+        if (plot.Axes.Rules
+                .OfType<AxisRules.SquareZoomOut>()
+                .Any())
+        {
+            return;
+        }
+
+        AxisRules.SquareZoomOut squareRule = new(Axes.XAxis, Axes.YAxis);
+        plot.Axes.Rules.Add(squareRule);
     }
 
     public abstract AxisLimits GetAxisLimits();

--- a/src/ScottPlot5/ScottPlot5/Plottables/PieBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/PieBase.cs
@@ -32,10 +32,8 @@ public abstract class PieBase : IPlottable, IManagesAxisLimits, IHasLine
 
     protected static SKPoint GetRotatedPoint(double radius, double angleInDegrees)
     {
-        double angleInRadians = angleInDegrees * (Math.PI / 180);
-        double x = radius * Math.Cos(angleInRadians);
-        double y = radius * Math.Sin(angleInRadians);
-        return new SKPoint((float)x, (float)y);
+        var polar = Coordinates.FromPolar(radius, Angle.FromDegrees(angleInDegrees));
+        return new SKPoint((float)polar.X, (float)polar.Y);
     }
 
     public virtual void UpdateAxisLimits(Plot plot)

--- a/src/ScottPlot5/ScottPlot5/Plottables/PieBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/PieBase.cs
@@ -30,12 +30,6 @@ public abstract class PieBase : IPlottable, IManagesAxisLimits, IHasLine
     /// </summary>
     public bool ManageAxisLimits { get; set; } = true;
 
-    protected static SKPoint GetRotatedPoint(double radius, double angleInDegrees)
-    {
-        var polar = Coordinates.FromPolar(radius, Angle.FromDegrees(angleInDegrees));
-        return new SKPoint((float)polar.X, (float)polar.Y);
-    }
-
     public virtual void UpdateAxisLimits(Plot plot)
     {
         if (plot.Axes.Rules

--- a/src/ScottPlot5/ScottPlot5/Plottables/PieBase.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/PieBase.cs
@@ -5,6 +5,8 @@ public abstract class PieBase : IPlottable, IManagesAxisLimits, IHasLine
     public IAxes Axes { get; set; } = new Axes();
     public bool IsVisible { get; set; } = true;
 
+    public Angle Rotation { get; set; } = Angle.FromDegrees(-90);
+
     public IEnumerable<LegendItem> LegendItems => Slices
         .Select((Func<PieSlice, LegendItem>)(slice => new LegendItem
         {

--- a/src/ScottPlot5/ScottPlot5/Plottables/PolarAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/PolarAxis.cs
@@ -214,7 +214,7 @@ public class PolarAxis : IPlottable, IManagesAxisLimits
         foreach (var spoke in Spokes)
         {
             PolarCoordinates tipPoint = new(spoke.Length, spoke.Angle);
-            Pixel tipPixel = Axes.GetPixel(tipPoint.CartesianCoordinates) - Axes.GetPixel(Coordinates.Origin);
+            Pixel tipPixel = Axes.GetPixel(tipPoint.ToCartesian()) - Axes.GetPixel(Coordinates.Origin);
             Drawing.DrawLine(rp.Canvas, paint, new Pixel(0, 0), tipPixel, spoke.LineStyle);
 
             spoke.LabelStyle.Text = spoke.LabelText ?? string.Empty;
@@ -222,7 +222,7 @@ public class PolarAxis : IPlottable, IManagesAxisLimits
             spoke.LabelStyle.Alignment = Alignment.MiddleCenter;
 
             PolarCoordinates labelPoint = new(spoke.LabelLength, tipPoint.Angle);
-            Pixel labelPixel = Axes.GetPixel(labelPoint.CartesianCoordinates) - Axes.GetPixel(Coordinates.Origin);
+            Pixel labelPixel = Axes.GetPixel(labelPoint.ToCartesian()) - Axes.GetPixel(Coordinates.Origin);
             spoke.LabelStyle.Render(rp.Canvas, labelPixel.WithOffset(0, 0), paint);
         }
     }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Angle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Angle.cs
@@ -54,4 +54,24 @@ public struct Angle
     {
         return FromDegrees(a.Degrees - b.Degrees);
     }
+
+    public static Angle operator *(Angle a, double b)
+    {
+        return FromDegrees(a.Degrees * b);
+    }
+
+    public static Angle operator *(double a, Angle b)
+    {
+        return FromDegrees(a * b.Degrees);
+    }
+
+    public static Angle operator /(Angle a, double b)
+    {
+        return FromDegrees(a.Degrees / b);
+    }
+
+    public static Angle operator %(Angle a, double b)
+    {
+        return FromDegrees(a.Degrees % b);
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Coordinates.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Coordinates.cs
@@ -110,42 +110,4 @@ public struct Coordinates : IEquatable<Coordinates>
     {
         return new(X + dX, Y + dY);
     }
-
-    #region Polar coordinate system
-
-    public static Coordinates FromPolar(
-        double distance, Angle angle, double originX = 0, double originY = 0)
-    {
-        return new(
-            distance * Math.Cos(angle.Radians) + originX,
-            distance * Math.Sin(angle.Radians) + originY);
-    }
-
-    public static Coordinates FromPolar(
-        double distance, Angle angle, Coordinates origin)
-    {
-        return FromPolar(distance, angle, origin.X, origin.Y);
-    }
-
-    public (double distance, Angle angle) ToPolar(
-        double originX = 0, double originY = 0)
-    {
-        return ToPolar(new(originX, originY));
-    }
-
-    public (double distance, Angle angle) ToPolar(Coordinates origin)
-    {
-        return new(
-            Distance(origin),
-            Angle.FromDegrees(Math.Atan2(Y - origin.Y, X - origin.X)));
-    }
-
-    public Coordinates WithPolarAngle(
-        Angle deltaAngle, double originX = 0, double originY = 0)
-    {
-        (double distance, Angle angle) = ToPolar(originX, originY);
-        return FromPolar(distance, angle + deltaAngle);
-    }
-
-    #endregion // Polar coordinate system
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Coordinates.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Coordinates.cs
@@ -110,4 +110,42 @@ public struct Coordinates : IEquatable<Coordinates>
     {
         return new(X + dX, Y + dY);
     }
+
+    #region Polar coordinate system
+
+    public static Coordinates FromPolar(
+        double distance, Angle angle, double originX = 0, double originY = 0)
+    {
+        return new(
+            distance * Math.Cos(angle.Radians) + originX,
+            distance * Math.Sin(angle.Radians) + originY);
+    }
+
+    public static Coordinates FromPolar(
+        double distance, Angle angle, Coordinates origin)
+    {
+        return FromPolar(distance, angle, origin.X, origin.Y);
+    }
+
+    public (double distance, Angle angle) ToPolar(
+        double originX = 0, double originY = 0)
+    {
+        return ToPolar(new(originX, originY));
+    }
+
+    public (double distance, Angle angle) ToPolar(Coordinates origin)
+    {
+        return new(
+            Distance(origin),
+            Angle.FromDegrees(Math.Atan2(Y - origin.Y, X - origin.X)));
+    }
+
+    public Coordinates WithPolarAngle(
+        Angle deltaAngle, double originX = 0, double originY = 0)
+    {
+        (double distance, Angle angle) = ToPolar(originX, originY);
+        return FromPolar(distance, angle + deltaAngle);
+    }
+
+    #endregion // Polar coordinate system
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/PolarCoordinates.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/PolarCoordinates.cs
@@ -6,21 +6,31 @@
 public struct PolarCoordinates(double radius, Angle angle)
 {
     public double Radius { get; set; } = radius;
-
     public Angle Angle { get; set; } = angle;
+
+    public PolarCoordinates WithRadius(double radius) => new(radius, Angle);
+    public PolarCoordinates WithAngle(Angle angle) => new(Radius, angle);
+    public PolarCoordinates WithAngleDegrees(double degrees) => new(Radius, Angle.FromDegrees(degrees));
+    public PolarCoordinates WithAngleRadians(double radians) => new(Radius, Angle.FromRadians(radians));
 
     public override readonly string ToString()
     {
         return $"PolarCoordinates {{ Radius = {Radius}, {Angle} }}";
     }
 
-    public Coordinates CartesianCoordinates
+    public Coordinates ToCartesian() => ToCartesian(Coordinates.Origin);
+    public Coordinates ToCartesian(Coordinates origin)
     {
-        get
-        {
-            return new Coordinates(
-                x: Radius * Math.Cos(Angle.Radians),
-                y: Radius * Math.Sin(Angle.Radians));
-        }
+        double x = Radius * Math.Cos(Angle.Radians) + origin.X;
+        double y = Radius * Math.Sin(Angle.Radians) + origin.Y;
+        return new(x, y);
+    }
+
+    public static PolarCoordinates FromCartesian(Coordinates pt) => FromCartesian(pt, Coordinates.Origin);
+    public static PolarCoordinates FromCartesian(Coordinates pt, Coordinates origin)
+    {
+        double radius = pt.Distance(origin);
+        double degrees = Math.Atan2(pt.Y - origin.Y, pt.X - origin.X);
+        return new PolarCoordinates(radius, Angle.FromDegrees(degrees));
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/PolarCoordinates.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/PolarCoordinates.cs
@@ -18,6 +18,9 @@ public struct PolarCoordinates(double radius, Angle angle)
         return $"PolarCoordinates {{ Radius = {Radius}, {Angle} }}";
     }
 
+    [Obsolete("use ToCartesian()", true)]
+    public Coordinates CartesianCoordinates => ToCartesian();
+
     public Coordinates ToCartesian() => ToCartesian(Coordinates.Origin);
     public Coordinates ToCartesian(Coordinates origin)
     {


### PR DESCRIPTION
## Main changes
- 1277609b19de7c3a6e92b565ea98dc0e103ee6e8 PieBase: Add Rotation property
  resolve #3962
- 3fbb04e23544243d342d27b55d552cde60795159 PieBase: Apply AxisRules.SquareZoomOut 
  fix display label position
  resolve #4216
  ![image](https://github.com/user-attachments/assets/54bc7f15-bc4c-42f4-9cee-3217d6f247ea)
- 5804220ae9e528078d72c8d3f5ffa73035118d00 Pie: Fixed donut style with only one PieSlice
  ![image](https://github.com/user-attachments/assets/ed6a16fc-1a58-422a-ada4-5dd8dc4a1a95)

and some trivial changes.

## sample
### result image
![image](https://github.com/user-attachments/assets/b15dd2f3-1b9d-4e10-89cc-d0297bb7485f)

### sample code
```cs
PieSlice slice1 = new() { Value = 5, FillColor = Colors.Red, Label = "Red" };
PieSlice slice2 = new() { Value = 2, FillColor = Colors.Orange, Label = "Orange" };
PieSlice slice3 = new() { Value = 8, FillColor = Colors.Gold, Label = "Yellow" };
PieSlice slice4 = new() { Value = 4, FillColor = Colors.Green, Label = "Green" };
PieSlice slice5 = new() { Value = 8, FillColor = Colors.Blue, Label = "Blue" };
List<PieSlice> slices = new() { slice1, slice2, slice3, slice4, slice5 };

// setup the pie to display slice labels
ScottPlot.Plottables.Pie pie = myPlot.Add.Pie(slices);
pie.DonutFraction = .5;
pie.ExplodeFraction = .1;
pie.ShowSliceLabels = true;
pie.SliceLabelDistance = 1.3;

// styling can be customized for individual slices
slice5.LabelStyle.FontSize = 22;
slice5.LabelStyle.ForeColor = Colors.Magenta;
slice5.LabelStyle.Bold = true;
```