### PR TITLE
Fix flickering while dragging alternate fill grid

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Primitives/GridStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/GridStyle.cs
@@ -57,12 +57,22 @@ public class GridStyle
             .Take(MaximumNumberOfGridLines)
             .ToArray();
 
+        int evenTick = 0; // 0 for even, 1 for odd.
+
+        var Ticks = ticks
+            .Where(x => x.IsMajor)
+            .Take(MaximumNumberOfGridLines)
+            .Take(2) // need only first 2
+            .ToArray();
+        if (Ticks.Length >= 2 && (Ticks[1].Position - Ticks[0].Position != 0))
+            evenTick = (int)(Ticks[0].Position / (Ticks[1].Position - Ticks[0].Position)) % 2;
+
         RenderGridLines(rp, xTicksMinor, axis.Edge, MinorLineStyle);
-        RenderAlternatingFill(rp, xTicksMajor, axis.Edge);
+        RenderAlternatingFill(rp, xTicksMajor, axis.Edge, evenTick);
         RenderGridLines(rp, xTicksMajor, axis.Edge, MajorLineStyle);
     }
 
-    private void RenderAlternatingFill(RenderPack rp, float[] positions, Edge edge)
+    private void RenderAlternatingFill(RenderPack rp, float[] positions, Edge edge, int evenTick)
     {
         if (!FillColorEnabled)
         {
@@ -85,7 +95,7 @@ public class GridStyle
 
         for (int i = 1; i < starts.Count(); i++)
         {
-            Color fillColor = i % 2 == 0 ? FillColor1 : FillColor2; // TODO: change this to minimize flicker while dragging
+            Color fillColor = (i + evenTick) % 2 == 0 ? FillColor1 : FillColor2;
             PixelRect rect = new(starts.ElementAt(i - 1), ends.ElementAt(i));
             Drawing.FillRectangle(rp.Canvas, rect, fillColor);
         }


### PR DESCRIPTION
The order of alternate fills is now determined by tick parity relative to the tick near the 0 position. Previously it was just the parity of ticks displayed on the screen, which led to consequences in the form of #4302
This problem was also signaled by:
```c#
// TODO: change this to minimize flicker while dragging
```
Now there is no flickering when dragging if the scale factor of ticks is not changed.
If the scale factor of ticks changes, the flicker is very noticeable. It is especially easy to check this with sharp zooms of Plot. However, such flickering when zooming is present even before using this PR. And I have no idea how to fix it either.