### PR TITLE
Bar: make `internal` properties `public`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _Not yet on NuGet..._
 * Ticks: Added an experimental `FinancialTickGenerator` for generating DateTime ticks from unevenly-spaced time data (#4385)
 * Financial Charting: Added experimental `FinancialTimeAxis` plottable as an alternative to using custom axes or tick generators (#4385) @quantfreedom @vladislavpweetsoft
 * Triangular Axis: Users may now `Add.TriangularAxis()` and use its methods to get Cartesian coordinates from points in triangular space (#4421, #4413) @manaruto
+* Bar: Exposed `Rect`, `ErrorLines`, and `AxisLimits` properties (#4423) @tiger2014
 
 ## ScottPlot 5.0.42
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-10-29_

--- a/src/ScottPlot5/ScottPlot5/Primitives/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Bar.cs
@@ -47,7 +47,7 @@ public class Bar : IHasFill, IHasLine
 
     public Orientation Orientation { get; set; } = Orientation.Vertical;
 
-    internal CoordinateRect Rect
+    public CoordinateRect Rect
     {
         get
         {
@@ -65,7 +65,7 @@ public class Bar : IHasFill, IHasLine
         }
     }
 
-    internal IEnumerable<CoordinateLine> ErrorLines
+    public IEnumerable<CoordinateLine> ErrorLines
     {
         get
         {
@@ -87,7 +87,7 @@ public class Bar : IHasFill, IHasLine
         }
     }
 
-    internal AxisLimits AxisLimits
+    public AxisLimits AxisLimits
     {
         get
         {


### PR DESCRIPTION
set Rect, ErrorLines, AxisLimits in Class Bar from internal to public

So we can access properties like this from outside the library