### PR TITLE
Controls: abort mouse drags if the window loses focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _Not yet on NuGet..._
 * VectorField: Added `MaximumArrowLength` property to allow arrow lengths to be customized (#3763) @hnMel
 * Signal: Reduced render artifacts for high density overlapping data by reducing pixel overlap (#4050, #3665) @StendProg
 * Label: Added border radius properties to customize corner curvature of labels and plottables with label styles (#4099)
+* Controls: Added `LostFocusAction` to abort mouse drags if they are interrupted by Alt+Tab or other events that lose window focus (#4103) @Max-i-m
 
 ## ScottPlot 5.0.43
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-03_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlot.cs
@@ -43,6 +43,8 @@ namespace ScottPlot.WPF
             SKElement.MouseWheel += SKElement_MouseWheel;
             SKElement.KeyDown += SKElement_KeyDown;
             SKElement.KeyUp += SKElement_KeyUp;
+            SKElement.LostMouseCapture += SKElement_LostFocus;
+            SKElement.LostKeyboardFocus += SKElement_LostFocus;
         }
 
         public override void Refresh()

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotBase.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -97,6 +98,11 @@ public abstract class WpfPlotBase : System.Windows.Controls.Control, IPlotContro
     {
         Interaction.KeyUp(e.OldToKey());
         UserInputProcessor.ProcessKeyUp(e);
+    }
+
+    internal void SKElement_LostFocus(object sender, RoutedEventArgs e)
+    {
+        UserInputProcessor.ProcessLostFocus();
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotGL.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotGL.cs
@@ -44,6 +44,8 @@ public class WpfPlotGL : WpfPlotBase
         SKElement.MouseWheel += SKElement_MouseWheel;
         SKElement.KeyDown += SKElement_KeyDown;
         SKElement.KeyUp += SKElement_KeyUp;
+        SKElement.LostMouseCapture += SKElement_LostFocus;
+        SKElement.LostKeyboardFocus += SKElement_LostFocus;
     }
 
     public override void Refresh()

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlot.cs
@@ -45,6 +45,7 @@ public class FormsPlot : FormsPlotBase
         SKControl.MouseWheel += SKElement_MouseWheel;
         SKControl.KeyDown += SKElement_KeyDown;
         SKControl.KeyUp += SKElement_KeyUp;
+        SKControl.LostFocus += SKElement_LostFocus;
 
         Controls.Add(SKControl);
     }
@@ -62,6 +63,7 @@ public class FormsPlot : FormsPlotBase
         SKControl.MouseWheel -= SKElement_MouseWheel;
         SKControl.KeyDown -= SKElement_KeyDown;
         SKControl.KeyUp -= SKElement_KeyUp;
+        SKControl.LostFocus -= SKElement_LostFocus;
 
         Controls.Remove(SKControl);
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotBase.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotBase.cs
@@ -158,6 +158,12 @@ public abstract class FormsPlotBase : UserControl, IPlotControl
         base.OnKeyUp(e);
     }
 
+    internal void SKElement_LostFocus(object? sender, System.EventArgs e)
+    {
+        FormsPlotExtensions.ProcessLostFocus(UserInputProcessor);
+        base.OnLostFocus(e);
+    }
+
     public float DetectDisplayScale()
     {
         using Graphics gfx = CreateGraphics();

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotExtensions.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotExtensions.cs
@@ -80,6 +80,11 @@ public static class FormsPlotExtensions
         processor.Process(action);
     }
 
+    public static void ProcessLostFocus(this Interactivity.UserInputProcessor processor)
+    {
+        processor.ProcessLostFocus();
+    }
+
     internal static Interactivity.Key GetKey(this KeyEventArgs e)
     {
         return GetKey(e.KeyCode);

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotGL.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotGL.cs
@@ -28,6 +28,7 @@ public class FormsPlotGL : FormsPlotBase
         SKElement.MouseWheel += SKElement_MouseWheel;
         SKElement.KeyDown += SKElement_KeyDown;
         SKElement.KeyUp += SKElement_KeyUp;
+        SKElement.LostFocus += SKElement_LostFocus;
 
         Controls.Add(SKElement);
 

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseDragPan.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseDragPan.cs
@@ -31,6 +31,11 @@ public class MouseDragPan(MouseButton button) : IUserActionResponse
     /// </summary>
     public bool LockX { get; set; } = false;
 
+    public void Abort()
+    {
+        RememberedLimits = null;
+    }
+
     public ResponseInfo Execute(Plot plot, IUserAction userInput, KeyboardState keys)
     {
         // mouse down starts drag

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseDragZoom.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseDragZoom.cs
@@ -29,6 +29,11 @@ public class MouseDragZoom(MouseButton button) : IUserActionResponse
     /// </summary>
     public bool LockX { get; set; } = false;
 
+    public void Abort()
+    {
+        RememberedLimits = null;
+    }
+
     public ResponseInfo Execute(Plot plot, IUserAction userInput, KeyboardState keys)
     {
         if (userInput is IMouseButtonAction mouseDownAction && mouseDownAction.Button == MouseButton && mouseDownAction.IsPressed)

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseDragZoomRectangle.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseDragZoomRectangle.cs
@@ -32,6 +32,12 @@ public class MouseDragZoomRectangle(MouseButton button) : IUserActionResponse
     /// </summary>
     public Key VerticalLockKey { get; set; } = StandardKeys.Shift;
 
+    public void Abort(Plot plot)
+    {
+        MouseDownPixel = Pixel.NaN;
+        plot.ZoomRectangle.IsVisible = false;
+    }
+
     public ResponseInfo Execute(Plot plot, IUserAction userAction, KeyboardState keys)
     {
         if (userAction is IMouseButtonAction buttonAction && buttonAction.IsPressed)

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserInputProcessor.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserInputProcessor.cs
@@ -1,4 +1,6 @@
-﻿namespace ScottPlot.Interactivity;
+﻿using ScottPlot.Interactivity.UserActionResponses;
+
+namespace ScottPlot.Interactivity;
 
 #pragma warning disable CS0618 // disable obsolete Interaction warning
 
@@ -175,6 +177,33 @@ public class UserInputProcessor
 
         if (refreshNeeded)
             PlotControl.Refresh();
+    }
+
+    public Action<IPlotControl> LostFocusAction = (IPlotControl plotControl) =>
+    {
+        var uiResponses = plotControl.UserInputProcessor.UserActionResponses;
+
+        foreach (var r in uiResponses.OfType<MouseDragZoomRectangle>())
+        {
+            r.Abort(plotControl.Plot);
+        }
+
+        foreach (var r in uiResponses.OfType<MouseDragPan>())
+        {
+            r.Abort();
+        }
+
+        foreach (var r in uiResponses.OfType<MouseDragZoom>())
+        {
+            r.Abort();
+        }
+
+        plotControl.Refresh();
+    };
+
+    public void ProcessLostFocus()
+    {
+        LostFocusAction.Invoke(PlotControl);
     }
 
     private void UpdateKeyboardState(IUserAction userAction)


### PR DESCRIPTION
This PR implements this feature for the WinForms and WPF controls.

It may be added to the other controls in the future as desired, or invoked manually on the client side.

Resolves #4103