### PR TITLE
Fix typo in GenerateTickPosition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## ScottPlot 5.0.41
 _Not yet on NuGet..._
+* Ticks: Improved automatic tick generation for axes of extremely small plots (#4353, #4354) @StendProg @Cassar17
 
 ## ScottPlot 5.0.40
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-10-16_

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/TickGenerators/DecimalTickSpacingCalculatorTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/TickGenerators/DecimalTickSpacingCalculatorTests.cs
@@ -18,4 +18,18 @@ internal class DecimalTickSpacingCalculatorTests
             spacePerLabel.Should().BeGreaterThan(maxLabelLength.Length);
         }
     }
+
+    [Test]
+    public void GenerateTickPositions__SmallAxisSize_2DifferentTickPostitions()
+    {
+        ScottPlot.TickGenerators.DecimalTickSpacingCalculator calc = new();
+        CoordinateRange range = new(1, 5);
+        PixelLength axisLength = new(50);
+        PixelLength maxLabelLength = 30;
+
+        double[] positions = calc.GenerateTickPositions(range, axisLength, maxLabelLength);
+
+        Assert.That(positions.Length, Is.EqualTo(2));
+        Assert.That(positions[0], Is.Not.EqualTo(positions[1]));
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/DecimalTickSpacingCalculator.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/DecimalTickSpacingCalculator.cs
@@ -22,7 +22,7 @@ public class DecimalTickSpacingCalculator
         {
             double tickBelow = range.Min - firstTickOffset;
             double firstTick = majorTickPositions.Length > 0 ? majorTickPositions[0] : tickBelow;
-            double nextTick = tickBelow + tickSpacing;
+            double nextTick = firstTick + tickSpacing;
             majorTickPositions = [firstTick, nextTick];
         }
 


### PR DESCRIPTION
With very small Plot sizes, MajorTickGenerator sometimes returned only 2 absolutely identical positions. This caused problems when calculating logarithmic axes. #4353
This may be due to a typo corrected in this PR.