### PR TITLE
SkiaSharp 2.88.8 →  2.88.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _Not yet on NuGet..._
 * WpfPlot: Re-implemented `GetPlotPixelPosition()` and `GetCurrentPlotPixelPosition()` (#4214, #3622) @wellsw @KroMignon
 * DataLogger: Narrowed the underlying data type from `IList<Coordinates>` to `List<Coordinates>` to allow `RemoveRange()` as seen in the cookbook (#4460) @Fruchtzwerg94
 * Maui: Improve visual appearance of plots during panning (#4416, #4417, #4447) @King-Taz @KosmosWerner
+* WinUI: Improved support for Windows platforms by upgrading to the latest SkiaSharp dependency and building for `windows10.0.19041` (#4258) @ArchieCoder @ProgrammerGuy76 @agneszitte @AzureGulf @Treppon
 
 ## ScottPlot 5.0.43
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-03_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/ScottPlot.Blazor.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/ScottPlot.Blazor.csproj
@@ -50,7 +50,7 @@
     <!-- Package dependencies -->
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
-        <PackageReference Include="SkiaSharp.Views.Blazor" Version="2.88.8" />
+        <PackageReference Include="SkiaSharp.Views.Blazor" Version="2.88.9" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/ScottPlot.Maui.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/ScottPlot.Maui.csproj
@@ -60,8 +60,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-        <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="2.88.8" />
-        <PackageReference Include="SkiaSharp.Views.Maui.Core" Version="2.88.8" />
+        <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="2.88.9" />
+        <PackageReference Include="SkiaSharp.Views.Maui.Core" Version="2.88.9" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/ScottPlot.WPF.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/ScottPlot.WPF.csproj
@@ -58,7 +58,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SkiaSharp.Views.WPF" Version="2.88.8" />
+        <PackageReference Include="SkiaSharp.Views.WPF" Version="2.88.9" />
         <ProjectReference Include="..\..\ScottPlot5\ScottPlot.csproj" />
     </ItemGroup>
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/ScottPlot.WinForms.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/ScottPlot.WinForms.csproj
@@ -52,7 +52,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SkiaSharp.Views.WindowsForms" Version="2.88.8" />
+        <PackageReference Include="SkiaSharp.Views.WindowsForms" Version="2.88.9" />
         <ProjectReference Include="..\..\ScottPlot5\ScottPlot.csproj" />
     </ItemGroup>
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/ScottPlot.WinUI.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/ScottPlot.WinUI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <!-- ref ; https://github.com/unoplatform/uno/discussions/10977 -->
     <PropertyGroup>
-        <TargetFrameworks>net6.0-windows10.0.18362;net6.0;net8.0;net8.0-windows10.0.19041.0;net8.0-ios;net8.0-maccatalyst;net8.0-android</TargetFrameworks>
+        <TargetFrameworks>net6.0-windows10.0.19041;net6.0;net8.0;net8.0-windows10.0.19041.0;net8.0-ios;net8.0-maccatalyst;net8.0-android</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
         <LangVersion>11</LangVersion>
@@ -64,14 +64,14 @@
     <ItemGroup Condition="$(TargetFramework.Contains('windows'))">
         <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
         <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240802000" />
-        <PackageReference Include="SkiaSharp.Views.WinUI" Version="2.88.8" />
+        <PackageReference Include="SkiaSharp.Views.WinUI" Version="2.88.9" />
         <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.27" />
         <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.27" />
     </ItemGroup>
 
     <ItemGroup Condition="!$(TargetFramework.Contains('windows'))">
         <PackageReference Include="Uno.WinUI" Version="4.10.39" />
-        <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.8" />
+        <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.9" />
     </ItemGroup>
 
 </Project>

--- a/src/ScottPlot5/ScottPlot5 Tests/Graphical Test Runner/Graphical Test Runner.csproj
+++ b/src/ScottPlot5/ScottPlot5 Tests/Graphical Test Runner/Graphical Test Runner.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SkiaSharp" Version="2.88.8" />
+      <PackageReference Include="SkiaSharp" Version="2.88.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/CodeTests/CsprojTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/CodeTests/CsprojTests.cs
@@ -65,7 +65,16 @@ internal class CsprojTests
                     continue;
 
                 string version = line.Split("Version=")[1].Split('"')[1];
-                versionsByFile[file] = version;
+
+                if (versionsByFile.ContainsKey(file))
+                {
+                    if (versionsByFile[file] != version)
+                        throw new InvalidDataException($"SkiaSharp has conflicting versions in {file}");
+                }
+                else
+                {
+                    versionsByFile[file] = version;
+                }
             }
         }
 

--- a/src/ScottPlot5/ScottPlot5/ScottPlot.csproj
+++ b/src/ScottPlot5/ScottPlot5/ScottPlot.csproj
@@ -48,8 +48,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SkiaSharp" Version="2.88.8" />
-        <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.8" />
+        <PackageReference Include="SkiaSharp" Version="2.88.9" />
+        <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.9" />
     </ItemGroup>
 
     <!-- Packages allowing modern C# language features to be used in .NET Framework project -->


### PR DESCRIPTION
Fixes WinUI issues on Windows by upgrading to the latest SkiaSharp dependency

resolves #4258