### PR TITLE
MAUI: improvements in pan and zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ _Not yet on NuGet..._
 * UserInputProcessor: Simplified how axis locking is achieved by adding `horizontal` and `vertical` arguments to `LeftClickDragPan()` and `RightClickDragZoom()`
 * Maui: Improved deployment pipeline so the latest `ScottPlot.Maui` package is always available on NuGet (#1391) @KosmosWerner @King-Taz @cosmicDustOfLightLength
 * Candlestick Plot: Exposed `Data` for easier access to underlying `OHLC` candle data (#4385) @quantfreedom
+* Maui: Improved cursor-driven pan and zoom on Desktop platform targets (#4417, #4416) @KosmosWerner @King-Taz
 
 ## ScottPlot 5.0.42
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-10-29_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlot.cs
@@ -104,12 +104,4 @@ public class MauiPlot : SKCanvasView, IPlotControl
 
         return DisplayScale;
     }
-
-    internal static Page? GetFirstPageParent(Element element)
-    {
-        if (element.Parent is null) return null;
-        else if (element.Parent is Page parent) return parent;
-        else if (element.Parent is Element e) return GetFirstPageParent(e);
-        else return null;
-    }
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlot.cs
@@ -1,5 +1,4 @@
-﻿using ScottPlot.Control;
-using SkiaSharp.Views.Maui;
+﻿using SkiaSharp.Views.Maui;
 using SkiaSharp.Views.Maui.Controls;
 
 namespace ScottPlot.Maui;
@@ -17,53 +16,54 @@ public class MauiPlot : SKCanvasView, IPlotControl
     public Interactivity.UserInputProcessor UserInputProcessor { get; }
     public float DisplayScale { get; set; } = 1;
     internal Pixel LastPixel { get; set; }
+    internal Pixel LastScalePixel { get; set; }
     public MauiPlot()
     {
         Plot = new Plot() { PlotControl = this };
         DisplayScale = DetectDisplayScale();
         Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
-        UserInputProcessor = new(this);
+        UserInputProcessor = new(this) { IsEnabled = true };
         Menu = new MauiPlotMenu(this);
 
-        var panGestureRecognizer = new PanGestureRecognizer();
-        var pointerGestureRecognizer = new PointerGestureRecognizer();
-        var tapGestureRecognizer = new TapGestureRecognizer() { Buttons = ButtonsMask.Secondary };
-        var pinchGestureRecognizer = new PinchGestureRecognizer();
+        IgnorePixelScaling = true;
 
-        panGestureRecognizer.PanUpdated += (s, e) =>
+        if (DeviceInfo.Idiom == DeviceIdiom.Desktop)
         {
-            UserInputProcessor.ProcessPanUpdated(this, e);
-        };
-
-        pinchGestureRecognizer.PinchUpdated += (s, e) =>
+            Touch += MauiPlot_Touch;
+            EnableTouchEvents = true;
+        }
+        else
         {
-            UserInputProcessor.ProcessPinchUpdated(this, e);
-        };
+            EnableTouchEvents = false;
+            var panGestureRecognizer = new PanGestureRecognizer();
+            var pinchGestureRecognizer = new PinchGestureRecognizer();
 
-        pointerGestureRecognizer.PointerMoved += (s, e) =>
+            panGestureRecognizer.PanUpdated += (s, e) => UserInputProcessor.ProcessPanUpdated(this, e);
+            pinchGestureRecognizer.PinchUpdated += (s, e) => UserInputProcessor.ProcessPinchUpdated(this, e, (float)Width, (float)Height);
+
+            GestureRecognizers.Add(pinchGestureRecognizer);
+            GestureRecognizers.Add(panGestureRecognizer);
+        }
+    }
+
+    private void MauiPlot_Touch(object? sender, SKTouchEventArgs e)
+    {
+        switch (e.ActionType)
         {
-            UserInputProcessor.ProcessPointerMoved(this, e);
-        };
-
-        pointerGestureRecognizer.PointerPressed += (s, e) =>
-        {
-            UserInputProcessor.ProcessPointerPressed(this, e);
-        };
-
-        pointerGestureRecognizer.PointerReleased += (s, e) =>
-        {
-            UserInputProcessor.ProcessPointerReleased(this, e);
-        };
-
-        tapGestureRecognizer.Tapped += (s, e) =>
-        {
-            UserInputProcessor.ProcessContext(this, e);
-        };
-
-        GestureRecognizers.Add(tapGestureRecognizer);
-        GestureRecognizers.Add(pointerGestureRecognizer);
-        GestureRecognizers.Add(pinchGestureRecognizer);
-        GestureRecognizers.Add(panGestureRecognizer);
+            case SKTouchAction.Pressed:
+                UserInputProcessor.ProcessMouseDown(this, e);
+                break;
+            case SKTouchAction.Moved:
+                UserInputProcessor.ProcessMouseMove(this, e);
+                break;
+            case SKTouchAction.Released:
+                UserInputProcessor.ProcessMouseUp(this, e);
+                break;
+            case SKTouchAction.WheelChanged:
+                UserInputProcessor.ProcessWheelChanged(this, e);
+                break;
+            default: break;
+        }
     }
 
     public void Reset()

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlotExtensions.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlotExtensions.cs
@@ -1,37 +1,26 @@
-﻿namespace ScottPlot.Maui;
+﻿using SkiaSharp;
+using SkiaSharp.Views.Maui;
+using ScottPlot.Interactivity;
+
+namespace ScottPlot.Maui;
 
 internal static class MauiPlotExtensions
 {
-    internal static Pixel ToPixel(this PointerEventArgs e, MauiPlot? plot)
+    internal static Pixel ToPixel(this PanUpdatedEventArgs e) => new Pixel(e.TotalX, e.TotalY);
+
+    internal static Pixel ToPixel(this Point e) => new Pixel(e.X, e.Y);
+
+    internal static Pixel ToPixelScaled(this Point e, float width, float height) => new Pixel(e.X * width, e.Y * height);
+
+    internal static Pixel ToPixel(this SKPoint e) => new Pixel(e.X, e.Y);
+
+    internal static void ProcessPanUpdated(this UserInputProcessor processor, MauiPlot plot, PanUpdatedEventArgs e)
     {
-        Point? position = e.GetPosition(plot);
-
-        if (position is null) return Pixel.NaN;
-        if (plot is null) return new(position.Value.X, position.Value.Y);
-        return new(position.Value.X * plot.DisplayScale, position.Value.Y * plot.DisplayScale);
-    }
-
-    internal static Pixel ToPixel(this TappedEventArgs e, MauiPlot? plot)
-    {
-        Point? position = e.GetPosition(plot);
-
-        if (position is null) return Pixel.NaN;
-        if (plot is null) return new(position.Value.X, position.Value.Y);
-        return new(position.Value.X * plot.DisplayScale, position.Value.Y * plot.DisplayScale);
-    }
-
-    internal static Pixel ToPixel(this PanUpdatedEventArgs e)
-    {
-        return new Pixel(e.TotalX, e.TotalY);
-    }
-
-    internal static void ProcessPanUpdated(this Interactivity.UserInputProcessor processor, MauiPlot plot, PanUpdatedEventArgs e)
-    {
-        Interactivity.IUserAction action = e.StatusType switch
+        IUserAction action = e.StatusType switch
         {
             GestureStatus.Started => new Interactivity.UserActions.LeftMouseDown(Pixel.Zero),
             GestureStatus.Running => new Interactivity.UserActions.MouseMove(e.ToPixel()),
-            GestureStatus.Completed => new Interactivity.UserActions.LeftMouseUp(plot.LastPixel), //When StatusType == Completed, e.ToPixel returns (0,0)
+            GestureStatus.Completed => new Interactivity.UserActions.LeftMouseUp(plot.LastPixel),
             _ => new Interactivity.UserActions.Unknown(),
         };
         plot.LastPixel = e.ToPixel();
@@ -39,59 +28,64 @@ internal static class MauiPlotExtensions
         processor.Process(action);
     }
 
-    internal static void ProcessPinchUpdated(this Interactivity.UserInputProcessor processor, MauiPlot plot, PinchGestureUpdatedEventArgs e)
+    internal static void ProcessPinchUpdated(this UserInputProcessor processor, MauiPlot plot, PinchGestureUpdatedEventArgs e, float width, float height)
     {
-        if (e.Status == GestureStatus.Running && e.Scale != 1.0)
+        if (e.Status == GestureStatus.Running)
         {
-            Interactivity.IUserAction action = e.Scale > 1
-                ? new ScottPlot.Interactivity.UserActions.MouseWheelUp(new Pixel(plot.Width / 2, plot.Height / 2))
-                : new ScottPlot.Interactivity.UserActions.MouseWheelDown(new Pixel(plot.Width / 2, plot.Height / 2));
+            Pixel pixel = e.ScaleOrigin.ToPixelScaled(width, height);
+
+            IUserAction action = e.Scale > 1
+                ? new ScottPlot.Interactivity.UserActions.MouseWheelUp(pixel)
+                : new ScottPlot.Interactivity.UserActions.MouseWheelDown(pixel);
 
             processor.Process(action);
         }
     }
 
-    internal static void ProcessPointerPressed(this Interactivity.UserInputProcessor processor, MauiPlot plot, PointerEventArgs e)
+    internal static void ProcessMouseDown(this UserInputProcessor processor, MauiPlot plot, SKTouchEventArgs e)
     {
-        Pixel pixel = e.ToPixel(plot);
+        Pixel pixel = e.Location.ToPixel();
 
-        //ProcessKeyModifiersPressed(processor, plot, e);
-        Interactivity.IUserAction action = new Interactivity.UserActions.LeftMouseDown(pixel);
+        IUserAction action = e.MouseButton switch
+        {
+            SKMouseButton.Left => new Interactivity.UserActions.LeftMouseDown(pixel),
+            SKMouseButton.Middle => new Interactivity.UserActions.MiddleMouseDown(pixel),
+            SKMouseButton.Right => new Interactivity.UserActions.RightMouseDown(pixel),
+            _ => new Interactivity.UserActions.Unknown()
+        };
         processor.Process(action);
     }
 
-    internal static void ProcessPointerMoved(this Interactivity.UserInputProcessor processor, MauiPlot plot, PointerEventArgs e)
+    internal static void ProcessMouseUp(this UserInputProcessor processor, MauiPlot plot, SKTouchEventArgs e)
     {
-        Pixel pixel = e.ToPixel(plot);
+        Pixel pixel = e.Location.ToPixel();
 
-        Interactivity.IUserAction action = new Interactivity.UserActions.MouseMove(pixel);
+        IUserAction action = e.MouseButton switch
+        {
+            SKMouseButton.Left => new Interactivity.UserActions.LeftMouseUp(pixel),
+            SKMouseButton.Middle => new Interactivity.UserActions.MiddleMouseUp(pixel),
+            SKMouseButton.Right => new Interactivity.UserActions.RightMouseUp(pixel),
+            _ => new Interactivity.UserActions.Unknown()
+        };
         processor.Process(action);
     }
 
-    internal static void ProcessPointerReleased(this Interactivity.UserInputProcessor processor, MauiPlot plot, PointerEventArgs e)
+    internal static void ProcessMouseMove(this UserInputProcessor processor, MauiPlot plot, SKTouchEventArgs e)
     {
-        Pixel pixel = e.ToPixel(plot);
+        Pixel pixel = e.Location.ToPixel();
 
-        Interactivity.IUserAction action = new Interactivity.UserActions.LeftMouseUp(pixel);
+        IUserAction action = new Interactivity.UserActions.MouseMove(pixel);
         processor.Process(action);
     }
 
-    internal static void ProcessContext(this Interactivity.UserInputProcessor processor, MauiPlot plot, TappedEventArgs e)
+    internal static void ProcessWheelChanged(this UserInputProcessor processor, MauiPlot plot, SKTouchEventArgs e)
     {
-        Pixel pixel = e.ToPixel(plot);
+        Pixel pixel = e.Location.ToPixel();
 
-        Interactivity.IUserAction action = new Interactivity.UserActions.RightMouseDown(pixel);
-        processor.Process(action);
-        action = new Interactivity.UserActions.RightMouseUp(pixel);
-        processor.Process(action);
-    }
+        IUserAction action = e.WheelDelta > 0
+          ? new ScottPlot.Interactivity.UserActions.MouseWheelUp(pixel)
+          : new ScottPlot.Interactivity.UserActions.MouseWheelDown(pixel);
 
-    internal static void ProcessZoomAll(this Interactivity.UserInputProcessor processor, MauiPlot plot, TappedEventArgs e)
-    {
-        Pixel pixel = e.ToPixel(plot);
-
-        Interactivity.IUserAction action = new Interactivity.UserActions.MouseWheelUp(pixel);
         processor.Process(action);
     }
 }
-

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlotMenu.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlotMenu.cs
@@ -54,9 +54,7 @@ public class MauiPlotMenu : IPlotMenu
 
     public async void SaveImageDialog(IPlotControl plotControl)
     {
-        if (plotControl is not MauiPlot mauiPlot) return;
-
-        var page = MauiPlot.GetFirstPageParent(mauiPlot);
+        Page? page = Application.Current?.MainPage;
         if (page == null) return;
 
         string[] formats = [
@@ -70,14 +68,14 @@ public class MauiPlotMenu : IPlotMenu
         try
         {
             var format = await page.DisplayActionSheet("Select a format", null, null, formats);
-            if (format is null) return;
+            if (string.IsNullOrEmpty(format)) return;
             ImageFormat imgformat = ImageFormats.FromFilename(format);
 
 
             string tempFileName = $"Plot_{DateTime.Now:yyyyMMdd_HHmmss}";
             var name = await page.DisplayPromptAsync("File name", "Enter the file name", placeholder: tempFileName);
-            if (name is null) return;
-            if (name.Length == 0) name = tempFileName;
+            if (string.Equals(name, "Cancel")) return;
+            if (string.IsNullOrEmpty(name)) name = tempFileName;
 
 
             var folder = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/Platforms/Windows/PlatformClass1.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/Platforms/Windows/PlatformClass1.cs
@@ -5,37 +5,5 @@ namespace ScottPlot.Maui;
 
 // All the code in this file is only included on Windows.
 public class PlatformClass1
-//internal static partial class MauiPlotExtensions
 {
-//    static partial void ProcessKeyModifiersPressed(UserInputProcessor processor, MauiPlot plot, PointerEventArgs e)
-//    {
-//        var args = e.PlatformArgs?.PointerRoutedEventArgs;
-//        if (args is null) return;
-//        var keyModifiers = args.KeyModifiers;
-
-
-//        if (keyModifiers is null) return;
-
-//        bool control = ((uint)keyModifiers & (uint)VirtualKeyModifiers.Control) > 0;
-//        bool shift = ((int)keyModifiers & (int)VirtualKeyModifiers.Shift) > 0;
-//        bool alt = ((int)keyModifiers & (int)VirtualKeyModifiers.Menu) > 0;
-
-
-//        IUserAction actionShift = shift
-//            ? new Interactivity.UserActions.KeyDown(StandardKeys.Shift)
-//            : new Interactivity.UserActions.KeyUp(StandardKeys.Shift);
-//        processor.Process(actionShift);
-
-//        IUserAction actionControl = control
-//            ? new Interactivity.UserActions.KeyDown(StandardKeys.Control)
-//            : new Interactivity.UserActions.KeyUp(StandardKeys.Control);
-//        processor.Process(actionControl);
-
-//        IUserAction actionAlt = alt
-//            ? new Interactivity.UserActions.KeyDown(StandardKeys.Alt)
-//            : new Interactivity.UserActions.KeyUp(StandardKeys.Alt);
-//        processor.Process(actionAlt);
-
-//        Trace.WriteLine($"dsa{args}");
-//    }
 }


### PR DESCRIPTION
Hi! In https://github.com/ScottPlot/ScottPlot/issues/4416, errors were reported in the desktop version. These errors have been fixed, and some unnecessary parts of the code have also been removed.
These errors were caused because two events were responsible for panning the plot. Mouse buttons as well as the scroll wheel can now be used in desktop versions 😀
There is still a minor issue: when holding down the screen and then adding another finger to zoom, the plot jumps. This is equivalent to holding down the mouse click and then moving the scroll wheel. However, for now, these are the most critical fixes