### PR TITLE
feat: Add CoordinateLine getter and setter for LinePlot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ _Not yet on NuGet..._
 * Generate: Improved `RandomNumbers()` to include lower boundary as described in XML docs (#4251, #4252) @aespitia @LeaFrock @ArchieCoder
 * LinePattern: Added `Name` property and added support for custom patterns (#4275, #4289) @CoderPM2011
 * DataSources: Created `IDataSource` to standardize and simplify data access, render index management, and pixel/coordinate conversion (#3807, #4270) @RFBomb @StendProg
+* LinePlot: Added `CoordinateLine` property (#4277, #4274) @aespitia
 
 ## ScottPlot 5.0.39
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-08-02_

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/Plottable/LinePlotTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/Plottable/LinePlotTests.cs
@@ -1,0 +1,23 @@
+﻿using ScottPlot.Plottables;
+
+namespace ScottPlotTests.RenderTests.Plottable;
+
+internal class LinePlotTests
+{
+    [Test]
+    public void Test_LinePlotGetSet()
+    {
+        Coordinates start = new Coordinates(0, 0);
+        Coordinates end = new Coordinates(5, 6);
+
+        LinePlot lp = new();
+
+        lp.Line = new CoordinateLine(start, end);
+
+        var newStart = lp.Line.Start;
+        var newEnd = lp.Line.End;
+
+        newStart.Should().Be(start);
+        newEnd.Should().Be(end);
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/Plottable/LinePlotTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/Plottable/LinePlotTests.cs
@@ -33,7 +33,7 @@ internal class LinePlotTests
         lp.End = end;
 
         var cl = new CoordinateLine(start, end);
-        
+
         cl.Should().Be(lp.Line);
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/Plottable/LinePlotTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/Plottable/LinePlotTests.cs
@@ -5,7 +5,7 @@ namespace ScottPlotTests.RenderTests.Plottable;
 internal class LinePlotTests
 {
     [Test]
-    public void Test_LinePlotGetSet()
+    public void Test_LinePlotSet()
     {
         Coordinates start = new Coordinates(0, 0);
         Coordinates end = new Coordinates(5, 6);
@@ -19,5 +19,21 @@ internal class LinePlotTests
 
         newStart.Should().Be(start);
         newEnd.Should().Be(end);
+    }
+
+    [Test]
+    public void Test_LinePlotGet()
+    {
+        Coordinates start = new Coordinates(0, 0);
+        Coordinates end = new Coordinates(5, 6);
+
+        LinePlot lp = new();
+
+        lp.Start = start;
+        lp.End = end;
+
+        var cl = new CoordinateLine(start, end);
+        
+        cl.Should().Be(lp.Line);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/LinePlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/LinePlot.cs
@@ -4,6 +4,18 @@ public class LinePlot : IPlottable, IHasLine, IHasMarker, IHasLegendText
 {
     public Coordinates Start { get; set; }
     public Coordinates End { get; set; }
+    public CoordinateLine Line
+    {
+        get
+        {
+            return new CoordinateLine(Start, End);
+        }
+        set
+        {
+            Start = value.Start;
+            End = value.End;
+        }
+    }
 
     public MarkerStyle MarkerStyle { get; set; } = new() { Size = 0 };
     public MarkerShape MarkerShape { get => MarkerStyle.Shape; set => MarkerStyle.Shape = value; }


### PR DESCRIPTION
Add CoordinateLine getter and setter for LinePlot

#4274

included unit tests
```cs
        Coordinates start = new Coordinates(0, 0);
        Coordinates end = new Coordinates(5, 6);

        LinePlot lp = new();

        lp.Line = new CoordinateLine(start, end);

        var newStart = lp.Line.Start;
        var newEnd = lp.Line.End;
```

Is this what you had in mind @swharden?