### PR TITLE
Axes: Add `ClipLabel` option to opt-in to axis label clipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _Not yet on NuGet..._
 * Pie: Improved label alignment (#4211) @CoderPM2011
 * Pie: First slice now starts vertically (-90 degrees) instead of to the right (0 degrees) (#4211) @CoderPM2011
 * Generate: Random seed uses `System.Random.Shared` on .NET platforms where it is available (#4217) @LeaFrock
+* Axes: Added `ClipLabel` option to prevent long labels from overlapping on very small plots (#4219) @drolevar
 
 ## ScottPlot 5.0.38
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-09-02_

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
@@ -16,6 +16,11 @@ public abstract class AxisBase : LabelStyleProperties
     public PixelPadding PaddingBetweenTickAndAxisLabels { get; set; } = new(5, 3);
     public PixelPadding PaddingOutsideAxisLabels { get; set; } = new(2, 2);
 
+    /// <summary>
+    /// Controls whether labels should be clipped to the boundaries of the data area
+    /// </summary>
+    public bool ClipLabel { get; set; } = false;
+
     public double Min
     {
         get => Range.Min;

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/XAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/XAxisBase.cs
@@ -96,7 +96,13 @@ public abstract class XAxisBase : AxisBase, IXAxis
         }
 
         LabelAlignment = Alignment.LowerCenter;
+        
+        rp.CanvasState.Save();
+        rp.CanvasState.Clip(panelRect);
+
         LabelStyle.Render(rp.Canvas, labelPoint, paint);
+        
+        rp.CanvasState.Restore();
 
         DrawTicks(rp, TickLabelStyle, panelRect, TickGenerator.Ticks, this, MajorTickStyle, MinorTickStyle);
         DrawFrame(rp, panelRect, Edge, FrameLineStyle);

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/XAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/XAxisBase.cs
@@ -96,12 +96,14 @@ public abstract class XAxisBase : AxisBase, IXAxis
         }
 
         LabelAlignment = Alignment.LowerCenter;
-        
+
         rp.CanvasState.Save();
-        rp.CanvasState.Clip(panelRect);
+
+        if (ClipLabel)
+            rp.CanvasState.Clip(panelRect);
 
         LabelStyle.Render(rp.Canvas, labelPoint, paint);
-        
+
         rp.CanvasState.Restore();
 
         DrawTicks(rp, TickLabelStyle, panelRect, TickGenerator.Ticks, this, MajorTickStyle, MinorTickStyle);

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
@@ -87,7 +87,9 @@ public abstract class YAxisBase : AxisBase, IYAxis
         LabelAlignment = Alignment.UpperCenter;
 
         rp.CanvasState.Save();
-        rp.CanvasState.Clip(panelRect);
+
+        if (ClipLabel)
+            rp.CanvasState.Clip(panelRect);
 
         LabelStyle.Render(rp.Canvas, labelPoint, paint);
 

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
@@ -85,7 +85,13 @@ public abstract class YAxisBase : AxisBase, IYAxis
 
         using SKPaint paint = new();
         LabelAlignment = Alignment.UpperCenter;
+
+        rp.CanvasState.Save();
+        rp.CanvasState.Clip(panelRect);
+
         LabelStyle.Render(rp.Canvas, labelPoint, paint);
+
+        rp.CanvasState.Restore();
 
         DrawTicks(rp, TickLabelStyle, panelRect, TickGenerator.Ticks, this, MajorTickStyle, MinorTickStyle);
         DrawFrame(rp, panelRect, Edge, FrameLineStyle);


### PR DESCRIPTION
It's similar to my PR about legends.

When axis titles are rather long, and the plot window is downsized, the titles start overlapping each other, which is not too esthetic. I have added clipping the titles to the axis panel rectangle, which solves the issue.

| Before | After |
| ------- | ----- |
| ![image](https://github.com/user-attachments/assets/eca9b592-8453-45d4-9c07-4fa4f47053df) | ![image](https://github.com/user-attachments/assets/c7c015de-8de0-4c46-b638-ba6ed2d74eb7) |

I understand, that on the example it's rather ugly both ways, but on bigger plots with longer axis names that makes a difference.

