### PR TITLE
Font.GetTypeface(): use caching to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## ScottPlot 5.0.40
 _Not yet on NuGet..._
 * DataLogger: Added `Add()` overloads to be consistent the original DataLogger API (#4243, #4114) @drolevar @jpgarza93
+* Fonts: Improve typeface caching to significantly improve Avalonia performance on Linux (#3439, #4250) @kebox7
 
 ## ScottPlot 5.0.39
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-08-02_

--- a/src/ScottPlot5/ScottPlot5/Fonts.cs
+++ b/src/ScottPlot5/ScottPlot5/Fonts.cs
@@ -1,6 +1,5 @@
 ﻿using ScottPlot.FontResolvers;
 using System.Collections.Concurrent;
-using System.Runtime.Serialization;
 
 namespace ScottPlot;
 
@@ -91,7 +90,9 @@ public static class Fonts
             }
         }
 
-        return SystemFontResolver.CreateDefaultTypeface();
+        SKTypeface defaultTypeface = SystemFontResolver.CreateDefaultTypeface();
+        TypefaceCache.TryAdd(typefaceCacheKey, defaultTypeface);
+        return defaultTypeface;
     }
 
     #region Font Detection


### PR DESCRIPTION
Fix #3439 