### PR TITLE
MultiPlot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ _Not yet on NuGet..._
 * Colormap: added `MellowRainbow` similar to Jet and Turbo but with mellow tones to improve appearance of thin lines on a white background (#4325)
 * ScaleBar: New plot type for communicating scale as a concise alternative to the axis frame (#4319, #4337, #4329) @CoderPM2011
 * PixelLine: Added `Center` property (#4335, #4318) @brokoli777
+* MultiPlot: New class for creating composite figures containing multiple distinct `Plot` figures (#3948)
 
 ## ScottPlot 5.0.39
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-08-02_

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/Extensions.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/Extensions.cs
@@ -136,4 +136,25 @@ internal static class Extensions
     {
         return new PlotAssertions(plot);
     }
+
+    internal static void SaveTestImage(this MultiPlot multiplot, int width = 600, int height = 600, string subName = "")
+    {
+        StackTrace stackTrace = new();
+        StackFrame frame = stackTrace.GetFrame(1) ?? throw new InvalidOperationException("unknown caller");
+        MethodBase method = frame.GetMethod() ?? throw new InvalidDataException("unknown method");
+        string callingMethod = method.Name;
+
+        if (!string.IsNullOrWhiteSpace(subName))
+            subName = "_" + subName;
+
+        string saveFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, "test-images");
+        if (!Directory.Exists(saveFolder))
+            Directory.CreateDirectory(saveFolder);
+
+        string fileName = callingMethod + subName + ".png";
+        string filePath = Path.Combine(saveFolder, fileName);
+        Console.WriteLine(filePath);
+
+        multiplot.SavePng(filePath, width, height);
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/MultiPlotTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/MultiPlotTests.cs
@@ -1,0 +1,29 @@
+﻿namespace ScottPlotTests.RenderTests;
+
+class MultiPlotTests
+{
+    private static Plot MakePlot(string label)
+    {
+        Plot plot = new();
+        plot.Add.Signal(Generate.Sin());
+        plot.Add.Signal(Generate.Cos());
+        var an = plot.Add.Annotation(label, Alignment.MiddleCenter);
+        an.LabelFontSize = 100;
+        an.LabelBackgroundColor = Colors.Transparent;
+        an.LabelShadowColor = Colors.Transparent;
+        an.LabelBorderColor = Colors.Transparent;
+        an.LabelBold = true;
+        an.LabelFontColor = Colors.Black.WithAlpha(.5);
+        return plot;
+    }
+
+
+    [Test]
+    public void Test_Multiplot_Basic()
+    {
+        MultiPlot mp = new();
+        mp.AddSubplot(MakePlot("one"), 0, 2, 0, 1);
+        mp.AddSubplot(MakePlot("two"), 1, 2, 0, 1);
+        mp.SaveTestImage();
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/MultiPlotTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/MultiPlotTests.cs
@@ -21,9 +21,19 @@ class MultiPlotTests
     [Test]
     public void Test_Multiplot_Basic()
     {
+        Plot plot1 = new();
+        var sig1 = plot1.Add.Signal(Generate.Sin());
+        sig1.Color = Colors.Blue;
+        sig1.LineWidth = 5;
+
+        Plot plot2 = new();
+        var sig2 = plot2.Add.Signal(Generate.Cos());
+        sig2.Color = Colors.Red;
+        sig2.LineWidth = 5;
+
         MultiPlot mp = new();
-        mp.AddSubplot(MakePlot("one"), 0, 2, 0, 1);
-        mp.AddSubplot(MakePlot("two"), 1, 2, 0, 1);
+        mp.AddSubplot(plot1, 0, 2, 0, 1);
+        mp.AddSubplot(plot2, 1, 2, 0, 1);
         mp.SaveTestImage();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/MultiPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/MultiPlot.cs
@@ -1,0 +1,134 @@
+﻿namespace ScottPlot;
+
+public class MultiPlot
+{
+    // TODO: refactor the private classes inside this class then expose them
+
+    // TODO: refactor functionality so we could add plots simply then arrange them on a grid later
+
+    private class SubPlot(Plot plot, SubPlotRect rect)
+    {
+        public Plot Plot { get; set; } = plot;
+        public SubPlotRect Rect { get; set; } = rect;
+        public PixelRect GetPixelRect(int width, int height) => Rect.GetPixelRect(width, height);
+        public static SubPlot FullSize(Plot plot) => new SubPlot(plot, SubPlotRect.FullSize);
+    }
+
+    private class SubPlotRect
+    {
+        public double Width { get; set; }
+        public double Height { get; set; }
+        public double Left { get; set; }
+        public double Top { get; set; }
+        public bool Fractional { get; set; }
+
+        public static SubPlotRect FullSize => new()
+        {
+            Width = 1,
+            Height = 1,
+            Left = 0,
+            Top = 0,
+            Fractional = true,
+        };
+
+        public PixelRect GetPixelRect(int width, int height)
+        {
+            if (!Fractional)
+            {
+                Pixel topLeft = new(Left, Top);
+                PixelSize size = new(Width, Height);
+                return new PixelRect(topLeft, size);
+            }
+            else
+            {
+                Pixel topLeft = new(Left * width, Top * height);
+                PixelSize size = new(Width * width, Height * height);
+                return new PixelRect(topLeft, size);
+            }
+        }
+    }
+
+    private class SizedPlot(Plot plot, PixelSize size)
+    {
+        public Plot? Plot { get; } = plot;
+        public MultiPlot? MultiPlot { get; } = null;
+        public PixelSize Size { get; } = size;
+    }
+
+    private List<SubPlot> SubPlots { get; } = [];
+
+    public Plot[] Plots => SubPlots.Select(x => x.Plot).ToArray();
+
+    public MultiPlot()
+    {
+    }
+
+    public static MultiPlot WithGrid(Plot[,] plots)
+    {
+        MultiPlot mp = new();
+
+        int rows = plots.GetLength(0);
+        int cols = plots.GetLength(1);
+
+        for (int y = 0; y < rows; y++)
+        {
+            for (int x = 0; x < cols; x++)
+            {
+                mp.AddSubplot(plots[y, x], y, rows, x, cols);
+            }
+        }
+
+        return mp;
+    }
+
+    public static MultiPlot WithSinglePlot(Plot plot)
+    {
+        MultiPlot mp = new();
+        SubPlot sp = SubPlot.FullSize(plot);
+        mp.SubPlots.Add(sp);
+        return mp;
+    }
+
+    public void AddSubplot(Plot plot, int rowIndex, int totalRows, int columnIndex, int totalColumns)
+    {
+        if (totalRows < 1)
+            throw new ArgumentException($"{nameof(totalRows)} must be at least 1");
+
+        if (totalColumns < 1)
+            throw new ArgumentException($"{nameof(totalColumns)} must be at least 1");
+
+        double colWidth = 1.0 / totalColumns;
+        double colHeight = 1.0 / totalRows;
+
+        SubPlotRect rect = new()
+        {
+            Width = colWidth,
+            Height = colHeight,
+            Left = colWidth * columnIndex,
+            Top = colHeight * rowIndex,
+            Fractional = true,
+        };
+
+        SubPlots.Add(new(plot, rect));
+    }
+
+    public Image Render(int width, int height)
+    {
+        SKImageInfo imageInfo = new(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        SKSurface surface = SKSurface.Create(imageInfo);
+
+        foreach (SubPlot subplot in SubPlots)
+        {
+            PixelRect rect = subplot.GetPixelRect(width, height);
+            subplot.Plot.RenderManager.ClearCanvasBeforeEachRender = false;
+            subplot.Plot.Render(surface.Canvas, rect);
+        }
+
+        return new(surface);
+    }
+
+    public SavedImageInfo SavePng(string filename, int width = 800, int height = 600)
+    {
+        return Render(width, height).SavePng(filename);
+    }
+}


### PR DESCRIPTION
This PR adds a simple `Multiplot` class for creating figures containing multiple `Plot` objects. Refinements to the API will be made in subsequent PRs.

This is only useful for saving image files. This type of plot is not supported in the user controls. To achieve this type of functionality in an interactive app, place multiple controls on the window.

```cs
Plot plot1 = new();
var sig1 = plot1.Add.Signal(Generate.Sin());
sig1.Color = Colors.Blue;
sig1.LineWidth = 5;

Plot plot2 = new();
var sig2 = plot2.Add.Signal(Generate.Cos());
sig2.Color = Colors.Red;
sig2.LineWidth = 5;

MultiPlot mp = new();
mp.AddSubplot(plot1, 0, 2, 0, 1);
mp.AddSubplot(plot2, 1, 2, 0, 1);
mp.SavePng("test.png");
```

![image](https://github.com/user-attachments/assets/002e2358-d417-4a69-a403-f9692dbb00bf)
