### PR TITLE
RTL support

### DIFF
--- a/.github/workflows/pr1.yaml
+++ b/.github/workflows/pr1.yaml
@@ -21,8 +21,8 @@ jobs:
       - name: Build
         run: bash .github/workflows/scripts/check-build.sh
       - name: ScottPlot5 Unit Tests
-        run: dotnet test "src/ScottPlot5/ScottPlot5 Tests/Unit Tests/ScottPlot Unit Tests.csproj" --configuration Release --no-build --verbosity minimal
+        run: dotnet test "src/ScottPlot5/ScottPlot5 Tests/Unit Tests/ScottPlot Unit Tests.csproj" --configuration Release --verbosity minimal
       - name: ScottPlot5 Cookbook
-        run: dotnet test "src/ScottPlot5/ScottPlot5 Cookbook/ScottPlot Cookbook.csproj" --configuration Release --no-build --verbosity minimal
+        run: dotnet test "src/ScottPlot5/ScottPlot5 Cookbook/ScottPlot Cookbook.csproj" --configuration Release --verbosity minimal
       - name: ScottPlot5 Tests
-        run: dotnet test "src/ScottPlot4/ScottPlot/ScottPlot.csproj" --configuration Release --no-build --verbosity minimal
+        run: dotnet test "src/ScottPlot4/ScottPlot/ScottPlot.csproj" --configuration Release --verbosity minimal

--- a/.github/workflows/pr1.yaml
+++ b/.github/workflows/pr1.yaml
@@ -17,7 +17,8 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
+          dotnet-quality: "preview"
       - name: Build
         run: bash .github/workflows/scripts/check-build.sh
       - name: ScottPlot5 Unit Tests

--- a/.github/workflows/task-full.yaml
+++ b/.github/workflows/task-full.yaml
@@ -23,9 +23,9 @@ jobs:
           build-mode: manual
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
-        #with:
-          #dotnet-version: "9.0"
-          #dotnet-quality: "preview"
+        with:
+          dotnet-version: "9.0"
+          dotnet-quality: "preview"
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
       - name: Setup Java

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _Not yet on NuGet..._
 * Controls: Improve interactivity behavior by resetting drag events when interactivity is disabled (#4481) @hljlishen
 * SignalConst: Deprecated the `SignalConst` type in favor of a `Signal` with a `SignalConstSource` data source (#4492)
 * Signal: Refactored multiple signal plot and data source types for improved performance, increased customization, and better consistency (#4492) @StendProg
+* Text: Added a static `LabelStyle.RTLSupport` flag to enable support for right-to-left (RTL) languages (#4500, #4306) @StendProg @moranmono
 
 ## ScottPlot 5.0.44
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-09_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/Legend.cs
@@ -25,6 +25,26 @@ public class Legend : ICategory
         }
     }
 
+    public class LegendWithRTLText : RecipeBase
+    {
+        public override string Name => "RTL text Legend Item";
+        public override string Description => "Enabling RTL support correctly renders text in RTL languages.";
+
+        [Test]
+        public override void Execute()
+        {
+            LabelStyle.RTLSupport = true;
+
+            var sig1 = myPlot.Add.Signal(Generate.Sin(51));
+            sig1.LegendText = "אמת";
+
+            var sig2 = myPlot.Add.Signal(Generate.Cos(51));
+            sig2.LegendText = "English";
+
+            myPlot.ShowLegend();
+        }
+    }
+
     public class ManualLegend : RecipeBase
     {
         public override string Name => "Manual Legend Items";

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/Legend.cs
@@ -27,19 +27,20 @@ public class Legend : ICategory
 
     public class LegendWithRTLText : RecipeBase
     {
-        public override string Name => "RTL text Legend Item";
-        public override string Description => "Enabling RTL support correctly renders text in RTL languages.";
+        public override string Name => "Right To Left (RTL) text support";
+        public override string Description => "Enabling Right To Left (RTL) support " +
+            "correctly renders text in RTL languages.";
 
         [Test]
         public override void Execute()
         {
-            LabelStyle.RTLSupport = true;
+            LabelStyle.RTLSupport = true; // enable right-to-left text support
 
             var sig1 = myPlot.Add.Signal(Generate.Sin(51));
-            sig1.LegendText = "אמת";
+            sig1.LegendText = "אמת"; // example right-to-left text
 
             var sig2 = myPlot.Add.Signal(Generate.Cos(51));
-            sig2.LegendText = "English";
+            sig2.LegendText = "English"; // example left-to-right text
 
             myPlot.ShowLegend();
         }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/ScottPlot Cookbook.csproj
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/ScottPlot Cookbook.csproj
@@ -12,7 +12,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.9" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="NUnit" Version="4.2.2" />

--- a/src/ScottPlot5/ScottPlot5 Cookbook/ScottPlot Cookbook.csproj
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/ScottPlot Cookbook.csproj
@@ -12,6 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.9" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="NUnit" Version="4.2.2" />

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WPF Demo/DemoWindows/Quickstart.xaml.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WPF Demo/DemoWindows/Quickstart.xaml.cs
@@ -12,12 +12,7 @@ public partial class Quickstart : Window, IDemoWindow
     {
         InitializeComponent();
 
-        LabelStyle.RTLSupport = true;
-        var sig1 = WpfPlot1.Plot.Add.Signal(ScottPlot.Generate.Sin());
-        var sig2 = WpfPlot1.Plot.Add.Signal(ScottPlot.Generate.Cos());
-        sig1.LegendText = "אמת";
-        sig2.LegendText = "Engish";
-        WpfPlot1.Plot.Legend.FontSize = 40;
-        WpfPlot1.Plot.ShowLegend();
+        WpfPlot1.Plot.Add.Signal(ScottPlot.Generate.Sin());
+        WpfPlot1.Plot.Add.Signal(ScottPlot.Generate.Cos());
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WPF Demo/DemoWindows/Quickstart.xaml.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WPF Demo/DemoWindows/Quickstart.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using ScottPlot;
+using System.Windows;
 
 namespace WPF_Demo.DemoWindows;
 
@@ -11,7 +12,12 @@ public partial class Quickstart : Window, IDemoWindow
     {
         InitializeComponent();
 
-        WpfPlot1.Plot.Add.Signal(ScottPlot.Generate.Sin());
-        WpfPlot1.Plot.Add.Signal(ScottPlot.Generate.Cos());
+        LabelStyle.RTLSupport = true;
+        var sig1 = WpfPlot1.Plot.Add.Signal(ScottPlot.Generate.Sin());
+        var sig2 = WpfPlot1.Plot.Add.Signal(ScottPlot.Generate.Cos());
+        sig1.LegendText = "אמת";
+        sig2.LegendText = "Engish";
+        WpfPlot1.Plot.Legend.FontSize = 40;
+        WpfPlot1.Plot.ShowLegend();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/LabelStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LabelStyle.cs
@@ -1,10 +1,13 @@
-﻿namespace ScottPlot;
+﻿using SkiaSharp.HarfBuzz;
+
+namespace ScottPlot;
 
 [Obsolete("Label has been renamed to LabelStyle", true)]
 public class Label : LabelStyle { }
 
 public class LabelStyle
 {
+    public static bool RTLSupport { get; set; } = false;
     public bool IsVisible { get; set; } = true;
 
     // TODO: deprecate this and pass text into the render method
@@ -295,14 +298,26 @@ public class LabelStyle
 
                 float xPx = textRect.Left + dX;
                 float yPx = textRect.Top + (1 + i) * lineHeight + dY;
-                canvas.DrawText(lines[i], xPx, yPx, paint);
+                if (LabelStyle.RTLSupport)
+                {
+                    using (var shaper = new SKShaper(paint.Typeface))
+                        canvas.DrawShapedText(shaper, lines[i], xPx, yPx, paint);
+                }
+                else
+                    canvas.DrawText(lines[i], xPx, yPx, paint);
             }
         }
         else
         {
             float xPx = textRect.Left;
             float yPx = textRect.Bottom + dY;
-            canvas.DrawText(Text, xPx, yPx, paint);
+            if (LabelStyle.RTLSupport)
+            {
+                using (var shaper = new SKShaper(paint.Typeface))
+                    canvas.DrawShapedText(shaper, Text, xPx, yPx, paint);
+            }
+            else
+                canvas.DrawText(Text, xPx, yPx, paint);
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5/Primitives/LabelStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LabelStyle.cs
@@ -7,6 +7,9 @@ public class Label : LabelStyle { }
 
 public class LabelStyle
 {
+    /// <summary>
+    /// Set this to globally enable support for right-to-left (RTL) languages
+    /// </summary>
     public static bool RTLSupport { get; set; } = false;
     public bool IsVisible { get; set; } = true;
 

--- a/src/ScottPlot5/ScottPlot5/ScottPlot.csproj
+++ b/src/ScottPlot5/ScottPlot5/ScottPlot.csproj
@@ -49,6 +49,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="SkiaSharp" Version="2.88.9" />
+        <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.8" />
         <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.9" />
     </ItemGroup>
 

--- a/src/ScottPlot5/ScottPlot5/ScottPlot.csproj
+++ b/src/ScottPlot5/ScottPlot5/ScottPlot.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net462;netstandard2.0;net6.0;net8.0</TargetFrameworks>
@@ -49,7 +49,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="SkiaSharp" Version="2.88.9" />
-        <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.8" />
+        <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.9" />
         <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.9" />
     </ItemGroup>
 

--- a/src/ScottPlot5/ScottPlot5/ScottPlot.csproj
+++ b/src/ScottPlot5/ScottPlot5/ScottPlot.csproj
@@ -50,6 +50,7 @@
         </PackageReference>
         <PackageReference Include="SkiaSharp" Version="2.88.9" />
         <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.9" />
+        <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0.3" />
         <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.9" />
     </ItemGroup>
 


### PR DESCRIPTION
Adds support for Right to Left languages. #4306
This change affects the output of absolutely all texts, not just legends as suggested by #4306.

RTL support is disabled by default, and everything works as before, unchanged.
Setting the `LabelStyle.RTLSupport` static property results in additional wrapping of the output text in `Shaper`.
Actually this change may include a lot more than just RTL support, since there's a whole separate engine under the hood for rendering characters, but I'm not good at that.

I really don't like customizing the behavior with a static property, but I don't see any other easy ways to solve this problem. `LabelStyle` constructors are spread all over the project in large numbers.

Added a demo of RTL usage to be displayed in the legend. I'm sure you can fix/extend for better user experience.

```c#
LabelStyle.RTLSupport = true;
var sig1 = myPlot.Add.Signal(Generate.Sin(51));
sig1.LegendText = "אמת";
```