### PR TITLE
FloatingAxis: new plottable for displaying axes anywhere in the data area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _Not yet on NuGet..._
 * Bar: Exposed `Rect`, `ErrorLines`, and `AxisLimits` properties (#4423) @tiger2014
 * Axes: `SquareUnits()` now uses `SquareZoomOut` for console apps and `SquarePreserveX` for interactive apps (#4422) @King-Taz @KosmosWerner
 * Bar: Improved support for bat plots with custom hatch patterns (#3386)
+* Floating Axis: New plot type for displaying axes anywhere inside the data area (#3377) @ZTaiIT1025
 
 ## ScottPlot 5.0.42
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-10-29_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/AxisRecipes.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/AxisRecipes.cs
@@ -322,4 +322,30 @@ public class AxisAndTicks : ICategory
             };
         }
     }
+
+    public class FloatingAxis : RecipeBase
+    {
+        public override string Name => "Floating Axis";
+        public override string Description => "A floating or centered axis may be realized by " +
+            "hiding the default axes which appear at the edges of the plot and creating a new " +
+            "floating axis and adding it to the plot.";
+
+        [Test]
+        public override void Execute()
+        {
+            // create floating X and Y axes using one of the existing axes for reference
+            ScottPlot.Plottables.FloatingAxis floatingX = new(myPlot.Axes.Bottom);
+            ScottPlot.Plottables.FloatingAxis floatingY = new(myPlot.Axes.Left);
+
+            // hide the default axes and add the custom ones to the plot
+            myPlot.Axes.Frameless();
+            myPlot.HideGrid();
+            myPlot.Add.Plottable(floatingX);
+            myPlot.Add.Plottable(floatingY);
+
+            // add sample data last so it appears on top
+            myPlot.Add.Signal(Generate.Sin(51));
+            myPlot.Add.Signal(Generate.Cos(51));
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/FloatingAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/FloatingAxis.cs
@@ -36,7 +36,7 @@ public class FloatingAxis : IPlottable
         TickLabelStyle.Alignment = Alignment.MiddleRight;
     }
 
-    public void Render(RenderPack rp)
+    public virtual void Render(RenderPack rp)
     {
         if (IsVertical)
         {

--- a/src/ScottPlot5/ScottPlot5/Plottables/FloatingAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/FloatingAxis.cs
@@ -1,0 +1,101 @@
+﻿namespace ScottPlot.Plottables;
+
+/// <summary>
+/// This plottable renders an axis line, ticks, and tick labels inside the data area
+/// </summary>
+public class FloatingAxis : IPlottable
+{
+    public bool IsVisible { get; set; } = true;
+    public IAxes Axes { get; set; } = new Axes();
+    public IEnumerable<LegendItem> LegendItems => LegendItem.None;
+    public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
+
+    LineStyle SpineLineStyle { get; set; } = new(1, Colors.Black);
+    TickMarkStyle MajorTickMarkStyle { get; set; } = new() { Color = Colors.Black };
+    TickMarkStyle MinorTickMarkStyle { get; set; } = new() { Color = Colors.Black.WithAlpha(.2) };
+    LabelStyle TickLabelStyle { get; set; } = LabelStyle.Default;
+
+    float TickLength { get; set; } = 5;
+    bool SkipCenterTickLabel { get; set; } = true;
+
+    public bool IsVertical { get; }
+    public ITickGenerator TickGenerator { get; }
+    public double Position = 0.5;
+
+    public FloatingAxis(IXAxis axis)
+    {
+        IsVertical = false;
+        TickGenerator = axis.TickGenerator;
+        TickLabelStyle.Alignment = Alignment.UpperCenter;
+    }
+
+    public FloatingAxis(IYAxis axis)
+    {
+        IsVertical = true;
+        TickGenerator = axis.TickGenerator;
+        TickLabelStyle.Alignment = Alignment.MiddleRight;
+    }
+
+    public void Render(RenderPack rp)
+    {
+        if (IsVertical)
+        {
+            RenderVerticalAxis(rp);
+        }
+        else
+        {
+            RenderHorizontalAxis(rp);
+        }
+    }
+
+    public void RenderVerticalAxis(RenderPack rp)
+    {
+        float x = (float)(rp.DataRect.Width * Position + rp.DataRect.Left);
+        PixelLine spineLine = new(x, rp.DataRect.Top, x, rp.DataRect.Bottom);
+        Console.WriteLine(spineLine.ToString());
+        Drawing.DrawLine(rp.Canvas, rp.Paint, spineLine, SpineLineStyle);
+
+        float x1 = x - TickLength / 2;
+        float x2 = x + TickLength / 2;
+        foreach (var tick in TickGenerator.Ticks)
+        {
+            float y = Axes.YAxis.GetPixel(tick.Position, rp.DataRect);
+            PixelLine tickLine = new(x1, y, x2, y);
+            if (tick.IsMajor)
+            {
+                MajorTickMarkStyle.Render(rp.Canvas, rp.Paint, tickLine);
+                if (SkipCenterTickLabel && (Math.Abs(y - rp.DataRect.VerticalCenter) < 1.5)) continue;
+                TickLabelStyle.Render(rp.Canvas, tickLine.Pixel1, rp.Paint, tick.Label);
+            }
+            else
+            {
+                MinorTickMarkStyle.Render(rp.Canvas, rp.Paint, tickLine);
+            }
+        }
+    }
+
+    public void RenderHorizontalAxis(RenderPack rp)
+    {
+        float y = (float)(rp.DataRect.Height * Position + rp.DataRect.Top);
+        PixelLine spineLine = new(rp.DataRect.Left, y, rp.DataRect.Right, y);
+        Drawing.DrawLine(rp.Canvas, rp.Paint, spineLine, SpineLineStyle);
+
+        float y1 = y - TickLength / 2;
+        float y2 = y + TickLength / 2;
+        foreach (var tick in TickGenerator.Ticks)
+        {
+            float x = Axes.XAxis.GetPixel(tick.Position, rp.DataRect);
+            PixelLine tickLine = new(x, y1, x, y2);
+            if (tick.IsMajor)
+            {
+                MajorTickMarkStyle.Render(rp.Canvas, rp.Paint, tickLine);
+                if (SkipCenterTickLabel && (Math.Abs(x - rp.DataRect.HorizontalCenter) < 1.5)) continue;
+                TickLabelStyle.Render(rp.Canvas, tickLine.Pixel2, rp.Paint, tick.Label);
+            }
+            else
+            {
+                MinorTickMarkStyle.Render(rp.Canvas, rp.Paint, tickLine);
+            }
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Primitives/LabelStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LabelStyle.cs
@@ -74,6 +74,8 @@ public class LabelStyle
     public float BorderRadiusX = 0;
     public float BorderRadiusY = 0;
 
+    public static LabelStyle Default => new() { IsVisible = true, ForeColor = Colors.Black };
+
     /// <summary>
     /// Use the characters in <see cref="Text"/> to determine an installed
     /// system font most likely to support this character set.


### PR DESCRIPTION
Resolves #3377

```cs
// create floating X and Y axes using one of the existing axes for reference
ScottPlot.Plottables.FloatingAxis floatingX = new(myPlot.Axes.Bottom);
ScottPlot.Plottables.FloatingAxis floatingY = new(myPlot.Axes.Left);

// hide the default axes and add the custom ones to the plot
myPlot.Axes.Frameless();
myPlot.HideGrid();
myPlot.Add.Plottable(floatingX);
myPlot.Add.Plottable(floatingY);

// add sample data last so it appears on top
myPlot.Add.Signal(Generate.Sin(51));
myPlot.Add.Signal(Generate.Cos(51));
```

![image](https://github.com/user-attachments/assets/7c90a51e-4d5d-4674-bb05-a83e5a9fc3c7)
