### PR TITLE
SignalConst simplify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ _Not yet on NuGet..._
 * Blazor: Added UI event handlers with names consistent with those of other controls (#4480) @Saklut
 * SignalConst: Improve automatic axis limit detection when X and Y data offsets are used (#4485) @matej-mnoucek
 * Controls: Improve interactivity behavior by resetting drag events when interactivity is disabled (#4481) @hljlishen
+* SignalConst: Deprecated the `SignalConst` type in favor of a `Signal` with a `SignalConstSource` data source (#4492)
+* Signal: Refactored multiple signal plot and data source types for improved performance, increased customization, and better consistency (#4492) @StendProg
 
 ## ScottPlot 5.0.44
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-09_

--- a/src/ScottPlot5/ScottPlot5/DataSources/FastSignalSourceDouble.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/FastSignalSourceDouble.cs
@@ -23,6 +23,8 @@ public class FastSignalSourceDouble : SignalSourceBase, ISignalSource, IDataSour
 
     public IEnumerable<double> GetYs(int i1, int i2)
     {
+        i1 = Math.Max(i1, MinRenderIndex);
+        i2 = Math.Min(i2, MaxRenderIndex);
         for (int i = i1; i <= i2; i++)
         {
             yield return Ys[i];

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalConstSource.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalConstSource.cs
@@ -1,100 +1,18 @@
 ﻿namespace ScottPlot.DataSources;
 
-public class SignalConstSource<T>
+public class SignalConstSource<T> : SignalSourceGenericArray<T>
     where T : struct, IComparable
 {
     public readonly SegmentedTree<T> SegmentedTree = new();
 
-    public readonly T[] Ys;
-    public readonly double Period;
-
-    public double XOffset = 0;
-    public double YOffset = 0;
-    public int MinRenderIndex = 0;
-    public int MaxRenderIndex = int.MaxValue;
-
-    public SignalConstSource(T[] ys, double period)
+    public SignalConstSource(T[] ys, double period) : base(ys, period)
     {
-        Ys = ys;
-        Period = period;
         SegmentedTree.SourceArray = ys;
-        MaxRenderIndex = ys.Length - 1;
     }
 
-    public AxisLimits GetAxisLimits()
-    {
-        SegmentedTree.MinMaxRangeQuery(0, Ys.Length - 1, out double low, out double high);
-        return new AxisLimits(
-            left: 0 + XOffset,
-            right: Ys.Length * Period + XOffset,
-            bottom: low + YOffset,
-            top: high + YOffset);
-    }
-
-    public int GetIndex(double x, bool visibleDataOnly)
-    {
-        int i = (int)Math.Floor((x - XOffset) / Period);
-
-        if (visibleDataOnly)
-        {
-            i = Math.Max(i, MinRenderIndex);
-            i = Math.Min(i, MaxRenderIndex);
-        }
-
-        return i;
-    }
-
-    public bool RangeContainsSignal(double xMin, double xMax)
-    {
-        int xMinIndex = GetIndex(xMin, false);
-        int xMaxIndex = GetIndex(xMax, false);
-        return xMaxIndex >= MinRenderIndex && xMinIndex <= MaxRenderIndex;
-    }
-
-    public SignalRangeY GetLimitsY(int firstIndex, int lastIndex)
+    public override SignalRangeY GetLimitsY(int firstIndex, int lastIndex)
     {
         SegmentedTree.MinMaxRangeQuery(firstIndex, lastIndex, out double min, out double max);
         return new(min, max);
-    }
-
-    public List<PixelColumn> GetPixelColumns(IAxes axes)
-    {
-        List<PixelColumn> cols = new();
-
-        // ensure the same i1 isn't sampled twice
-        int latIndex1 = int.MinValue;
-        for (int xPixelIndex = 0; xPixelIndex < (int)axes.DataRect.Width; xPixelIndex++)
-        {
-            float xPixel = axes.DataRect.Left + xPixelIndex;
-            double xRangeMin = axes.GetCoordinateX(xPixel);
-            float xUnitsPerPixel = (float)(axes.XAxis.Width / axes.DataRect.Width);
-            double xRangeMax = xRangeMin + xUnitsPerPixel;
-
-            // off the edge of the data
-            if (RangeContainsSignal(xRangeMin, xRangeMax) == false)
-                continue;
-
-            // determine column limits horizontally
-            int i1 = GetIndex(xRangeMin, true);
-            int i2 = GetIndex(xRangeMax, true);
-            if (i1 == latIndex1)
-                continue;
-            latIndex1 = i1;
-
-            // first and last Y vales for this column
-            double y1 = NumericConversion.GenericToDouble(Ys, i1);
-            double y2 = NumericConversion.GenericToDouble(Ys, i2);
-            float yEnter = axes.GetPixelY(y1 + YOffset);
-            float yExit = axes.GetPixelY(y2 + YOffset);
-
-            // column min and max
-            SignalRangeY rangeY = GetLimitsY(i1, i2);
-            float yBottom = axes.GetPixelY(rangeY.Min + YOffset);
-            float yTop = axes.GetPixelY(rangeY.Max + YOffset);
-
-            cols.Add(new PixelColumn(xPixel, yEnter, yExit, yBottom, yTop));
-        }
-
-        return cols;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceDouble.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceDouble.cs
@@ -19,6 +19,8 @@ public class SignalSourceDouble : SignalSourceBase, ISignalSource, IDataSource
 
     public IEnumerable<double> GetYs(int i1, int i2)
     {
+        i1 = Math.Max(i1, MinRenderIndex);
+        i2 = Math.Min(i2, MaxRenderIndex);
         for (int i = i1; i <= i2; i++)
         {
             yield return Ys[i];

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericArray.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericArray.cs
@@ -2,7 +2,7 @@
 
 public class SignalSourceGenericArray<T> : SignalSourceBase, ISignalSource, IDataSource
 {
-    private readonly T[] Ys;
+    protected readonly T[] Ys;
     public override int Length => Ys.Length;
 
     bool IDataSource.PreferCoordinates => false;
@@ -20,6 +20,8 @@ public class SignalSourceGenericArray<T> : SignalSourceBase, ISignalSource, IDat
 
     public IEnumerable<double> GetYs(int i1, int i2)
     {
+        i1 = Math.Max(i1, MinRenderIndex);
+        i2 = Math.Min(i2, MaxRenderIndex);
         for (int i = i1; i <= i2; i++)
         {
             yield return NumericConversion.GenericToDouble(ref Ys[i]);
@@ -68,16 +70,9 @@ public class SignalSourceGenericArray<T> : SignalSourceBase, ISignalSource, IDat
         float yExit = axes.GetPixelY(NumericConversion.GenericToDouble(Ys, i2) * YScale + YOffset);
 
         // determine column span vertically
-        double yMin = double.PositiveInfinity;
-        double yMax = double.NegativeInfinity;
-        for (int i = i1; i <= i2; i++)
-        {
-            double value = NumericConversion.GenericToDouble(Ys, i);
-            yMin = Math.Min(yMin, value);
-            yMax = Math.Max(yMax, value);
-        }
-        yMin = yMin * YScale + YOffset;
-        yMax = yMax * YScale + YOffset;
+        SignalRangeY rangeY = GetLimitsY(i1, i2);
+        double yMin = rangeY.Min * YScale + YOffset;
+        double yMax = rangeY.Max * YScale + YOffset;
 
         float yBottom = axes.GetPixelY(yMin);
         float yTop = axes.GetPixelY(yMax);

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericList.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceGenericList.cs
@@ -19,6 +19,8 @@ public class SignalSourceGenericList<T> : SignalSourceBase, ISignalSource, IData
 
     public IEnumerable<double> GetYs(int i1, int i2)
     {
+        i1 = Math.Max(i1, MinRenderIndex);
+        i2 = Math.Min(i2, MaxRenderIndex);
         for (int i = i1; i <= i2; i++)
         {
             T genericValue = Ys[i];

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -1076,17 +1076,11 @@ public class PlottableAdder(Plot plot)
         return Signal(source, color);
     }
 
-    public SignalConst<T> SignalConst<T>(T[] ys, double period = 1, Color? color = null)
+    public Signal SignalConst<T>(T[] ys, double period = 1, Color? color = null)
         where T : struct, IComparable
     {
-        SignalConst<T> sig = new(ys, period)
-        {
-            Color = color ?? GetNextColor()
-        };
-
-        Plot.PlottableList.Add(sig);
-
-        return sig;
+        SignalConstSource<T> source = new(ys, period);
+        return Signal(source, color);
     }
 
     public SignalXY SignalXY(ISignalXYSource source, Color? color = null)

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -73,7 +73,7 @@ public class Signal(ISignalSource data) : IPlottable, IHasLine, IHasMarker, IHas
 
     public virtual void Render(RenderPack rp)
     {
-        if (!Data.GetYs().Any())
+        if (!Data.GetYs(MinRenderIndex, MaxRenderIndex).Any())
         {
             return;
         }

--- a/src/ScottPlot5/ScottPlot5/Plottables/SignalConst.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/SignalConst.cs
@@ -2,120 +2,15 @@
 
 namespace ScottPlot.Plottables;
 
-public class SignalConst<T>(T[] ys, double period) : IPlottable, IHasLine, IHasMarker, IHasLegendText
+public class SignalConst<T> : Signal, IPlottable, IHasLine, IHasMarker, IHasLegendText
     where T : struct, IComparable
 {
-    public SignalConstSource<T> Data { get; } = new(ys, period);
-
-    public MarkerStyle MarkerStyle { get; set; } = new();
-    public MarkerShape MarkerShape { get => MarkerStyle.Shape; set => MarkerStyle.Shape = value; }
-    public float MarkerSize { get => MarkerStyle.Size; set => MarkerStyle.Size = value; }
-    public Color MarkerFillColor { get => MarkerStyle.FillColor; set => MarkerStyle.FillColor = value; }
-    public Color MarkerLineColor { get => MarkerStyle.LineColor; set => MarkerStyle.LineColor = value; }
-    public Color MarkerColor { get => MarkerStyle.MarkerColor; set => MarkerStyle.MarkerColor = value; }
-    public float MarkerLineWidth { get => MarkerStyle.LineWidth; set => MarkerStyle.LineWidth = value; }
-    /// <summary>
-    /// Maximum size of the marker (in pixels) to display
-    /// at each data point when the plot is zoomed far in.
-    /// </summary>
-    public float MaximumMarkerSize { get; set; } = 4;
-
-    public LineStyle LineStyle { get; set; } = new() { Width = 1 };
-    public float LineWidth { get => LineStyle.Width; set => LineStyle.Width = value; }
-    public LinePattern LinePattern { get => LineStyle.Pattern; set => LineStyle.Pattern = value; }
-    public Color LineColor { get => LineStyle.Color; set => LineStyle.Color = value; }
-
-    [Obsolete("use LegendText")]
-    public string Label { get => LegendText; set => LegendText = value; }
-    public string LegendText { get; set; } = string.Empty;
-
-    public int MinRenderIndex { get => Data.MinRenderIndex; set => Data.MinRenderIndex = value; }
-    public int MaxRenderIndex { get => Data.MaxRenderIndex; set => Data.MaxRenderIndex = value; }
-
-    public Color Color
+    public SignalConst(SignalConstSource<T> data) : base(data)
     {
-        get => LineStyle.Color;
-        set
-        {
-            LineColor = value;
-            MarkerFillColor = value;
-            MarkerLineColor = value;
-        }
     }
 
-    /// <summary>
-    /// Setting this flag causes lines to be drawn between every visible point
-    /// (similar to scatter plots) to improve anti-aliasing in static images.
-    /// Setting this will decrease performance for large datasets 
-    /// and is not recommended for interactive environments.
-    /// </summary>
-    public bool AlwaysUseLowDensityMode { get; set; } = false;
-
-    public bool IsVisible { get; set; } = true;
-    public IAxes Axes { get; set; } = ScottPlot.Axes.Default;
-
-    public IEnumerable<LegendItem> LegendItems => LegendItem.Single(LegendText, MarkerStyle, LineStyle);
-
-    public AxisLimits GetAxisLimits() => Data.GetAxisLimits();
-
-    public virtual void Render(RenderPack rp)
+    public SignalConst(T[] ys, double period) : this(new SignalConstSource<T>(ys, period))
     {
-        if (!IsVisible)
-            return;
-
-        using SKPaint paint = new();
-        LineStyle.ApplyToPaint(paint);
-
-        List<PixelColumn> cols = Data.GetPixelColumns(Axes);
-        List<Pixel> points = [];
-        double pointsPerPx = PointsPerPixel();
-        bool useLowDensityMode = pointsPerPx < 1 || AlwaysUseLowDensityMode;
-
-        if (!cols.Any())
-            return;
-
-        using SKPath path = new();
-        path.MoveTo(cols.First().X, cols.First().Enter);
-
-        foreach (PixelColumn col in cols)
-        {
-            path.LineTo(col.X, col.Enter);
-            if ((int)col.Top != (int)col.Bottom)
-            {
-                path.MoveTo(col.X, col.Bottom);
-                path.LineTo(col.X, col.Top);
-                path.MoveTo(col.X, col.Exit);
-            }
-            if (useLowDensityMode)
-            {
-                points.Add(new(col.X, col.Enter));
-            }
-        }
-
-        rp.Canvas.DrawPath(path, paint);
-
-        if (useLowDensityMode)
-        {
-            paint.IsStroke = false;
-            float radius = (float)Math.Min(Math.Sqrt(.2 / pointsPerPx), MaximumMarkerSize);
-            MarkerSize = radius * MaximumMarkerSize * .2f;
-            Drawing.DrawMarkers(rp.Canvas, paint, points, MarkerStyle);
-        }
-
-    }
-
-    private CoordinateRange GetVisibleXRange(PixelRect dataRect)
-    {
-        // TODO: put GetRange in axis translator
-        double xViewLeft = Axes.GetCoordinateX(dataRect.Left);
-        double xViewRight = Axes.GetCoordinateX(dataRect.Right);
-        return (xViewLeft <= xViewRight)
-            ? new CoordinateRange(xViewLeft, xViewRight)
-            : new CoordinateRange(xViewRight, xViewLeft);
-    }
-
-    private double PointsPerPixel()
-    {
-        return GetVisibleXRange(Axes.DataRect).Span / Axes.DataRect.Width / Data.Period;
     }
 }
+

--- a/src/ScottPlot5/ScottPlot5/Plottables/SignalConst.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/SignalConst.cs
@@ -2,6 +2,9 @@
 
 namespace ScottPlot.Plottables;
 
+[Obsolete("SignalConst has been deprecated, " +
+    "but its functionality may be achieved by creating a Signal plot with a SignalConstSource data source. " +
+    "See the Add.SignalConst() method for reference.", true)]
 public class SignalConst<T> : Signal, IPlottable, IHasLine, IHasMarker, IHasLegendText
     where T : struct, IComparable
 {


### PR DESCRIPTION
1. `SignalConstSource` is now based on `SignalSourceGenericArray`, except for `GetLimitsY()` which uses SegmentedTree for fast searching.
`SignalConst<T>` is also based on `Signal`. We can actually get rid of it as a standalone plottable by replacing it with `Signal `with `SignalConstSource` as the `DataSource`. I decided to keep it to preserve the API in this PR.
We lost the rendering version for SignalConst it was very different, and maybe looked like a more optimized version. But in the end `SignalConst` is still very fast.
2. A separate change in this PR is to change the check for an empty array. It was not done in an optimal way. For generic types, the entire array was converted to perform a single check (this slowed `SignalConst` down significantly). I used Enumerable version, but it did not check indexes for correctness in any way, I had to add checks to all `SignalDataSources`.
Actually, the problem here is a bit different. The `ISignalSource` interface does not provide access to the `MinRenderIndex` and `MaxRenderIndex` properties. Instead, there is access to the `MinimumIndex` and `MaximumIndex` fields. `MaximumIndex` is initiated by `Int.Max` and feels fine because it is covered by the `MaxRenderIndex` property, which is unfortunately unavailable from outside `SignalSources`.
Adding `MinRenderIndex` and `MaxRenderIndex` to the `ISignalSource` interface would be a major change, so it's left as is. But this change is requested. 