### PR TITLE
LabelStyle: add support for image labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## ScottPlot 5.0.46
 _Not yet on NuGet..._
+* Axes: Added support for displaying bitmaps as axis labels allowing rich text to be rendered using a third party package and displayed in any plot (#4503, #3222, #2905) @Liwr9537 @CBrauer @DaveMartel
 
 ## ScottPlot 5.0.45
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-12_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/AxisRecipes.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/AxisRecipes.cs
@@ -365,4 +365,34 @@ public class AxisAndTicks : ICategory
             myPlot.Grid.LinePattern = LinePattern.Dotted;
         }
     }
+
+    public class ImageAxisLabel : RecipeBase
+    {
+        public override string Name => "Image Axis Label";
+        public override string Description => "For cases where axis label font styling " +
+            "does not provide the desired level of customization, a bitmap image may be " +
+            "displayed as an axis label. This strategy allows rich text to be realized " +
+            "using any third party tool that can render that text as a bitmap. It also " +
+            "enables users to place icons or images in their axis labels.";
+
+        [Test]
+        public override void Execute()
+        {
+            myPlot.Add.Signal(Generate.Sin(51));
+            myPlot.Add.Signal(Generate.Cos(51));
+
+            // This array holds the bytes of a bitmap. Here it's generated,
+            // but it could be a byte array read from a bitmap file on disk.
+            byte[] bytes1 = SampleImages.NoisyText("Horiz", 150, 50).GetImageBytes();
+            byte[] bytes2 = SampleImages.NoisyText("Vert", 150, 50).GetImageBytes();
+
+            // Create a ScottPlot.Image from the bitmap bytes
+            ScottPlot.Image img1 = new(bytes1);
+            ScottPlot.Image img2 = new(bytes2);
+
+            // Display the image for the bottom axis label
+            myPlot.Axes.Bottom.Label.Image = img1;
+            myPlot.Axes.Left.Label.Image = img2;
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/XAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/XAxisBase.cs
@@ -25,7 +25,7 @@ public abstract class XAxisBase : AxisBase, IXAxis
             ? TickGenerator.Ticks.Select(x => TickLabelStyle.Measure(x.Label, paint).Height).Max()
             : 0;
 
-        float axisLabelHeight = string.IsNullOrEmpty(LabelStyle.Text)
+        float axisLabelHeight = string.IsNullOrEmpty(LabelStyle.Text) && LabelStyle.Image is null
             ? EmptyLabelPadding.Vertical
             : LabelStyle.Measure(LabelText, paint).LineHeight
                 + PaddingBetweenTickAndAxisLabels.Vertical

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
@@ -33,7 +33,7 @@ public abstract class YAxisBase : AxisBase, IYAxis
             ? TickGenerator.Ticks.Select(x => TickLabelStyle.Measure(x.Label, paint).Width).Max()
             : 0;
 
-        float axisLabelHeight = string.IsNullOrEmpty(LabelStyle.Text)
+        float axisLabelHeight = string.IsNullOrEmpty(LabelStyle.Text) && LabelStyle.Image is null
             ? EmptyLabelPadding.Horizontal
             : LabelStyle.Measure(LabelText, paint).LineHeight
                 + PaddingBetweenTickAndAxisLabels.Horizontal

--- a/src/ScottPlot5/ScottPlot5/Primitives/LabelStyle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/LabelStyle.cs
@@ -88,6 +88,11 @@ public class LabelStyle
         }
     }
 
+    /// <summary>
+    /// If supplied, this label will be displayed as an image and its text and styling properties will be ignored
+    /// </summary>
+    public Image? Image { get; set; } = null;
+
     public static LabelStyle Default => new() { IsVisible = true, ForeColor = Colors.Black };
 
     /// <summary>
@@ -169,6 +174,18 @@ public class LabelStyle
 
     public MeasuredText Measure(string text, SKPaint paint)
     {
+        if (Image is not null)
+        {
+            return new MeasuredText()
+            {
+                Size = Image.Size,
+                LineHeight = Image.Height,
+                LineWidths = [Image.Width],
+                VerticalOffset = 0,
+                Bottom = 0,
+            };
+        }
+
         string[] lines = string.IsNullOrEmpty(text) ? [] : text.Split('\n');
         ApplyToPaint(paint);
         float lineHeight = paint.GetFontMetrics(out SKFontMetrics metrics);
@@ -245,7 +262,7 @@ public class LabelStyle
         if (!IsVisible)
             return;
 
-        if (string.IsNullOrEmpty(Text))
+        if (string.IsNullOrEmpty(Text) && Image is null)
             return;
 
         ApplyToPaint(paint);
@@ -258,10 +275,17 @@ public class LabelStyle
         canvas.Translate(px.X + OffsetX, px.Y + OffsetY);
         canvas.RotateDegrees(Rotation);
 
-        DrawBackground(canvas, px, paint, textRect);
-        DrawText(canvas, measured, paint, textRect, bottom);
-        DrawBorder(canvas, px, paint, textRect);
-        DrawPoint(canvas, px, paint);
+        if (Image is null)
+        {
+            DrawBackground(canvas, px, paint, textRect);
+            DrawText(canvas, measured, paint, textRect, bottom);
+            DrawBorder(canvas, px, paint, textRect);
+            DrawPoint(canvas, px, paint);
+        }
+        else
+        {
+            Image.Render(canvas, textRect, paint, false);
+        }
 
         canvasState.Restore();
     }

--- a/src/ScottPlot5/ScottPlot5/SampleImages.cs
+++ b/src/ScottPlot5/ScottPlot5/SampleImages.cs
@@ -1,4 +1,6 @@
-﻿namespace ScottPlot;
+﻿using System.Runtime.InteropServices;
+
+namespace ScottPlot;
 
 public class SampleImages
 {
@@ -84,5 +86,49 @@ public class SampleImages
 
         fillStyle.ApplyToPaint(paint, canvasRect);
         canvas.DrawPath(path, paint);
+    }
+
+    public static Image NoiseGrayscale(int width, int height, int seed = 0)
+    {
+        RandomDataGenerator gen = new(seed);
+
+        byte[,] noise = new byte[height, width];
+        for (int y = 0; y < height; y++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                noise[y, x] = gen.RandomByte();
+            }
+        }
+
+        return new Image(noise);
+    }
+
+    public static Image NoisyText(string text, int width, int height)
+    {
+        PixelRect rect = new(0, width, height, 0);
+        using SKSurface surface = Drawing.CreateSurface((int)rect.Width, (int)rect.Height);
+        using SKCanvas canvas = surface.Canvas;
+        using SKPaint paint = new();
+
+        Image noiseImage = NoiseGrayscale(width, height);
+        noiseImage.Render(canvas, rect, paint, false);
+
+        paint.Color = Colors.LightBlue.WithAlpha(.5).ToSKColor();
+        Drawing.DrawRectangle(canvas, rect, paint);
+        Drawing.DrawDebugRectangle(canvas, rect);
+
+        LabelStyle label = new()
+        {
+            Alignment = Alignment.MiddleCenter,
+            ForeColor = Colors.Navy,
+            FontSize = 36,
+            Bold = true,
+        };
+
+        label.Render(canvas, rect.Center, paint, text);
+
+        Image img = new(surface);
+        return img;
     }
 }


### PR DESCRIPTION
This PR adds a nullable `Image` to `LabelStyle` so a bitmap image can be displayed anywhere a text label may be placed.

This enables users to use third-party packages to render rich text or emoji as a bitmap image, then display it as an axis label

* Resolves: #4503
* Resolves: #3222
* Related: #2905

```cs
myPlot.Add.Signal(Generate.Sin(51));
myPlot.Add.Signal(Generate.Cos(51));

// This array holds the bytes of a bitmap. Here it's generated,
// but it could be a byte array read from a bitmap file on disk.
byte[] bytes1 = SampleImages.NoisyText("Horiz", 150, 50).GetImageBytes();
byte[] bytes2 = SampleImages.NoisyText("Vert", 150, 50).GetImageBytes();

// Create a ScottPlot.Image from the bitmap bytes
ScottPlot.Image img1 = new(bytes1);
ScottPlot.Image img2 = new(bytes2);

// Display the image for the bottom axis label
myPlot.Axes.Bottom.Label.Image = img1;
myPlot.Axes.Left.Label.Image = img2;
```

![image](https://github.com/user-attachments/assets/107a3805-1c3e-4ac2-93dc-3548c435c106)
