### PR TITLE
Signal data sources: disable pixel overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _Not yet on NuGet..._
 * LineStyle: Added a `HandDrawn` flag with customizable `HandDrawnJitter` and `HandDrawnSegmentLength` to create XKCD-style plots (#4435, #3239) @sdpenner
 * SignalConst: Exposed `Data` so users may access offset configuration settings (#4440, #4253) @matej-mnoucek
 * VectorField: Added `MaximumArrowLength` property to allow arrow lengths to be customized (#3763) @hnMel
+* Signal: Reduced render artifacts for high density overlapping data by reducing pixel overlap (#4050, #3665) @StendProg
 
 ## ScottPlot 5.0.43
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-03_

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceBase.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceBase.cs
@@ -11,6 +11,8 @@ public abstract class SignalSourceBase
     public int MinRenderIndex => Math.Max(0, MinimumIndex);
     public int MaxRenderIndex => Math.Min(Length - 1, MaximumIndex);
 
+    public bool UsePixelOverlap { get; } = false; // https://github.com/ScottPlot/ScottPlot/issues/3665
+
     public double XOffset { get; set; } = 0;
     public double YOffset { get; set; } = 0;
     public double YScale { get; set; } = 1;

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceDouble.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceDouble.cs
@@ -51,9 +51,10 @@ public class SignalSourceDouble : SignalSourceBase, ISignalSource, IDataSource
         float xUnitsPerPixel = (float)(axes.XAxis.Width / axes.DataRect.Width);
         double xRangeMax = xRangeMin + Math.Abs(xUnitsPerPixel);
 
-        // add slight overlap to prevent floating point errors from missing points
-        // https://github.com/ScottPlot/ScottPlot/issues/3665
-        xRangeMax += xUnitsPerPixel * .01;
+        if (UsePixelOverlap)
+        {
+            xRangeMax += xUnitsPerPixel * .01;
+        }
 
         if (RangeContainsSignal(xRangeMin, xRangeMax) == false)
             return PixelColumn.WithoutData(xPixel);

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericArray.cs
@@ -53,9 +53,10 @@ public class SignalSourceGenericArray<T> : SignalSourceBase, ISignalSource, IDat
         float xUnitsPerPixel = (float)(axes.XAxis.Width / axes.DataRect.Width);
         double xRangeMax = xRangeMin + xUnitsPerPixel;
 
-        // add slight overlap to prevent floating point errors from missing points
-        // https://github.com/ScottPlot/ScottPlot/issues/3665
-        xRangeMax += xUnitsPerPixel * .01;
+        if (UsePixelOverlap)
+        {
+            xRangeMax += xUnitsPerPixel * .01;
+        }
 
         if (RangeContainsSignal(xRangeMin, xRangeMax) == false)
             return PixelColumn.WithoutData(xPixel);

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericList.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericList.cs
@@ -55,9 +55,10 @@ public class SignalSourceGenericList<T> : SignalSourceBase, ISignalSource, IData
         float xUnitsPerPixel = (float)(axes.XAxis.Width / axes.DataRect.Width);
         double xRangeMax = xRangeMin + xUnitsPerPixel;
 
-        // add slight overlap to prevent floating point errors from missing points
-        // https://github.com/ScottPlot/ScottPlot/issues/3665
-        xRangeMax += xUnitsPerPixel * .01;
+        if (UsePixelOverlap)
+        {
+            xRangeMax += xUnitsPerPixel * .01;
+        }
 
         if (RangeContainsSignal(xRangeMin, xRangeMax) == false)
             return PixelColumn.WithoutData(xPixel);

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceDoubleArray.cs
@@ -24,6 +24,8 @@ public class SignalXYSourceDoubleArray : ISignalXYSource, IDataSource, IGetNeare
     int IDataSource.MinRenderIndex => MinimumIndex;
     int IDataSource.MaxRenderIndex => MaximumIndex;
 
+    public bool UsePixelOverlap { get; } = false; // https://github.com/ScottPlot/ScottPlot/issues/3665
+
     public SignalXYSourceDoubleArray(double[] xs, double[] ys)
     {
         if (xs.Length != ys.Length)
@@ -186,10 +188,10 @@ public class SignalXYSourceDoubleArray : ISignalXYSource, IDataSource, IGetNeare
         double start = axes.XAxis.Min + unitsPerPixelX * pixelColumnIndex;
         double end = start + unitsPerPixelX;
 
-        // add slight overlap to prevent floating point errors from missing points
-        // https://github.com/ScottPlot/ScottPlot/issues/3665
-        double overlap = unitsPerPixelX * .01;
-        end += overlap;
+        if (UsePixelOverlap)
+        {
+            end += unitsPerPixelX * .01;
+        }
 
         var (startIndex, _) = SearchIndex(start, rng);
         var (endIndex, _) = SearchIndex(end, rng);

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericArray.cs
@@ -21,6 +21,8 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource, IDataSource, 
     int IDataSource.MinRenderIndex => MinimumIndex;
     int IDataSource.MaxRenderIndex => MaximumIndex;
 
+    public bool UsePixelOverlap { get; } = false; // https://github.com/ScottPlot/ScottPlot/issues/3665
+
     public SignalXYSourceGenericArray(TX[] xs, TY[] ys)
     {
         if (xs.Length != ys.Length)
@@ -182,10 +184,10 @@ public class SignalXYSourceGenericArray<TX, TY> : ISignalXYSource, IDataSource, 
         double start = axes.XAxis.Min + unitsPerPixelX * pixelColumnIndex;
         double end = start + unitsPerPixelX;
 
-        // add slight overlap to prevent floating point errors from missing points
-        // https://github.com/ScottPlot/ScottPlot/issues/3665
-        double overlap = unitsPerPixelX * .01;
-        end += overlap;
+        if (UsePixelOverlap)
+        {
+            end += unitsPerPixelX * .01;
+        }
 
         var (startIndex, _) = SearchIndex(start, rng);
         var (endIndex, _) = SearchIndex(end, rng);


### PR DESCRIPTION
This functionality is hidden behind a flag so it can still be tested or reverted if necessary

resolves #4050