### PR TITLE
Markers: add support for colormap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _Not yet on NuGet..._
 * Generate: Random seed uses `System.Random.Shared` on .NET platforms where it is available (#4217) @LeaFrock
 * Axes: Added `ClipLabel` option to prevent long labels from overlapping on very small plots (#4219) @drolevar
 * Plot: Improved performance when adding new plot objects by reducing complexity of color palette sampling (#4218) @0xfded @StendProg
+* Colormap: Added `GetColor()` overload to get color of an item in a collection with an option to sample from a range of the colormap
 
 ## ScottPlot 5.0.38
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-09-02_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ _Not yet on NuGet..._
 * Axes: Added `ClipLabel` option to prevent long labels from overlapping on very small plots (#4219) @drolevar
 * Plot: Improved performance when adding new plot objects by reducing complexity of color palette sampling (#4218) @0xfded @StendProg
 * Colormap: Added `GetColor()` overload to get color of an item in a collection with an option to sample from a range of the colormap
+* Markers: Added optional `Colormap` so marker colors can be sampled from a colormap instead of assigned manually (#4143)
 
 ## ScottPlot 5.0.38
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-09-02_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Marker.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Marker.cs
@@ -103,6 +103,22 @@ public class Marker : ICategory
         }
     }
 
+    public class MarkersColormap : RecipeBase
+    {
+        public override string Name => "Marker with Colormap";
+        public override string Description => "A colormap may be used to style a collection of markers";
+
+        [Test]
+        public override void Execute()
+        {
+            double[] xs = Generate.Consecutive(51);
+            double[] ys = Generate.Sin(51);
+
+            var markers = myPlot.Add.Markers(xs, ys);
+            markers.Colormap = new ScottPlot.Colormaps.Turbo();
+        }
+    }
+
     public class ImageMarkerQuickstart : RecipeBase
     {
         public override string Name => "Image Marker";

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.UnoPlatform/Sandbox.UnoPlatform.csproj
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.UnoPlatform/Sandbox.UnoPlatform.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\..\ScottPlot5 Controls\ScottPlot.WinUI\ScottPlot.WinUI.csproj" />
+        <ProjectReference Include="..\..\ScottPlot5 Controls\ScottPlot.WinUI\ScottPlot.WinUI.csproj" />
         <PackageReference Include="System.Text.Json" Version="8.0.4" />
     </ItemGroup>
 

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -304,6 +304,21 @@ public static class Drawing
         }
     }
 
+    public static void DrawMarkers(SKCanvas canvas, SKPaint paint, IReadOnlyList<Pixel> pixels, MarkerStyle style, IColormap colormap)
+    {
+        if (!style.IsVisible)
+            return;
+
+        IMarker marker = style.CustomRenderer ?? style.Shape.GetMarker();
+
+        for (int i = 0; i < pixels.Count; i++)
+        {
+            Pixel pixel = pixels[i];
+            style.MarkerColor = colormap.GetColor(i, pixels.Count);
+            marker.Render(canvas, paint, pixel, style.Size, style);
+        }
+    }
+
     public static SKBitmap BitmapFromArgbs(uint[] argbs, int width, int height)
     {
         GCHandle handle = GCHandle.Alloc(argbs, GCHandleType.Pinned);

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IColormap.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IColormap.cs
@@ -78,4 +78,21 @@ public static class IColormapExtensions
             .Select(i => colormap.GetColor(i * fractionStep + minFraction))
             .ToArray();
     }
+
+    /// <summary>
+    /// Return the color for an item at index <paramref name="index"/> of a collection of size <paramref name="count"/>.
+    /// The <paramref name="startFraction"/> and <paramref name="endFraction"/> may be customized to restrict sampling to a portion of the colormap.
+    /// </summary>
+    public static Color GetColor(this IColormap cmap, int index, int count, double startFraction = 0, double endFraction = 1)
+    {
+        if (count == 1)
+            return cmap.GetColor(.5);
+
+        double fraction = (double)index / (count - 1);
+
+        double fractionRange = endFraction - startFraction;
+        fraction = fraction * fractionRange + startFraction;
+
+        return cmap.GetColor(fraction);
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/Markers.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Markers.cs
@@ -28,6 +28,8 @@ public class Markers(IScatterSource data) : IPlottable, IHasMarker, IHasLegendTe
         }
     }
 
+    public IColormap? Colormap { get; set; } = null;
+
     public AxisLimits GetAxisLimits() => Data.GetLimits();
 
     public IEnumerable<LegendItem> LegendItems => LegendItem.Single(LegendText, MarkerStyle);
@@ -39,9 +41,17 @@ public class Markers(IScatterSource data) : IPlottable, IHasMarker, IHasLegendTe
         if (this.MarkerStyle == MarkerStyle.None || points.Count == 0)
             return;
 
-        IEnumerable<Pixel> markerPixels = Data.GetScatterPoints().Select(Axes.GetPixel);
+        Pixel[] markerPixels = Data.GetScatterPoints().Select(Axes.GetPixel).ToArray();
 
         using SKPaint paint = new();
-        Drawing.DrawMarkers(rp.Canvas, paint, markerPixels, MarkerStyle);
+
+        if (Colormap is not null)
+        {
+            Drawing.DrawMarkers(rp.Canvas, paint, markerPixels, MarkerStyle, Colormap);
+        }
+        else
+        {
+            Drawing.DrawMarkers(rp.Canvas, paint, markerPixels, MarkerStyle);
+        }
     }
 }


### PR DESCRIPTION
resolves #4143

```cs
var markers = myPlot.Add.Markers(xs, ys);
markers.Colormap = new ScottPlot.Colormaps.Turbo();
```

![image](https://github.com/user-attachments/assets/d8cbfcaa-6f84-426c-89e9-d46b88035a7c)
