### PR TITLE
CoordinateRangeMutable: Adjust based on CoordinationRange

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/AxisRecipes.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/AxisRecipes.cs
@@ -293,7 +293,7 @@ public class AxisAndTicks : ICategory
                 new ScottPlot.TickGenerators.TimeUnits.Hour(), 1,
                 // Here we provide a delegate to override when the ticks start. In this case, we want the majors to be
                 // 00:00, 06:00, 12:00, etc. and the minors to be on the hour, every hour, so we start at midnight.
-                // If you do not provide this delegate, the ticks will start at whatever the Min on the x-axis is.
+                // If you do not provide this delegate, the ticks will start at whatever the Value1 on the x-axis is.
                 // The major ticks might end up as 1:30am, 7:30am, etc, and the tick positions will be fixed on the plot
                 // when it is panned around.
                 dt => new DateTime(dt.Year, dt.Month, dt.Day));

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/DataSourceUtilitiesTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/DataSourceUtilitiesTests.cs
@@ -204,7 +204,7 @@ internal class DataSourceUtilitiesTests
         Assert.That(data.GetRenderIndexCount(), Is.EqualTo(data.Length), "- Failed Nominal Check"); // nominal -- MaxRenderIndex == data.Length -1
 
         data.MaxRenderIndex = int.MaxValue;
-        Assert.That(data.GetRenderIndexCount(), Is.EqualTo(data.Length), "- Failed int.Max check"); // int.Max
+        Assert.That(data.GetRenderIndexCount(), Is.EqualTo(data.Length), "- Failed int.Value2 check"); // int.Value2
 
         data.MaxRenderIndex = data.Length - 5;
         Assert.That(data.GetRenderIndexCount(), Is.EqualTo(data.MaxRenderIndex + 1), "- Failed MaxRenderIndex < data.Length"); // MaxRenderIndex < data.Length
@@ -217,7 +217,7 @@ internal class DataSourceUtilitiesTests
         data.MaxRenderIndex = -25;
         Assert.That(data.GetRenderIndexCount(), Is.EqualTo(0), "- Failed Negative MaxRenderIndex Check");
 
-        // Negative Min has no effect -- Max(0,minIndex)
+        // Negative Value1 has no effect -- Value2(0,minIndex)
         data.MinRenderIndex = -100;
         Assert.That(data.GetRenderIndexCount(), Is.EqualTo(0));
     }

--- a/src/ScottPlot5/ScottPlot5/AutoScalers/FractionalAutoScaler.cs
+++ b/src/ScottPlot5/ScottPlot5/AutoScalers/FractionalAutoScaler.cs
@@ -66,8 +66,8 @@ public class FractionalAutoScaler : IAutoScaler
 
         foreach (IAxis xAxis in xAxes)
         {
-            double left = xAxis.Range.Min - (xAxis.Range.Span * LeftFraction);
-            double right = xAxis.Range.Max + (xAxis.Range.Span * RightFraction);
+            double left = xAxis.Range.Value1 - (xAxis.Range.Span * LeftFraction);
+            double right = xAxis.Range.Value2 + (xAxis.Range.Span * RightFraction);
             if (NumericConversion.IsReal(left) && NumericConversion.IsReal(right))
             {
                 if (InvertedX)
@@ -83,8 +83,8 @@ public class FractionalAutoScaler : IAutoScaler
 
         foreach (IYAxis yAxis in yAxes)
         {
-            double bottom = yAxis.Range.Min - (yAxis.Range.Span * BottomFraction);
-            double top = yAxis.Range.Max + (yAxis.Range.Span * TopFraction);
+            double bottom = yAxis.Range.Value1 - (yAxis.Range.Span * BottomFraction);
+            double top = yAxis.Range.Value2 + (yAxis.Range.Span * TopFraction);
             if (NumericConversion.IsReal(bottom) && NumericConversion.IsReal(top))
             {
                 if (InvertedY)

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/AxisBase.cs
@@ -23,14 +23,14 @@ public abstract class AxisBase : LabelStyleProperties
 
     public double Min
     {
-        get => Range.Min;
-        set => Range.Min = value;
+        get => Range.Value1;
+        set => Range.Value1 = value;
     }
 
     public double Max
     {
-        get => Range.Max;
-        set => Range.Max = value;
+        get => Range.Value2;
+        set => Range.Value2 = value;
     }
 
     public override string ToString()

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/XAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/XAxisBase.cs
@@ -124,6 +124,6 @@ public abstract class XAxisBase : AxisBase, IXAxis
     {
         using SKPaint paint = new();
         TickLabelStyle.ApplyToPaint(paint);
-        TickGenerator.Regenerate(Range.ToCoordinateRange, Edge, size, paint, TickLabelStyle);
+        TickGenerator.Regenerate(Range.ToCoordinateRange(), Edge, size, paint, TickLabelStyle);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
@@ -113,6 +113,6 @@ public abstract class YAxisBase : AxisBase, IYAxis
     {
         using SKPaint paint = new();
         TickLabelStyle.ApplyToPaint(paint);
-        TickGenerator.Regenerate(Range.ToCoordinateRange, Edge, size, paint, TickLabelStyle);
+        TickGenerator.Regenerate(Range.ToCoordinateRange(), Edge, size, paint, TickLabelStyle);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisRules/LockedBottom.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/LockedBottom.cs
@@ -7,6 +7,6 @@ public class LockedBottom(IYAxis yAxis, double yMin) : IAxisRule
 
     public void Apply(RenderPack rp, bool beforeLayout)
     {
-        YAxis.Range.Min = YMin;
+        YAxis.Range.Value1 = YMin;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisRules/LockedLeft.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/LockedLeft.cs
@@ -7,6 +7,6 @@ public class LockedLeft(IXAxis xAxis, double xMin) : IAxisRule
 
     public void Apply(RenderPack rp, bool beforeLayout)
     {
-        XAxis.Range.Min = XMin;
+        XAxis.Range.Value1 = XMin;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisRules/LockedRight.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/LockedRight.cs
@@ -7,6 +7,6 @@ public class LockedRight(IXAxis xAxis, double xMax) : IAxisRule
 
     public void Apply(RenderPack rp, bool beforeLayout)
     {
-        XAxis.Range.Max = XMax;
+        XAxis.Range.Value2 = XMax;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisRules/LockedTop.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/LockedTop.cs
@@ -7,6 +7,6 @@ public class LockedTop(IYAxis yAxis, double yMax) : IAxisRule
 
     public void Apply(RenderPack rp, bool beforeLayout)
     {
-        YAxis.Range.Max = YMax;
+        YAxis.Range.Value2 = YMax;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisRules/MaximumBoundary.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/MaximumBoundary.cs
@@ -11,28 +11,28 @@ public class MaximumBoundary(IXAxis xAxis, IYAxis yAxis, AxisLimits limits) : IA
         double xSpan = Math.Min(XAxis.Range.Span, Limits.HorizontalSpan);
         double ySpan = Math.Min(YAxis.Range.Span, Limits.VerticalSpan);
 
-        if (XAxis.Range.Max > Limits.Right)
+        if (XAxis.Range.Value2 > Limits.Right)
         {
-            XAxis.Range.Max = Limits.Right;
-            XAxis.Range.Min = Limits.Right - xSpan;
+            XAxis.Range.Value2 = Limits.Right;
+            XAxis.Range.Value1 = Limits.Right - xSpan;
         }
 
-        if (XAxis.Range.Min < Limits.Left)
+        if (XAxis.Range.Value1 < Limits.Left)
         {
-            XAxis.Range.Min = Limits.Left;
-            XAxis.Range.Max = Limits.Left + xSpan;
+            XAxis.Range.Value1 = Limits.Left;
+            XAxis.Range.Value2 = Limits.Left + xSpan;
         }
 
-        if (YAxis.Range.Max > Limits.Top)
+        if (YAxis.Range.Value2 > Limits.Top)
         {
-            YAxis.Range.Max = Limits.Top;
-            YAxis.Range.Min = Limits.Top - ySpan;
+            YAxis.Range.Value2 = Limits.Top;
+            YAxis.Range.Value1 = Limits.Top - ySpan;
         }
 
-        if (YAxis.Range.Min < Limits.Bottom)
+        if (YAxis.Range.Value1 < Limits.Bottom)
         {
-            YAxis.Range.Min = Limits.Bottom;
-            YAxis.Range.Max = Limits.Bottom + ySpan;
+            YAxis.Range.Value1 = Limits.Bottom;
+            YAxis.Range.Value2 = Limits.Bottom + ySpan;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisRules/MinimumBoundary.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/MinimumBoundary.cs
@@ -11,28 +11,28 @@ public class MinimumBoundary(IXAxis xAxis, IYAxis yAxis, AxisLimits limits) : IA
         double xSpan = Math.Max(XAxis.Range.Span, Limits.HorizontalSpan);
         double ySpan = Math.Max(YAxis.Range.Span, Limits.VerticalSpan);
 
-        if (XAxis.Range.Max < Limits.Right)
+        if (XAxis.Range.Value2 < Limits.Right)
         {
-            XAxis.Range.Max = Limits.Right;
-            XAxis.Range.Min = Limits.Right - xSpan;
+            XAxis.Range.Value2 = Limits.Right;
+            XAxis.Range.Value1 = Limits.Right - xSpan;
         }
 
-        if (XAxis.Range.Min > Limits.Left)
+        if (XAxis.Range.Value1 > Limits.Left)
         {
-            XAxis.Range.Min = Limits.Left;
-            XAxis.Range.Max = Limits.Left + xSpan;
+            XAxis.Range.Value1 = Limits.Left;
+            XAxis.Range.Value2 = Limits.Left + xSpan;
         }
 
-        if (YAxis.Range.Max < Limits.Top)
+        if (YAxis.Range.Value2 < Limits.Top)
         {
-            YAxis.Range.Max = Limits.Top;
-            YAxis.Range.Min = Limits.Top - ySpan;
+            YAxis.Range.Value2 = Limits.Top;
+            YAxis.Range.Value1 = Limits.Top - ySpan;
         }
 
-        if (YAxis.Range.Min > Limits.Bottom)
+        if (YAxis.Range.Value1 > Limits.Bottom)
         {
-            YAxis.Range.Min = Limits.Bottom;
-            YAxis.Range.Max = Limits.Bottom + ySpan;
+            YAxis.Range.Value1 = Limits.Bottom;
+            YAxis.Range.Value2 = Limits.Bottom + ySpan;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisRules/SnapToTicksX.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/SnapToTicksX.cs
@@ -17,8 +17,8 @@ public class SnapToTicksX(IXAxis xAxis) : IAxisRule
         var oldRight = rp.Plot.LastRender.AxisLimitsByAxis[XAxis].Max;
         var oldLeft = rp.Plot.LastRender.AxisLimitsByAxis[XAxis].Min;
         var newLimits = XAxis.Range;
-        double newRight = newLimits.Max;
-        double newLeft = newLimits.Min;
+        double newRight = newLimits.Value2;
+        double newLeft = newLimits.Value1;
 
         // do not attempt to set limits if they have not changed
         if (newRight == oldRight & newLeft == oldLeft)
@@ -91,7 +91,7 @@ public class SnapToTicksX(IXAxis xAxis) : IAxisRule
         }
 
         //This is to handle panning, which can be jumpy if we snap before it has panned more than half the tick interval
-        if (isPanning & Math.Abs(newLimits.Max - oldRight) < tickDelta / 2)
+        if (isPanning & Math.Abs(newLimits.Value2 - oldRight) < tickDelta / 2)
         {
             newRight = oldRight;
             newLeft = oldLeft;

--- a/src/ScottPlot5/ScottPlot5/AxisRules/SnapToTicksY.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/SnapToTicksY.cs
@@ -15,8 +15,8 @@ public class SnapToTicksY(IYAxis yAxis) : IAxisRule
         var oldTop = rp.Plot.LastRender.AxisLimitsByAxis[YAxis].Max;
         var oldBottom = rp.Plot.LastRender.AxisLimitsByAxis[YAxis].Min;
         var newLimits = YAxis.Range;
-        double newTop = newLimits.Max;
-        double newBottom = newLimits.Min;
+        double newTop = newLimits.Value2;
+        double newBottom = newLimits.Value1;
 
         // do not attempt to set limits if they have not changed
         if (newTop == oldTop & newBottom == oldBottom)
@@ -89,7 +89,7 @@ public class SnapToTicksY(IYAxis yAxis) : IAxisRule
         }
 
         //This is to handle panning, which can be jumpy if we snap before it has panned more than half the tick interval
-        if (isPanning & Math.Abs(newLimits.Max - oldTop) < tickDelta / 2)
+        if (isPanning & Math.Abs(newLimits.Value2 - oldTop) < tickDelta / 2)
         {
             newTop = oldTop;
             newBottom = oldBottom;

--- a/src/ScottPlot5/ScottPlot5/Control/MultiAxisLimitManager.cs
+++ b/src/ScottPlot5/ScottPlot5/Control/MultiAxisLimitManager.cs
@@ -65,8 +65,8 @@ public class MultiAxisLimitManager
             if (!RememberedLimits.ContainsKey(axis))
                 continue;
 
-            axis.Range.Min = RememberedLimits[axis].Min;
-            axis.Range.Max = RememberedLimits[axis].Max;
+            axis.Range.Value1 = RememberedLimits[axis].Min;
+            axis.Range.Value2 = RememberedLimits[axis].Max;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IAxis.cs
@@ -9,7 +9,7 @@
 public interface IAxis : IPanel
 {
     /// <summary>
-    /// Min/Max range currently displayed by this axis
+    /// Value1/Value2 range currently displayed by this axis
     /// </summary>
     CoordinateRangeMutable Range { get; } // TODO: don't expose this
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/FunctionPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/FunctionPlot.cs
@@ -113,6 +113,6 @@ public class FunctionPlot(IFunctionSource source) : IPlottable, IHasLine, IHasLe
                 MaxObservedRangeY = MaxObservedRangeY.Expanded(max);
         }
 
-        LastRenderHorizontalSpan = Axes.XAxis.Range.ToCoordinateRange;
+        LastRenderHorizontalSpan = Axes.XAxis.Range.ToCoordinateRange();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/AxisLimits3d.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/AxisLimits3d.cs
@@ -35,6 +35,6 @@ public readonly struct AxisLimits3d
             zRange.Expand(c.Z);
         }
 
-        return new AxisLimits3d(xRange.Min, xRange.Max, yRange.Min, yRange.Max, zRange.Min, zRange.Max);
+        return new AxisLimits3d(xRange.Value1, xRange.Value2, yRange.Value1, yRange.Value2, zRange.Value1, zRange.Value2);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/CoordinateRangeMutable.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/CoordinateRangeMutable.cs
@@ -161,7 +161,7 @@ public class CoordinateRangeMutable : IEquatable<CoordinateRangeMutable> // TODO
         if (other is null)
             return false;
 
-        return Equals(Min, other.Min) && Equals(Min, other.Min);
+        return Equals(Min, other.Min) && Equals(Max, other.Max);
     }
 
     public override bool Equals(object? obj)

--- a/src/ScottPlot5/ScottPlot5/Primitives/CoordinateRect.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/CoordinateRect.cs
@@ -39,10 +39,10 @@ public struct CoordinateRect : IEquatable<CoordinateRect>
 
     public CoordinateRect(CoordinateRangeMutable xRange, CoordinateRangeMutable yRange)
     {
-        Left = xRange.Min;
-        Right = xRange.Max;
-        Bottom = yRange.Min;
-        Top = yRange.Max;
+        Left = xRange.Value1;
+        Right = xRange.Value2;
+        Bottom = yRange.Value1;
+        Top = yRange.Value2;
     }
 
     public CoordinateRect(IAxes axes) : this(axes.XAxis.Range, axes.YAxis.Range)

--- a/src/ScottPlot5/ScottPlot5/Primitives/MultiAxisLimits.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/MultiAxisLimits.cs
@@ -7,7 +7,7 @@
 public class MultiAxisLimits(Plot plot)
 {
     private readonly Dictionary<IAxis, CoordinateRange> AxisRanges = plot.Axes.GetAxes()
-        .ToDictionary(x => x, x => x.Range.ToCoordinateRange);
+        .ToDictionary(x => x, x => x.Range.ToCoordinateRange());
 
     /// <summary>
     /// Set all axis limits to their original ranges

--- a/src/ScottPlot5/ScottPlot5/Primitives/Range.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Range.cs
@@ -31,7 +31,7 @@ public readonly struct Range // TODO: evaluate if this can be replaced with more
     }
 
     /// <summary>
-    /// Returns the given value as a fraction of the difference between Min and Max. This is a min-max feature scaling.
+    /// Returns the given value as a fraction of the difference between Value1 and Value2. This is a min-max feature scaling.
     /// </summary>
     /// <param name="value">The value to normalize</param>
     /// <param name="clamp">If true, values outside of the range will be clamped onto the interval [0, 1].</param>

--- a/src/ScottPlot5/ScottPlot5/Primitives/RenderDetails.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/RenderDetails.cs
@@ -92,7 +92,7 @@ public readonly struct RenderDetails
         AxisLimits = rp.Plot.Axes.GetLimits();
         PreviousAxisLimits = lastRender.AxisLimits;
         PreviousAxisLimitsByAxis = lastRender.AxisLimitsByAxis;
-        AxisLimitsByAxis = rp.Plot.Axes.GetAxes().ToDictionary(x => x, x => x.Range.ToCoordinateRange);
+        AxisLimitsByAxis = rp.Plot.Axes.GetAxes().ToDictionary(x => x, x => x.Range.ToCoordinateRange());
         Layout = rp.Layout;
         Count = lastRender.Count + 1;
         AxisLimitsChanged = AxisLimitsChangedChecker();

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
@@ -180,7 +180,7 @@ public class RenderManager(Plot plot)
 
             CoordinateRangeMutable rangeNow = axis.Range;
             CoordinateRange rangeBefore = LastRender.AxisLimitsByAxis[axis];
-            bool axisLimitsChanged = rangeNow.Min != rangeBefore.Min || rangeNow.Max != rangeBefore.Max;
+            bool axisLimitsChanged = rangeNow.Value1 != rangeBefore.Min || rangeNow.Value2 != rangeBefore.Max;
             if (axisLimitsChanged)
                 return true;
         }

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/DateTimeAutomatic.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/DateTimeAutomatic.cs
@@ -130,7 +130,7 @@ public class DateTimeAutomatic : IDateTimeTickGenerator
         DateTime rangeMin = NumericConversion.ToDateTime(range.Min);
         DateTime rangeMax = NumericConversion.ToDateTime(range.Max);
 
-        // range.Min could be anything, but when calculating start it must be "snapped" to the best tick
+        // range.Value1 could be anything, but when calculating start it must be "snapped" to the best tick
         DateTime start = GetLargerTimeUnit(unit).Snap(rangeMin);
 
         start = unit.Next(start, -increment);


### PR DESCRIPTION
Since the `CoordinationRange` was adjusted in #4316, 
`CoordinateRangeMutable` should also try to maintain the same architecture as `CoordinationRange`.