### PR TITLE
Resolve Issue 3807,  Add IGetNearest interface

### DIFF
--- a/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceCoordinatesArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceCoordinatesArray.cs
@@ -1,9 +1,11 @@
-﻿namespace ScottPlot.DataSources;
+﻿using ScottPlot.Interfaces;
+
+namespace ScottPlot.DataSources;
 
 /// <summary>
 /// This data source manages X/Y points as a collection of coordinates
 /// </summary>
-public class ScatterSourceCoordinatesArray(Coordinates[] coordinates) : IScatterSource
+public class ScatterSourceCoordinatesArray(Coordinates[] coordinates) : IScatterSource, IGetNearest
 {
     private readonly Coordinates[] Coordinates = coordinates;
 
@@ -68,10 +70,29 @@ public class ScatterSourceCoordinatesArray(Coordinates[] coordinates) : IScatter
 
     public DataPoint GetNearestX(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
     {
-        // TODO: Implement GetNearestX() in this DataSource
-        // Code can be copied from ScatterSourceDoubleArray.GetNearestX() and modified as needed
-        // Contributions are welcome!
-        // https://github.com/ScottPlot/ScottPlot/issues/3807
-        throw new NotImplementedException();
+        double closestDistance = double.PositiveInfinity;
+
+        int closestIndex = 0;
+        double closestX = double.PositiveInfinity;
+        double closestY = double.PositiveInfinity;
+
+        for (int i2 = 0; i2 < RenderIndexCount; i2++)
+        {
+            int i = MinRenderIndex + i2;
+            var coordinate = this.Coordinates[i];
+            double dX = Math.Abs(coordinate.X - mouseLocation.X) * renderInfo.PxPerUnitX;
+
+            if (dX <= closestDistance)
+            {
+                closestDistance = dX;
+                closestX = coordinate.X;
+                closestY = coordinate.Y;
+                closestIndex = i;
+            }
+        }
+
+        return closestDistance <= maxDistance
+            ? new DataPoint(closestX, closestY, closestIndex)
+            : DataPoint.None;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceCoordinatesList.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceCoordinatesList.cs
@@ -1,9 +1,11 @@
-﻿namespace ScottPlot.DataSources;
+﻿using ScottPlot.Interfaces;
+
+namespace ScottPlot.DataSources;
 
 /// <summary>
 /// This data source manages X/Y points as a collection of coordinates
 /// </summary>
-public class ScatterSourceCoordinatesList(List<Coordinates> coordinates) : IScatterSource
+public class ScatterSourceCoordinatesList(List<Coordinates> coordinates) : IScatterSource, IGetNearest
 {
     private readonly List<Coordinates> Coordinates = coordinates;
 
@@ -68,10 +70,29 @@ public class ScatterSourceCoordinatesList(List<Coordinates> coordinates) : IScat
 
     public DataPoint GetNearestX(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
     {
-        // TODO: Implement GetNearestX() in this DataSource
-        // Code can be copied from ScatterSourceDoubleArray.GetNearestX() and modified as needed
-        // Contributions are welcome!
-        // https://github.com/ScottPlot/ScottPlot/issues/3807
-        throw new NotImplementedException();
+        double closestDistance = double.PositiveInfinity;
+
+        int closestIndex = 0;
+        double closestX = double.PositiveInfinity;
+        double closestY = double.PositiveInfinity;
+
+        for (int i2 = 0; i2 < RenderIndexCount; i2++)
+        {
+            int i = MinRenderIndex + i2;
+            var coordinate = this.Coordinates[i];
+            double dX = Math.Abs(coordinate.X - mouseLocation.X) * renderInfo.PxPerUnitX;
+
+            if (dX <= closestDistance)
+            {
+                closestDistance = dX;
+                closestX = coordinate.X;
+                closestY = coordinate.Y;
+                closestIndex = i;
+            }
+        }
+
+        return closestDistance <= maxDistance
+            ? new DataPoint(closestX, closestY, closestIndex)
+            : DataPoint.None;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceDoubleArray.cs
@@ -1,9 +1,11 @@
-﻿namespace ScottPlot.DataSources;
+﻿using ScottPlot.Interfaces;
+
+namespace ScottPlot.DataSources;
 
 /// <summary>
 /// This data source manages X/Y points as separate X and Y collections
 /// </summary>
-public class ScatterSourceDoubleArray(double[] xs, double[] ys) : IScatterSource
+public class ScatterSourceDoubleArray(double[] xs, double[] ys) : IScatterSource, IGetNearest
 {
     private readonly double[] Xs = xs;
     private readonly double[] Ys = ys;

--- a/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceGenericArray.cs
@@ -1,9 +1,11 @@
-﻿namespace ScottPlot.DataSources;
+﻿using ScottPlot.Interfaces;
+
+namespace ScottPlot.DataSources;
 
 /// <summary>
 /// This data source manages X/Y points as separate X and Y collections
 /// </summary>
-public class ScatterSourceGenericArray<T1, T2>(T1[] xs, T2[] ys) : IScatterSource
+public class ScatterSourceGenericArray<T1, T2>(T1[] xs, T2[] ys) : IScatterSource, IGetNearest
 {
     private readonly T1[] Xs = xs;
     private readonly T2[] Ys = ys;
@@ -80,10 +82,32 @@ public class ScatterSourceGenericArray<T1, T2>(T1[] xs, T2[] ys) : IScatterSourc
 
     public DataPoint GetNearestX(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
     {
-        // TODO: Implement GetNearestX() in this DataSource
-        // Code can be copied from ScatterSourceDoubleArray.GetNearestX() and modified as needed
-        // Contributions are welcome!
-        // https://github.com/ScottPlot/ScottPlot/issues/3807
-        throw new NotImplementedException();
+        double closestDistance = double.PositiveInfinity;
+
+        int closestIndex = 0;
+        double closestX = double.PositiveInfinity;
+        double closestY = double.PositiveInfinity;
+
+        for (int i2 = 0; i2 < RenderIndexCount; i2++)
+        {
+            int i = MinRenderIndex + i2;
+
+            T1 xValue = Xs[i];
+            double xValueDouble = NumericConversion.GenericToDouble(ref xValue);
+            double dX = Math.Abs(xValueDouble - mouseLocation.X) * renderInfo.PxPerUnitX;
+
+            if (dX <= closestDistance)
+            {
+                T2 yValue = Ys[i];
+                closestDistance = dX;
+                closestX = xValueDouble;
+                closestY = NumericConversion.GenericToDouble(ref yValue);
+                closestIndex = i;
+            }
+        }
+
+        return closestDistance <= maxDistance
+            ? new DataPoint(closestX, closestY, closestIndex)
+            : DataPoint.None;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceGenericList.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceGenericList.cs
@@ -1,9 +1,11 @@
-﻿namespace ScottPlot.DataSources;
+﻿using ScottPlot.Interfaces;
+
+namespace ScottPlot.DataSources;
 
 /// <summary>
 /// This data source manages X/Y points as separate X and Y collections
 /// </summary>
-public class ScatterSourceGenericList<T1, T2>(List<T1> xs, List<T2> ys) : IScatterSource
+public class ScatterSourceGenericList<T1, T2>(List<T1> xs, List<T2> ys) : IScatterSource, IGetNearest
 {
     private readonly List<T1> Xs = xs;
     private readonly List<T2> Ys = ys;
@@ -80,10 +82,32 @@ public class ScatterSourceGenericList<T1, T2>(List<T1> xs, List<T2> ys) : IScatt
 
     public DataPoint GetNearestX(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
     {
-        // TODO: Implement GetNearestX() in this DataSource
-        // Code can be copied from ScatterSourceDoubleArray.GetNearestX() and modified as needed
-        // Contributions are welcome!
-        // https://github.com/ScottPlot/ScottPlot/issues/3807
-        throw new NotImplementedException();
+        double closestDistance = double.PositiveInfinity;
+
+        int closestIndex = 0;
+        double closestX = double.PositiveInfinity;
+        double closestY = double.PositiveInfinity;
+
+        for (int i2 = 0; i2 < RenderIndexCount; i2++)
+        {
+            int i = MinRenderIndex + i2;
+
+            T1 xValue = Xs[i];
+            double xValueDouble = NumericConversion.GenericToDouble(ref xValue);
+            double dX = Math.Abs(xValueDouble - mouseLocation.X) * renderInfo.PxPerUnitX;
+
+            if (dX <= closestDistance)
+            {
+                T2 yValue = Ys[i];
+                closestDistance = dX;
+                closestX = xValueDouble;
+                closestY = NumericConversion.GenericToDouble(ref yValue);
+                closestIndex = i;
+            }
+        }
+
+        return closestDistance <= maxDistance
+            ? new DataPoint(closestX, closestY, closestIndex)
+            : DataPoint.None;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceWithCachedLimits.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/ScatterSourceWithCachedLimits.cs
@@ -1,6 +1,6 @@
 ﻿namespace ScottPlot.DataSources;
 
-public class CacheScatterLimitsDecorator(IScatterSource source) : IScatterSource
+public class CacheScatterLimitsDecorator(IScatterSource source) : IScatterSource, IGetNearest
 {
     private readonly IScatterSource _source = source;
 
@@ -56,10 +56,6 @@ public class CacheScatterLimitsDecorator(IScatterSource source) : IScatterSource
 
     public DataPoint GetNearestX(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
     {
-        // TODO: Implement GetNearestX() in this DataSource
-        // Code can be copied from ScatterSourceDoubleArray.GetNearestX() and modified as needed
-        // Contributions are welcome!
-        // https://github.com/ScottPlot/ScottPlot/issues/3807
-        throw new NotImplementedException();
+        return _source.GetNearestX(mouseLocation, renderInfo, maxDistance);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/DataSources/VectorFieldDataSourceCoordinatesList.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/VectorFieldDataSourceCoordinatesList.cs
@@ -1,6 +1,8 @@
-﻿namespace ScottPlot.DataSources;
+﻿using ScottPlot.Interfaces;
 
-public class VectorFieldDataSourceCoordinatesList(IList<RootedCoordinateVector> rootedVectors) : IVectorFieldSource
+namespace ScottPlot.DataSources;
+
+public class VectorFieldDataSourceCoordinatesList(IList<RootedCoordinateVector> rootedVectors) : IVectorFieldSource, IGetNearest
 {
     private readonly IList<RootedCoordinateVector> RootedVectors = rootedVectors;
 
@@ -59,6 +61,34 @@ public class VectorFieldDataSourceCoordinatesList(IList<RootedCoordinateVector> 
         }
 
         return closestDistanceSquared <= maxDistanceSquared
+            ? new DataPoint(closestX, closestY, closestIndex)
+            : DataPoint.None;
+    }
+
+    public DataPoint GetNearestX(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
+    {
+        double closestDistance = double.PositiveInfinity;
+
+        int closestIndex = 0;
+        double closestX = double.PositiveInfinity;
+        double closestY = double.PositiveInfinity;
+
+        for (int i2 = 0; i2 < RenderIndexCount; i2++)
+        {
+            int i = MinRenderIndex + i2;
+            var coordinate = this.RootedVectors[i].Point;
+            double dX = Math.Abs(coordinate.X - mouseLocation.X) * renderInfo.PxPerUnitX;
+
+            if (dX <= closestDistance)
+            {
+                closestDistance = dX;
+                closestX = coordinate.X;
+                closestY = coordinate.Y;
+                closestIndex = i;
+            }
+        }
+
+        return closestDistance <= maxDistance
             ? new DataPoint(closestX, closestY, closestIndex)
             : DataPoint.None;
     }

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IGetNearest.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IGetNearest.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlot.Interfaces
+{
+    /// <summary>
+    /// This interface is used by plottables that can locate a <see cref="DataPoint"> within a specified range of a coordinate on the plot.
+    /// </summary>
+    public interface IGetNearest
+    {
+        /// <summary>
+        /// Return the point nearest a specific location given the X/Y pixel scaling information from a previous render.
+        /// Will return <see cref="DataPoint.None"/> if the nearest point is greater than <paramref name="maxDistance"/> pixels away.
+        /// </summary>
+        DataPoint GetNearest(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15);
+
+        /// <summary>
+        /// Return the point nearest a specific X location given the X/Y pixel scaling information from a previous render.
+        /// Will return <see cref="DataPoint.None"/> if the nearest point is greater than <paramref name="maxDistance"/> pixels away.
+        /// </summary>
+        DataPoint GetNearestX(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
@@ -1,9 +1,10 @@
-﻿using System.Data;
+﻿using ScottPlot.Interfaces;
+using System.Data;
 using System.Linq;
 
 namespace ScottPlot.Plottables;
 
-public class Scatter(IScatterSource data) : IPlottable, IHasLine, IHasMarker, IHasLegendText
+public class Scatter(IScatterSource data) : IPlottable, IHasLine, IHasMarker, IHasLegendText, IGetNearest
 {
     [Obsolete("use LegendText")]
     public string Label { get => LegendText; set => LegendText = value; }
@@ -296,4 +297,10 @@ public class Scatter(IScatterSource data) : IPlottable, IHasLine, IHasMarker, IH
 
         return pixelsStep;
     }
+
+    public DataPoint GetNearest(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
+        => Data.GetNearest(mouseLocation, renderInfo, maxDistance);
+
+    public DataPoint GetNearestX(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
+        => Data.GetNearestX(mouseLocation, renderInfo, maxDistance);
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/SignalXY.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/SignalXY.cs
@@ -1,6 +1,8 @@
-﻿namespace ScottPlot.Plottables;
+﻿using ScottPlot.Interfaces;
 
-public class SignalXY(ISignalXYSource dataSource) : IPlottable, IHasLine, IHasMarker, IHasLegendText
+namespace ScottPlot.Plottables;
+
+public class SignalXY(ISignalXYSource dataSource) : IPlottable, IHasLine, IHasMarker, IHasLegendText, IGetNearest
 {
     public ISignalXYSource Data { get; set; } = dataSource;
 
@@ -51,6 +53,9 @@ public class SignalXY(ISignalXYSource dataSource) : IPlottable, IHasLine, IHasMa
 
     public DataPoint GetNearest(Coordinates location, RenderDetails renderInfo, float maxDistance = 15) =>
         Data.GetNearest(location, renderInfo, maxDistance);
+
+    public DataPoint GetNearestX(Coordinates location, RenderDetails renderInfo, float maxDistance = 15)
+        => Data.GetNearestX(location, renderInfo, maxDistance);
 
     public virtual void Render(RenderPack rp)
     {


### PR DESCRIPTION
Use this space to describe what this pull request accomplishes. 

- Introduces the 'IGetNearest' interface for plottables that have the `GetNearest` and `GetNearestX` methods
- Applies the IGetNearest interface to all Scatter data sources, as well as SignalXY and VectorFieldDataSource
- Implement GetNearestX for all scatter data sources

Issue #3807 

Notes:
- When using Mouse-Over events to, for example create a tooltip that shows the values of a data point, you would use the GetNearest and GetNearestX methods to locate the datapoint. Unfortunately, there is no common interface for signal sources (such as scatter and signalxy), so I introduced an interface to handle that particular use-case.
