### PR TITLE
Bring back Add method overloads to DataLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## ScottPlot 5.0.40
 _Not yet on NuGet..._
+* DataLogger: Added `Add()` overloads to be consistent the original DataLogger API (#4243, #4114) @drolevar @jpgarza93
 
 ## ScottPlot 5.0.39
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-08-02_

--- a/src/ScottPlot5/ScottPlot5/Plottables/DataLogger.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/DataLogger.cs
@@ -181,6 +181,31 @@ public class DataLogger : IPlottable, IManagesAxisLimits, IHasLine, IHasMarker, 
             Add(y);
         }
     }
+    
+    public void Add(double[] xs, double[] ys)
+    {
+        if (xs is null || ys is null)
+            throw new ArgumentException($"{nameof(xs)} and {nameof(ys)} must not be null");
+
+        if (xs.Length != ys.Length)
+            throw new ArgumentException($"{nameof(xs).Length} and {nameof(ys).Length} must have equal length");
+
+        for (int i = 0; i < xs.Length; i++)
+        {
+            Add(xs[i], ys[i]);
+        }
+    }
+
+    public void Add(Coordinates[] coordinates)
+    {
+        if (coordinates is null)
+            throw new ArgumentException($"{coordinates} must not be null");
+
+        for (int i = 0; i < coordinates.Length; i++)
+        {
+            Add(coordinates[i]);
+        }
+    }    
 
     public void UpdateAxisLimits(Plot plot)
     {


### PR DESCRIPTION
Due to the reimplementation of the DataLogger two of the Add overloads were dropped.
But as @jpgarza93 has mentioned in #4114, they can be useful. Bringing them back.