### PR TITLE
Contour lines on rectangular grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _Not yet on NuGet..._
 * SignalXY: Fixed bug causing plots with inverted horizontal axes to crash under specific conditions (#4313, #4315) @StendProg @lguelat
 * CoordinateRange: Refactored to improve support for inverted ranges (#4316) @CoderPM2011
 * Axes: Added a `Plot.Axes.TightMargins()` shortcut for setting autoscale margins to tightly fit the data
-* ContourLines: New plot type for displaying lines that mark points of equal elevation given a collection of 3D points (#4296, #2330, #3795) @jon-rizzo @StendProg
+* ContourLines: New plot type for displaying lines that mark points of equal elevation given a collection of 3D points (#4296, #2330, #3795, #4326) @jon-rizzo @StendProg
 * Maui: Improved the .NET MAUI ScottPlot control and added quickstart documentation to the website (#4320, #4023, #4013) @KosmosWerner @ByteSore
 * Radar: Improved rotational direction of labels (#4321, #4310) @CoderPM2011 @bry-decelles
 * Axes: Added `Plot.Axes.MarginsX()` and `Plot.Axes.MarginsY()` for changing margins in a single axis without changing the other (#4246)

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Contour.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Contour.cs
@@ -77,7 +77,9 @@ public class Contour : ICategory
                 }
             }
 
-            myPlot.Add.Heatmap(cs);
+            var heatmap = myPlot.Add.Heatmap(cs);
+            heatmap.FlipVertically = true;
+
             myPlot.Add.ContourLines(cs);
 
             myPlot.Axes.TightMargins();

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Contour.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Contour.cs
@@ -27,7 +27,9 @@ public class Contour : ICategory
                 }
             }
 
-            myPlot.Add.ContourLines(cs);
+            var contour = myPlot.Add.ContourLines(cs);
+            contour.LineColor = Colors.Black.WithAlpha(.5);
+            contour.LinePattern = LinePattern.Dotted;
 
             myPlot.Axes.TightMargins();
             myPlot.HideGrid();
@@ -43,7 +45,8 @@ public class Contour : ICategory
         [Test]
         public override void Execute()
         {
-            Coordinates3d[] cs = new Coordinates3d[50];
+            // generate irregularly spaced X/Y/Z data points
+            Coordinates3d[] cs = new Coordinates3d[1000];
             for (int i = 0; i < cs.Length; i++)
             {
                 double x = Generate.RandomNumber(0, Math.PI * 2);
@@ -52,8 +55,23 @@ public class Contour : ICategory
                 cs[i] = new(x, y, z);
             }
 
-            myPlot.Add.ContourLines(cs);
+            // place markers at each data point
+            double minZ = cs.Select(x => x.Z).Min();
+            double maxZ = cs.Select(x => x.Z).Max();
+            double spanZ = maxZ - minZ;
+            IColormap cmap = new ScottPlot.Colormaps.MellowRainbow();
+            for (int i = 0; i < cs.Length; i++)
+            {
+                double fraction = (cs[i].Z - minZ) / (spanZ);
+                var marker = myPlot.Add.Marker(cs[i].X, cs[i].Y);
+                marker.Color = cmap.GetColor(fraction).WithAlpha(.8);
+                marker.Size = 5;
+            }
 
+            // show contour lines
+            var contour = myPlot.Add.ContourLines(cs);
+
+            // style the plot
             myPlot.Axes.TightMargins();
             myPlot.HideGrid();
         }
@@ -79,8 +97,12 @@ public class Contour : ICategory
 
             var heatmap = myPlot.Add.Heatmap(cs);
             heatmap.FlipVertically = true;
+            heatmap.Colormap = new ScottPlot.Colormaps.MellowRainbow();
 
-            myPlot.Add.ContourLines(cs);
+            var contour = myPlot.Add.ContourLines(cs);
+            contour.LabelStyle.Bold = true;
+            contour.LinePattern = LinePattern.DenselyDashed;
+            contour.LineColor = Colors.Black.WithAlpha(.5);
 
             myPlot.Axes.TightMargins();
             myPlot.HideGrid();
@@ -107,8 +129,9 @@ public class Contour : ICategory
             }
 
             var cl = myPlot.Add.ContourLines(cs, count: 25);
-            cl.Colormap = new ScottPlot.Colormaps.Turbo();
+            cl.Colormap = new ScottPlot.Colormaps.MellowRainbow();
             cl.LineWidth = 3;
+            cl.LabelStyle.IsVisible = false;
 
             myPlot.Axes.TightMargins();
             myPlot.HideGrid();

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -100,8 +100,9 @@ public static class Drawing
 
         labelStyle.ApplyToPaint(paint);
 
+        var measuredText = paint.MeasureText(label);
         using (SKPathMeasure pathMeasure = new SKPathMeasure(path, false, 1))
-            DrawTextOnPath(canvas, paint, path, label, pathMeasure.Length / 5, 0);
+            DrawTextOnPath(canvas, paint, path, label, pathMeasure.Length / 4 - measuredText / 4, 0);
     }
 
     public static void DrawTextOnPath(SKCanvas canvas, SKPaint paint, SKPath path, string text, float hOffset = 0, float vOffset = 0)

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -78,9 +78,46 @@ public static class Drawing
         DrawPath(canvas, paint, path, lineStyle);
     }
 
+    public static void DrawPath(SKCanvas canvas, SKPaint paint, IEnumerable<Pixel> pixels, LineStyle lineStyle, string label, LabelStyle labelStyle, bool close = false)
+    {
+        if (!lineStyle.CanBeRendered) return;
+
+        using SKPath path = new();
+        path.MoveTo(pixels.First().ToSKPoint());
+        foreach (Pixel px in pixels.Skip(1))
+        {
+            path.LineTo(px.ToSKPoint());
+        }
+
+        if (close)
+        {
+            path.LineTo(pixels.First().ToSKPoint());
+        }
+        DrawPath(canvas, paint, path, lineStyle);
+
+        if (labelStyle.IsVisible == false)
+            return;
+
+        labelStyle.ApplyToPaint(paint);
+
+        using (SKPathMeasure pathMeasure = new SKPathMeasure(path, false, 1))
+            DrawTextOnPath(canvas, paint, path, label, pathMeasure.Length / 5, 0);
+    }
+
+    public static void DrawTextOnPath(SKCanvas canvas, SKPaint paint, SKPath path, string text, float hOffset = 0, float vOffset = 0)
+    {
+        if (string.IsNullOrEmpty(text))
+            return;
+        canvas.DrawTextOnPath(text, path, hOffset, vOffset, paint);
+    }
+
     public static void DrawPath(SKCanvas canvas, SKPaint paint, PixelPath path, LineStyle lineStyle)
     {
         DrawPath(canvas, paint, path.Pixels, lineStyle);
+    }
+    public static void DrawPath(SKCanvas canvas, SKPaint paint, PixelPath path, LineStyle lineStyle, string text, LabelStyle labelStyle)
+    {
+        DrawPath(canvas, paint, path.Pixels, lineStyle, text, labelStyle);
     }
 
     public static void DrawPath(SKCanvas canvas, SKPaint paint, PixelPath path, FillStyle fillStyle)

--- a/src/ScottPlot5/ScottPlot5/Plottables/ContourLines.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/ContourLines.cs
@@ -9,7 +9,7 @@ public class ContourLines : IPlottable, IHasLine
     private AxisLimits AxisLimits = AxisLimits.NoLimits;
     public AxisLimits GetAxisLimits() => AxisLimits;
 
-    public List<ContourLine> Lines { get; } = [];
+    public List<ContourLine> Lines { get; private set; } = [];
 
     public LineStyle LineStyle { get; set; } = new() { Width = 1, Color = Colors.Black };
     public LabelStyle LabelStyle { get; set; } = new();
@@ -59,8 +59,7 @@ public class ContourLines : IPlottable, IHasLine
         MaxZ = coordinateGrid.Cast<Coordinates3d>().Max(p => p.Z);
         double[] zs = ContourLineLevels ?? Enumerable.Range(0, ContourLineCount + 2).Select(x => MinZ + (MaxZ - MinZ) * (x) / (ContourLineCount + 1)).ToArray();
 
-        Lines.Clear();
-        Lines.AddRange(Triangulation.RectangularGrid.GetContourLines(coordinateGrid, zs));
+        Lines = Triangulation.RectangularGrid.GetContourLines(coordinateGrid, zs);
         UpdateAxisLimits();
     }
 

--- a/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGrid.cs
+++ b/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGrid.cs
@@ -88,10 +88,9 @@
         private static List<List<IEdge>> MergeContourParts(List<EdgeLine> edgeLines, int GridHeight)
         {
             var edgeLineLookup = edgeLines.ToDictionary(el => el.CellID);
-            int Count = edgeLines.Count;
 
             List<List<IEdge>> result = new List<List<IEdge>>();
-            while (Count > 0)
+            while (edgeLineLookup.Count > 0)
             {
                 List<IEdge> currentPath = new List<IEdge>();
 
@@ -99,10 +98,9 @@
                 var startEL = startELEntry.Value;
 
                 edgeLineLookup.Remove(startELEntry.Key);
-                Count--;
 
-                var rightSearch = FindNeigbhorsChain(startEL.second, startEL.CellID, edgeLineLookup, GridHeight, ref Count);
-                var leftSearch = FindNeigbhorsChain(startEL.first, startEL.CellID, edgeLineLookup, GridHeight, ref Count);
+                var rightSearch = FindNeigbhorsChain(startEL.second, startEL.CellID, edgeLineLookup, GridHeight);
+                var leftSearch = FindNeigbhorsChain(startEL.first, startEL.CellID, edgeLineLookup, GridHeight);
 
                 leftSearch.Reverse();
                 currentPath.AddRange(leftSearch);
@@ -115,7 +113,7 @@
             return result;
         }
 
-        private static List<IEdge> FindNeigbhorsChain(IEdge startEdge, int startCellId, Dictionary<int, EdgeLine> edgeLineLookup, int GridHeight, ref int Count)
+        private static List<IEdge> FindNeigbhorsChain(IEdge startEdge, int startCellId, Dictionary<int, EdgeLine> edgeLineLookup, int GridHeight)
         {
             List<IEdge> currentPath = new List<IEdge>();
             IEdge current = startEdge;
@@ -129,7 +127,6 @@
                 if (found)
                 {
                     edgeLineLookup.Remove(key);
-                    Count--;
                     if (candidate is EdgeLinePair candidatePair)
                     {
                         if (candidate.first.Equals(current))
@@ -137,28 +134,24 @@
                             current = candidate.second;
                             currentPath.Add(current);
                             edgeLineLookup.Add(key, new EdgeLine(candidatePair.first1, candidatePair.second1, candidatePair.CellID));
-                            Count++;
                         }
                         else if (candidate.second.Equals(current))
                         {
                             current = candidate.first;
                             currentPath.Add(current);
                             edgeLineLookup.Add(key, new EdgeLine(candidatePair.first1, candidatePair.second1, candidatePair.CellID));
-                            Count++;
                         }
                         else if (candidatePair.first1.Equals(current))
                         {
                             current = candidatePair.second1;
                             currentPath.Add(current);
                             edgeLineLookup.Add(key, new EdgeLine(candidatePair.first, candidatePair.second, candidatePair.CellID));
-                            Count++;
                         }
                         else if (candidatePair.second1.Equals(current))
                         {
                             current = candidatePair.first1;
                             currentPath.Add(current);
                             edgeLineLookup.Add(key, new EdgeLine(candidatePair.first, candidatePair.second, candidatePair.CellID));
-                            Count++;
                         }
                     }
 

--- a/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGrid.cs
+++ b/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGrid.cs
@@ -1,0 +1,139 @@
+﻿namespace ScottPlot.Triangulation
+{
+    public static class RectangularGrid
+    {
+        public static ContourLine[] GetContourLines(Coordinates3d[,] coordinateGrid, double[] zs)
+        {
+            List<ContourLine> paths = new List<ContourLine>();
+
+            foreach ( double z in zs)
+            {
+                List<Coordinates> pts = [];
+                List<EdgeLine> edgeLines = [];
+                for (int j = 0; j < coordinateGrid.GetLength(0) - 1; j++)
+                    for (int i = 0; i < coordinateGrid.GetLength(1) - 1; i++)
+                    {
+                        edgeLines.AddRange(LookupSquare(coordinateGrid, i, j, z));
+                    }
+
+                var groupedEdges = GroupEdges(edgeLines);
+                paths.AddRange(groupedEdges.Select(elem => new ContourLine(CoordinatePath.Open(elem.Select(edge => edge.Interpolate(coordinateGrid, z)).ToList()), z)));
+            }
+            return paths.Where(p => p.Path.Points.Length > 0).ToArray();
+        }
+        private static EdgeLine[] LookupSquare(Coordinates3d[,] CoordinateGrid, int i, int j, double Z)
+        {
+            int index = 0;
+
+            // lb - LeftBottom, lt - leftTop, rb - RightBottom, rt - RightTop
+            Vertex lb = new(i, j);
+            Vertex lt = new(i, j + 1);
+            Vertex rb = new(i + 1, j);
+            Vertex rt = new(i + 1, j + 1);
+
+            if (CoordinateGrid[lb.j, lb.i].Z > Z)
+                index += 1;
+            if (CoordinateGrid[rb.j, rb.i].Z > Z)
+                index += 2;
+            if (CoordinateGrid[rt.j, rt.i].Z > Z)
+                index += 4;
+            if (CoordinateGrid[lt.j, lt.i].Z > Z)
+                index += 8;
+
+            if (index == 5 || index == 10) // saddle point fix
+            {
+                var midpoint = CoordinateGrid[lb.j, lb.i].Z
+                               + CoordinateGrid[rb.j, rb.i].Z
+                               + CoordinateGrid[rt.j, rt.i].Z
+                               + CoordinateGrid[lt.j, lt.i].Z;
+                midpoint /= 4;
+                if (midpoint <= Z)
+                {
+                    if (index == 5)
+                        index = 10;
+                    else
+                        index = 5;
+                }
+            }
+
+            Edge l = new VerticalEdge(lb, lt); // Left edge
+            Edge r = new VerticalEdge(rb, rt); // Right edge
+            Edge b = new HorizontalEdge(lb, rb); // Bottom edge
+            Edge t = new HorizontalEdge(lt, rt); // Top edge
+
+            // all cases described in https://en.wikipedia.org/wiki/Marching_squares
+            return index switch
+            {
+                0 => [],
+                1 => [new(l, b)],
+                2 => [new(b, r)],
+                3 => [new(l, r)],
+                4 => [new(t, r)],
+                5 => [new(l, t), new(b, r)],
+                6 => [new(b, t)],
+                7 => [new(l, t)],
+                8 => [new(l, t)],
+                9 => [new(b, t)],
+                10 => [new(l, b), new(t, r)],
+                11 => [new(t, r)],
+                12 => [new(l, r)],
+                13 => [new(b, r)],
+                14 => [new(l, b)],
+                15 => [],
+                _ => throw new Exception("Unexpected case"),
+            };
+        }
+        private static List<List<Edge>> GroupEdges(List<EdgeLine> edgeLinesArg)
+        {
+            var edgeLines = edgeLinesArg.ToList();
+            List<List<Edge>> result = new List<List<Edge>>();
+            while (edgeLines.Count > 0)
+            {
+                List<Edge> currentPath = new List<Edge>();
+                currentPath.Add(edgeLines[0].first);
+                currentPath.Add(edgeLines[0].second);
+
+                var current = edgeLines[0].second;
+                edgeLines.RemoveAt(0);
+                int candidateIndex;
+                // search for a right side neighbors
+                while ((candidateIndex = edgeLines.FindIndex(e => e.first.Equals(current) || e.second.Equals(current))) != -1)
+                {
+                    var candidate = edgeLines[candidateIndex];
+                    edgeLines.RemoveAt(candidateIndex);
+                    if (candidate.first.Equals(current))
+                    {
+                        current = candidate.second;
+                        currentPath.Add(current);
+                    }
+                    else
+                    {
+                        current = candidate.first;
+                        currentPath.Add(current);
+                    }
+                }
+                current = currentPath[0];
+                // search for a left side neighbors
+                while ((candidateIndex = edgeLines.FindIndex(e => e.first.Equals(current) || e.second.Equals(current))) != -1)
+                {
+                    var candidate = edgeLines[candidateIndex];
+                    edgeLines.RemoveAt(candidateIndex);
+                    if (candidate.first.Equals(current))
+                    {
+                        current = candidate.second;
+                        currentPath.Insert(0, current);
+                    }
+                    else
+                    {
+                        current = candidate.first;
+                        currentPath.Insert(0, current);
+                    }
+                }
+                result.Add(currentPath);
+            }
+
+            return result;
+        }
+
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGrid.cs
+++ b/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGrid.cs
@@ -1,4 +1,5 @@
-﻿namespace ScottPlot.Triangulation
+﻿#nullable disable
+namespace ScottPlot.Triangulation
 {
     public static class RectangularGrid
     {
@@ -121,7 +122,7 @@
             bool found = false;
             do
             {
-                EdgeLine? candidate;
+                EdgeLine candidate;
                 var key = GetNeigbhorCell(current, currentCellId, GridHeight);
                 found = edgeLineLookup.TryGetValue(key, out candidate);
                 if (found)

--- a/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGrid.cs
+++ b/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGrid.cs
@@ -5,116 +5,136 @@ namespace ScottPlot.Triangulation
     {
         public static ContourLine[] GetContourLines(Coordinates3d[,] coordinateGrid, double[] zs)
         {
-            List<ContourLine> paths = new List<ContourLine>();
-
-            foreach (double z in zs)
+            var paths = zs.Select(z =>
             {
-                List<Coordinates> pts = [];
-                List<EdgeLine> edgeLines = [];
-                for (int j = 0; j < coordinateGrid.GetLength(0) - 1; j++)
-                    for (int i = 0; i < coordinateGrid.GetLength(1) - 1; i++)
+                var edgeLines = LookupSquare(coordinateGrid, z).ToDictionary(e => e.CellID);
+                var mergedPaths = MergeContourParts(edgeLines, coordinateGrid.GetLength(0));
+                return mergedPaths.Select(elem => new ContourLine(CoordinatePath.Open(elem.Select(edge => edge.Interpolate(coordinateGrid, z))), z));
+            });
+            return paths.SelectMany(elem => elem).ToArray();
+        }
+
+        private static IEnumerable<EdgeLine> LookupSquare(Coordinates3d[,] CoordinateGrid, double Z)
+        {
+            for (int j = 0; j < CoordinateGrid.GetLength(0) - 1; j++)
+                for (int i = 0; i < CoordinateGrid.GetLength(1) - 1; i++)
+                {
+                    // lb - LeftBottom, lt - leftTop, rb - RightBottom, rt - RightTop
+                    Vertex lb = new(i, j);
+                    Vertex lt = new(i, j + 1);
+                    Vertex rb = new(i + 1, j);
+                    Vertex rt = new(i + 1, j + 1);
+
+                    int cellID = j * CoordinateGrid.GetLength(0) + i;
+
+                    int index = 0;
+
+                    if (CoordinateGrid[lb.j, lb.i].Z > Z)
+                        index += 1;
+                    if (CoordinateGrid[rb.j, rb.i].Z > Z)
+                        index += 2;
+                    if (CoordinateGrid[rt.j, rt.i].Z > Z)
+                        index += 4;
+                    if (CoordinateGrid[lt.j, lt.i].Z > Z)
+                        index += 8;
+
+                    if (index == 5 || index == 10) // saddle point fix
                     {
-                        edgeLines.AddRange(LookupSquare(coordinateGrid, i, j, z));
+                        var midpoint = CoordinateGrid[lb.j, lb.i].Z
+                                       + CoordinateGrid[rb.j, rb.i].Z
+                                       + CoordinateGrid[rt.j, rt.i].Z
+                                       + CoordinateGrid[lt.j, lt.i].Z;
+                        midpoint /= 4;
+                        if (midpoint <= Z)
+                        {
+                            if (index == 5)
+                                index = 10;
+                            else
+                                index = 5;
+                        }
                     }
 
-                var mergedPaths = MergeContourParts(edgeLines, coordinateGrid.GetLength(0));
-                paths.AddRange(mergedPaths.Select(elem => new ContourLine(CoordinatePath.Open(elem.Select(edge => edge.Interpolate(coordinateGrid, z)).ToList()), z)));
-            }
-            return paths.Where(p => p.Path.Points.Length > 0).ToArray();
-        }
-        private static EdgeLine[] LookupSquare(Coordinates3d[,] CoordinateGrid, int i, int j, double Z)
-        {
-            // lb - LeftBottom, lt - leftTop, rb - RightBottom, rt - RightTop
-            Vertex lb = new(i, j);
-            Vertex lt = new(i, j + 1);
-            Vertex rb = new(i + 1, j);
-            Vertex rt = new(i + 1, j + 1);
+                    IEdge l = new VerticalEdge(lb); // Left edge
+                    IEdge r = new VerticalEdge(rb); // Right edge
+                    IEdge b = new HorizontalEdge(lb); // Bottom edge
+                    IEdge t = new HorizontalEdge(lt); // Top edge
 
-            int cellID = j * CoordinateGrid.GetLength(0) + i;
-
-            int index = 0;
-
-            if (CoordinateGrid[lb.j, lb.i].Z > Z)
-                index += 1;
-            if (CoordinateGrid[rb.j, rb.i].Z > Z)
-                index += 2;
-            if (CoordinateGrid[rt.j, rt.i].Z > Z)
-                index += 4;
-            if (CoordinateGrid[lt.j, lt.i].Z > Z)
-                index += 8;
-
-            if (index == 5 || index == 10) // saddle point fix
-            {
-                var midpoint = CoordinateGrid[lb.j, lb.i].Z
-                               + CoordinateGrid[rb.j, rb.i].Z
-                               + CoordinateGrid[rt.j, rt.i].Z
-                               + CoordinateGrid[lt.j, lt.i].Z;
-                midpoint /= 4;
-                if (midpoint <= Z)
-                {
-                    if (index == 5)
-                        index = 10;
-                    else
-                        index = 5;
+                    // all cases described in https://en.wikipedia.org/wiki/Marching_squares
+                    switch (index)
+                    {
+                        case 0:
+                            break;
+                        case 1:
+                            yield return new(l, b, cellID);
+                            break;
+                        case 2:
+                            yield return new(b, r, cellID);
+                            break;
+                        case 3:
+                            yield return new(l, r, cellID);
+                            break;
+                        case 4:
+                            yield return new(t, r, cellID);
+                            break;
+                        case 5:
+                            yield return new EdgeLinePair(l, t, b, r, cellID);
+                            break;
+                        case 6:
+                            yield return new(b, t, cellID);
+                            break;
+                        case 7:
+                            yield return new(l, t, cellID);
+                            break;
+                        case 8:
+                            yield return new(l, t, cellID);
+                            break;
+                        case 9:
+                            yield return new(b, t, cellID);
+                            break;
+                        case 10:
+                            yield return new EdgeLinePair(l, b, t, r, cellID);
+                            break;
+                        case 11:
+                            yield return new(t, r, cellID);
+                            break;
+                        case 12:
+                            yield return new(l, r, cellID);
+                            break;
+                        case 13:
+                            yield return new(b, r, cellID);
+                            break;
+                        case 14:
+                            yield return new(l, b, cellID);
+                            break;
+                        case 15:
+                            break;
+                        default: throw new Exception("Unexpected case");
+                    }
                 }
-            }
-
-            IEdge l = new VerticalEdge(lb); // Left edge
-            IEdge r = new VerticalEdge(rb); // Right edge
-            IEdge b = new HorizontalEdge(lb); // Bottom edge
-            IEdge t = new HorizontalEdge(lt); // Top edge
-
-            // all cases described in https://en.wikipedia.org/wiki/Marching_squares
-            return index switch
-            {
-                0 => [],
-                1 => [new(l, b, cellID)],
-                2 => [new(b, r, cellID)],
-                3 => [new(l, r, cellID)],
-                4 => [new(t, r, cellID)],
-                5 => [new EdgeLinePair(l, t, b, r, cellID)],
-                6 => [new(b, t, cellID)],
-                7 => [new(l, t, cellID)],
-                8 => [new(l, t, cellID)],
-                9 => [new(b, t, cellID)],
-                10 => [new EdgeLinePair(l, b, t, r, cellID)],
-                11 => [new(t, r, cellID)],
-                12 => [new(l, r, cellID)],
-                13 => [new(b, r, cellID)],
-                14 => [new(l, b, cellID)],
-                15 => [],
-                _ => throw new Exception("Unexpected case"),
-            };
         }
-        private static List<List<IEdge>> MergeContourParts(List<EdgeLine> edgeLines, int GridHeight)
+        private static IEnumerable<IEnumerable<IEdge>> MergeContourParts(Dictionary<int, EdgeLine> edgeLines, int GridHeight)
         {
-            var edgeLineLookup = edgeLines.ToDictionary(el => el.CellID);
-
-            List<List<IEdge>> result = new List<List<IEdge>>();
-            while (edgeLineLookup.Count > 0)
+            while (edgeLines.Count > 0)
             {
                 List<IEdge> currentPath = new List<IEdge>();
 
-                var startELEntry = edgeLineLookup.First();
+                var startELEntry = edgeLines.First();
                 var startEL = startELEntry.Value;
 
-                edgeLineLookup.Remove(startELEntry.Key);
+                edgeLines.Remove(startELEntry.Key);
 
-                var rightSearch = FindNeigbhorsChain(startEL.second, startEL.CellID, edgeLineLookup, GridHeight);
-                var leftSearch = FindNeigbhorsChain(startEL.first, startEL.CellID, edgeLineLookup, GridHeight);
+                var rightSearch = FindNeigbhorsChain(startEL.second, startEL.CellID, edgeLines, GridHeight);
+                var leftSearch = FindNeigbhorsChain(startEL.first, startEL.CellID, edgeLines, GridHeight);
 
-                leftSearch.Reverse();
-                currentPath.AddRange(leftSearch);
-                currentPath.Add(startEL.first);
-                currentPath.Add(startEL.second);
-                currentPath.AddRange(rightSearch);
-
-                result.Add(currentPath);
+                var contour =
+                    leftSearch.Reverse()
+                    .Concat([startEL.first, startEL.second])
+                    .Concat(rightSearch);
+                yield return contour;
             }
-            return result;
         }
 
-        private static List<IEdge> FindNeigbhorsChain(IEdge startEdge, int startCellId, Dictionary<int, EdgeLine> edgeLineLookup, int GridHeight)
+        private static IEnumerable<IEdge> FindNeigbhorsChain(IEdge startEdge, int startCellId, Dictionary<int, EdgeLine> edgeLineLookup, int GridHeight)
         {
             List<IEdge> currentPath = new List<IEdge>();
             IEdge current = startEdge;
@@ -133,43 +153,44 @@ namespace ScottPlot.Triangulation
                         if (candidate.first.Equals(current))
                         {
                             current = candidate.second;
-                            currentPath.Add(current);
                             edgeLineLookup.Add(key, new EdgeLine(candidatePair.first1, candidatePair.second1, candidatePair.CellID));
                         }
                         else if (candidate.second.Equals(current))
                         {
                             current = candidate.first;
-                            currentPath.Add(current);
                             edgeLineLookup.Add(key, new EdgeLine(candidatePair.first1, candidatePair.second1, candidatePair.CellID));
                         }
                         else if (candidatePair.first1.Equals(current))
                         {
                             current = candidatePair.second1;
-                            currentPath.Add(current);
                             edgeLineLookup.Add(key, new EdgeLine(candidatePair.first, candidatePair.second, candidatePair.CellID));
                         }
                         else if (candidatePair.second1.Equals(current))
                         {
                             current = candidatePair.first1;
-                            currentPath.Add(current);
                             edgeLineLookup.Add(key, new EdgeLine(candidatePair.first, candidatePair.second, candidatePair.CellID));
                         }
-                    }
+                        currentCellId = candidate.CellID;
 
-                    if (candidate.first.Equals(current))
-                    {
-                        current = candidate.second;
-                        currentPath.Add(current);
                     }
                     else
                     {
-                        current = candidate.first;
-                        currentPath.Add(current);
+                        if (candidate.first.Equals(current))
+                        {
+                            current = candidate.second;
+                            currentPath.Add(current);
+                        }
+                        else
+                        {
+                            current = candidate.first;
+                            currentPath.Add(current);
+                        }
                     }
+
+                    yield return current;
                     currentCellId = candidate.CellID;
                 }
             } while (found);
-            return currentPath;
         }
 
         private static int GetNeigbhorCell(IEdge edge, int edgeCell, int GridHeight)

--- a/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGrid.cs
+++ b/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGrid.cs
@@ -3,17 +3,17 @@ namespace ScottPlot.Triangulation
 {
     public static class RectangularGrid
     {
-        public static ContourLine[] GetContourLines(Coordinates3d[,] coordinateGrid, double[] zs, bool fixContourDirections = true)
+        public static List<ContourLine> GetContourLines(Coordinates3d[,] coordinateGrid, double[] zs, bool fixContourDirections = true)
         {
-            ContourLine[] result;
-            result =  zs.Select(z =>
+            List<ContourLine> result;
+            result = zs.Select(z =>
             {
                 var edgeLines = MarchingSquares(coordinateGrid, z).ToDictionary(e => e.CellID);
                 var mergedPaths = MergeContourParts(edgeLines, coordinateGrid.GetLength(0));
                 return mergedPaths.Select(elem => new ContourLine(CoordinatePath.Open(elem.Select(edge => edge.Interpolate(coordinateGrid, z))), z));
             })
             .SelectMany(elem => elem)
-            .ToArray();
+            .ToList();
 
             if (fixContourDirections)
                 return FixContourDirections(result);
@@ -21,20 +21,20 @@ namespace ScottPlot.Triangulation
                 return result;
         }
 
-        public static ContourLine[] FixContourDirections(ContourLine[] contours)
+        public static List<ContourLine> FixContourDirections(List<ContourLine> contours)
         {
-            for (int i = 0; i < contours.Length; i++)
+            for (int i = 0; i < contours.Count; i++)
             {
                 // closed contour, make it starts from a top 
                 if (Math.Abs(contours[i].Path.Points[0].X - contours[i].Path.Points[^1].X) < 0.0000000001
-                    && Math.Abs(contours[i].Path.Points[0].Y - contours[i].Path.Points[^1].Y) < 0.0000000001 )
+                    && Math.Abs(contours[i].Path.Points[0].Y - contours[i].Path.Points[^1].Y) < 0.0000000001)
                 {
                     var points = contours[i].Path.Points;
                     var max = points[0].Y;
                     var maxIndex = 0;
-                    for(int j = 0; j < points.Length; j++ )
+                    for (int j = 0; j < points.Length; j++)
                     {
-                        if (points[j].Y > max )
+                        if (points[j].Y > max)
                         {
                             max = points[j].Y;
                             maxIndex = j;

--- a/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGrid.cs
+++ b/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGrid.cs
@@ -6,7 +6,7 @@
         {
             List<ContourLine> paths = new List<ContourLine>();
 
-            foreach ( double z in zs)
+            foreach (double z in zs)
             {
                 List<Coordinates> pts = [];
                 List<EdgeLine> edgeLines = [];
@@ -56,10 +56,10 @@
                 }
             }
 
-            Edge l = new VerticalEdge(lb, lt); // Left edge
-            Edge r = new VerticalEdge(rb, rt); // Right edge
-            Edge b = new HorizontalEdge(lb, rb); // Bottom edge
-            Edge t = new HorizontalEdge(lt, rt); // Top edge
+            IEdge l = new VerticalEdge(lb); // Left edge
+            IEdge r = new VerticalEdge(rb); // Right edge
+            IEdge b = new HorizontalEdge(lb); // Bottom edge
+            IEdge t = new HorizontalEdge(lt); // Top edge
 
             // all cases described in https://en.wikipedia.org/wiki/Marching_squares
             return index switch
@@ -83,13 +83,13 @@
                 _ => throw new Exception("Unexpected case"),
             };
         }
-        private static List<List<Edge>> GroupEdges(List<EdgeLine> edgeLinesArg)
+        private static List<List<IEdge>> GroupEdges(List<EdgeLine> edgeLinesArg)
         {
             var edgeLines = edgeLinesArg.ToList();
-            List<List<Edge>> result = new List<List<Edge>>();
+            List<List<IEdge>> result = new List<List<IEdge>>();
             while (edgeLines.Count > 0)
             {
-                List<Edge> currentPath = new List<Edge>();
+                List<IEdge> currentPath = new List<IEdge>();
                 currentPath.Add(edgeLines[0].first);
                 currentPath.Add(edgeLines[0].second);
 

--- a/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGrid.cs
+++ b/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGrid.cs
@@ -7,7 +7,7 @@ namespace ScottPlot.Triangulation
         {
             return zs.Select(z =>
             {
-                var edgeLines = LookupSquare(coordinateGrid, z).ToDictionary(e => e.CellID);
+                var edgeLines = MarchingSquares(coordinateGrid, z).ToDictionary(e => e.CellID);
                 var mergedPaths = MergeContourParts(edgeLines, coordinateGrid.GetLength(0));
                 return mergedPaths.Select(elem => new ContourLine(CoordinatePath.Open(elem.Select(edge => edge.Interpolate(coordinateGrid, z))), z));
             })
@@ -15,7 +15,7 @@ namespace ScottPlot.Triangulation
             .ToArray();
         }
 
-        private static IEnumerable<EdgeLine> LookupSquare(Coordinates3d[,] CoordinateGrid, double Z)
+        private static IEnumerable<EdgeLine> MarchingSquares(Coordinates3d[,] CoordinateGrid, double Z)
         {
             for (int j = 0; j < CoordinateGrid.GetLength(0) - 1; j++)
                 for (int i = 0; i < CoordinateGrid.GetLength(1) - 1; i++)

--- a/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGridPrimitives.cs
+++ b/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGridPrimitives.cs
@@ -1,0 +1,73 @@
+﻿namespace ScottPlot.Triangulation
+{
+    public record Vertex(int i, int j);
+    public record EdgeLine(Edge first, Edge second);
+
+    public abstract class Edge
+    {
+        public Vertex First { get; }
+        public Vertex Second { get; }
+        public Edge(Vertex first, Vertex second)
+        {
+            First = first;
+            Second = second;
+        }
+
+        public virtual Coordinates Interpolate(Coordinates3d[,] coordinateGrid, double Z)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool Equals(object? obj)
+        {
+            var other = obj as Edge;
+            if (other is null)
+                return false;
+
+            return (this.First.i == other.First.i && this.First.j == other.First.j && this.Second.i == other.Second.i && this.Second.j == other.Second.j);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 23 + First.i.GetHashCode();
+                hash = hash * 23 + First.j.GetHashCode();
+                hash = hash * 23 + Second.i.GetHashCode();
+                hash = hash * 23 + Second.j.GetHashCode();
+                return hash;
+            }
+        }
+    }
+
+    public class HorizontalEdge : Edge
+    {
+        public HorizontalEdge(Vertex first, Vertex second) : base(first, second)
+        {
+        }
+
+        public override Coordinates Interpolate(Coordinates3d[,] coordinateGrid, double Z)
+        {
+            Coordinates3d first = coordinateGrid[First.j, First.i];
+            Coordinates3d second = coordinateGrid[Second.j, Second.i];
+            var x = first.X + (second.X - first.X) / (second.Z - first.Z) * (Z - first.Z);
+            return new Coordinates(x, first.Y);
+        }
+    }
+
+    public class VerticalEdge : Edge
+    {
+        public VerticalEdge(Vertex first, Vertex second) : base(first, second)
+        {
+        }
+
+        public override Coordinates Interpolate(Coordinates3d[,] coordinateGrid, double Z)
+        {
+            Coordinates3d first = coordinateGrid[First.j, First.i];
+            Coordinates3d second = coordinateGrid[Second.j, Second.i];
+            var y = first.Y + (second.Y - first.Y) / (second.Z - first.Z) * (Z - first.Z);
+            return new Coordinates(first.X, y);
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGridPrimitives.cs
+++ b/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGridPrimitives.cs
@@ -1,30 +1,27 @@
 ﻿namespace ScottPlot.Triangulation
 {
     public record Vertex(int i, int j);
-    public record EdgeLine(Edge first, Edge second);
+    public record EdgeLine(IEdge first, IEdge second);
 
-    public abstract class Edge
+    public interface IEdge
+    {
+        Coordinates Interpolate(Coordinates3d[,] coordinateGrid, double Z);
+    }
+
+    public class HorizontalEdge : IEdge
     {
         public Vertex First { get; }
-        public Vertex Second { get; }
-        public Edge(Vertex first, Vertex second)
+        public HorizontalEdge(Vertex first)
         {
             First = first;
-            Second = second;
         }
-
-        public virtual Coordinates Interpolate(Coordinates3d[,] coordinateGrid, double Z)
-        {
-            throw new NotImplementedException();
-        }
-
         public override bool Equals(object? obj)
         {
-            var other = obj as Edge;
+            var other = obj as HorizontalEdge;
             if (other is null)
                 return false;
 
-            return (this.First.i == other.First.i && this.First.j == other.First.j && this.Second.i == other.Second.i && this.Second.j == other.Second.j);
+            return this.First.i == other.First.i && this.First.j == other.First.j;
         }
 
         public override int GetHashCode()
@@ -34,38 +31,51 @@
                 int hash = 17;
                 hash = hash * 23 + First.i.GetHashCode();
                 hash = hash * 23 + First.j.GetHashCode();
-                hash = hash * 23 + Second.i.GetHashCode();
-                hash = hash * 23 + Second.j.GetHashCode();
                 return hash;
             }
         }
-    }
 
-    public class HorizontalEdge : Edge
-    {
-        public HorizontalEdge(Vertex first, Vertex second) : base(first, second)
-        {
-        }
-
-        public override Coordinates Interpolate(Coordinates3d[,] coordinateGrid, double Z)
+        public Coordinates Interpolate(Coordinates3d[,] coordinateGrid, double Z)
         {
             Coordinates3d first = coordinateGrid[First.j, First.i];
-            Coordinates3d second = coordinateGrid[Second.j, Second.i];
+            Coordinates3d second = coordinateGrid[First.j, First.i + 1];
             var x = first.X + (second.X - first.X) / (second.Z - first.Z) * (Z - first.Z);
             return new Coordinates(x, first.Y);
         }
     }
 
-    public class VerticalEdge : Edge
+    public class VerticalEdge : IEdge
     {
-        public VerticalEdge(Vertex first, Vertex second) : base(first, second)
+        public Vertex First { get; }
+        public VerticalEdge(Vertex first)
         {
+            First = first;
         }
 
-        public override Coordinates Interpolate(Coordinates3d[,] coordinateGrid, double Z)
+        public override bool Equals(object? obj)
+        {
+            var other = obj as VerticalEdge;
+            if (other is null)
+                return false;
+
+            return (this.First.i == other.First.i && this.First.j == other.First.j);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 23 + First.i.GetHashCode();
+                hash = hash * 23 + First.j.GetHashCode();
+                return hash;
+            }
+        }
+
+        public Coordinates Interpolate(Coordinates3d[,] coordinateGrid, double Z)
         {
             Coordinates3d first = coordinateGrid[First.j, First.i];
-            Coordinates3d second = coordinateGrid[Second.j, Second.i];
+            Coordinates3d second = coordinateGrid[First.j + 1, First.i];
             var y = first.Y + (second.Y - first.Y) / (second.Z - first.Z) * (Z - first.Z);
             return new Coordinates(first.X, y);
         }

--- a/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGridPrimitives.cs
+++ b/src/ScottPlot5/ScottPlot5/Triangulation/RectangularGridPrimitives.cs
@@ -1,10 +1,34 @@
 ﻿namespace ScottPlot.Triangulation
 {
     public record Vertex(int i, int j);
-    public record EdgeLine(IEdge first, IEdge second);
+    public class EdgeLine
+    {
+        public IEdge first { get; }
+        public IEdge second { get; }
+        public int CellID { get; set; }
+
+        public EdgeLine(IEdge first, IEdge second, int cellId)
+        {
+            this.first = first;
+            this.second = second;
+            CellID = cellId;
+        }
+    }
+
+    public class EdgeLinePair : EdgeLine
+    {
+        public IEdge first1 { get; }
+        public IEdge second1 { get; }
+        public EdgeLinePair(IEdge first, IEdge second, IEdge first1, IEdge second1, int cellId) : base(first, second, cellId)
+        {
+            this.first1 = first1;
+            this.second1 = second1;
+        }
+    }
 
     public interface IEdge
     {
+        Vertex First { get; }
         Coordinates Interpolate(Coordinates3d[,] coordinateGrid, double Z);
     }
 
@@ -23,6 +47,7 @@
 
             return this.First.i == other.First.i && this.First.j == other.First.j;
         }
+
 
         public override int GetHashCode()
         {


### PR DESCRIPTION
Contour lines are now calculated without triangulation of the original grid.

The MarchingSquares algorithm is used to find the contour.
The resulting lines are merged into a common path. There can be several of them for one elevation level.

Since our lines are merged into a path, we can add a label on top of the drawn path.

Grid primitives use indexes instead of real values. This is useful for accurate comparison of integer values, and reduces the number of interpolations by about half (we discard half of the points in the merge process)
![ContoursWithLabels](https://github.com/user-attachments/assets/69c8ae2e-d598-45d3-8d12-27873a55ca53)


It looks like the Heatmap was originally flipped by Y. I did the reverse flip manually in the cookBook example.