### PR TITLE
Scatter: Fills now respect both OffsetX and OffsetY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ _Not yet on NuGet..._
 * Grid: Added `Color`, `LineWidth`, and `LinePattern` properties for quickly setting major line styles of primary X and Y axes grid lines (#4384)
 * DataLogger: Exposed `HasNewData` to allow signaling that new renders are required after manually editing logger data (#4470, #4460) @Fruchtzwerg94
 * Marker: Improved support for filled markers with opt-in outlines (#4387)
+* Generate: Added `RangeWithStep()` and `RangeWithCount()` as more explicit alternatives to the ambiguously named `Range()` method
 
 ## ScottPlot 5.0.43
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-03_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ _Not yet on NuGet..._
 * DataLogger: Exposed `HasNewData` to allow signaling that new renders are required after manually editing logger data (#4470, #4460) @Fruchtzwerg94
 * Marker: Improved support for filled markers with opt-in outlines (#4387)
 * Generate: Added `RangeWithStep()` and `RangeWithCount()` as more explicit alternatives to the ambiguously named `Range()` method
+* Scatter: Filled areas previously only respected `OffsetX` but now respect `OffsetY` too (#4433)
 
 ## ScottPlot 5.0.43
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-03_

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/Plottable/ScatterTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/Plottable/ScatterTests.cs
@@ -244,4 +244,30 @@ internal class ScatterTests
 
         plt.Should().SavePngWithoutThrowing();
     }
+
+    [Test]
+    public void Test_Scatter_FillAndOffset()
+    {
+        // https://github.com/ScottPlot/ScottPlot/issues/4433
+        
+        // create data points that resemble a "hump"
+        double[] ys = Generate.Cos(100, oscillations: 0.5, phase: -0.25);
+        double[] xs = Generate.RangeWithCount(0, 1, ys.Length);
+        
+        Plot plot = new();
+        
+        var sp1 = plot.Add.ScatterLine(xs, ys);
+        sp1.LineWidth = 3;
+        sp1.LineColor = Colors.Black;
+        sp1.FillY = true;
+        
+        var sp2 = plot.Add.ScatterLine(xs, ys);
+        sp2.LineWidth = 3;
+        sp2.LineColor = Colors.Black;
+        sp2.FillY = true;
+        sp2.OffsetX = 2;
+        sp2.OffsetY = 2;
+        
+        plot.SaveTestImage();
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Generate.cs
+++ b/src/ScottPlot5/ScottPlot5/Generate.cs
@@ -183,6 +183,7 @@ public static class Generate
         return Enumerable.Range(0, n).Select(i => (stop - start) * i / (n - 1) + start);
     }
 
+    // TODO: obsolete this
     /// <summary>
     /// Return values from <paramref name="start"/> to <paramref name="stop"/> (inclusive) separated by <paramref name="step"/>
     /// </summary>
@@ -190,6 +191,23 @@ public static class Generate
     {
         int n = (int)Math.Round((stop - start) / step) + 1;
         return Range(start, stop, n).ToArray();
+    }
+    
+    /// <summary>
+    /// Return values from <paramref name="start"/> to <paramref name="stop"/> (inclusive) separated by <paramref name="step"/>
+    /// </summary>
+    public static double[] RangeWithStep(double start, double stop, double step = 1)
+    {
+        int n = (int)Math.Round((stop - start) / step) + 1;
+        return Range(start, stop, n).ToArray();
+    }
+
+    /// <summary>
+    /// Return <paramref name="count"/> values from <paramref name="start"/> to <paramref name="stop"/> (inclusive)
+    /// </summary>
+    public static double[] RangeWithCount(double start, double stop, int count)
+    {
+        return Range(start, stop, count).ToArray();
     }
 
     #endregion

--- a/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
@@ -238,7 +238,7 @@ public class Scatter(IScatterSource data) : IPlottable, IHasLine, IHasMarker, IH
             PixelRect dataPxRect = new(markerPixels);
 
             PixelRect rect = new(linePixels);
-            float yValuePixel = Axes.YAxis.GetPixel(FillYValue, rp.DataRect);
+            float yValuePixel = Axes.YAxis.GetPixel(FillYValue + OffsetY, rp.DataRect);
 
             using SKPath fillPath = new(path);
             fillPath.LineTo(rect.Right, yValuePixel);


### PR DESCRIPTION
Scatter plot fills now respect both OffsetX and OffsetY. Previously only OffsetX was respected.

Resolves #4433

```cs
// create data points that resemble a "hump"
double[] ys = Generate.Cos(100, oscillations: 0.5, phase: -0.25);
double[] xs = Generate.RangeWithCount(0, 1, ys.Length);
```

```cs
// scatter with no offset
var sp1 = plot.Add.ScatterLine(xs, ys);
sp1.LineWidth = 3;
sp1.LineColor = Colors.Black;
sp1.FillY = true;

// scatter with offset
var sp2 = plot.Add.ScatterLine(xs, ys);
sp2.LineWidth = 3;
sp2.LineColor = Colors.Black;
sp2.FillY = true;
sp2.OffsetX = 2;
sp2.OffsetY = 2;
```

original behavior | new behavior
---|---
![Test_Scatter_FillAndOffset](https://github.com/user-attachments/assets/38449ea8-2df7-4225-bbe4-9ce02c85b74f)|![Test_Scatter_FillAndOffset](https://github.com/user-attachments/assets/44f41833-0ed5-4cec-94f9-e31f6b54c2f2)