### PR TITLE
Added Center property to PixelLine.cs

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Primitives/PixelLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/PixelLine.cs
@@ -25,6 +25,8 @@ public readonly struct PixelLine
 
     public Pixel Pixel2 => new(X2, Y2);
 
+    public Pixel Center => new Pixel((X1 + X2) / 2, (Y1 + Y2) / 2);
+
     public PixelLine(float x1, float y1, float x2, float y2)
     {
         X1 = x1;


### PR DESCRIPTION
Fixes #4318

Hi! Just added a center property based on the issue above.

If the center property was just for the Pixel 1, please let me know and I can fix it.