### PR TITLE
Added Center property back to CoordinateRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## ScottPlot 5.0.41
 _Not yet on NuGet..._
 * Ticks: Improved automatic tick generation for axes of extremely small plots (#4353, #4354) @StendProg @Cassar17
+* CoordinateRange: Added a `Center` property to return the value halfway between the range boundary values (#4316, #4357) @idotta
 
 ## ScottPlot 5.0.40
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-10-16_

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/PrimitiveTests/CoordinateRangeTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/PrimitiveTests/CoordinateRangeTests.cs
@@ -54,4 +54,40 @@ internal class CoordinateRangeTests
         new CoordinateRange(2, 4).Rectified().Should().Be(new CoordinateRange(2, 4));
         new CoordinateRange(4, 2).Rectified().Should().Be(new CoordinateRange(2, 4));
     }
+
+    [Test]
+    public void Test_CoordinateRange_Span()
+    {
+        new CoordinateRange(2, 10).Span.Should().Be(8);
+        new CoordinateRange(-10, 2).Span.Should().Be(12);
+        new CoordinateRange(-2, 10).Span.Should().Be(12);
+
+        new CoordinateRange(10, 2).Span.Should().Be(-8);
+        new CoordinateRange(2, -10).Span.Should().Be(-12);
+        new CoordinateRange(10, -2).Span.Should().Be(-12);
+    }
+
+    [Test]
+    public void Test_CoordinateRange_Center()
+    {
+        new CoordinateRange(2, 10).Center.Should().Be(6);
+        new CoordinateRange(-10, 2).Center.Should().Be(-4);
+        new CoordinateRange(-2, 10).Center.Should().Be(4);
+
+        new CoordinateRange(10, 2).Center.Should().Be(6);
+        new CoordinateRange(2, -10).Center.Should().Be(-4);
+        new CoordinateRange(10, -2).Center.Should().Be(4);
+    }
+
+    [Test]
+    public void Test_CoordinateRange_Length()
+    {
+        new CoordinateRange(2, 10).Length.Should().Be(8);
+        new CoordinateRange(-10, 2).Length.Should().Be(12);
+        new CoordinateRange(-2, 10).Length.Should().Be(12);
+
+        new CoordinateRange(10, 2).Length.Should().Be(8);
+        new CoordinateRange(2, -10).Length.Should().Be(12);
+        new CoordinateRange(10, -2).Length.Should().Be(12);
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/CoordinateRange.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/CoordinateRange.cs
@@ -20,6 +20,11 @@ public readonly struct CoordinateRange(double value1, double value2)
     public double Span => Value2 - Value1;
 
     /// <summary>
+    /// Value located in the center of the range, between <see cref="Value1"/> and <see cref="Value2"/> (may be negative)
+    /// </summary>
+    public double Center => (Value1 + Value2) / 2;
+
+    /// <summary>
     /// Distance from <see cref="Min"/> to <see cref="Max"/> (always positive)
     /// </summary>
     public double Length => Math.Abs(Span);


### PR DESCRIPTION
Added Center property back to CoordinateRange, removed unintentionally in #4316.

Also added tests for properties `Span`, `Center` and `Length`, to make sure they're not removed unintentionally.

```cs
CoordinateRange range = new(0, 10);
double center = range.Center;
```