### PR TITLE
OpenGL Controls: add methods to save/restore GL state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _Not yet on NuGet..._
 * Pie: Slices now have distinct `Label` and `LegendText` properties (#3295, #4280) @LeaFrock @sterenas @Martin12350
 * SignalXY: Fixed bug introduced in the last version that caused off-screen data to throw an ascending value exception (#4261, #4286) @RFBomb @StendProg
 * Controls: Added strong naming by signing assemblies for the WPF, Maui, and Eto controls (#4295) @RFBomb
+* OpenGL: Improve behavior of plots when grid lines are rendered beneath plottables (#4298) @StendProg
 
 ## ScottPlot 5.0.39
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-08-02_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/Plottables/ScatterGL.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/Plottables/ScatterGL.cs
@@ -71,36 +71,28 @@ public class ScatterGL : Scatter, IPlottableGL
         return translate * scale;
     }
 
-    public new void Render(RenderPack rp)
-    {
-        System.Diagnostics.Debug.WriteLine("WARNING: Software rendering (not OpenGL) is being used");
-        base.Render(rp);
-    }
 
-    public void Render(SKSurface surface)
+    public override void Render(RenderPack rp)
     {
-        if (PlotControl.GRContext is not null && surface.Context is not null)
+        if (PlotControl.GRContext is not null)
         {
-            RenderWithOpenGL(surface, PlotControl.GRContext);
+            RenderWithOpenGL(rp.Canvas, PlotControl.GRContext);
             return;
         }
 
         if (Fallback == GLFallbackRenderStrategy.Software)
         {
-            surface.Canvas.ClipRect(Axes.DataRect.ToSKRect());
-            PixelSize figureSize = new(surface.Canvas.LocalClipBounds.Width, surface.Canvas.LocalClipBounds.Height);
+            rp.Canvas.ClipRect(Axes.DataRect.ToSKRect());
+            PixelSize figureSize = new(rp.Canvas.LocalClipBounds.Width, rp.Canvas.LocalClipBounds.Height);
             PixelRect rect = new(0, figureSize.Width, figureSize.Height, 0);
-            RenderPack rp = new(PlotControl.Plot, rect, surface.Canvas);
-            Render(rp);
+            RenderPack rp1 = new(PlotControl.Plot, rect, rp.Canvas);
+            base.Render(rp1);
         }
     }
 
-    protected virtual void RenderWithOpenGL(SKSurface surface, GRContext context)
+    protected virtual void RenderWithOpenGL(SKCanvas canvas, GRContext context)
     {
-        int height = (int)surface.Canvas.LocalClipBounds.Height;
-
-        context.Flush();
-        context.ResetContext();
+        int height = (int)canvas.LocalClipBounds.Height;
 
         if (!GLHasBeenInitialized)
             InitializeGL();
@@ -125,7 +117,7 @@ public class ScatterGL : Scatter, IPlottableGL
 
     protected void RenderMarkers()
     {
-        if (MarkerStyle.Shape == MarkerShape.None || MarkerStyle.Size == 0)
+        if (MarkerStyle.Shape == MarkerShape.None || MarkerStyle.Size == 0 || MarkerStyle.IsVisible == false)
             return;
 
         IMarkersDrawProgram? newProgram = MarkerStyle.Shape switch
@@ -158,4 +150,18 @@ public class ScatterGL : Scatter, IPlottableGL
     }
 
     public void GLFinish() => LinesProgram?.GLFinish();
+    public void StoreGLState()
+    {
+        if (PlotControl.GRContext is not null)
+            GL.PushAttrib(AttribMask.AllAttribBits);
+    }
+    public void RestoreGLState()
+    {
+        if (PlotControl.GRContext is not null)
+        {
+            PlotControl.GRContext.Flush();
+            PlotControl.GRContext.ResetContext();
+            GL.PopAttrib();
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/Plottables/ScatterGLCustom.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/Plottables/ScatterGLCustom.cs
@@ -25,9 +25,9 @@ public class ScatterGLCustom : ScatterGL
         JoinsProgram = new MarkerFillCircleProgram();
     }
 
-    protected override void RenderWithOpenGL(SKSurface surface, GRContext context)
+    protected override void RenderWithOpenGL(SKCanvas canvas, GRContext context)
     {
-        int height = (int)surface.Canvas.LocalClipBounds.Height;
+        int height = (int)canvas.LocalClipBounds.Height;
 
         context.Flush();
         context.ResetContext();

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/OpenGL.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/OpenGL.cs
@@ -15,6 +15,7 @@ public partial class OpenGL : Form, IDemoWindow
         cbDataType.Items.Add("Random Walk");
         cbDataType.Items.Add("Sine Wave");
         cbDataType.Items.Add("Random Values");
+        cbDataType.Items.Add("Random Walk Spiral");
         cbDataType.SelectedIndex = 0;
         cbDataType.SelectedIndexChanged += (s, e) => UpdatePlots();
 
@@ -22,12 +23,13 @@ public partial class OpenGL : Form, IDemoWindow
         cbPointCount.Items.Add("10k");
         cbPointCount.Items.Add("100k");
         cbPointCount.Items.Add("1M");
+        cbPointCount.Items.Add("10M");
         cbPointCount.SelectedIndex = 1;
         cbPointCount.SelectedIndexChanged += (s, e) => UpdatePlots();
 
         cbPlotType.Items.Add("Signal Plot");
         cbPlotType.Items.Add("Scatter Plot");
-        cbPlotType.SelectedIndex = 0;
+        cbPlotType.SelectedIndex = 1;
         cbPlotType.SelectedIndexChanged += (s, e) => UpdatePlots();
 
         formsPlot1.Plot.Title("FormsPlot");
@@ -44,13 +46,26 @@ public partial class OpenGL : Form, IDemoWindow
         string countString = cbPointCount.Text.Replace("k", "000").Replace("M", "000000");
         int count = int.Parse(countString);
 
-        double[] data = cbDataType.Text switch
+        double[] xs;
+        double[] data;
+        if (cbDataType.Text == "Random Walk Spiral")
         {
-            "Random Walk" => Generate.RandomWalk(count),
-            "Sine Wave" => Generate.Sin(count),
-            "Random Values" => Generate.RandomSample(count),
-            _ => throw new NotImplementedException(),
-        };
+            double rotations = 10.0;
+            var linear = Generate.RandomWalk(count);
+            xs = linear.Select((x, i) => x * Math.Cos(rotations * 2.0 * Math.PI * i / count)).ToArray();
+            data = linear.Select((x, i) => x * Math.Sin(rotations * 2.0 * Math.PI * i / count)).ToArray();
+        }
+        else
+        {
+            xs = Generate.Consecutive(count);
+            data = cbDataType.Text switch
+            {
+                "Random Walk" => Generate.RandomWalk(count),
+                "Sine Wave" => Generate.Sin(count),
+                "Random Values" => Generate.RandomSample(count),
+                _ => throw new NotImplementedException(),
+            };
+        }
 
         formsPlot1.Plot.Clear();
         formsPlotgl1.Plot.Clear();
@@ -62,12 +77,11 @@ public partial class OpenGL : Form, IDemoWindow
         }
         else
         {
-            double[] xs = Generate.Consecutive(count);
 
             var sp1 = formsPlot1.Plot.Add.Scatter(xs, data);
             sp1.MarkerStyle.IsVisible = false;
 
-            var sp2 = formsPlotgl1.Plot.Add.Scatter(xs, data);
+            var sp2 = formsPlotgl1.Plot.Add.ScatterGL(formsPlotgl1, xs, data);
             sp2.MarkerStyle.IsVisible = false;
         }
 

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IPlottableGL.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IPlottableGL.cs
@@ -1,6 +1,4 @@
-﻿using ScottPlot.Control;
-
-namespace ScottPlot;
+﻿namespace ScottPlot;
 
 /// <summary>
 /// This interface is applied to plottables which can be rendered directly on the GPU using an OpenGL shader
@@ -17,4 +15,12 @@ public interface IPlottableGL : IPlottable
     /// Used to manually synchronize rendering
     /// </summary>
     void GLFinish();
+    /// <summary>
+    /// Store OpenGL atributes
+    /// </summary>
+    void StoreGLState();
+    /// <summary>
+    /// Restore previously saved OpenGL atributes
+    /// </summary>
+    void RestoreGLState();
 }

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/RestoreGLState.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/RestoreGLState.cs
@@ -1,0 +1,11 @@
+﻿namespace ScottPlot.Rendering.RenderActions;
+
+public class RestoreGLState : IRenderAction
+{
+    public void Render(RenderPack rp)
+    {
+        var glPlottables = rp.Plot.PlottableList.OfType<IPlottableGL>();
+
+        glPlottables.FirstOrDefault()?.RestoreGLState();
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/StoreGLState.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderActions/StoreGLState.cs
@@ -1,0 +1,11 @@
+﻿namespace ScottPlot.Rendering.RenderActions;
+
+public class StoreGLState : IRenderAction
+{
+    public void Render(RenderPack rp)
+    {
+        var glPlottables = rp.Plot.PlottableList.OfType<IPlottableGL>();
+
+        glPlottables.FirstOrDefault()?.StoreGLState();
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ScottPlot.Rendering.RenderActions;
+using System;
 using System.Data;
 
 namespace ScottPlot.Rendering;
@@ -23,7 +24,9 @@ public class RenderManager(Plot plot)
         new RenderActions.RegenerateTicks(),
         new RenderActions.RenderStartingEvent(),
         new RenderActions.RenderDataBackground(),
+        new RenderActions.StoreGLState(),
         new RenderActions.RenderGridsBelowPlottables(),
+        new RenderActions.RestoreGLState(),
         new RenderActions.RenderPlottables(),
         new RenderActions.RenderGridsAbovePlottables(),
         new RenderActions.RenderLegends(),

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
@@ -24,7 +24,7 @@ public class RenderManager(Plot plot)
         new RenderActions.RegenerateTicks(),
         new RenderActions.RenderStartingEvent(),
         new RenderActions.RenderDataBackground(),
-        new RenderActions.StoreGLState(),
+        new RenderActions.StoreGLState(), // https://github.com/ScottPlot/ScottPlot/pull/4298
         new RenderActions.RenderGridsBelowPlottables(),
         new RenderActions.RestoreGLState(),
         new RenderActions.RenderPlottables(),


### PR DESCRIPTION
Restore broken ScatterGL.

Adapted to changed interfaces.
Update WinForms.OpenGL demo to demonstrate features.

`RenderGridsBelowPlottables` stage uses Path to draw the grid lines. For some reason this completely breaks the OpenGL context needed for further drawing (I couldn't manage it, drawing a mesh with simple lines doesn't break anything). That's why we added stages of saving/restoring OpenGL attributes, before/after the RenderGridsBelowPlottables stage. They should not affect anything and will be just empty when GLPlottables are not used or Control does not support OpenGL acceleration.

![ScatterGLCompare](https://github.com/user-attachments/assets/0749c52b-2077-4e67-a242-b48a932f98c8)