### PR TITLE
FinancialTickGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ _Not yet on NuGet..._
 * Candlestick Plot: Exposed `Data` for easier access to underlying `OHLC` candle data (#4385) @quantfreedom
 * Maui: Improved cursor-driven pan and zoom on Desktop platform targets (#4417, #4416) @KosmosWerner @King-Taz
 * Candlestick Plot: Improved visibility of candles with zero price movement (#3337) @Lyakabynka @bukowa
+* Ticks: Added an experimental `FinancialTickGenerator` for generating DateTime ticks from unevenly-spaced time data (#4385)
 
 ## ScottPlot 5.0.42
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-10-29_

--- a/src/ScottPlot5/ScottPlot5/Primitives/OHLC.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/OHLC.cs
@@ -6,6 +6,9 @@ public struct OHLC
     public double High { get; set; }
     public double Low { get; set; }
     public double Close { get; set; }
+
+    // TODO: deprecate this eventually. OHLC should be price information only.
+    // Perhaps create a Candle primitive that contains time information.
     public DateTime DateTime { get; set; }
     public TimeSpan TimeSpan { get; set; }
 

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/FinancialTickGenerator.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/FinancialTickGenerator.cs
@@ -1,0 +1,101 @@
+﻿namespace ScottPlot.TickGenerators;
+
+/// <summary>
+/// Experimental tick generator designed for displaying financial time series data
+/// where values are evenly spaced visually despite having DateTimes which may contain gaps.
+/// </summary>
+public class FinancialTickGenerator(DateTime[] dates) : ITickGenerator
+{
+    // NOTE: Using a tick generator like this for financial charting is probably not the best solution.
+    // Tick generators are for things like tick marks and grid lines.
+    // Tick marks strictly have a single text label, but financial charts may benefit
+    // from stacked labels like month on top and day on bottom.
+    // A custom plottable may be ideal for displaying DateTime labels outside the data area.
+    // This class works somewhat, but is limited in how much it can do.
+
+    private DateTime[] Dates { get; } = dates;
+
+    public Tick[] Ticks { get; private set; } = [];
+
+    public int MaxTickCount { get; set; } = 1000;
+
+    public void Regenerate(CoordinateRange range, Edge edge, PixelLength size, SKPaint paint, LabelStyle labelStyle)
+    {
+        if (Dates.Length == 0)
+        {
+            if (Ticks.Length > 0)
+                Ticks = [];
+            return;
+        }
+
+        // TODO: add different functions for year, month and day, day, etc. based on range
+        int minIndexInView = (int)(Math.Max(0, range.Min));
+        int maxIndexInView = (int)(Math.Min(Dates.Length - 1, range.Max));
+        if (minIndexInView >= maxIndexInView)
+        {
+            Ticks = [];
+            return;
+        }
+
+        TimeSpan timeSpanInView = Dates[maxIndexInView] - Dates[minIndexInView];
+
+        if (timeSpanInView.TotalDays < 45)
+        {
+            Ticks = GetDayTicks();
+        }
+        else if (timeSpanInView.TotalDays < 365 * 2)
+        {
+            Ticks = GetMonthTicks();
+        }
+        else
+        {
+            Ticks = []; // TODO: year ticks
+        }
+    }
+
+    private Tick[] GetMonthTicks()
+    {
+        List<Tick> ticks = [];
+
+        int lastMonth = Dates.First().Month;
+
+        for (int i = 0; i < Dates.Length; i++)
+        {
+            DateTime date = Dates[i];
+            if (date.Month != lastMonth)
+            {
+                string label = date.ToString("MMM");
+                ticks.Add(Tick.Major(i, label));
+                lastMonth = date.Month;
+            }
+        }
+
+        return [.. ticks];
+    }
+
+    private Tick[] GetDayTicks()
+    {
+        List<Tick> ticks = [];
+
+        int lastDay = Dates.First().Day;
+        int lastMonth = Dates.First().Month;
+
+        for (int i = 0; i < Dates.Length; i++)
+        {
+            DateTime date = Dates[i];
+            if (date.Day != lastDay)
+            {
+                string label = date.Day.ToString();
+                if (date.Month != lastMonth)
+                {
+                    lastMonth = date.Month;
+                    label = date.ToString("MMM");
+                }
+                ticks.Add(Tick.Major(i, label));
+                lastDay = date.Day;
+            }
+        }
+
+        return [.. ticks];
+    }
+}


### PR DESCRIPTION
resolves #4385

I think ultimately a financial tick rendering system that uses `IPlottable` to place labels is the best solution. In such a case the axis tick generator would be completely disabled.

This is an interesting intermediate solution that demonstrates how the tick system _could_ be harnessed to display improved tick labels for unevenly spaced financial data. It only supports two scales and could use more features (like not returning ticks outside the visible range) but it's a good start if someone wants to extend it.

![ticks-date](https://github.com/user-attachments/assets/ab31be30-1235-412c-a695-d53857223013)
