### PR TITLE
WinUI: fix conditional compilation for .NET 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ _Not yet on NuGet..._
 * Bar: Use `LineStyle` and `FillStyle` similar to other plottables and deprecate old property names
 * Histogram: Refactored to simplify creation of creating probability curves and cumulative probability histograms (#4287, #4367)
 * Colormap: Refactor all `ScottPlot.Colormaps` to favor composition over inheritance and add extension methods to `IColormap` (#4248)
+* WinUI: Improve support for .NET 8 platform targets (#4288, #4374) @vilgotf
 
 ## ScottPlot 5.0.40
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-10-16_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/WinUIPlotMenu.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/WinUIPlotMenu.cs
@@ -81,11 +81,10 @@ public class WinUIPlotMenu : IPlotMenu
         dialog.FileTypeChoices.Add("WebP Files", new List<string>() { ".webp" });
         dialog.FileTypeChoices.Add("SVG Files", new List<string>() { ".svg" });
 
-#if NET6_0_WINDOWS10_0_18362 // https://github.com/microsoft/CsWinRT/blob/master/docs/interop.md#windows-sdk
+        // https://github.com/microsoft/CsWinRT/blob/master/docs/interop.md#windows-sdk
         // TODO: launch a pop-up window or otherwise inform if AppWindow is not set before using save-dialog
         var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(ThisControl.AppWindow);
         WinRT.Interop.InitializeWithWindow.Initialize(dialog, hwnd);
-#endif
 
         var file = await dialog.PickSaveFileAsync();
 


### PR DESCRIPTION
.NET 8 was recently added as a target framework which exposed this condition as too limited as it is only true for .NET 6.

Since WinUI 3 requires .NET 6 and Windows 10 1809, this condition can be wholly removed; dependents will fail the WASDK conditions regardless.

Closes #4288