### PR TITLE
UserInputProcessor: consume an `IPlotControl` instead of a `Plot` when constructing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-## ScottPlot 5.0.42
+## ScottPlot 5.0.43
 _Not yet on NuGet..._
+
+## ScottPlot 5.0.42
+_Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-10-29_
+* Controls: Refactor to allow the user input processor to function as `IPlotControl.Reset()` changes the underlying `Plot` (#4404) @Or8e4m4n
 
 ## ScottPlot 5.0.41
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-10-27_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
@@ -33,7 +33,7 @@ public class AvaPlot : Controls.Control, IPlotControl
         ClipToBounds = true;
         DisplayScale = DetectDisplayScale();
         Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
-        UserInputProcessor = new(Plot);
+        UserInputProcessor = new(this);
         Menu = new AvaPlotMenu(this);
         Focusable = true; // Required for keyboard events
         Refresh();

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/BlazorPlotBase.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/BlazorPlotBase.cs
@@ -29,7 +29,7 @@ public abstract class BlazorPlotBase : ComponentBase, IPlotControl
         Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
 #pragma warning restore CS0618
 
-        UserInputProcessor = new(Plot) { IsEnabled = true };
+        UserInputProcessor = new(this) { IsEnabled = true };
         Menu = new BlazorPlotMenu();
     }
 
@@ -50,9 +50,7 @@ public abstract class BlazorPlotBase : ComponentBase, IPlotControl
         Plot oldPlot = Plot;
         Plot = plot;
         oldPlot?.Dispose();
-
         Plot.PlotControl = this;
-        UserInputProcessor.Plot = Plot;
     }
 
     public virtual void Refresh() { }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Eto/EtoPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Eto/EtoPlot.cs
@@ -24,7 +24,7 @@ public class EtoPlot : Drawable, IPlotControl
         Plot = new() { PlotControl = this };
         DisplayScale = DetectDisplayScale();
         Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
-        UserInputProcessor = new(Plot);
+        UserInputProcessor = new(this);
         Menu = new EtoPlotMenu(this);
 
         MouseDown += OnMouseDown;

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlot.cs
@@ -1,4 +1,4 @@
-using ScottPlot.Control;
+﻿using ScottPlot.Control;
 using SkiaSharp.Views.Maui;
 using SkiaSharp.Views.Maui.Controls;
 
@@ -22,7 +22,7 @@ public class MauiPlot : SKCanvasView, IPlotControl
         Plot = new Plot() { PlotControl = this };
         DisplayScale = DetectDisplayScale();
         Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
-        UserInputProcessor = new(Plot);
+        UserInputProcessor = new(this);
         Menu = new MauiPlotMenu(this);
 
         var panGestureRecognizer = new PanGestureRecognizer();

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotBase.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotBase.cs
@@ -34,7 +34,7 @@ public abstract class WpfPlotBase : System.Windows.Controls.Control, IPlotContro
         Plot = new Plot() { PlotControl = this };
         DisplayScale = DetectDisplayScale();
         Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
-        UserInputProcessor = new(Plot);
+        UserInputProcessor = new(this);
         Menu = new WpfPlotMenu(this);
         Focusable = true;
     }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotBase.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotBase.cs
@@ -27,7 +27,7 @@ public abstract class FormsPlotBase : UserControl, IPlotControl
         Plot = new() { PlotControl = this };
         DisplayScale = DetectDisplayScale();
         Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
-        UserInputProcessor = new(Plot);
+        UserInputProcessor = new(this);
         Menu = new FormsPlotMenu(this);
 
         // TODO: replace this with an annotation instead of title

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/WinUIPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/WinUIPlot.cs
@@ -27,7 +27,7 @@ public partial class WinUIPlot : UserControl, IPlotControl
     {
         Plot = new() { PlotControl = this };
         Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
-        UserInputProcessor = new(Plot);
+        UserInputProcessor = new(this);
         Menu = new WinUIPlotMenu(this);
 
         Background = new SolidColorBrush(Microsoft.UI.Colors.White);

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml
@@ -9,5 +9,10 @@
         WindowStartupLocation="CenterScreen"
         Title="ScottPlot 5 - WPF Sandbox" 
         Height="600" Width="800">
-    <ScottPlot:WpfPlot Name="WpfPlot1" />
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal">
+            <Button Padding="10" Margin="10" FontSize="16" Click="Button_Click">Reset</Button>
+        </StackPanel>
+        <ScottPlot:WpfPlot Name="WpfPlot1" />
+    </DockPanel>
 </Window>

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WPF/MainWindow.xaml.cs
@@ -9,9 +9,14 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
 
-        WpfPlot1.UserInputProcessor.IsEnabled = true;
-
         WpfPlot1.Plot.Add.Signal(Generate.Sin());
         WpfPlot1.Plot.Add.Signal(Generate.Cos());
+    }
+
+    private void Button_Click(object sender, RoutedEventArgs e)
+    {
+        WpfPlot1.Reset();
+        WpfPlot1.Plot.Add.Signal(Generate.RandomWalk(100));
+        WpfPlot1.Refresh();
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Sandbox.WinForms.csproj
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Sandbox.WinForms.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net7.0-windows</TargetFramework>
+        <TargetFramework>net8.0-windows</TargetFramework>
         <Nullable>enable</Nullable>
         <UseWindowsForms>true</UseWindowsForms>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserInputProcessor.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserInputProcessor.cs
@@ -12,7 +12,7 @@ public class UserInputProcessor
     /// <summary>
     /// The plot this input processor will act on
     /// </summary>
-    public Plot Plot { get; set; }
+    public IPlotControl PlotControl { get; }
 
     /// <summary>
     /// Tracks which keys are currently pressed
@@ -30,7 +30,7 @@ public class UserInputProcessor
             _IsEnabled = value;
             if (value)
             {
-                Plot.PlotControl?.Interaction.Disable();
+                PlotControl?.Interaction.Disable();
             }
         }
     }
@@ -54,9 +54,9 @@ public class UserInputProcessor
     /// </summary>
     public readonly List<IUserActionResponse> UserActionResponses = [];
 
-    public UserInputProcessor(Plot plot)
+    public UserInputProcessor(IPlotControl plotControl)
     {
-        Plot = plot;
+        PlotControl = plotControl;
         KeyState = new();
         Reset();
         IsEnabled = true;
@@ -166,7 +166,7 @@ public class UserInputProcessor
         bool refreshNeeded = ExecuteUserInputResponses(userAction);
 
         if (refreshNeeded)
-            Plot.PlotControl?.Refresh();
+            PlotControl.Refresh();
     }
 
     private void UpdateKeyboardState(IUserAction userAction)
@@ -187,7 +187,7 @@ public class UserInputProcessor
         bool refreshNeeded = false;
 
         // lock onto the sync object to prevent actions from being applied while a render is in progress
-        lock (Plot.Sync)
+        lock (PlotControl.Plot.Sync)
         {
             foreach (IUserActionResponse response in UserActionResponses)
             {
@@ -196,7 +196,7 @@ public class UserInputProcessor
                     continue;
                 }
 
-                ResponseInfo info = response.Execute(Plot, userAction, KeyState);
+                ResponseInfo info = response.Execute(PlotControl.Plot, userAction, KeyState);
                 if (info.RefreshNeeded)
                     refreshNeeded = true;
 

--- a/src/ScottPlot5/ScottPlot5/Testing/MockPlotControl.cs
+++ b/src/ScottPlot5/ScottPlot5/Testing/MockPlotControl.cs
@@ -18,7 +18,7 @@ public class MockPlotControl : IPlotControl
     public GRContext? GRContext => null;
 
     public IPlotInteraction Interaction { get; set; }
-    public Interactivity.UserInputProcessor UserInputProcessor { get; }
+    public UserInputProcessor UserInputProcessor { get; }
 
     public IPlotMenu? Menu // TODO: mock menu
     {
@@ -34,7 +34,7 @@ public class MockPlotControl : IPlotControl
         Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
 #pragma warning restore CS0618
 
-        UserInputProcessor = new(Plot) { IsEnabled = true };
+        UserInputProcessor = new(this) { IsEnabled = true };
 
         // force a render on startup so we can immediately use pixel drag actions
         Refresh();


### PR DESCRIPTION
This allows the correct `Plot` to be acted upon even if `IPlotControl.Reset()` changes it.

* Resolves #4404