### PR TITLE
LinePattern: add support for custom patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ _Not yet on NuGet..._
 * DataLogger: Added `Add()` overloads to be consistent the original DataLogger API (#4243, #4114) @drolevar @jpgarza93
 * Fonts: Improve typeface caching to significantly improve Avalonia performance on Linux (#3439, #4250) @kebox7
 * Generate: Improved `RandomNumbers()` to include lower boundary as described in XML docs (#4251, #4252) @aespitia @LeaFrock @ArchieCoder
+* LinePattern: Added `Name` property and added support for custom patterns (#4275, #4289) @CoderPM2011
 
 ## ScottPlot 5.0.39
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-08-02_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
@@ -132,7 +132,20 @@ public class Styling : ICategory
         [Test]
         public override void Execute()
         {
-            LinePattern[] linePatterns = Enum.GetValues<LinePattern>().ToArray();
+            string[] patternNames = new string[] {
+                "Solid",
+                "Dashed",
+                "DenselyDashed",
+                "Dotted",
+                "Customization",
+            };
+            LinePattern[] linePatterns = new LinePattern[] {
+                LinePattern.Solid,
+                LinePattern.Dashed,
+                LinePattern.DenselyDashed,
+                LinePattern.Dotted,
+                new LinePattern(new float[] { 10, 3 }, 5)
+            };
 
             for (int i = 0; i < linePatterns.Length; i++)
             {
@@ -143,7 +156,7 @@ public class Styling : ICategory
                 line.LineWidth = 2;
                 line.Color = Colors.Black;
 
-                var txt = myPlot.Add.Text(pattern.ToString(), 1.1, -i);
+                var txt = myPlot.Add.Text(patternNames[i], 1.1, -i);
                 txt.LabelFontSize = 18;
                 txt.LabelBold = true;
                 txt.LabelFontColor = Colors.Black;

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Introduction/Styling.cs
@@ -132,31 +132,20 @@ public class Styling : ICategory
         [Test]
         public override void Execute()
         {
-            string[] patternNames = new string[] {
-                "Solid",
-                "Dashed",
-                "DenselyDashed",
-                "Dotted",
-                "Customization",
-            };
-            LinePattern[] linePatterns = new LinePattern[] {
-                LinePattern.Solid,
-                LinePattern.Dashed,
-                LinePattern.DenselyDashed,
-                LinePattern.Dotted,
-                new LinePattern(new float[] { 10, 3 }, 5)
-            };
+            List<LinePattern> patterns = [];
+            patterns.AddRange(LinePattern.GetAllPatterns());
+            patterns.Add(new([2, 2, 5, 10], 0, "Custom"));
 
-            for (int i = 0; i < linePatterns.Length; i++)
+            for (int i = 0; i < patterns.Count; i++)
             {
-                LinePattern pattern = linePatterns[i];
+                LinePattern pattern = patterns[i];
 
                 var line = myPlot.Add.Line(0, -i, 1, -i);
                 line.LinePattern = pattern;
                 line.LineWidth = 2;
                 line.Color = Colors.Black;
 
-                var txt = myPlot.Add.Text(patternNames[i], 1.1, -i);
+                var txt = myPlot.Add.Text(patterns[i].Name, 1.1, -i);
                 txt.LabelFontSize = 18;
                 txt.LabelBold = true;
                 txt.LabelFontColor = Colors.Black;

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Scatter.cs
@@ -152,26 +152,15 @@ public class Scatter : ICategory
         [Test]
         public override void Execute()
         {
-            string[] patternNames = new string[] {
-                "Solid",
-                "Dashed",
-                "DenselyDashed",
-                "Dotted",
-                "Customization",
-            };
-            LinePattern[] patterns = new LinePattern[] {
-                LinePattern.Solid,
-                LinePattern.Dashed,
-                LinePattern.DenselyDashed,
-                LinePattern.Dotted,
-                new LinePattern(new float[] { 10, 3 }, 5)
-            };
+            List<LinePattern> patterns = [];
+            patterns.AddRange(LinePattern.GetAllPatterns());
+            patterns.Add(new([2, 2, 5, 10], 0, "Custom"));
 
             ScottPlot.Palettes.ColorblindFriendly palette = new();
 
-            for (int i = 0; i < patterns.Length; i++)
+            for (int i = 0; i < patterns.Count; i++)
             {
-                double yOffset = patterns.Length - i;
+                double yOffset = patterns.Count - i;
                 double[] xs = Generate.Consecutive(51);
                 double[] ys = Generate.Sin(51, offset: yOffset);
 
@@ -181,7 +170,7 @@ public class Scatter : ICategory
                 sp.LinePattern = patterns[i];
                 sp.Color = palette.GetColor(i);
 
-                var txt = myPlot.Add.Text(patternNames[i], 51, yOffset);
+                var txt = myPlot.Add.Text(patterns[i].Name, 51, yOffset);
                 txt.LabelFontColor = sp.Color;
                 txt.LabelFontSize = 22;
                 txt.LabelBold = true;

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Scatter.cs
@@ -152,7 +152,21 @@ public class Scatter : ICategory
         [Test]
         public override void Execute()
         {
-            LinePattern[] patterns = Enum.GetValues<LinePattern>();
+            string[] patternNames = new string[] {
+                "Solid",
+                "Dashed",
+                "DenselyDashed",
+                "Dotted",
+                "Customization",
+            };
+            LinePattern[] patterns = new LinePattern[] {
+                LinePattern.Solid,
+                LinePattern.Dashed,
+                LinePattern.DenselyDashed,
+                LinePattern.Dotted,
+                new LinePattern(new float[] { 10, 3 }, 5)
+            };
+
             ScottPlot.Palettes.ColorblindFriendly palette = new();
 
             for (int i = 0; i < patterns.Length; i++)
@@ -167,7 +181,7 @@ public class Scatter : ICategory
                 sp.LinePattern = patterns[i];
                 sp.Color = palette.GetColor(i);
 
-                var txt = myPlot.Add.Text(patterns[i].ToString(), 51, yOffset);
+                var txt = myPlot.Add.Text(patternNames[i], 51, yOffset);
                 txt.LabelFontColor = sp.Color;
                 txt.LabelFontSize = 22;
                 txt.LabelBold = true;

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/PrimitiveTests/LinePatternTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/PrimitiveTests/LinePatternTests.cs
@@ -3,19 +3,25 @@
 public class LinePatternTests
 {
     [Test]
-    public void Test_EveryLinePattern_HasPathEffect()
+    public void Test_EveryLinePattern_CanBeRendered()
     {
-        LinePattern[] patterns = new LinePattern[] {
-            LinePattern.Solid,
-            LinePattern.Dashed,
-            LinePattern.DenselyDashed,
-            LinePattern.Dotted,
-            new LinePattern(new float[] { 10, 3 }, 5)
-        };
-        foreach (LinePattern pattern in patterns)
+        List<LinePattern> patterns = [];
+        patterns.AddRange(LinePattern.GetAllPatterns());
+        patterns.Add(new([2, 2, 5, 10], 0, "Custom"));
+
+        Plot plot = new();
+        for (int i = 0; i < patterns.Count; i++)
         {
-            Action act = () => pattern.GetPathEffect();
-            act.Should().NotThrow();
+            var line = plot.Add.Line(0, i - 1, 10, i);
+            line.LinePattern = patterns[i];
+            line.LineWidth = 2;
+            plot.Add.Text(patterns[i].Name, 10, i);
         }
+
+        plot.Axes.Frameless();
+        plot.HideGrid();
+        plot.Axes.SetLimitsX(-1, 15);
+
+        plot.SaveTestImage();
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/PrimitiveTests/LinePatternTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/PrimitiveTests/LinePatternTests.cs
@@ -5,7 +5,14 @@ public class LinePatternTests
     [Test]
     public void Test_EveryLinePattern_HasPathEffect()
     {
-        foreach (LinePattern pattern in Enum.GetValues<LinePattern>())
+        LinePattern[] patterns = new LinePattern[] {
+            LinePattern.Solid,
+            LinePattern.Dashed,
+            LinePattern.DenselyDashed,
+            LinePattern.Dotted,
+            new LinePattern(new float[] { 10, 3 }, 5)
+        };
+        foreach (LinePattern pattern in patterns)
         {
             Action act = () => pattern.GetPathEffect();
             act.Should().NotThrow();

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -45,7 +45,7 @@ public static class Drawing
         canvas.DrawLine(pt1.ToSKPoint(), pt2.ToSKPoint(), paint);
     }
 
-    public static void DrawLine(SKCanvas canvas, SKPaint paint, Pixel pt1, Pixel pt2, Color color, float width = 1, bool antiAlias = true, LinePattern pattern = LinePattern.Solid)
+    public static void DrawLine(SKCanvas canvas, SKPaint paint, Pixel pt1, Pixel pt2, Color color, float width = 1, bool antiAlias = true, LinePattern pattern = default)
     {
         if (width == 0)
             return;

--- a/src/ScottPlot5/ScottPlot5/Generate.cs
+++ b/src/ScottPlot5/ScottPlot5/Generate.cs
@@ -749,11 +749,7 @@ public static class Generate
 
     public static LinePattern RandomLinePattern()
     {
-        LinePattern[] linePatterns = Enum
-            .GetValues(typeof(LinePattern))
-            .Cast<LinePattern>()
-            .ToArray();
-
+        LinePattern[] linePatterns = LinePattern.GetAllPatterns();
         int i = RandomInteger(linePatterns.Length);
         return linePatterns[i];
     }

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -381,7 +381,7 @@ public class PlottableAdder(Plot plot)
         return heatmap;
     }
 
-    public HorizontalLine HorizontalLine(double y, float width = 2, Color? color = null, LinePattern pattern = LinePattern.Solid)
+    public HorizontalLine HorizontalLine(double y, float width = 2, Color? color = null, LinePattern pattern = default)
     {
         Color color2 = color ?? GetNextColor();
         HorizontalLine line = new()
@@ -1038,7 +1038,7 @@ public class PlottableAdder(Plot plot)
         return field;
     }
 
-    public VerticalLine VerticalLine(double x, float width = 2, Color? color = null, LinePattern pattern = LinePattern.Solid)
+    public VerticalLine VerticalLine(double x, float width = 2, Color? color = null, LinePattern pattern = default)
     {
         Color color2 = color ?? GetNextColor();
         VerticalLine line = new()

--- a/src/ScottPlot5/ScottPlot5/Primitives/LinePattern.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LinePattern.cs
@@ -3,27 +3,27 @@
 // NOTE: names are consistent with matplotlib linestyles
 // https://matplotlib.org/stable/gallery/lines_bars_and_markers/linestyles.html
 
-// TODO: add support for more line styles
+// TODO: add more preset LinePatterns
 
-public enum LinePattern
+public readonly struct LinePattern(float[] intervals, float phase)
 {
-    Solid,
-    Dashed,
-    DenselyDashed,
-    Dotted,
-}
+    // default(LinePattern) is actually "Solid"
+    public static LinePattern Solid { get; } = default;
+    public static LinePattern Dashed { get; } = new([10, 10], 0);
+    public static LinePattern DenselyDashed { get; } = new([6, 6], 0);
+    public static LinePattern Dotted { get; } = new([3, 5], 0);
 
-public static class LinePatternExtensions
-{
-    public static SKPathEffect? GetPathEffect(this LinePattern pattern)
+    public float[] Intervals { get; } = intervals;
+
+    public float Phase { get; } = phase;
+
+    // default(LinePattern) does not set _hasBeenSet to true.
+    private readonly bool _hasBeenSet = true;
+
+    public SKPathEffect? GetPathEffect()
     {
-        return pattern switch
-        {
-            LinePattern.Solid => null,
-            LinePattern.Dashed => SKPathEffect.CreateDash(new float[] { 10, 10 }, 0),
-            LinePattern.DenselyDashed => SKPathEffect.CreateDash(new float[] { 6, 6 }, 0),
-            LinePattern.Dotted => SKPathEffect.CreateDash(new float[] { 3, 5 }, 0),
-            _ => throw new NotImplementedException($"Line pattern '{pattern}' has no matching path effect"),
-        };
+        return !_hasBeenSet || Intervals is null
+            ? null
+            : SKPathEffect.CreateDash(Intervals, Phase);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/LinePattern.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LinePattern.cs
@@ -1,29 +1,36 @@
-﻿namespace ScottPlot;
+﻿using System.Reflection;
+
+namespace ScottPlot;
 
 // NOTE: names are consistent with matplotlib linestyles
 // https://matplotlib.org/stable/gallery/lines_bars_and_markers/linestyles.html
 
 // TODO: add more preset LinePatterns
 
-public readonly struct LinePattern(float[] intervals, float phase)
+public readonly struct LinePattern(float[] intervals, float phase, string name)
 {
-    // default(LinePattern) is actually "Solid"
-    public static LinePattern Solid { get; } = default;
-    public static LinePattern Dashed { get; } = new([10, 10], 0);
-    public static LinePattern DenselyDashed { get; } = new([6, 6], 0);
-    public static LinePattern Dotted { get; } = new([3, 5], 0);
+    public static LinePattern Solid { get; } = new([], 0, "Solid");
+    public static LinePattern Dashed { get; } = new([10, 10], 0, "Dashed");
+    public static LinePattern DenselyDashed { get; } = new([6, 6], 0, "DenselyDashed");
+    public static LinePattern Dotted { get; } = new([3, 5], 0, "Dotted");
 
     public float[] Intervals { get; } = intervals;
-
     public float Phase { get; } = phase;
+    public string Name { get; } = name;
 
-    // default(LinePattern) does not set _hasBeenSet to true.
-    private readonly bool _hasBeenSet = true;
-
-    public SKPathEffect? GetPathEffect()
+    public static LinePattern[] GetAllPatterns()
     {
-        return !_hasBeenSet || Intervals is null
-            ? null
+        return typeof(LinePattern)
+            .GetProperties()
+            .Select(property => property.GetValue(Solid))
+            .OfType<LinePattern>()
+            .ToArray();
+    }
+
+    public SKPathEffect GetPathEffect()
+    {
+        return Intervals is null
+            ? Solid.GetPathEffect()
             : SKPathEffect.CreateDash(Intervals, Phase);
     }
 }


### PR DESCRIPTION
Under the existing code, I cannot implement the following styles by myself.
![image](https://github.com/user-attachments/assets/785294e2-6b09-4bad-8753-12950d240422)

So I changed the `LinePattern` from an `enum` to a `readonly struct` to allow the user to set the desired style.

The API is the same as before, except for the method parameter defaults.
Since the method's parameter defaults need to be determined at compile time, I've switched to using `default` instead of `LinePattern.Solid`.

#### How it's done
When `struct` is assigned a value of `default`, the internal real-value type member is set to the default value, so I declared a private `bool` flag to detect if the object is generated by `default`.

#### References
1. linestyles
  https://matplotlib.org/stable/gallery/lines_bars_and_markers/linestyles.html
1. Default values ​​of struct
  https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/default-values .

---

The following is an sample I wrote based on the reference.
### result image
![image](https://github.com/user-attachments/assets/53c52236-3737-47ec-addc-0fa176936ed9)

### sample code
```cs
var plot = formsPlot1.Plot.Add.Line(-1, 0, 1, 0);
plot.LineWidth = 5;
plot.LinePattern = new LinePattern(new float[] { 10, 3 }, 5);
```