### PR TITLE
FinancialTimeAxis: A start toward improving support for financial charts with unevenly spaced time data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _Not yet on NuGet..._
 * Maui: Improved cursor-driven pan and zoom on Desktop platform targets (#4417, #4416) @KosmosWerner @King-Taz
 * Candlestick Plot: Improved visibility of candles with zero price movement (#3337) @Lyakabynka @bukowa
 * Ticks: Added an experimental `FinancialTickGenerator` for generating DateTime ticks from unevenly-spaced time data (#4385)
+* Financial Charting: Added experimental `FinancialTimeAxis` plottable as an alternative to using custom axes or tick generators (#4385) @quantfreedom @vladislavpweetsoft
 
 ## ScottPlot 5.0.42
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-10-29_

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IFinancialTickGenerator.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IFinancialTickGenerator.cs
@@ -1,0 +1,6 @@
+﻿namespace ScottPlot;
+
+public interface IFinancialTickGenerator
+{
+    List<(int, string)> GetTicks(DateTime[] DateTimes, int minIndexInView, int maxIndexInView);
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/FinancialTimeAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/FinancialTimeAxis.cs
@@ -1,0 +1,66 @@
+﻿namespace ScottPlot.Plottables;
+
+/// <summary>
+/// This plottable renders date tick labels for financial charts where
+/// data is displayed sequentially along the horizontal axis despite
+/// DateTimes not being evenly spaced (e.g., data may include gaps)
+/// </summary>
+public class FinancialTimeAxis(DateTime[] dateTimes) : IPlottable
+{
+    public DateTime[] DateTimes { get; set; } = dateTimes;
+    public bool IsVisible { get; set; } = true;
+    public IAxes Axes { get; set; } = new Axes();
+    public IEnumerable<LegendItem> LegendItems => LegendItem.None;
+
+    public LabelStyle LabelStyle { get; set; } = new()
+    {
+        FontSize = 14,
+        Alignment = Alignment.UpperCenter,
+    };
+
+    public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
+
+    public void Render(RenderPack rp)
+    {
+        if (DateTimes.Length == 0)
+            return;
+
+        // allow drawing outside the data area
+        rp.CanvasState.DisableClipping();
+
+        // get the best tick generator given the field of view
+        int minIndexInView = (int)(Math.Max(0, Axes.XAxis.Range.Min));
+        int maxIndexInView = (int)(Math.Min(DateTimes.Length - 1, Axes.XAxis.Range.Max));
+        if (maxIndexInView <= minIndexInView) return;
+        TimeSpan timeSpanInView = DateTimes[maxIndexInView] - DateTimes[minIndexInView];
+        IFinancialTickGenerator tickGenerator = GetBestTickGenerator(timeSpanInView, rp.DataRect.Width);
+        List<(int, string)> ticks = tickGenerator.GetTicks(DateTimes, minIndexInView, maxIndexInView);
+
+        // render each tick label
+        using SKPaint paint = new();
+        foreach ((int x, string label) in ticks)
+        {
+            Pixel px = new(Axes.XAxis.GetPixel(x, rp.DataRect), rp.DataRect.Bottom);
+            LabelStyle.Render(rp.Canvas, px, paint, label);
+        }
+    }
+
+    private static IFinancialTickGenerator GetBestTickGenerator(TimeSpan timeSpan, float widthInPixels)
+    {
+        // adjust the scale so small plots show fewer ticks
+        double scaledViewDays = timeSpan.TotalDays * 600 / widthInPixels;
+
+        if (scaledViewDays < 180)
+        {
+            return new TickGenerators.Financial.MonthsAndMondays();
+        }
+        else if (scaledViewDays < 360 * 2)
+        {
+            return new TickGenerators.Financial.Months();
+        }
+        else
+        {
+            return new TickGenerators.Financial.Years();
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Plottables/FinancialTimeAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/FinancialTimeAxis.cs
@@ -20,7 +20,7 @@ public class FinancialTimeAxis(DateTime[] dateTimes) : IPlottable
 
     public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
 
-    public void Render(RenderPack rp)
+    public virtual void Render(RenderPack rp)
     {
         if (DateTimes.Length == 0)
             return;

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/Financial/Months.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/Financial/Months.cs
@@ -1,0 +1,23 @@
+﻿namespace ScottPlot.TickGenerators.Financial;
+
+public class Months : IFinancialTickGenerator
+{
+    public List<(int, string)> GetTicks(DateTime[] DateTimes, int minIndexInView, int maxIndexInView)
+    {
+        List<(int, string)> ticks = [];
+
+        int lastMonth = DateTimes[0].Month;
+        for (int i = minIndexInView; i <= maxIndexInView; i++)
+        {
+            DateTime dt = DateTimes[i];
+            if (dt.Month != lastMonth)
+            {
+                string label = dt.Month == 1 ? dt.Year.ToString() : dt.ToString("MMM");
+                ticks.Add((i, label));
+                lastMonth = dt.Month;
+            }
+        }
+
+        return ticks;
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/Financial/MonthsAndMondays.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/Financial/MonthsAndMondays.cs
@@ -1,0 +1,26 @@
+﻿namespace ScottPlot.TickGenerators.Financial;
+
+public class MonthsAndMondays : IFinancialTickGenerator
+{
+    public List<(int, string)> GetTicks(DateTime[] DateTimes, int minIndexInView, int maxIndexInView)
+    {
+        List<(int, string)> ticks = [];
+
+        int lastMonth = DateTimes[0].Month;
+        for (int i = minIndexInView; i <= maxIndexInView; i++)
+        {
+            DateTime dt = DateTimes[i];
+            if (dt.Month != lastMonth)
+            {
+                ticks.Add((i, dt.ToString("MMM")));
+                lastMonth = dt.Month;
+            }
+            else if (dt.DayOfWeek == DayOfWeek.Monday && dt.Day > 14 && dt.Day < 27)
+            {
+                ticks.Add((i, dt.Day.ToString()));
+            }
+        }
+
+        return ticks;
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/Financial/None.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/Financial/None.cs
@@ -1,0 +1,9 @@
+﻿namespace ScottPlot.TickGenerators.Financial;
+
+public class None : IFinancialTickGenerator
+{
+    public List<(int, string)> GetTicks(DateTime[] DateTimes, int minIndexInView, int maxIndexInView)
+    {
+        return [];
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/TickGenerators/Financial/Years.cs
+++ b/src/ScottPlot5/ScottPlot5/TickGenerators/Financial/Years.cs
@@ -1,0 +1,22 @@
+﻿namespace ScottPlot.TickGenerators.Financial;
+
+public class Years : IFinancialTickGenerator
+{
+    public List<(int, string)> GetTicks(DateTime[] DateTimes, int minIndexInView, int maxIndexInView)
+    {
+        List<(int, string)> ticks = [];
+
+        int lastYear = DateTimes[0].Year;
+        for (int i = minIndexInView; i <= maxIndexInView; i++)
+        {
+            DateTime dt = DateTimes[i];
+            if (dt.Year != lastYear)
+            {
+                ticks.Add((i, dt.Year.ToString()));
+                lastYear = dt.Year;
+            }
+        }
+
+        return ticks;
+    }
+}


### PR DESCRIPTION
This PR adds a new plottable which simulates the behavior of a horizontal axis, but which is designed to be customized and extended to improve support for showing dates and times on the horizontal axis to represent time data which may not be evenly spaced.

See the `Sandbox.WinFormsFinance` project for a working demo.

This PR is a proof of concept demonstration, and users who may wish to build upon this strategy (e.g., @quantfreedom and @vladislavpweetsoft) are encouraged to refine the work started here and create a pull request which I will review in good time.

See #4385 for additional discussion

![ticks-date2](https://github.com/user-attachments/assets/5d3933a0-8bed-4891-bf92-cb5ddacb8714)