### PR TITLE
WPF: Implement `IMultiThreadedPlotControl` with demo

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WPF Demo/DemoWindows/MultiThreading.xaml
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WPF Demo/DemoWindows/MultiThreading.xaml
@@ -1,0 +1,29 @@
+﻿<Window x:Class="WPF_Demo.DemoWindows.MultiThreading"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:WPF_Demo.DemoWindows" xmlns:wpf="clr-namespace:ScottPlot.WPF;assembly=ScottPlot.WPF"
+        mc:Ignorable="d"
+        Title="MultiThreading" Height="450" Width="800">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition></RowDefinition>
+            <RowDefinition Height="auto"></RowDefinition>
+        </Grid.RowDefinitions>
+        <wpf:WpfPlot Grid.Row="0" Name="WpfPlot1" />
+        <StackPanel Grid.Row="1" Orientation="Horizontal">
+            <CheckBox
+                FontSize="18" 
+                Padding="5 0"
+                Margin="5"
+                VerticalContentAlignment="Center"
+                Content="Continuously Render"/>
+            <Button
+                FontSize="18" 
+                Padding="5 0"
+                Margin="5"
+                Content="Change Data"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WPF Demo/DemoWindows/MultiThreading.xaml.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WPF Demo/DemoWindows/MultiThreading.xaml.cs
@@ -1,0 +1,14 @@
+﻿using System.Windows;
+
+namespace WPF_Demo.DemoWindows;
+
+public partial class MultiThreading : Window, IDemoWindow
+{
+    public string DemoTitle => "WPF Multi-Threading";
+    public string Description => "Demonstrate how to safely change data while rendering asynchronously.";
+
+    public MultiThreading()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IMultiThreadedPlotControl.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IMultiThreadedPlotControl.cs
@@ -1,0 +1,31 @@
+﻿namespace ScottPlot;
+
+public interface IMultiThreadedPlotControl
+{
+    /// <summary>
+    /// Returns only when the plot is successfully locked and rendering has stopped.
+    /// </summary>
+    void Lock();
+
+    /// <summary>
+    /// Releases the plot lock and permits rendering again.
+    /// </summary>
+    void UnLock();
+
+    /// <summary>
+    /// Attempt to lock the plot and return whether a lock was achieved.
+    /// If true is returned, the plot is locked and rendering has stopped.
+    /// If false is returned, the plot was not successfully locked and rendering is permitted.
+    /// </summary>
+    bool TryLock();
+
+    /// <summary>
+    /// Returns whether true if the plot currently locked.
+    /// </summary>
+    void IsLocked();
+
+    /// <summary>
+    /// Returns whether true if the plot is locked by the calling thread.
+    /// </summary>
+    void IsEntered();
+}


### PR DESCRIPTION
This PR creates an `IMultiThreadedPlotControl` interface which may be implemented by controls that support asynchronous rendering. It provides methods to help users modify plot data while the plot is not actively rendering to avoid race conditions. Resolves #4174