### PR TITLE
IUserActionResponse: ResetState()

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Interactivity/IUserActionResponse.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/IUserActionResponse.cs
@@ -9,4 +9,12 @@ public interface IUserActionResponse
     /// Perform the given action on the specified plot and return a result indicating what to do next.
     /// </summary>
     ResponseInfo Execute(Plot plot, IUserAction userActions, KeyboardState keys);
+
+    /// <summary>
+    /// Reset state to what it was when the action response was first created.
+    /// This method is called when the user processor resets (e.g., when the 
+    /// control loses and re-gains focus or is disabled and re-enabled) and
+    /// is designed to reset responses like mouse-drag events that accumulate state.
+    /// </summary>
+    void ResetState(Plot plot);
 }

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/DoubleClickResponse.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/DoubleClickResponse.cs
@@ -23,6 +23,12 @@ public class DoubleClickResponse(MouseButton button, Action<Plot, Pixel> action)
 
     private DateTime PreviousMouseDownTime = DateTime.MinValue;
 
+    public void ResetState(Plot plot)
+    {
+        LatestMouseDownTime = DateTime.MinValue;
+        PreviousMouseDownTime = DateTime.MinValue;
+    }
+
     public ResponseInfo Execute(Plot plot, IUserAction userAction, KeyboardState keys)
     {
         if (userAction is IMouseButtonAction mouseAction && mouseAction.Button == MouseButton)

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/KeyPressResponse.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/KeyPressResponse.cs
@@ -8,6 +8,8 @@ public class KeyPressResponse(Key key, Action<Plot, Pixel> action) : IUserAction
 
     Action<Plot, Pixel> ResponseAction { get; } = action;
 
+    public void ResetState(Plot plot) { }
+
     public ResponseInfo Execute(Plot plot, IUserAction userAction, KeyboardState keys)
     {
         if (userAction is KeyDown keyDownAction)

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/KeyboardPanAndZoom.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/KeyboardPanAndZoom.cs
@@ -29,6 +29,8 @@ public class KeyboardPanAndZoom : IUserActionResponse
     public double DeltaZoomIn { get; set; } = 0.85f;
     public double DeltaZoomOut { get; set; } = 1.15f;
 
+    public void ResetState(Plot plot) { }
+
     public ResponseInfo Execute(Plot plot, IUserAction userInput, KeyboardState keys)
     {
         if (userInput is UserActions.KeyDown keyDown)

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseDragPan.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseDragPan.cs
@@ -7,7 +7,7 @@ public class MouseDragPan(MouseButton button) : IUserActionResponse
     /// </summary>
     public MouseButton MouseButton { get; } = button;
 
-    private Pixel MouseDownPixel;
+    private Pixel MouseDownPixel = Pixel.NaN;
 
     private MultiAxisLimits? RememberedLimits = null;
 
@@ -31,9 +31,10 @@ public class MouseDragPan(MouseButton button) : IUserActionResponse
     /// </summary>
     public bool LockX { get; set; } = false;
 
-    public void Abort()
+    public void ResetState(Plot plot)
     {
         RememberedLimits = null;
+        MouseDownPixel = Pixel.NaN;
     }
 
     public ResponseInfo Execute(Plot plot, IUserAction userInput, KeyboardState keys)

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseDragZoom.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseDragZoom.cs
@@ -41,9 +41,10 @@ public class MouseDragZoom(MouseButton button) : IUserActionResponse
     /// </summary>
     public double SensitivityY { get; set; } = 1.0;
 
-    public void Abort()
+    public void ResetState(Plot plot)
     {
         RememberedLimits = null;
+        MouseDownPixel = Pixel.NaN;
     }
 
     public ResponseInfo Execute(Plot plot, IUserAction userInput, KeyboardState keys)

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseDragZoomRectangle.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseDragZoomRectangle.cs
@@ -32,7 +32,7 @@ public class MouseDragZoomRectangle(MouseButton button) : IUserActionResponse
     /// </summary>
     public Key VerticalLockKey { get; set; } = StandardKeys.Shift;
 
-    public void Abort(Plot plot)
+    public void ResetState(Plot plot)
     {
         MouseDownPixel = Pixel.NaN;
         plot.ZoomRectangle.IsVisible = false;

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseWheelZoom.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseWheelZoom.cs
@@ -16,6 +16,8 @@ public class MouseWheelZoom(Key horizontalLockKey, Key verticalLockKey) : IUserA
 
     Key LockVerticalKey { get; } = verticalLockKey;
 
+    public void ResetState(Plot plot) { }
+
     public ResponseInfo Execute(Plot plot, IUserAction userInput, KeyboardState keys)
     {
         if (userInput is UserActions.MouseWheelUp mouseDownInput)

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/SingleClickResponse.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/SingleClickResponse.cs
@@ -17,6 +17,11 @@ public class SingleClickResponse(MouseButton button, Action<Plot, Pixel> action)
     /// </summary>
     private Pixel MouseDownPixel = Pixel.NaN;
 
+    public void ResetState(Plot plot)
+    {
+        MouseDownPixel = Pixel.NaN;
+    }
+
     public ResponseInfo Execute(Plot plot, IUserAction userAction, KeyboardState keys)
     {
         if (userAction is IMouseButtonAction buttonAction && buttonAction.Button == MouseButton)

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserInputProcessor.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserInputProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using ScottPlot.Interactivity.UserActionResponses;
+using System.Reflection.Emit;
 
 namespace ScottPlot.Interactivity;
 
@@ -185,25 +186,23 @@ public class UserInputProcessor
 
     public Action<IPlotControl> LostFocusAction = (IPlotControl plotControl) =>
     {
-        var uiResponses = plotControl.UserInputProcessor.UserActionResponses;
-
-        foreach (var r in uiResponses.OfType<MouseDragZoomRectangle>())
-        {
-            r.Abort(plotControl.Plot);
-        }
-
-        foreach (var r in uiResponses.OfType<MouseDragPan>())
-        {
-            r.Abort();
-        }
-
-        foreach (var r in uiResponses.OfType<MouseDragZoom>())
-        {
-            r.Abort();
-        }
-
+        ResetState(plotControl);
         plotControl.Refresh();
     };
+
+    /// <summary>
+    /// Reset state of all user action responses to do things like 
+    /// abort mouse-down-drag actions or key press-and-hold actions
+    /// </summary>
+    public static void ResetState(IPlotControl plotControl)
+    {
+        foreach(var response in plotControl.UserInputProcessor.UserActionResponses)
+        {
+            response.ResetState(plotControl.Plot);
+        }
+
+        plotControl.UserInputProcessor.KeyState.Reset();
+    }
 
     public void ProcessLostFocus()
     {


### PR DESCRIPTION
Extend the user action response interface to allow actions to be reset if the control loses and regains focus or the processor becomes disabled and re-enabled. Extends #4489 and #4481