### PR TITLE
Coookbook: Fix histogram recipe

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Statistics/Histograms.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Statistics/Histograms.cs
@@ -1,0 +1,37 @@
+﻿namespace ScottPlotCookbook.Recipes.PlotTypes;
+
+public class Histograms : ICategory
+{
+    public string Chapter => "Statistics";
+    public string CategoryName => "Histogram";
+    public string CategoryDescription => "Histograms graphically represent the distribution of numerical data " +
+        "by grouping values into ranges (bins) and displaying the frequency or count of points in each bin.";
+
+    public class HistogramQuickstart : RecipeBase
+    {
+        public override string Name => "Histogram Quickstart";
+        public override string Description => "A histogram can be created from a collection of values.";
+
+        [Test]
+        public override void Execute()
+        {
+            // Create a histogram from a collection of values
+            double[] heights = Generate.RandomNormal(count: 1000, mean: 160, stdDev: 20);
+            ScottPlot.Statistics.Histogram hist = new(heights, 20);
+
+            // Display the histogram as a bar plot
+            var barPlot = myPlot.Add.Bars(hist.Bins, hist.Counts);
+
+            // Size each bar slightly less than the width of a bin
+            foreach (var bar in barPlot.Bars)
+            {
+                bar.Size = hist.BinSize * .8;
+            }
+
+            // Customize plot style
+            myPlot.Axes.Margins(bottom: 0);
+            myPlot.YLabel("Number of People");
+            myPlot.XLabel("Height (cm)");
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Statistics/Regression.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/Statistics/Regression.cs
@@ -8,7 +8,7 @@ public class Regression : ICategory
 
     public class Linear : RecipeBase
     {
-        public override string Name => "LinearRegression";
+        public override string Name => "Linear Regression";
         public override string Description => "Fit a line to a collection of X/Y data points.";
 
         [Test]

--- a/src/ScottPlot5/ScottPlot5/Statistics/Histogram.cs
+++ b/src/ScottPlot5/ScottPlot5/Statistics/Histogram.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace ScottPlot.Statistics;
+﻿namespace ScottPlot.Statistics;
 
 public class Histogram
 {
@@ -66,6 +62,14 @@ public class Histogram
     /// Number of values that were greater than the upper edge of the last bin.
     /// </summary>
     public int MaxOutlierCount { get; private set; } = 0;
+
+    /// <summary>
+    /// Create a histogram with the given number of bins arranged to contain the full range of data values
+    /// </summary>
+    public Histogram(IEnumerable<double> values, int binCount = 10) : this(values.Min(), values.Max(), binCount)
+    {
+        AddRange(values);
+    }
 
     /// <summary>
     /// Create a histogram which will count values supplied by <see cref="Add(double)"/> and <see cref="AddRange(IEnumerable{double})"/>


### PR DESCRIPTION
This PR adds a `Histogram` constructor that accepts data values and demonstrates its use in the cookbook (which previously had a very broken histogram recipe page).

The `Histogram` class needs to be extensively refactored to improve support for arbitrary bins and add methods for getting percentage and cumulative probabilities (#4287)