### PR TITLE
OpenGL: Use version-specific OpenTK dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _Not yet on NuGet..._
 * SignalXY: Fixed bug introduced in the last version that caused off-screen data to throw an ascending value exception (#4261, #4286) @RFBomb @StendProg
 * Controls: Added strong naming by signing assemblies for the WPF, Maui, and Eto controls (#4295) @RFBomb
 * OpenGL: Improve behavior of plots when grid lines are rendered beneath plottables (#4298) @StendProg
+* OpenGL: Improve support for OpenGL controls on modern .NET using platform-specific OpenTK versions (#4301) @StendProg
 
 ## ScottPlot 5.0.39
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-08-02_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLExtensions.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLExtensions.cs
@@ -1,9 +1,13 @@
 ﻿namespace ScottPlot;
+using OpenTK.Graphics;
+#if NETCOREAPP || NET
+using OpenTK.Mathematics;
+#endif
 
 public static class GLExtensions
 {
-    public static OpenTK.Graphics.Color4 ToTkColor(this ScottPlot.Color color)
+    public static Color4 ToTkColor(this ScottPlot.Color color)
     {
-        return new OpenTK.Graphics.Color4(color.Red, color.Green, color.Blue, color.Alpha);
+        return new Color4(color.Red, color.Green, color.Blue, color.Alpha);
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/ILinesDrawProgram.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/ILinesDrawProgram.cs
@@ -1,5 +1,8 @@
 ﻿using OpenTK;
 using OpenTK.Graphics;
+#if NETCOREAPP || NET
+using OpenTK.Mathematics;
+#endif
 
 namespace ScottPlot.OpenGL.GLPrograms;
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/IMarkersDrawProgram.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/IMarkersDrawProgram.cs
@@ -1,5 +1,8 @@
 ﻿using OpenTK;
 using OpenTK.Graphics;
+#if NETCOREAPP || NET
+using OpenTK.Mathematics;
+#endif
 
 namespace ScottPlot.OpenGL.GLPrograms;
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/LinesProgram.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/LinesProgram.cs
@@ -2,6 +2,9 @@
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 using System;
+#if NETCOREAPP || NET
+using OpenTK.Mathematics;
+#endif
 
 namespace ScottPlot.OpenGL.GLPrograms;
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/LinesProgramCustom.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/LinesProgramCustom.cs
@@ -1,6 +1,9 @@
 ﻿using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
+#if NETCOREAPP || NET
+using OpenTK.Mathematics;
+#endif
 
 namespace ScottPlot.OpenGL.GLPrograms;
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/MarkerOpenCircleProgram.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/MarkerOpenCircleProgram.cs
@@ -1,5 +1,8 @@
 ﻿using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
+#if NETCOREAPP || NET
+using OpenTK.Mathematics;
+#endif
 
 namespace ScottPlot.OpenGL.GLPrograms;
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/MarkerOpenSquareProgram.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/MarkerOpenSquareProgram.cs
@@ -1,5 +1,8 @@
 ﻿using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
+#if NETCOREAPP || NET
+using OpenTK.Mathematics;
+#endif
 
 namespace ScottPlot.OpenGL.GLPrograms;
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/MarkerProgram.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/MarkerProgram.cs
@@ -1,6 +1,9 @@
 ﻿using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
+#if NETCOREAPP || NET
+using OpenTK.Mathematics;
+#endif
 
 namespace ScottPlot.OpenGL.GLPrograms;
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/Plottables/ScatterGL.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/Plottables/ScatterGL.cs
@@ -4,6 +4,9 @@ using ScottPlot.OpenGL;
 using ScottPlot.OpenGL.GLPrograms;
 using SkiaSharp;
 using System;
+#if NETCOREAPP || NET
+using OpenTK.Mathematics;
+#endif
 
 namespace ScottPlot.Plottables;
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/ScottPlot.OpenGL.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/ScottPlot.OpenGL.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net6.0-windows;net462</TargetFrameworks>
@@ -41,15 +41,21 @@
         <None Include="../../../../dev/icon/v5/scottplot-icon-rounded-border-128.png" Pack="true" PackagePath="icon.png" />
         <None Include="nuget-readme.md" Pack="true" PackagePath="readme.md" />
     </ItemGroup>
-    
+
     <!-- Package dependencies -->
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SkiaSharp.Views" Version="2.88.8" />
         <ProjectReference Include="..\..\ScottPlot5\ScottPlot.csproj" />
     </ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+		<PackageReference Include="OpenTK" Version="3.3.1" NoWarn="NU1701" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' != 'net462'">
+		<PackageReference Include="OpenTK" Version="4.3.0" NoWarn="NU1701" />
+	</ItemGroup>
 
 </Project>

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/WinForms Demo.csproj
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/WinForms Demo.csproj
@@ -23,7 +23,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\ScottPlot5 Controls\ScottPlot.OpenGL\ScottPlot.OpenGL.csproj" />
+        <ProjectReference Include="..\..\ScottPlot5 Controls\ScottPlot.OpenGL\ScottPlot.OpenGL.csproj">
+            <SetTargetFramework>TargetFramework=net462</SetTargetFramework>
+        </ProjectReference>
         <ProjectReference Include="..\..\ScottPlot5 Controls\ScottPlot.WinForms\ScottPlot.WinForms.csproj" />
         <ProjectReference Include="..\..\ScottPlot5 Cookbook\ScottPlot Cookbook.csproj" />
         <ProjectReference Include="..\..\ScottPlot5\ScottPlot.csproj" />


### PR DESCRIPTION
The build system of the `ScottPlot.OpenGL` project has been revised.
The `.NET Framework 462` version is now built with `OpenTK 3.3.1`.
And the version for modern `.NET` is built with `OpenTK 4.3.0`.

This allows us to use `ScatterGL` on `WpfPlotGL` control with modern .NET versions. (The old `ScottPlot.OpenGL` version was always built for `OpenTK 3.3.1` and actually resulted in an Exception when using `ScatterGL` on `WpfPlotGL`).

On the downside, `ScottPlot.OpenGL` support for `FormsPlotGL` breaks on modern versions of .NET. As a solution, for such projects it is suggested to include `ScottPlot.OpenGL` in this way:
```xml
<ProjectReference Include="..\..\ScottPlot5 Controls\ScottPlot.OpenGL\ScottPlot.OpenGL.csproj">
	<SetTargetFramework>TargetFramework=net462</SetTargetFramework>
</ProjectReference>
```
This approach completely solves the problem, although it is a bit of a messy solution.

This PR makes no sense without a PR #4298 restoring ScatterGL functionality. I decided to make the changes separately for simplicity. These PRs should not have merge conflicts.