### PR TITLE
WIP. SignalXY.GetNearest() improvements

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/ShowValueUnderMouseSignalXY.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/ShowValueUnderMouseSignalXY.cs
@@ -21,8 +21,8 @@ public partial class ShowValueUnderMouseSignalXY : Form, IDemoWindow
     {
         InitializeComponent();
 
-        double[] xs = Generate.Consecutive(1000);
-        double[] ys = Generate.RandomWalk(1000);
+        double[] xs = Generate.Consecutive(10_000_000);
+        double[] ys = Generate.RandomWalk(10_000_000);
 
         double[] xs1 = Generate.Consecutive(2000);
         double[] ys1 = Generate.RandomWalk(2000);
@@ -31,6 +31,7 @@ public partial class ShowValueUnderMouseSignalXY : Form, IDemoWindow
         formsPlot1.Plot.Axes.AddTopAxis();
 
         MySignal = formsPlot1.Plot.Add.SignalXY(xs, ys);
+        MySignal.Data.Rotated = true;
 
         MySignalDifferentAxes = formsPlot1.Plot.Add.SignalXY(xs1, ys1);
         MySignalDifferentAxes.Axes.XAxis = formsPlot1.Plot.Axes.Top;

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalXYDrag.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/SignalXYDrag.cs
@@ -102,7 +102,7 @@ public partial class SignalXYDrag : Form, IDemoWindow
 
         foreach (SignalXY signal in plot.GetPlottables<SignalXY>().Reverse())
         {
-            DataPoint nearest = signal.Data.GetNearest(mouseLocation, plot.LastRender);
+            DataPoint nearest = signal.GetNearest(mouseLocation, plot.LastRender);
             if (nearest.IsReal)
             {
                 return (signal, nearest);

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace ScottPlot.DataSources;
+﻿namespace ScottPlot.DataSources;
 
 public class SignalXYSourceDoubleArray : ISignalXYSource
 {
@@ -393,7 +391,7 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
         return (SearchedPosition: index, LimitedIndex: index > indexRange.Max ? indexRange.Max : index);
     }
 
-    public DataPoint GetNearest(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
+    public DataPoint GetNearest(Coordinates mouseLocation, double PxPerUnitX, double PxPerUnitY, float maxDistance = 15)
     {
         double maxDistanceSquared = maxDistance * maxDistance;
         double closestDistanceSquared = double.PositiveInfinity;
@@ -405,11 +403,11 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
         for (int i = 0; i < Xs.Length; i++)
         {
             double dX = Rotated ?
-                 (Ys[i] * YScale + YOffset - mouseLocation.X) * renderInfo.PxPerUnitX :
-                 (Xs[i] * XScale + XOffset - mouseLocation.X) * renderInfo.PxPerUnitX;
+                 (Ys[i] * YScale + YOffset - mouseLocation.X) * PxPerUnitX :
+                 (Xs[i] * XScale + XOffset - mouseLocation.X) * PxPerUnitX;
             double dY = Rotated ?
-                (Xs[i] * XScale + XOffset - mouseLocation.Y) * renderInfo.PxPerUnitY :
-                (Ys[i] * YScale + YOffset - mouseLocation.Y) * renderInfo.PxPerUnitY;
+                (Xs[i] * XScale + XOffset - mouseLocation.Y) * PxPerUnitY :
+                (Ys[i] * YScale + YOffset - mouseLocation.Y) * PxPerUnitY;
 
             double distanceSquared = dX * dX + dY * dY;
 
@@ -433,11 +431,11 @@ public class SignalXYSourceDoubleArray : ISignalXYSource
             : DataPoint.None;
     }
 
-    public DataPoint GetNearestX(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
+    public DataPoint GetNearestX(Coordinates mouseLocation, double PxPerUnitX, double PxPerUnitY, float maxDistance = 15)
     {
         var MousePosition = Rotated ? mouseLocation.Y : mouseLocation.X;
         int i = GetIndex(MousePosition); // TODO: check the index after too?
-        var PxPerPositionUnit = Rotated ? renderInfo.PxPerUnitY : renderInfo.PxPerUnitX;
+        var PxPerPositionUnit = Rotated ? PxPerUnitY : PxPerUnitX;
 
         double distance = (Xs[i] * XScale + XOffset - MousePosition) * PxPerPositionUnit;
         var closestX = Rotated ? Ys[i] * YScale + YOffset : Xs[i] * XScale + XOffset;

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
@@ -397,7 +397,7 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
         return (SearchedPosition: index, LimitedIndex: index > indexRange.Max ? indexRange.Max : index);
     }
 
-    public DataPoint GetNearest(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
+    public DataPoint GetNearest(Coordinates mouseLocation, double PxPerUnitX, double PxPerUnitY, float maxDistance = 15)
     {
         double maxDistanceSquared = maxDistance * maxDistance;
         double closestDistanceSquared = double.PositiveInfinity;
@@ -409,11 +409,11 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
         for (int i = 0; i < Xs.Length; i++)
         {
             double dX = Rotated ?
-                 (NumericConversion.GenericToDouble(Ys, i) * YScale + YOffset - mouseLocation.X) * renderInfo.PxPerUnitX :
-                 (NumericConversion.GenericToDouble(Xs, i) * XScale + XOffset - mouseLocation.X) * renderInfo.PxPerUnitX;
+                 (NumericConversion.GenericToDouble(Ys, i) * YScale + YOffset - mouseLocation.X) * PxPerUnitX :
+                 (NumericConversion.GenericToDouble(Xs, i) * XScale + XOffset - mouseLocation.X) * PxPerUnitX;
             double dY = Rotated ?
-                (NumericConversion.GenericToDouble(Xs, i) * XScale + XOffset - mouseLocation.Y) * renderInfo.PxPerUnitY :
-                (NumericConversion.GenericToDouble(Ys, i) * YScale + YOffset - mouseLocation.Y) * renderInfo.PxPerUnitY;
+                (NumericConversion.GenericToDouble(Xs, i) * XScale + XOffset - mouseLocation.Y) * PxPerUnitY :
+                (NumericConversion.GenericToDouble(Ys, i) * YScale + YOffset - mouseLocation.Y) * PxPerUnitY;
             double distanceSquared = dX * dX + dY * dY;
 
             if (distanceSquared <= closestDistanceSquared)
@@ -436,11 +436,11 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource
             : DataPoint.None;
     }
 
-    public DataPoint GetNearestX(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
+    public DataPoint GetNearestX(Coordinates mouseLocation, double PxPerUnitX, double PxPerUnitY, float maxDistance = 15)
     {
         var MousePosition = Rotated ? mouseLocation.Y : mouseLocation.X;
         int i = GetIndex(MousePosition); // TODO: check the index after too?
-        var PxPerPositionUnit = Rotated ? renderInfo.PxPerUnitY : renderInfo.PxPerUnitX;
+        var PxPerPositionUnit = Rotated ? PxPerUnitY : PxPerUnitX;
         double x = NumericConversion.GenericToDouble(Xs, i);
         double y = NumericConversion.GenericToDouble(Ys, i);
         double distance = (x * XScale + XOffset - MousePosition) * PxPerPositionUnit;

--- a/src/ScottPlot5/ScottPlot5/Interfaces/ISignalXYSource.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/ISignalXYSource.cs
@@ -57,11 +57,11 @@ public interface ISignalXYSource
     /// Return the point nearest a specific location given the X/Y pixel scaling information from a previous render.
     /// Will return <see cref="DataPoint.None"/> if the nearest point is greater than <paramref name="maxDistance"/> pixels away.
     /// </summary>
-    DataPoint GetNearest(Coordinates location, RenderDetails renderInfo, float maxDistance = 15);
+    DataPoint GetNearest(Coordinates location, double PxPerUnitX, double PxPerUnitY, float maxDistance = 15);
 
     /// <summary>
     /// Return the point nearest a specific X location given the X/Y pixel scaling information from a previous render.
     /// Will return <see cref="DataPoint.None"/> if the nearest point is greater than <paramref name="maxDistance"/> pixels away.
     /// </summary>
-    DataPoint GetNearestX(Coordinates location, RenderDetails renderInfo, float maxDistance = 15);
+    DataPoint GetNearestX(Coordinates location, double PxPerUnitX, double PxPerUnitY, float maxDistance = 15);
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/SignalXY.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/SignalXY.cs
@@ -50,7 +50,10 @@ public class SignalXY(ISignalXYSource dataSource) : IPlottable, IHasLine, IHasMa
     public AxisLimits GetAxisLimits() => Data.GetAxisLimits();
 
     public DataPoint GetNearest(Coordinates location, RenderDetails renderInfo, float maxDistance = 15) =>
-        Data.GetNearest(location, renderInfo, maxDistance);
+        Data.GetNearest(location, renderInfo.GetPxPerUnitXForAxis(Axes.XAxis), renderInfo.GetPxPerUnitYForAxis(Axes.YAxis), maxDistance);
+
+    public DataPoint GetNearestX(Coordinates location, RenderDetails renderInfo, float maxDistance = 15) =>
+        Data.GetNearestX(location, renderInfo.GetPxPerUnitXForAxis(Axes.XAxis), renderInfo.GetPxPerUnitYForAxis(Axes.YAxis), maxDistance);
 
     public virtual void Render(RenderPack rp)
     {

--- a/src/ScottPlot5/ScottPlot5/Primitives/RenderDetails.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/RenderDetails.cs
@@ -80,6 +80,44 @@ public readonly struct RenderDetails
     public double UnitsPerPxX => AxisLimits.HorizontalSpan / DataRect.Width;
     public double UnitsPerPxY => AxisLimits.VerticalSpan / DataRect.Height;
 
+    public double GetPxPerUnitXForAxis(IAxis axis)
+    {
+        if (axis is null)
+            return PxPerUnitX;
+        if (AxisLimitsByAxis.TryGetValue(axis, out var range))
+            return DataRect.Width / range.Span;
+        throw new Exception($"Unknown axis {axis}");
+    }
+
+    public double GetPxPerUnitYForAxis(IAxis axis)
+    {
+        if (axis is null)
+            return PxPerUnitY;
+        if (AxisLimitsByAxis.TryGetValue(axis, out var range))
+            return DataRect.Height / range.Span;
+        throw new Exception($"Unknown axis {axis}");
+    }
+
+    public double GetUnitsPerPxXForAxis(IAxis axis)
+    {
+        if (axis is null)
+            return UnitsPerPxX;
+        if (AxisLimitsByAxis.TryGetValue(axis, out var range))
+            return range.Span / DataRect.Width;
+
+        throw new Exception($"Unknown axis {axis}");
+    }
+
+    public double GetUnitsPerPxYForAxis(IAxis axis)
+    {
+        if (axis is null)
+            return UnitsPerPxY;
+        if (AxisLimitsByAxis.TryGetValue(axis, out var range))
+            return range.Span / DataRect.Height;
+
+        throw new Exception($"Unknown axis {axis}");
+    }
+
     public RenderDetails(RenderPack rp, (string, TimeSpan)[] actionTimes, RenderDetails lastRender)
     {
         // TODO: extend actionTimes report individual plottables, axes, etc.


### PR DESCRIPTION
The relevance of this PR has been completely lost. PR #4270 brings all the changes implemented here.

1. Fix additional axes support for SignalXY.GetNearest() and SignalXY.GetNearestX()

Allows user to search for nearest points on `SignalXY` that use additional axes.

Added methods to `RenderDetails` to get current resolution of additional axes.

`ISignalXYSource` interface has been slightly modified. It doesn't need to know about RenderDetails because it doesn't know about axes used by Plottable. Therefore, it is passed the axis resolutions that are calculated in Plottable.

The ShowValueUnderMouseSignalXY Demo has been significantly modified to show how additional axes can be used. It was largely used for debugging purposes. So you can safely undo/modify according to your vision.

It's not hard to apply a similar fix to `ScatterSources`, but there are a lot of implementations out there and I'd rather wait for the current design to be approved.

2. The performance of the `SignalXY.GetNearest()` method has been significantly improved.

Instead of a complete search of all points, we start with the point closest to the X coordinate. Then we move to the left or right until the X distance exceeds maxDistance. At the same time, if we have found points matching the criterion (distance less than maxDistance), the threshold for stopping (maxDistance) is also updated (decreased).

In my tests, finding the nearest point for a 10 million signal stays within the interactive performance limits.

It is not difficult to think of examples when this algorithm degenerates into a complete search of all points, consuming large computations due to more complex checks. But as it seems to me, in most cases when maxDistance is small and the density of points per pixel is relatively small, this algorithm gives a significant performance gain.
