### PR TITLE
Title: option to align to the figure instead of data area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _Not yet on NuGet..._
 * Label: Added border radius properties to customize corner curvature of labels and plottables with label styles (#4099)
 * Controls: Added `LostFocusAction` to abort mouse drags if they are interrupted by Alt+Tab or other events that lose window focus (#4103) @Max-i-m
 * Polygon: Improved performance and reduced anti-alias artifacts by preventing multiple overlapping drawings of identical lines (#4141) @HandsomeGoldenKnight
+* Title: Added `FullFigureCenter` flag to allow titles to be centered in the figure instead of over the data area (#4455, #364) @jaguarxii
 
 ## ScottPlot 5.0.43
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-03_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/Styling.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/Styling.cs
@@ -315,4 +315,19 @@ public class Styling : ICategory
             myPlot.Axes.Bottom.SetTicks([10, 50, 75], ["Minutes", "Days", "Weeks"]);
         }
     }
+
+    public class TitleAlignment : RecipeBase
+    {
+        public override string Name => "Title Alignment";
+        public override string Description => "The title is centered over the data area by default, " +
+            "but a flag allows users to center it relative to the figure instead";
+
+        [Test]
+        public override void Execute()
+        {
+            myPlot.Add.Signal(Generate.Sin(51, mult: 1e9));
+            myPlot.Title("This title is centered in the figure");
+            myPlot.Axes.Title.FullFigureCenter = true;
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Panels/TitlePanel.cs
+++ b/src/ScottPlot5/ScottPlot5/Panels/TitlePanel.cs
@@ -10,6 +10,12 @@ public class TitlePanel : IPanel
     public float MinimumSize { get; set; } = 0;
     public float MaximumSize { get; set; } = float.MaxValue;
 
+    /// <summary>
+    /// Enable this to center the panel using the full width of the figure rather than
+    /// centering it over the width of the data area.
+    /// </summary>
+    public bool FullFigureCenter { get; set; } = false;
+
     public TitlePanel()
     {
         Label.Rotation = 0;
@@ -58,6 +64,11 @@ public class TitlePanel : IPanel
         using SKPaint paint = new();
 
         PixelRect panelRect = GetPanelRect(rp.DataRect, size, offset);
+
+        if (FullFigureCenter)
+        {
+            panelRect = new(rp.FigureRect.Left, rp.DataRect.Right, panelRect.Bottom, panelRect.Top);
+        }
 
         Pixel labelPoint = new(panelRect.HorizontalCenter, panelRect.Bottom);
 


### PR DESCRIPTION
resolves #4455

```cs
formsPlot1.Plot.Axes.Title.FullFigureCenter = true;
```

default | FullFigureCenter
---|---
![test](https://github.com/user-attachments/assets/ad17e31d-6896-47e3-8f73-31be3b698a52)|![test](https://github.com/user-attachments/assets/0070620d-d5ca-419c-b80e-bb92a8d6d49e)