### PR TITLE
WinForms: improve the designer experience for .NET Framework apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ _Not yet on NuGet..._
 * Financial Charting: Added experimental `FinancialTimeAxis` plottable as an alternative to using custom axes or tick generators (#4385) @quantfreedom @vladislavpweetsoft
 * Triangular Axis: Users may now `Add.TriangularAxis()` and use its methods to get Cartesian coordinates from points in triangular space (#4421, #4413, #4424) @manaruto
 * Bar: Exposed `Rect`, `ErrorLines`, and `AxisLimits` properties (#4423) @tiger2014
+* FormsPlot: Improved the Visual Studio design time experience for users working on .NET Framework projects (#4425, #4362) @CoderPM2011
 
 ## ScottPlot 5.0.42
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-10-29_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlot.cs
@@ -19,7 +19,7 @@ public class FormsPlot : FormsPlotBase
 
     public FormsPlot() : base()
     {
-        if (NotFoundSkiaDll)
+        if (IsDesignerAlternative)
         {
             return;
         }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlot.cs
@@ -9,18 +9,20 @@ namespace ScottPlot.WinForms;
 [ToolboxItem(true)]
 public class FormsPlot : FormsPlotBase
 {
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [Browsable(false)]
     public SKControl? SKControl { get; private set; }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [Browsable(false)]
     public override GRContext GRContext => null!;
 
-    public FormsPlot()
+    public FormsPlot() : base()
     {
-
-#if NETFRAMEWORK
-        // do not attempt renders inside visual studio at design time
-        if (LicenseManager.UsageMode == LicenseUsageMode.Designtime)
+        if (NotFoundSkiaDll)
+        {
             return;
-#endif
+        }
 
         HandleCreated += (s, e) => SetupSKControl();
         HandleDestroyed += (s, e) => TeardownSKControl();
@@ -52,7 +54,7 @@ public class FormsPlot : FormsPlotBase
         if (SKControl is null)
             return;
 
-        SKControl.PaintSurface -= SKElement_PaintSurface; ;
+        SKControl.PaintSurface -= SKElement_PaintSurface;
         SKControl.MouseDown -= SKElement_MouseDown;
         SKControl.MouseUp -= SKElement_MouseUp;
         SKControl.MouseMove -= SKElement_MouseMove;

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotDesignerAlternative.Designer.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotDesignerAlternative.Designer.cs
@@ -1,0 +1,93 @@
+﻿namespace ScottPlot.WinForms;
+
+partial class FormsPlotDesignerAlternative
+{
+    /// <summary> 
+    /// Required designer variable.
+    /// </summary>
+    private System.ComponentModel.IContainer components = null;
+
+    /// <summary> 
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && (components != null))
+        {
+            components.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+
+    #region Component Designer generated code
+
+    /// <summary> 
+    /// Required method for Designer support - do not modify 
+    /// the contents of this method with the code editor.
+    /// </summary>
+    private void InitializeComponent()
+    {
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.richTextBox1 = new System.Windows.Forms.RichTextBox();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Font = new System.Drawing.Font("Segoe UI Semibold", 21.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.ForeColor = System.Drawing.Color.White;
+            this.label1.Location = new System.Drawing.Point(8, 10);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(222, 40);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "ScottPlot 5.0.00";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.ForeColor = System.Drawing.Color.White;
+            this.label2.Location = new System.Drawing.Point(10, 50);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(204, 21);
+            this.label2.TabIndex = 1;
+            this.label2.Text = "Visual Studio Designer View";
+            // 
+            // richTextBox1
+            // 
+            this.richTextBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.richTextBox1.BackColor = System.Drawing.Color.Navy;
+            this.richTextBox1.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.richTextBox1.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.richTextBox1.ForeColor = System.Drawing.Color.Gray;
+            this.richTextBox1.Location = new System.Drawing.Point(15, 83);
+            this.richTextBox1.Name = "richTextBox1";
+            this.richTextBox1.Size = new System.Drawing.Size(403, 206);
+            this.richTextBox1.TabIndex = 2;
+            this.richTextBox1.Text = "details";
+            // 
+            // FormsPlotDesignerAlternative
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.Navy;
+            this.Controls.Add(this.richTextBox1);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.label1);
+            this.Name = "FormsPlotDesignerAlternative";
+            this.Size = new System.Drawing.Size(430, 302);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+    }
+
+    #endregion
+
+    private System.Windows.Forms.Label label1;
+    private System.Windows.Forms.Label label2;
+    private System.Windows.Forms.RichTextBox richTextBox1;
+}

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotDesignerAlternative.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotDesignerAlternative.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel;
+using System.Windows.Forms;
+
+namespace ScottPlot.WinForms;
+
+[ToolboxItem(false)]
+public partial class FormsPlotDesignerAlternative : UserControl
+{
+    public FormsPlotDesignerAlternative()
+    {
+        InitializeComponent();
+
+        label1.Text = ScottPlot.Version.LongString;
+        label2.Text = "Visual Studio Designer View";
+        richTextBox1.Text = "It appears you are working inside Visual Studio and a " +
+            "DLL required for rendering failed to load, so this placeholder will be displayed " +
+            "in the designer but will be replaced by an interactive plot when the program is run.";
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotDesignerAlternative.resx
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotDesignerAlternative.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotGL.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotGL.cs
@@ -8,12 +8,17 @@ namespace ScottPlot.WinForms;
 [ToolboxItem(false)]
 public class FormsPlotGL : FormsPlotBase
 {
-    public SKGLControl SKElement { get; }
+    public SKGLControl SKElement { get; } = null!;
 
     public override GRContext GRContext => SKElement.GRContext;
 
-    public FormsPlotGL()
+    public FormsPlotGL() : base()
     {
+        if (IsDesignerAlternative)
+        {
+            return;
+        }
+
         SKElement = new() { Dock = DockStyle.Fill, VSync = true };
         SKElement.PaintSurface += SKControl_PaintSurface;
         SKElement.MouseDown += SKElement_MouseDown;

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.Designer.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.Designer.cs
@@ -28,28 +28,31 @@ partial class Form1
     /// </summary>
     private void InitializeComponent()
     {
-        formsPlot1 = new ScottPlot.WinForms.FormsPlot();
-        SuspendLayout();
-        // 
-        // formsPlot1
-        // 
-        formsPlot1.DisplayScale = 1F;
-        formsPlot1.Dock = DockStyle.Fill;
-        formsPlot1.Location = new Point(0, 0);
-        formsPlot1.Name = "formsPlot1";
-        formsPlot1.Size = new Size(592, 359);
-        formsPlot1.TabIndex = 1;
-        // 
-        // Form1
-        // 
-        AutoScaleDimensions = new SizeF(7F, 15F);
-        AutoScaleMode = AutoScaleMode.Font;
-        ClientSize = new Size(592, 359);
-        Controls.Add(formsPlot1);
-        Name = "Form1";
-        StartPosition = FormStartPosition.CenterScreen;
-        Text = "ScottPlot 5 - Windows Forms Sandbox";
-        ResumeLayout(false);
+            this.formsPlot1 = new ScottPlot.WinForms.FormsPlot();
+            this.SuspendLayout();
+            // 
+            // formsPlot1
+            // 
+            this.formsPlot1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.formsPlot1.DisplayScale = 1F;
+            this.formsPlot1.Location = new System.Drawing.Point(12, 12);
+            this.formsPlot1.Name = "formsPlot1";
+            this.formsPlot1.Size = new System.Drawing.Size(483, 287);
+            this.formsPlot1.TabIndex = 1;
+            // 
+            // Form1
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(507, 311);
+            this.Controls.Add(this.formsPlot1);
+            this.Name = "Form1";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "ScottPlot 5 - Windows Forms Sandbox";
+            this.ResumeLayout(false);
+
     }
 
     #endregion

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.resx
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
+  <!-- 
     Microsoft ResX Schema 
-
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Program.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Program.cs
@@ -2,15 +2,13 @@
 
 static class Program
 {
-    /// <summary>
-    ///  The main entry point for the application.
-    /// </summary>
     [STAThread]
     static void Main()
     {
-        // To customize application configuration such as set high DPI settings or default font,
-        // see https://aka.ms/applicationconfiguration.
+#if NETFRAMEWORK
+#else
         ApplicationConfiguration.Initialize();
+#endif
         Application.Run(new Form1());
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Sandbox.WinForms.csproj
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Sandbox.WinForms.csproj
@@ -1,18 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+
+        <!-- 
+        NOTE FOR TESTING THIS APP ON .NET FRAMEWORK
+        The designer may crash or not display the control in the toolbox unless you 
+        temporarially edit the ScottPlot.WinForm project file to only target a single
+        target framework and match it to the one this application targets.
+        -->
+        <TargetFramework>net462</TargetFramework>
+
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net8.0-windows</TargetFramework>
         <Nullable>enable</Nullable>
         <UseWindowsForms>true</UseWindowsForms>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>false</IsPackable>
         <SignAssembly>True</SignAssembly>
+        <LangVersion>Latest</LangVersion>
         <AssemblyOriginatorKeyFile>../../Key.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\ScottPlot5 Controls\ScottPlot.OpenGL\ScottPlot.OpenGL.csproj" />
         <ProjectReference Include="..\..\ScottPlot5 Controls\ScottPlot.WinForms\ScottPlot.WinForms.csproj" />
         <ProjectReference Include="..\..\ScottPlot5\ScottPlot.csproj" />
     </ItemGroup>


### PR DESCRIPTION
resolve #4362

After investigation, it was found that `FormsPlot` inherits `FormsPlotBase`, and its member `Plot` will call the method in `SkiaSharp`, so `FormsPlotBase` also needs to be adjusted.

Adjusted to detect whether `FormsPlotBase` throws an exception that `libSkiaSharp.dll` cannot be found, and display the current version and error message on the control.

like this
![image](https://github.com/user-attachments/assets/5b719154-5807-4396-9b88-02697355876a)

--- 

I found that I had to be careful whether `FormsPlot` properties were set in `Form.Designer.cs`.
If the property calls `SkiaSharp`, it may also affect the control and cause an error.🤔