### PR TITLE
Maui: Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ _Not yet on NuGet..._
 * CoordinateRange: Refactored to improve support for inverted ranges (#4316) @CoderPM2011
 * Axes: Added a `Plot.Axes.TightMargins()` shortcut for setting autoscale margins to tightly fit the data
 * ContourLines: New plot type for displaying lines that mark points of equal elevation given a collection of 3D points (#4296, #2330, #3795) @jon-rizzo @StendProg
-* Maui: Improved the .NET MAUI ScottPlot control and added quickstart documentation to the website (#4320, #4023, #4013) @KosmosWerner @ByteSore
+* Maui: Improved the .NET MAUI ScottPlot control and added quickstart documentation to the website (#4320, #4023, #4013, #4342) @KosmosWerner @ByteSore
 * Radar: Improved rotational direction of labels (#4321, #4310) @CoderPM2011 @bry-decelles
 * Axes: Added `Plot.Axes.MarginsX()` and `Plot.Axes.MarginsY()` for changing margins in a single axis without changing the other (#4246)
 * Colormap: Added `Colormap.FromColors()` to generate colormaps using interpolated gradients between a user defined collection of colors (#4247, #4324)

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlotExtensions.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlotExtensions.cs
@@ -2,63 +2,96 @@
 
 internal static class MauiPlotExtensions
 {
-    internal static Pixel Pixel(this TappedEventArgs e, MauiPlot plot)
+    internal static Pixel ToPixel(this PointerEventArgs e, MauiPlot? plot)
     {
-        Point? position = e.GetPosition(null);
+        Point? position = e.GetPosition(plot);
 
-        if (position is null)
-            return new(double.NaN, double.NaN);
-
-        Point tmpPos = new Point(
-                position.Value.X * plot.DisplayScale,
-                position.Value.X * plot.DisplayScale
-            );
-
-        return tmpPos.ToPixel();
+        if (position is null) return Pixel.NaN;
+        if (plot is null) return new(position.Value.X, position.Value.Y);
+        return new(position.Value.X * plot.DisplayScale, position.Value.Y * plot.DisplayScale);
     }
 
-    internal static Pixel ToPixel(this Point p)
+    internal static Pixel ToPixel(this TappedEventArgs e, MauiPlot? plot)
     {
-        return new Pixel((float)p.X, (float)p.Y);
+        Point? position = e.GetPosition(plot);
+
+        if (position is null) return Pixel.NaN;
+        if (plot is null) return new(position.Value.X, position.Value.Y);
+        return new(position.Value.X * plot.DisplayScale, position.Value.Y * plot.DisplayScale);
     }
 
-    internal static Point ToPoint(this Pixel p)
+    internal static Pixel ToPixel(this PanUpdatedEventArgs e)
     {
-        return new Point(p.X, p.Y);
+        return new Pixel(e.TotalX, e.TotalY);
     }
 
-    internal static Control.MouseButton ToButton(this TappedEventArgs e, MauiPlot plot)
+    internal static void ProcessPanUpdated(this Interactivity.UserInputProcessor processor, MauiPlot plot, PanUpdatedEventArgs e)
     {
-        var props = e.GetPosition(plot);
-        switch (e.Buttons)
+        Interactivity.IUserAction action = e.StatusType switch
         {
-            case ButtonsMask.Primary:
-                return Control.MouseButton.Left;
-            case ButtonsMask.Secondary:
-                return Control.MouseButton.Right;
-            default:
-                return Control.MouseButton.Unknown;
+            GestureStatus.Started => new Interactivity.UserActions.LeftMouseDown(Pixel.Zero),
+            GestureStatus.Running => new Interactivity.UserActions.MouseMove(e.ToPixel()),
+            GestureStatus.Completed => new Interactivity.UserActions.LeftMouseUp(plot.LastPixel), //When StatusType == Completed, e.ToPixel returns (0,0)
+            _ => new Interactivity.UserActions.Unknown(),
+        };
+        plot.LastPixel = e.ToPixel();
+
+        processor.Process(action);
+    }
+
+    internal static void ProcessPinchUpdated(this Interactivity.UserInputProcessor processor, MauiPlot plot, PinchGestureUpdatedEventArgs e)
+    {
+        if (e.Status == GestureStatus.Running && e.Scale != 1.0)
+        {
+            Interactivity.IUserAction action = e.Scale > 1
+                ? new ScottPlot.Interactivity.UserActions.MouseWheelUp(new Pixel(plot.Width / 2, plot.Height / 2))
+                : new ScottPlot.Interactivity.UserActions.MouseWheelDown(new Pixel(plot.Width / 2, plot.Height / 2));
+
+            processor.Process(action);
         }
     }
 
-    /*internal static Control.Key Key(this KeyRoutedEventArgs e)
+    internal static void ProcessPointerPressed(this Interactivity.UserInputProcessor processor, MauiPlot plot, PointerEventArgs e)
     {
-        return e.Key switch
-        {
-            VirtualKey.Control => Control.Key.Ctrl,
-            VirtualKey.LeftControl => Control.Key.Ctrl,
-            VirtualKey.RightControl => Control.Key.Ctrl,
+        Pixel pixel = e.ToPixel(plot);
 
-            VirtualKey.Menu => Control.Key.Alt,
-            VirtualKey.LeftMenu => Control.Key.Alt,
-            VirtualKey.RightMenu => Control.Key.Alt,
+        //ProcessKeyModifiersPressed(processor, plot, e);
+        Interactivity.IUserAction action = new Interactivity.UserActions.LeftMouseDown(pixel);
+        processor.Process(action);
+    }
 
-            VirtualKey.Shift => Control.Key.Shift,
-            VirtualKey.LeftShift => Control.Key.Shift,
-            VirtualKey.RightShift => Control.Key.Shift,
+    internal static void ProcessPointerMoved(this Interactivity.UserInputProcessor processor, MauiPlot plot, PointerEventArgs e)
+    {
+        Pixel pixel = e.ToPixel(plot);
 
-            _ => Control.Key.Unknown,
-        };
-    }*/
+        Interactivity.IUserAction action = new Interactivity.UserActions.MouseMove(pixel);
+        processor.Process(action);
+    }
+
+    internal static void ProcessPointerReleased(this Interactivity.UserInputProcessor processor, MauiPlot plot, PointerEventArgs e)
+    {
+        Pixel pixel = e.ToPixel(plot);
+
+        Interactivity.IUserAction action = new Interactivity.UserActions.LeftMouseUp(pixel);
+        processor.Process(action);
+    }
+
+    internal static void ProcessContext(this Interactivity.UserInputProcessor processor, MauiPlot plot, TappedEventArgs e)
+    {
+        Pixel pixel = e.ToPixel(plot);
+
+        Interactivity.IUserAction action = new Interactivity.UserActions.RightMouseDown(pixel);
+        processor.Process(action);
+        action = new Interactivity.UserActions.RightMouseUp(pixel);
+        processor.Process(action);
+    }
+
+    internal static void ProcessZoomAll(this Interactivity.UserInputProcessor processor, MauiPlot plot, TappedEventArgs e)
+    {
+        Pixel pixel = e.ToPixel(plot);
+
+        Interactivity.IUserAction action = new Interactivity.UserActions.MouseWheelUp(pixel);
+        processor.Process(action);
+    }
 }
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlotMenu.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlotMenu.cs
@@ -19,7 +19,7 @@ public class MauiPlotMenu : IPlotMenu
         ContextMenuItem saveImage = new()
         {
             Label = "Save Image",
-            OnInvoke = OpenSaveImageDialog,
+            OnInvoke = SaveImageDialog,
         };
 
         // TODO: ContextMenuItem copyImage
@@ -52,7 +52,7 @@ public class MauiPlotMenu : IPlotMenu
         };
     }
 
-    public async void OpenSaveImageDialog(IPlotControl plotControl)
+    public async void SaveImageDialog(IPlotControl plotControl)
     {
         if (plotControl is not MauiPlot mauiPlot) return;
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlotMenu.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlotMenu.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Maui.Controls;
-using ScottPlot.Control;
-using System.Text;
+﻿using ScottPlot.Control;
 
 namespace ScottPlot.Maui;
 
@@ -11,27 +9,21 @@ public class MauiPlotMenu : IPlotMenu
 
     public MauiPlotMenu(MauiPlot plot)
     {
-        this.MauiPlot = plot;
+        MauiPlot = plot;
         Reset();
     }
 
     public ContextMenuItem[] GetDefaultContextMenuItems()
     {
-        /*
+
         ContextMenuItem saveImage = new()
         {
             Label = "Save Image",
             OnInvoke = OpenSaveImageDialog,
         };
-       
 
-        TODO: Unable to assign an image to the clipboard using Clipboard.SetImage
-        ContextMenuItem copyImage = new()
-        {
-            Label = "Copy to Clipboard",
-            OnInvoke = CopyImageToClipboard,
-        };
-         */
+        // TODO: ContextMenuItem copyImage
+
         ContextMenuItem autoscale = new()
         {
             Label = "Autoscale",
@@ -40,78 +32,106 @@ public class MauiPlotMenu : IPlotMenu
 
         ContextMenuItem zoomIn = new()
         {
-            Label = "ZoomIn",
+            Label = "Zoom In",
             OnInvoke = ZoomIn,
         };
 
         ContextMenuItem zoomOut = new()
         {
-            Label = "ZoomOut",
+            Label = "Zoom Out",
             OnInvoke = ZoomOut,
         };
 
 
         return new ContextMenuItem[] {
-            //saveImage,
-            //copyImage,
+            saveImage,
+            new() { IsSeparator = true },
             autoscale,
             zoomIn,
             zoomOut,
         };
     }
 
-    private void ZoomOut(IPlotControl plotControl)
+    public async void OpenSaveImageDialog(IPlotControl plotControl)
     {
-        plotControl.Interaction.MouseWheelVertical(new Pixel(MauiPlot.Width / 2, MauiPlot.Height / 2), -1);
-    }
+        if (plotControl is not MauiPlot mauiPlot) return;
 
-    private void ZoomIn(IPlotControl plotControl)
-    {
-        plotControl.Interaction.MouseWheelVertical(new Pixel(MauiPlot.Width / 2, MauiPlot.Height / 2), 1);
+        var page = MauiPlot.GetFirstPageParent(mauiPlot);
+        if (page == null) return;
 
-    }
+        string[] formats = [
+            "PNG Files .png",
+            "JPEG Files .jpg",
+            "BMP Files .bmp",
+            "WebP Files .webp",
+            "SVG Files .svg"
+        ];
 
-    public MenuFlyout GetContextMenu(IPlotControl plotControl)
-    {
-        MenuFlyout flyout = new();
-
-        foreach (var curr in ContextMenuItems)
+        try
         {
-            if (curr.IsSeparator)
-            {
-                flyout.Add(new MenuFlyoutSeparator());
-            }
-            else
-            {
-                var menuItem = new MenuFlyoutItem { Text = curr.Label };
-                menuItem.Clicked += (s, e) => curr.OnInvoke(plotControl);
-                flyout.Add(menuItem);
-            }
+            var format = await page.DisplayActionSheet("Select a format", null, null, formats);
+            if (format is null) return;
+            ImageFormat imgformat = ImageFormats.FromFilename(format);
+
+
+            string tempFileName = $"Plot_{DateTime.Now:yyyyMMdd_HHmmss}";
+            var name = await page.DisplayPromptAsync("File name", "Enter the file name", placeholder: tempFileName);
+            if (name is null) return;
+            if (name.Length == 0) name = tempFileName;
+
+
+            var folder = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+            PixelSize lastRenderSize = plotControl.Plot.RenderManager.LastRender.FigureRect.Size;
+            plotControl.Plot.Save(Path.Combine(folder, $"{name}{format}"), (int)lastRenderSize.Width, (int)lastRenderSize.Height, imgformat);
+
+            await page.DisplayAlert("Success", $"Image saved to {folder}", "OK");
         }
 
-        return flyout;
-    }
+        catch (Exception)
+        {
+            await page.DisplayAlert("Error", $"Image save failed", "OK");
+            return;
+        }
 
-    public void OpenSaveImageDialog(IPlotControl plotControl)
-    {
-
-    }
-
-    public void CopyImageToClipboard(IPlotControl plotControl)
-    {
-        /* TODO
-        PixelSize lastRenderSize = plotControl.Plot.RenderManager.LastRender.FigureRect.Size;
-        Image bmp = plotControl.Plot.GetImage((int)lastRenderSize.Width, (int)lastRenderSize.Height);
-        byte[] bmpBytes = bmp.GetImageBytes();
-
-        Clipboard.SetTextAsync(Encoding.UTF8.GetString(bmpBytes, 0, bmpBytes.Length));
-        */
     }
 
     public void Autoscale(IPlotControl plotControl)
     {
         plotControl.Plot.Axes.AutoScale();
         plotControl.Refresh();
+    }
+
+    public void ZoomIn(IPlotControl plotControl)
+    {
+        plotControl.Plot.Axes.Zoom(1.5, 1.5);
+        plotControl.Refresh();
+    }
+
+    public void ZoomOut(IPlotControl plotControl)
+    {
+        plotControl.Plot.Axes.Zoom(0.5, 0.5);
+        plotControl.Refresh();
+    }
+
+    public MenuFlyout GetContextMenu(IPlotControl plotControl)
+    {
+        MenuFlyout flyout = new();
+
+        foreach (var item in ContextMenuItems)
+        {
+            if (item.IsSeparator)
+            {
+                flyout.Add(new MenuFlyoutSeparator());
+            }
+            else
+            {
+                var menuItem = new MenuFlyoutItem { Text = item.Label };
+                menuItem.Clicked += (s, e) => item.OnInvoke(plotControl);
+                flyout.Add(menuItem);
+            }
+        }
+
+        return flyout;
     }
 
     public void ShowContextMenu(Pixel pixel)
@@ -140,6 +160,4 @@ public class MauiPlotMenu : IPlotMenu
         Clear();
         ContextMenuItems.AddRange(GetDefaultContextMenuItems());
     }
-
-
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/Platforms/Windows/PlatformClass1.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/Platforms/Windows/PlatformClass1.cs
@@ -1,6 +1,41 @@
-﻿namespace ScottPlot.Maui;
+﻿using Windows.System;
+using ScottPlot.Interactivity;
+
+namespace ScottPlot.Maui;
 
 // All the code in this file is only included on Windows.
 public class PlatformClass1
+//internal static partial class MauiPlotExtensions
 {
+//    static partial void ProcessKeyModifiersPressed(UserInputProcessor processor, MauiPlot plot, PointerEventArgs e)
+//    {
+//        var args = e.PlatformArgs?.PointerRoutedEventArgs;
+//        if (args is null) return;
+//        var keyModifiers = args.KeyModifiers;
+
+
+//        if (keyModifiers is null) return;
+
+//        bool control = ((uint)keyModifiers & (uint)VirtualKeyModifiers.Control) > 0;
+//        bool shift = ((int)keyModifiers & (int)VirtualKeyModifiers.Shift) > 0;
+//        bool alt = ((int)keyModifiers & (int)VirtualKeyModifiers.Menu) > 0;
+
+
+//        IUserAction actionShift = shift
+//            ? new Interactivity.UserActions.KeyDown(StandardKeys.Shift)
+//            : new Interactivity.UserActions.KeyUp(StandardKeys.Shift);
+//        processor.Process(actionShift);
+
+//        IUserAction actionControl = control
+//            ? new Interactivity.UserActions.KeyDown(StandardKeys.Control)
+//            : new Interactivity.UserActions.KeyUp(StandardKeys.Control);
+//        processor.Process(actionControl);
+
+//        IUserAction actionAlt = alt
+//            ? new Interactivity.UserActions.KeyDown(StandardKeys.Alt)
+//            : new Interactivity.UserActions.KeyUp(StandardKeys.Alt);
+//        processor.Process(actionAlt);
+
+//        Trace.WriteLine($"dsa{args}");
+//    }
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/nuget-readme.md
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/nuget-readme.md
@@ -2,6 +2,12 @@
 
 [![](https://raw.githubusercontent.com/ScottPlot/ScottPlot/master/dev/graphics/ScottPlot.gif)](https://scottplot.net)
 
-## Quickstart and Documentation
+## MAUI Quickstart
 
-* https://scottplot.net/
+* https://scottplot.net/quickstart/maui/
+
+# Versions
+
+* **ScottPlot 5.0 is the newest version of ScottPlot.** ScottPlot 5 is actively developed and supports all operating systems. The API is similar but not identical to ScottPlot 4. See the [What's New in ScottPlot 5.0](https://scottplot.net/faq/version-5.0/) page for details.
+
+* **ScottPlot 4.1 is a stable version of ScottPlot** which continues to be maintained but no longer receives major new features. ScottPlot 4 supported all operating systems through .NET 6, but after .NET 7 it can only be used in projects that target Windows.

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.Maui/MainPage.xaml
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.Maui/MainPage.xaml
@@ -4,14 +4,5 @@
              xmlns:sp="clr-namespace:ScottPlot.Maui;assembly=ScottPlot.Maui"
              x:Class="Sandbox.Maui.MainPage"
              Title="ScottPlot">
-    <Grid
-        HorizontalOptions="FillAndExpand" 
-        VerticalOptions="FillAndExpand">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="*" />
-            <RowDefinition Height="100"/>
-        </Grid.RowDefinitions>
-        <sp:MauiPlot x:Name="MauiPlot1" Grid.Row="0" />
-        <Label Text="Label" Grid.Row="1" />
-    </Grid>
+    <sp:MauiPlot x:Name="MauiPlot1" Grid.Row="0" />
 </ContentPage>


### PR DESCRIPTION
Hello again, I made modifications to the MAUI implementation to align with the new pattern mentioned in https://github.com/ScottPlot/ScottPlot/pull/4322 to use `UserInputProcessor`, which will now be enabled by default.

I also implemented a `SaveImageDialog`, which saves images by default to the `MyPictures` folder. I aimed to use only .NET and MAUI methods, and while there are some classes in CommunityToolkit, this was implemented natively. However, clipboard functionality is still missing.

The controls, while limited by MAUI, allow panning, and zooming via the contextual menu on desktop, and on mobile, panning and zooming can be done using touch gestures.

I believe this is what can be achieved within MAUI's current limitations, such as not being able to detect whether the right or left mouse button was pressed or recognizing the mouse wheel. However, on mobile devices, it works well.

That's all for now. This should now be a functional version that adapts to the example projects. If there are any issues, please let me know.

![image](https://github.com/user-attachments/assets/4c66ee5a-2e46-484f-88d2-705ecbdb6982)

![image](https://github.com/user-attachments/assets/3c2bb300-537e-4dce-a8d6-afacbb8500a8)

![image](https://github.com/user-attachments/assets/d8e11ef9-b5f5-4816-989a-49c674780cb4)
