### PR TITLE
Controls: update mouse wheel zoom to zoom in and out identically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ _Not yet on NuGet..._
 * Axes: Added support for displaying bitmaps as axis labels allowing rich text to be rendered using a third party package and displayed in any plot (#4503, #3222, #2905) @Liwr9537 @CBrauer @DaveMartel
 * DataStreamerXY: A new type of plottable for displaying streaming Y with unevenly spaced, user-defined X values (#4507, #4460, #4518) @dlampa
 * DataLogger: Added `InvertX` and `InvertY` flags to control automatic axis limit management behavior (#4513) @Jofstera
+* Controls: Updated mouse wheel scroll fractions so zoom-out wheel events more accurately reverse zoom-in wheel events (#4516) @quantfreedom
 
 ## ScottPlot 5.0.45
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-12_

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseWheelZoom.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseWheelZoom.cs
@@ -18,20 +18,28 @@ public class MouseWheelZoom(Key horizontalLockKey, Key verticalLockKey) : IUserA
 
     public void ResetState(Plot plot) { }
 
+    /// <summary>
+    /// Fraction of the axis range to change when zooming in and out.
+    /// </summary>
+    public double ZoomFraction { get; set; } = 0.15;
+
+    private double ZoomInFraction => 1 + ZoomFraction;
+    private double ZoomOutFraction => 1 / ZoomInFraction;
+
     public ResponseInfo Execute(Plot plot, IUserAction userInput, KeyboardState keys)
     {
         if (userInput is UserActions.MouseWheelUp mouseDownInput)
         {
-            double xFrac = keys.IsPressed(LockHorizontalKey) ? 1 : 1.15;
-            double yFrac = keys.IsPressed(LockVerticalKey) ? 1 : 1.15;
+            double xFrac = keys.IsPressed(LockHorizontalKey) ? 1 : ZoomInFraction;
+            double yFrac = keys.IsPressed(LockVerticalKey) ? 1 : ZoomInFraction;
             MouseAxisManipulation.MouseWheelZoom(plot, xFrac, yFrac, mouseDownInput.Pixel, LockParallelAxes);
             return new ResponseInfo() { RefreshNeeded = true };
         }
 
         if (userInput is UserActions.MouseWheelDown mouseUpInput)
         {
-            double xFrac = keys.IsPressed(LockHorizontalKey) ? 1 : 0.85;
-            double yFrac = keys.IsPressed(LockVerticalKey) ? 1 : 0.85;
+            double xFrac = keys.IsPressed(LockHorizontalKey) ? 1 : ZoomOutFraction;
+            double yFrac = keys.IsPressed(LockVerticalKey) ? 1 : ZoomOutFraction;
             MouseAxisManipulation.MouseWheelZoom(plot, xFrac, yFrac, mouseUpInput.Pixel, LockParallelAxes);
             return new ResponseInfo() { RefreshNeeded = true };
         }


### PR DESCRIPTION
Previously repeated zoom in/out cycles would not restore the original axis limits. This change makes zooming out exactly reverse the zooming in scale, and also exposes a ZoomFraction property to let the user customize mouse scroll wheel sensitivity. Resolves #4516