### PR TITLE
OpenGL: update version line to fix bug causing lines not to be rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _Not yet on NuGet..._
 * Controls: Updated mouse wheel scroll fractions so zoom-out wheel events more accurately reverse zoom-in wheel events (#4516) @quantfreedom
 * Candlestick: Updated `FallingColor` property to change both the fill and line colors with one assignment (#4521) @czastack
 * Interactivity: Mouse click times in double-click events no longer resets after losing focus, improving double-click behavior in WPF controls (#4524) @onur-akaydin
+* OpenGL: Updated GLSL version number formatting to improve rendering on some platforms (#4519) @onur-akaydin @StendProg
 
 ## ScottPlot 5.0.45
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-12_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/LinesProgramCustom.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/LinesProgramCustom.cs
@@ -13,7 +13,7 @@ namespace ScottPlot.OpenGL.GLPrograms;
 public class LinesProgramCustom : GLProgramBase, ILinesDrawProgram
 {
     protected override string VertexShaderSource =>
-    @"# version 430 core
+    @"#version 430 core
         layout(location = 0) in dvec2 aPosition;
         layout(location = 0) uniform dmat4 transform;
 
@@ -25,7 +25,7 @@ public class LinesProgramCustom : GLProgramBase, ILinesDrawProgram
         }";
 
     protected override string GeometryShaderSource =>
-    @"# version 430 core
+    @"#version 430 core
         layout(lines) in;
         layout(triangle_strip, max_vertices=4) out;
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/MarkerFillCircleProgram.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/MarkerFillCircleProgram.cs
@@ -3,7 +3,7 @@
 public class MarkerFillCircleProgram : MarkersProgram
 {
     protected override string VertexShaderSource =>
-    @"# version 430 core
+    @"#version 430 core
         layout(location = 0) in dvec2 aPosition;
         uniform dmat4 transform;
 
@@ -15,7 +15,7 @@ public class MarkerFillCircleProgram : MarkersProgram
         }";
 
     protected override string GeometryShaderSource =>
-    @"# version 430 core
+    @"#version 430 core
         layout(points) in;
         layout(triangle_strip, max_vertices=4) out;
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/MarkerFillSquareProgram.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/MarkerFillSquareProgram.cs
@@ -3,7 +3,7 @@
 public class MarkerFillSquareProgram : MarkersProgram
 {
     protected override string VertexShaderSource =>
-    @"# version 430 core
+    @"#version 430 core
         layout(location = 0) in dvec2 aPosition;
         uniform dmat4 transform;
 
@@ -15,7 +15,7 @@ public class MarkerFillSquareProgram : MarkersProgram
         }";
 
     protected override string GeometryShaderSource =>
-    @"# version 430 core
+    @"#version 430 core
         layout(points) in;
         layout(triangle_strip, max_vertices=4) out;
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/MarkerOpenSquareProgram.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/GLPrograms/MarkerOpenSquareProgram.cs
@@ -9,7 +9,7 @@ namespace ScottPlot.OpenGL.GLPrograms;
 public class MarkerOpenSquareProgram : MarkerFillSquareProgram
 {
     protected override string GeometryShaderSource =>
-    @"# version 430 core
+    @"#version 430 core
         layout(points) in;
         layout(triangle_strip, max_vertices=4) out;
 


### PR DESCRIPTION
ScatterGLCustom is not drawing any line due to a small mistake in LinesProgramCustom.cs.

I'm not an expert in OpenGL, but when we write:
"#version 430 core"

instead of:
"# version 430 core"

ScatterGLCustom starts drawing the lines.