### PR TITLE
Modify PolarAxis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ _Not yet on NuGet..._
 * Axes: Added a `Plot.Axes.TightMargins()` shortcut for setting autoscale margins to tightly fit the data
 * ContourLines: New plot type for displaying lines that mark points of equal elevation given a collection of 3D points (#4296, #2330, #3795) @jon-rizzo @StendProg
 * Maui: Improved the .NET MAUI ScottPlot control and added quickstart documentation to the website (#4320, #4023, #4013) @KosmosWerner @ByteSore
+* Radar: Improved rotational direction of labels (#4321, #4310) @CoderPM2011 @bry-decelles
 
 ## ScottPlot 5.0.39
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-08-02_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Polar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Polar.cs
@@ -43,7 +43,7 @@ public class Polar : ICategory
         public override void Execute()
         {
             var polarAxis = myPlot.Add.PolarAxis(radius: 100);
-            polarAxis.RotationDegrees = -90;
+            polarAxis.Rotation = Angle.FromDegrees(-90);
 
             IColormap colormap = new ScottPlot.Colormaps.Turbo();
             foreach (double fraction in ScottPlot.Generate.Range(0, 1, 0.02))
@@ -148,7 +148,7 @@ public class Polar : ICategory
         public override void Execute()
         {
             var polarAxis = myPlot.Add.PolarAxis();
-            polarAxis.RotationDegrees = -90;
+            polarAxis.Rotation = Angle.FromDegrees(-90);
 
             double[] ticksPositions = { 5, 10, 15, 20 };
             string[] tickLabels = { "A", "B", "C", "D" };
@@ -205,7 +205,7 @@ public class Polar : ICategory
         public override void Execute()
         {
             var polarAxis = myPlot.Add.PolarAxis();
-            polarAxis.RotationDegrees = -90;
+            polarAxis.Rotation = Angle.FromDegrees(-90);
 
             // add labeled spokes
             string[] labels = { "Alpha", "Beta", "Gamma", "Delta", "Epsilon" };

--- a/src/ScottPlot5/ScottPlot5/Plottables/PolarAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/PolarAxis.cs
@@ -24,7 +24,7 @@ public class PolarAxis : IPlottable, IManagesAxisLimits
     /// <summary>
     /// Rotates the axis clockwise from its default position (where 0 points right)
     /// </summary>
-    public double RotationDegrees { get; set; } = 0;
+    public Angle Rotation { get; set; } = Angle.FromDegrees(0);
 
     /// <summary>
     /// If enabled, radial ticks will be drawn using straight lines connecting intersections circles and spokes
@@ -130,7 +130,7 @@ public class PolarAxis : IPlottable, IManagesAxisLimits
     /// </summary>
     public Coordinates GetCoordinates(double radius, double degrees)
     {
-        degrees -= RotationDegrees;
+        degrees -= Rotation.Degrees;
         double x = radius * Math.Cos(degrees * Math.PI / 180);
         double y = radius * Math.Sin(degrees * Math.PI / 180);
         return new Coordinates(x, y);
@@ -209,7 +209,7 @@ public class PolarAxis : IPlottable, IManagesAxisLimits
         using SKAutoCanvasRestore _ = new(rp.Canvas);
         Pixel origin = Axes.GetPixel(Coordinates.Origin);
         rp.Canvas.Translate(origin.X, origin.Y);
-        rp.Canvas.RotateDegrees((float)RotationDegrees);
+        rp.Canvas.RotateDegrees((float)Rotation.Degrees);
 
         foreach (var spoke in Spokes)
         {
@@ -218,7 +218,7 @@ public class PolarAxis : IPlottable, IManagesAxisLimits
             Drawing.DrawLine(rp.Canvas, paint, new Pixel(0, 0), tipPixel, spoke.LineStyle);
 
             spoke.LabelStyle.Text = spoke.LabelText ?? string.Empty;
-            spoke.LabelStyle.Rotation = -(float)RotationDegrees;
+            spoke.LabelStyle.Rotation = -(float)Rotation.Degrees;
             spoke.LabelStyle.Alignment = Alignment.MiddleCenter;
 
             PolarCoordinates labelPoint = new(spoke.LabelLength, tipPoint.Angle);

--- a/src/ScottPlot5/ScottPlot5/Plottables/PolarAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/PolarAxis.cs
@@ -130,10 +130,7 @@ public class PolarAxis : IPlottable, IManagesAxisLimits
     /// </summary>
     public Coordinates GetCoordinates(double radius, double degrees)
     {
-        degrees -= Rotation.Degrees;
-        double x = radius * Math.Cos(degrees * Math.PI / 180);
-        double y = radius * Math.Sin(degrees * Math.PI / 180);
-        return new Coordinates(x, y);
+        return GetCoordinates(radius, Angle.FromDegrees(degrees));
     }
 
     /// <summary>
@@ -141,7 +138,7 @@ public class PolarAxis : IPlottable, IManagesAxisLimits
     /// </summary>
     public Coordinates GetCoordinates(double radius, Angle angle)
     {
-        return GetCoordinates(radius, angle.Degrees);
+        return GetCoordinates(new PolarCoordinates(radius, angle));
     }
 
     /// <summary>
@@ -149,7 +146,7 @@ public class PolarAxis : IPlottable, IManagesAxisLimits
     /// </summary>
     public Coordinates GetCoordinates(PolarCoordinates point)
     {
-        return GetCoordinates(point.Radius, point.Angle.Degrees);
+        return point.WithAngle(point.Angle - Rotation).ToCartesian();
     }
 
     /// <summary>

--- a/src/ScottPlot5/ScottPlot5/Plottables/PolarAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/PolarAxis.cs
@@ -146,7 +146,7 @@ public class PolarAxis : IPlottable, IManagesAxisLimits
     /// </summary>
     public Coordinates GetCoordinates(PolarCoordinates point)
     {
-        return point.WithAngle(point.Angle - Rotation).ToCartesian();
+        return point.WithAngle(point.Angle + Rotation).ToCartesian();
     }
 
     /// <summary>
@@ -206,7 +206,7 @@ public class PolarAxis : IPlottable, IManagesAxisLimits
         using SKAutoCanvasRestore _ = new(rp.Canvas);
         Pixel origin = Axes.GetPixel(Coordinates.Origin);
         rp.Canvas.Translate(origin.X, origin.Y);
-        rp.Canvas.RotateDegrees((float)Rotation.Degrees);
+        rp.Canvas.RotateDegrees(-(float)Rotation.Degrees);
 
         foreach (var spoke in Spokes)
         {
@@ -215,7 +215,7 @@ public class PolarAxis : IPlottable, IManagesAxisLimits
             Drawing.DrawLine(rp.Canvas, paint, new Pixel(0, 0), tipPixel, spoke.LineStyle);
 
             spoke.LabelStyle.Text = spoke.LabelText ?? string.Empty;
-            spoke.LabelStyle.Rotation = -(float)Rotation.Degrees;
+            spoke.LabelStyle.Rotation = (float)Rotation.Degrees;
             spoke.LabelStyle.Alignment = Alignment.MiddleCenter;
 
             PolarCoordinates labelPoint = new(spoke.LabelLength, tipPoint.Angle);

--- a/src/ScottPlot5/ScottPlot5/Plottables/PolarAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/PolarAxis.cs
@@ -161,8 +161,8 @@ public class PolarAxis : IPlottable, IManagesAxisLimits
             throw new ArgumentException($"{nameof(values)} must have a length equal to the number of spokes");
 
         return clockwise
-            ? Enumerable.Range(0, Spokes.Count).Select(x => GetCoordinates(values[x], -Spokes[x].Angle)).ToArray()
-            : Enumerable.Range(0, Spokes.Count).Select(x => GetCoordinates(values[x], Spokes[x].Angle)).ToArray();
+            ? Enumerable.Range(0, Spokes.Count).Select(x => GetCoordinates(values[x], Spokes[x].Angle)).ToArray()
+            : Enumerable.Range(0, Spokes.Count).Select(x => GetCoordinates(values[x], -Spokes[x].Angle)).ToArray();
     }
 
     public AxisLimits GetAxisLimits()

--- a/src/ScottPlot5/ScottPlot5/Plottables/Radar.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Radar.cs
@@ -5,7 +5,7 @@ public class Radar() : IPlottable, IManagesAxisLimits
     /// <summary>
     /// The polar axis drawn beneath each radar series polygon
     /// </summary>
-    public PolarAxis PolarAxis { get; set; } = new() { RotationDegrees = -90 };
+    public PolarAxis PolarAxis { get; set; } = new() { Rotation = Angle.FromDegrees(-90) };
 
     /// <summary>
     /// A collection of RadarSeries, each of which hold a set of values and the styling information that controls how the shape is rendered

--- a/src/ScottPlot5/ScottPlot5/Plottables/Radar.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Radar.cs
@@ -5,7 +5,7 @@ public class Radar() : IPlottable, IManagesAxisLimits
     /// <summary>
     /// The polar axis drawn beneath each radar series polygon
     /// </summary>
-    public PolarAxis PolarAxis { get; set; } = new() { Rotation = Angle.FromDegrees(-90) };
+    public PolarAxis PolarAxis { get; set; } = new() { Rotation = Angle.FromDegrees(90) };
 
     /// <summary>
     /// A collection of RadarSeries, each of which hold a set of values and the styling information that controls how the shape is rendered


### PR DESCRIPTION
- fix clockwise and counterclockwise results of `GetCoordinates()`
  fixed #4310
- rename `RotationDegrees` to `Rotation` and change type to `Angle`
- refactor `GetCoordinates()` with `PolarCoordinates`
- synchronizes `Rotation` with the angular direction of the Cartesian coordinate system
  please refer to the following for differences

## Default
``` cs
var polarAxis = plot.Add.PolarAxis();
```
![image](https://github.com/user-attachments/assets/95ceb81b-c45d-4f61-84cc-316a8d9a4963)

## Rotating polar axis
``` cs
polarAxis.Rotation = Angle.FromDegrees(90);
```
### Before
![image](https://github.com/user-attachments/assets/bec5aa96-6db6-4551-8d4f-c8fe41d8107c)

### After
![image](https://github.com/user-attachments/assets/72872527-5db9-4ef0-b3f0-d8ca6429a031)
