### PR TITLE
Fix: restore original PlotControl after closing new window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## ScottPlot 5.0.47
 _Not yet on NuGet..._
+* Controls: Fix issue preventing the context menu from appearing after it was used to open a new window (#4529) @david3951445
 
 ## ScottPlot 5.0.46
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-17_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotViewer.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotViewer.cs
@@ -4,6 +4,7 @@ public static class WpfPlotViewer
 {
     public static void Launch(Plot plot, string title = "", int width = 600, int height = 400)
     {
+        IPlotControl? originalControl = plot.PlotControl;
         WpfPlot wpfPlot = new();
         wpfPlot.Reset(plot);
         System.Windows.Window win = new()
@@ -14,6 +15,7 @@ public static class WpfPlotViewer
             Title = title,
             Content = wpfPlot,
         };
+        win.Closed += (s, e) => plot.PlotControl = originalControl;
         win.ShowDialog();
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotViewer.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotViewer.cs
@@ -24,7 +24,9 @@ public static class FormsPlotViewer
 
     public static void Launch(Plot plot, string title = "", int width = 600, int height = 400, bool blocking = true)
     {
+        IPlotControl? originalControl = plot.PlotControl;
         Form form = CreateForm(plot, title, width, height);
+        form.FormClosed += (s, e) => plot.PlotControl = originalControl;
 
         if (blocking)
             form.ShowDialog();


### PR DESCRIPTION
This PR addresses an issue in ScottPlot 5 related to the "Open in New Window" functionality in both WinForms and WPF.

- Issue:
  - In WPF, after closing the new window, the ContextMenu on the original window would no longer appear.
  - In WinForms, the ContextMenu was shown at the wrong position because it was being displayed on the new PlotControl instead of the original one.
- Cause: The issue occurred because, during the process of moving the Plot content to the new window, the original window’s PlotControl was overwritten but not properly restored when the new window was closed.
- Solution: After the new window is closed, the PlotControl on the original window is properly restored, ensuring the ContextMenu behaves as expected.