### PR TITLE
Demo: detachable legend and click-to-toggle-visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _Not yet on NuGet..._
 * Bracket: New plot type for annotating ranges of linear lines in coordinate space (#4547, #1863) @FULL69 @bclehmann
 * Financial Charting: Improved `FinancialTimeAxis` tick generation behavior (#4483, #4551, #4385) @VladislavPustovarov @quantfreedom
 * Histogram: Created `Add.Histogram()` which accepts a `Histogram` and returns a `HistogramBars` plottable designed for displaying continuously updated histogram counts (#4557) @jpgarza93
+* Legend: Added support for paring each `LegendItem` with its parent `IPlottable` to facilitate mouse interaction (#4533) @BambOoxX
 
 ## ScottPlot 5.0.46
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-17_

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.Designer.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.Designer.cs
@@ -28,10 +28,27 @@
         /// </summary>
         private void InitializeComponent()
         {
-            components = new System.ComponentModel.Container();
+            formsPlot1 = new ScottPlot.WinForms.FormsPlot();
+            SuspendLayout();
+            // 
+            // formsPlot2
+            // 
+            formsPlot1.DisplayScale = 1F;
+            formsPlot1.Dock = DockStyle.Fill;
+            formsPlot1.Location = new Point(0, 0);
+            formsPlot1.Name = "formsPlot2";
+            formsPlot1.Size = new Size(800, 450);
+            formsPlot1.TabIndex = 0;
+            // 
+            // DetachedLegend
+            // 
+            AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(800, 450);
+            Controls.Add(formsPlot1);
+            Name = "DetachedLegend";
             Text = "Form1";
+            ResumeLayout(false);
         }
 
         #endregion

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.Designer.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.Designer.cs
@@ -1,0 +1,40 @@
+﻿namespace WinForms_Demo.Demos
+{
+    partial class DetachedLegend
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(800, 450);
+            Text = "Form1";
+        }
+
+        #endregion
+        private ScottPlot.WinForms.FormsPlot formsPlot1;
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -122,7 +122,7 @@ namespace WinForms_Demo.Demos
         {
             ContextMenuStrip customMenu = new();
 
-            customMenu.Items.Add(new ToolStripMenuItem("Delete", null, new EventHandler((s, e) => DeletePlottable(ClickedPlottable))));
+            customMenu.Items.Add(new ToolStripMenuItem("Delete", null, new EventHandler((s, e) => DeletePlottable(ClickedPlottable, skControl))));
 
             if (ClickedPlottable is IHasLine)
             {

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -88,13 +88,12 @@ namespace WinForms_Demo.Demos
             {
                 if (ClickedPlottable != null)
                 {
-                    OpenRightClickMenu(ClickedPlottable);
+                    OpenRightClickMenu(sender, ClickedPlottable);
                 }
             }
             formsPlot1.Refresh();
-            // TODO : How to trigger legend repaint ?
+            sender.Invalidate();
         }
-
 
         private LegendItem? GetLegendItemUnderMouse(SKControl sender, Point e)
         {
@@ -119,7 +118,7 @@ namespace WinForms_Demo.Demos
             return null;
         }
 
-        private void OpenRightClickMenu(IPlottable ClickedPlottable)
+        private void OpenRightClickMenu(SKControl skControl, IPlottable ClickedPlottable)
         {
             ContextMenuStrip customMenu = new();
 
@@ -131,16 +130,16 @@ namespace WinForms_Demo.Demos
                 var LinePatternMenu = new ToolStripMenuItem("Pattern");
                 foreach (LinePattern lp in LinePattern.GetAllPatterns())
                 {
-                    LinePatternMenu.DropDownItems.Add(new ToolStripMenuItem(lp.Name, null, new EventHandler((s, e) => ChangeLinePattern(s, ClickedPlottable))));
+                    LinePatternMenu.DropDownItems.Add(new ToolStripMenuItem(lp.Name, null, new EventHandler((s, e) => ChangeLinePattern(s, ClickedPlottable, skControl))));
                 }
                 LineMenu.DropDownItems.Add(LinePatternMenu);
                 var LineWidthMenu = new ToolStripMenuItem("Thickness");
                 foreach (string lw in new string[] { "much thinner", "thinner", "thicker", "much thicker" })
                 {
-                    LineWidthMenu.DropDownItems.Add(new ToolStripMenuItem(lw, null, new EventHandler((s, e) => ChangeLineWidth(s, ClickedPlottable))));
+                    LineWidthMenu.DropDownItems.Add(new ToolStripMenuItem(lw, null, new EventHandler((s, e) => ChangeLineWidth(s, ClickedPlottable, skControl))));
                 }
                 LineMenu.DropDownItems.Add(LineWidthMenu);
-                var LineColorMenu = new ToolStripMenuItem("Color", null, new EventHandler((s, e) => ChangeLineColor(s, ClickedPlottable)));
+                var LineColorMenu = new ToolStripMenuItem("Color", null, new EventHandler((s, e) => ChangeLineColor(s, ClickedPlottable, skControl)));
                 LineMenu.DropDownItems.Add(LineColorMenu);
                 customMenu.Items.Add(LineMenu);
             }
@@ -151,25 +150,25 @@ namespace WinForms_Demo.Demos
                 var MarkerShapeMenu = new ToolStripMenuItem("Shape");
                 foreach (MarkerShape ms in (MarkerShape[])Enum.GetValues(typeof(MarkerShape)))
                 {
-                    MarkerShapeMenu.DropDownItems.Add(new ToolStripMenuItem(ms.ToString(), null, new EventHandler((s, e) => ChangeMarkerShape(s, ClickedPlottable))));
+                    MarkerShapeMenu.DropDownItems.Add(new ToolStripMenuItem(ms.ToString(), null, new EventHandler((s, e) => ChangeMarkerShape(s, ClickedPlottable, skControl))));
                 }
                 MarkerMenu.DropDownItems.Add(MarkerShapeMenu);
                 var MarkerSizeMenu = new ToolStripMenuItem("Size");
                 foreach (string ms in new string[] { "much smaller", "smaller", "bigger", "much bigger" })
                 {
-                    MarkerSizeMenu.DropDownItems.Add(new ToolStripMenuItem(ms.ToString(), null, new EventHandler((s, e) => ChangeMarkerSize(s, ClickedPlottable))));
+                    MarkerSizeMenu.DropDownItems.Add(new ToolStripMenuItem(ms.ToString(), null, new EventHandler((s, e) => ChangeMarkerSize(s, ClickedPlottable, skControl))));
                 }
                 MarkerMenu.DropDownItems.Add(MarkerSizeMenu);
                 customMenu.Items.Add(MarkerMenu);
                 var MarkerLineWidthMenu = new ToolStripMenuItem("Thickness");
                 foreach (string lw in new string[] { "much thinner", "thinner", "thicker", "much thicker" })
                 {
-                    MarkerLineWidthMenu.DropDownItems.Add(new ToolStripMenuItem(lw, null, new EventHandler((s, e) => ChangeMarkerLineWidth(s, ClickedPlottable))));
+                    MarkerLineWidthMenu.DropDownItems.Add(new ToolStripMenuItem(lw, null, new EventHandler((s, e) => ChangeMarkerLineWidth(s, ClickedPlottable, skControl))));
                 }
                 MarkerMenu.DropDownItems.Add(MarkerLineWidthMenu);
-                var MarkerColorMenu = new ToolStripMenuItem("Marker Color", null, new EventHandler((s, e) => ChangeMarkerColor(s, ClickedPlottable)));
+                var MarkerColorMenu = new ToolStripMenuItem("Marker Color", null, new EventHandler((s, e) => ChangeMarkerColor(s, ClickedPlottable, skControl)));
                 MarkerMenu.DropDownItems.Add(MarkerColorMenu);
-                var MarkerLineColorMenu = new ToolStripMenuItem("Marker Line Color", null, new EventHandler((s, e) => ChangeMarkerLineColor(s, ClickedPlottable)));
+                var MarkerLineColorMenu = new ToolStripMenuItem("Marker Line Color", null, new EventHandler((s, e) => ChangeMarkerLineColor(s, ClickedPlottable, skControl)));
                 MarkerMenu.DropDownItems.Add(MarkerLineColorMenu);
                 customMenu.Items.Add(MarkerMenu);
             }
@@ -182,7 +181,7 @@ namespace WinForms_Demo.Demos
             formsPlot1.Plot.Remove(ClickedPlottable);
         }
 
-        private void ChangeLinePattern(object? sender, IPlottable ClickedPlottable)
+        private void ChangeLinePattern(object? sender, IPlottable ClickedPlottable, SKControl skControl)
         {
             if (sender is null)
                 return;
@@ -201,7 +200,7 @@ namespace WinForms_Demo.Demos
             }
         }
 
-        private void ChangeLineColor(object? sender, IPlottable ClickedPlottable)
+        private void ChangeLineColor(object? sender, IPlottable ClickedPlottable, SKControl skControl)
         {
             if (sender is null)
             {
@@ -217,7 +216,7 @@ namespace WinForms_Demo.Demos
             }
         }
 
-        private void ChangeLineWidth(object? sender, IPlottable ClickedPlottable)
+        private void ChangeLineWidth(object? sender, IPlottable ClickedPlottable, SKControl skControl)
         {
             if (sender is null)
             {
@@ -228,9 +227,12 @@ namespace WinForms_Demo.Demos
             {
                 line.LineWidth *= lwcoeff;
             }
+
+            formsPlot1.Refresh();
+            skControl.Invalidate();
         }
 
-        private void ChangeMarkerLineWidth(object? sender, IPlottable ClickedPlottable)
+        private void ChangeMarkerLineWidth(object? sender, IPlottable ClickedPlottable, SKControl skControl)
         {
             if (sender is null)
             {
@@ -241,9 +243,12 @@ namespace WinForms_Demo.Demos
             {
                 marker.MarkerLineWidth *= lwcoeff;
             }
+
+            formsPlot1.Refresh();
+            skControl.Invalidate();
         }
 
-        private void ChangeMarkerShape(object? sender, IPlottable ClickedPlottable)
+        private void ChangeMarkerShape(object? sender, IPlottable ClickedPlottable, SKControl skControl)
         {
             if (sender is null)
             {
@@ -267,9 +272,12 @@ namespace WinForms_Demo.Demos
                     }
                 }
             }
+
+            formsPlot1.Refresh();
+            skControl.Invalidate();
         }
 
-        private void ChangeMarkerSize(object? sender, IPlottable ClickedPlottable)
+        private void ChangeMarkerSize(object? sender, IPlottable ClickedPlottable, SKControl skControl)
         {
             if (sender is null)
             {
@@ -280,9 +288,12 @@ namespace WinForms_Demo.Demos
                 float coeff = MarkerSizeCoefficient(((ToolStripMenuItem)sender).Text);
                 marker.MarkerSize *= coeff;
             }
+
+            formsPlot1.Refresh();
+            skControl.Invalidate();
         }
 
-        private void ChangeMarkerColor(object? sender, IPlottable ClickedPlottable)
+        private void ChangeMarkerColor(object? sender, IPlottable ClickedPlottable, SKControl skControl)
         {
             if (sender is null)
             {
@@ -296,9 +307,12 @@ namespace WinForms_Demo.Demos
                     marker.MarkerColor = ScottPlot.Color.FromColor(colorDialog.Color);
                 }
             }
+
+            formsPlot1.Refresh();
+            skControl.Invalidate();
         }
 
-        private void ChangeMarkerLineColor(object? sender, IPlottable ClickedPlottable)
+        private void ChangeMarkerLineColor(object? sender, IPlottable ClickedPlottable, SKControl skControl)
         {
             if (sender is null)
             {
@@ -312,8 +326,10 @@ namespace WinForms_Demo.Demos
                     marker.MarkerLineColor = ScottPlot.Color.FromColor(colorDialog.Color);
                 }
             }
-        }
 
+            formsPlot1.Refresh();
+            skControl.Invalidate();
+        }
 
         private float LineWidthCoefficient(string lwstring)
         {
@@ -338,6 +354,5 @@ namespace WinForms_Demo.Demos
                 _ => throw new NotImplementedException(),
             };
         }
-
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -22,6 +22,7 @@ namespace WinForms_Demo.Demos
                 sig.Color = Colors.Category20[i];
                 sig.LineWidth = 2;
                 sig.LegendText = $"Line #{i + 1}";
+                sig.IsVisible = i % 5 > 0; // hide every 5th line
             }
 
             formsPlot1.Menu?.Add("Detach Legend", LaunchDetachedLegend);
@@ -31,6 +32,7 @@ namespace WinForms_Demo.Demos
         {
             // hide the legend in the original plot
             plotControl.Plot.Legend.IsVisible = false;
+            plotControl.Plot.Legend.ShowItemsFromHiddenPlottables = true;
             plotControl.Refresh();
 
             // create a form that displays a SkiaSharp canvas the legend can be drawn on
@@ -44,6 +46,7 @@ namespace WinForms_Demo.Demos
             {
                 // un-hide the legend in the original plot when the legend viewer is closed
                 plotControl.Plot.Legend.IsVisible = true;
+                plotControl.Plot.Legend.ShowItemsFromHiddenPlottables = false;
                 plotControl.Refresh();
             };
 
@@ -66,7 +69,7 @@ namespace WinForms_Demo.Demos
             PixelSize size = new(skControl.Width, skControl.Height);
             PixelRect rect = new(Pixel.Zero, size);
             SKCanvas canvas = e.Surface.Canvas;
-            formsPlot1.Plot.Legend.Render(canvas, rect, Alignment.UpperLeft, false);
+            formsPlot1.Plot.Legend.Render(canvas, rect, Alignment.UpperLeft);
         }
 
         private void LegendControl_MouseClick(SKControl sender, EventArgs ee)
@@ -98,8 +101,8 @@ namespace WinForms_Demo.Demos
         private LegendItem? GetLegendItemUnderMouse(SKControl sender, Point e)
         {
             PixelSize size = new(sender.Width, sender.Height);
-            LegendItem[] items = formsPlot1.Plot.Legend.GetItems(false);
-            LegendLayout layout = formsPlot1.Plot.Legend.GetLayout(size, false);
+            LegendItem[] items = formsPlot1.Plot.Legend.GetItems();
+            LegendLayout layout = formsPlot1.Plot.Legend.GetLayout(size);
             if (items.Count() == 0)
                 return null;
 

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -1,4 +1,4 @@
-using ScottPlot;
+﻿using ScottPlot;
 using SkiaSharp;
 using SkiaSharp.Views.Desktop;
 
@@ -42,7 +42,9 @@ namespace WinForms_Demo.Demos
             skControl.PaintSurface += (s, e) => { PaintDetachedLegend((SKControl)s, (SKPaintSurfaceEventArgs)e); };
             skControl.MouseClick += (s, e) => {LegendControl_MouseClick((SKControl)s, e); };
             form.Controls.Add(skControl);
-            formsPlot1.Plot.Legend.IsVisible = formsPlot1.Plot.Legend.IsVisible && false;
+            bool initialLegendState = formsPlot1.Plot.Legend.IsVisible;
+            formsPlot1.Plot.Legend.IsVisible = false;
+            form.FormClosing += (s, e) => { formsPlot1.Plot.Legend.IsVisible = initialLegendState; formsPlot1.Refresh(); };
             form.Show();
         }
 
@@ -165,7 +167,6 @@ namespace WinForms_Demo.Demos
         private void DeletePlottable(IPlottable ClickedPlottable)
         {
             formsPlot1.Plot.Remove(ClickedPlottable);
-            formsPlot1.Refresh();
         }
 
         private void ChangeLinePattern(object sender, IPlottable ClickedPlottable)

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -4,7 +4,7 @@ using SkiaSharp.Views.Desktop;
 
 namespace WinForms_Demo.Demos
 {
-    public partial class DetachedLegend : Form, IDemoWindow
+    public partial class DetachedLegend : Form//, IDemoWindow
     {
         public string Title => "Detachable Legend";
 

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -1,4 +1,6 @@
 ﻿using ScottPlot;
+using SkiaSharp;
+using SkiaSharp.Views.Desktop;
 
 namespace WinForms_Demo.Demos
 {
@@ -22,19 +24,31 @@ namespace WinForms_Demo.Demos
                 sig.LegendText = $"Line #{i + 1}";
             }
 
-            formsPlot1.Plot.Legend.OutlineWidth = 0;
-            formsPlot1.Plot.Legend.BackgroundColor = ScottPlot.Color.FromColor(SystemColors.Control);
-            ScottPlot.Image legendImage = formsPlot1.Plot.GetLegendImage();
-            byte[] legendBitmapBytes = legendImage.GetImageBytes(ImageFormat.Bmp);
-            MemoryStream ms = new(legendBitmapBytes);
-            Bitmap bmp = new(ms);
+            formsPlot1.Menu?.Add("Detach Legend", LaunchDetachedLegend);
+        }
 
-            // add menu items with custom actions
-            formsPlot1.Menu?.Add("Detached Legend", (formsplot1) =>
+        private void LaunchDetachedLegend(IPlotControl plotControl)
+        {
+            Form form = new()
             {
-               // To be replaced with 
-            });
+                Text = "Detached Legend",
+                StartPosition = FormStartPosition.CenterScreen,
+            };
 
+            SKControl skControl = new()
+            {
+                Dock = DockStyle.Fill
+            };
+
+            skControl.PaintSurface += (s, e) =>
+            {
+                PixelSize size = new(skControl.Width, skControl.Height);
+                PixelRect rect = new(Pixel.Zero, size);
+                formsPlot1.Plot.Legend.Render(e.Surface.Canvas, rect, Alignment.MiddleCenter);
+            };
+
+            form.Controls.Add(skControl);
+            form.Show();
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -176,9 +176,11 @@ namespace WinForms_Demo.Demos
             customMenu.Show(Cursor.Position);
         }
 
-        private void DeletePlottable(IPlottable ClickedPlottable)
+        private void DeletePlottable(IPlottable ClickedPlottable, SKControl skControl)
         {
             formsPlot1.Plot.Remove(ClickedPlottable);
+            formsPlot1.Refresh();
+            skControl.Invalidate();
         }
 
         private void ChangeLinePattern(object? sender, IPlottable ClickedPlottable, SKControl skControl)
@@ -198,6 +200,9 @@ namespace WinForms_Demo.Demos
                     }
                 }
             }
+
+            formsPlot1.Refresh();
+            skControl.Invalidate();
         }
 
         private void ChangeLineColor(object? sender, IPlottable ClickedPlottable, SKControl skControl)
@@ -214,6 +219,9 @@ namespace WinForms_Demo.Demos
                     line.LineColor = ScottPlot.Color.FromColor(colorDialog.Color);
                 }
             }
+
+            formsPlot1.Refresh();
+            skControl.Invalidate();
         }
 
         private void ChangeLineWidth(object? sender, IPlottable ClickedPlottable, SKControl skControl)

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -1,0 +1,36 @@
+﻿using ScottPlot;
+
+namespace WinForms_Demo.Demos
+{
+    public partial class DetachedLegend : Form
+    {
+        public DetachedLegend()
+        {
+            InitializeComponent();
+
+            int count = 20;
+            for (int i = 0; i < 20; i++)
+            {
+                double[] ys = Generate.Sin(100, phase: i / (2.0 * count));
+                var sig = formsPlot1.Plot.Add.Signal(ys);
+                sig.Color = Colors.Category20[i];
+                sig.LineWidth = 2;
+                sig.LegendText = $"Line #{i + 1}";
+            }
+
+            formsPlot1.Plot.Legend.OutlineWidth = 0;
+            formsPlot1.Plot.Legend.BackgroundColor = ScottPlot.Color.FromColor(SystemColors.Control);
+            ScottPlot.Image legendImage = formsPlot1.Plot.GetLegendImage();
+            byte[] legendBitmapBytes = legendImage.GetImageBytes(ImageFormat.Bmp);
+            MemoryStream ms = new(legendBitmapBytes);
+            Bitmap bmp = new(ms);
+
+            // add menu items with custom actions
+            formsPlot1.Menu?.Add("Detached Legend", (formsplot1) =>
+            {
+               // To be replaced with 
+            });
+
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -33,6 +33,9 @@ namespace WinForms_Demo.Demos
             // hide the legend in the original plot
             plotControl.Plot.Legend.IsVisible = false;
             plotControl.Plot.Legend.ShowItemsFromHiddenPlottables = true;
+            plotControl.Plot.Legend.OutlineWidth = 0;
+            plotControl.Plot.Legend.BackgroundColor = ScottPlot.Color.FromSDColor(SystemColors.Control);
+            plotControl.Plot.Legend.ShadowColor = Colors.Transparent;
             plotControl.Refresh();
 
             // create a form that displays a SkiaSharp canvas the legend can be drawn on
@@ -40,6 +43,7 @@ namespace WinForms_Demo.Demos
             {
                 Text = "Detached Legend",
                 StartPosition = FormStartPosition.CenterScreen,
+                FormBorderStyle = FormBorderStyle.SizableToolWindow,
             };
 
             form.FormClosed += (s, e) =>
@@ -47,6 +51,9 @@ namespace WinForms_Demo.Demos
                 // un-hide the legend in the original plot when the legend viewer is closed
                 plotControl.Plot.Legend.IsVisible = true;
                 plotControl.Plot.Legend.ShowItemsFromHiddenPlottables = false;
+                plotControl.Plot.Legend.OutlineWidth = 1;
+                plotControl.Plot.Legend.BackgroundColor = ScottPlot.Colors.White;
+                plotControl.Plot.Legend.ShadowColor = Colors.Black.WithOpacity(.2);
                 plotControl.Refresh();
             };
 

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -198,7 +198,7 @@ namespace WinForms_Demo.Demos
             if (sender is null)
                 return;
 
-            string lpstring = ((ToolStripMenuItem)sender).Text;
+            string lpstring = ((ToolStripMenuItem)sender).Text ?? string.Empty;
             if (ClickedPlottable is IHasLine line)
             {
                 // TODO: streamline this
@@ -240,7 +240,7 @@ namespace WinForms_Demo.Demos
             {
                 return;
             }
-            var lwcoeff = LineWidthCoefficient(((ToolStripMenuItem)sender).Text);
+            var lwcoeff = LineWidthCoefficient(((ToolStripMenuItem)sender).Text ?? string.Empty);
             if (ClickedPlottable is IHasLine line)
             {
                 line.LineWidth *= lwcoeff;
@@ -256,7 +256,7 @@ namespace WinForms_Demo.Demos
             {
                 return;
             }
-            var lwcoeff = LineWidthCoefficient(((ToolStripMenuItem)sender).Text);
+            var lwcoeff = LineWidthCoefficient(((ToolStripMenuItem)sender).Text ?? string.Empty);
             if (ClickedPlottable is IHasMarker marker)
             {
                 marker.MarkerLineWidth *= lwcoeff;
@@ -272,7 +272,7 @@ namespace WinForms_Demo.Demos
             {
                 return;
             }
-            string msstring = ((ToolStripMenuItem)sender).Text;
+            string msstring = ((ToolStripMenuItem)sender).Text ?? string.Empty;
             if (ClickedPlottable is IHasMarker marker)
             {
                 if (msstring != "None")
@@ -303,7 +303,7 @@ namespace WinForms_Demo.Demos
             }
             if (ClickedPlottable is IHasMarker marker)
             {
-                float coeff = MarkerSizeCoefficient(((ToolStripMenuItem)sender).Text);
+                float coeff = MarkerSizeCoefficient(((ToolStripMenuItem)sender).Text ?? string.Empty);
                 marker.MarkerSize *= coeff;
             }
 

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -2,8 +2,12 @@
 
 namespace WinForms_Demo.Demos
 {
-    public partial class DetachedLegend : Form
+    public partial class DetachedLegend : Form, IDemoWindow
     {
+        public string Title => "Detachable Legend";
+
+        public string Description => "Add an option to the right-click menu to display the legend in a pop-up window";
+
         public DetachedLegend()
         {
             InitializeComponent();

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -39,16 +39,302 @@ namespace WinForms_Demo.Demos
             {
                 Dock = DockStyle.Fill
             };
-
-            skControl.PaintSurface += (s, e) =>
-            {
-                PixelSize size = new(skControl.Width, skControl.Height);
-                PixelRect rect = new(Pixel.Zero, size);
-                formsPlot1.Plot.Legend.Render(e.Surface.Canvas, rect, Alignment.MiddleCenter);
-            };
-
+            skControl.PaintSurface += (s, e) => { PaintDetachedLegend((SKControl)s, (SKPaintSurfaceEventArgs)e); };
+            skControl.MouseClick += (s, e) => {LegendControl_MouseClick((SKControl)s, e); };
             form.Controls.Add(skControl);
+            formsPlot1.Plot.Legend.IsVisible = formsPlot1.Plot.Legend.IsVisible && false;
             form.Show();
         }
+
+        private void PaintDetachedLegend(SKControl skControl, SKPaintSurfaceEventArgs e)
+        {
+            PixelSize size = new(skControl.Width, skControl.Height);
+            PixelRect rect = new(Pixel.Zero, size);
+            SKCanvas canvas = e.Surface.Canvas;
+            formsPlot1.Plot.Legend.Render(canvas, rect, Alignment.UpperLeft, false);
+            LegendLayout layout = formsPlot1.Plot.Legend.GetLayout(size, false);
+
+            using SKPaint paint = new();
+            for (int i = 0; i < layout.LegendItems.Length; i++)
+            {
+                LegendItem item = layout.LegendItems[i];
+                PixelRect symbolRect = layout.SymbolRects[i];
+
+                if (!item.IsVisible)
+                {
+                    Drawing.DrawRectangle(canvas, symbolRect, Colors.Red.WithAlpha(.2));
+                    // TODO : How to trigger visible updates of the canvas ?
+                }
+            }
+        }
+
+        private void LegendControl_MouseClick(SKControl sender, EventArgs ee)
+        {
+            var e = (MouseEventArgs)ee;
+
+            var item = GetLegendItemUnderMouse(sender, e.Location);
+            var ClickedPlottable = item != null ? item.Plottable: null;
+
+            if (e.Button == MouseButtons.Left)
+            {
+                if (ClickedPlottable != null)
+                {
+                    ClickedPlottable.IsVisible = !ClickedPlottable.IsVisible;
+
+                }
+            }
+            else if (e.Button == MouseButtons.Right)
+            {
+                if (ClickedPlottable != null)
+                {
+                    OpenRightClickMenu(ClickedPlottable);
+                }
+            }
+            formsPlot1.Refresh();
+            // TODO : How to trigger legend repaint ?
+        }
+
+
+        private LegendItem? GetLegendItemUnderMouse(SKControl sender, Point e)
+        {
+            PixelSize size = new(sender.Width, sender.Height);
+            LegendItem[] items = formsPlot1.Plot.Legend.GetItems(false);
+            LegendLayout layout = formsPlot1.Plot.Legend.GetLayout(size, false);
+            if (items.Count() == 0)
+                return null;
+
+            // mouse hit logic must go here because Legend doesn't know about image stretching or display scaling
+            var itemslayout = Enumerable.Zip(items, layout.LabelRects, layout.SymbolRects);
+            foreach (var il in itemslayout)
+                {
+                var item = il.First;
+                var lrect = il.Second;
+                var srect = il.Third;
+                if (lrect.Contains(e.X, e.Y) || srect.Contains(e.X, e.Y))
+                {
+                        return item;
+                }
+            }
+            return null;
+        }
+
+        private void OpenRightClickMenu(IPlottable ClickedPlottable)
+        {
+            ContextMenuStrip customMenu = new();
+
+            customMenu.Items.Add(new ToolStripMenuItem("Delete", null, new EventHandler((s,e) => DeletePlottable(ClickedPlottable))));
+
+            if (ClickedPlottable is IHasLine)
+            {
+                var LineMenu = new ToolStripMenuItem("Line");
+                var LinePatternMenu = new ToolStripMenuItem("Pattern");
+                foreach (LinePattern lp in LinePattern.GetAllPatterns())
+                {
+                    LinePatternMenu.DropDownItems.Add(new ToolStripMenuItem(lp.Name, null, new EventHandler((s, e) => ChangeLinePattern(s, ClickedPlottable))));
+                }
+                LineMenu.DropDownItems.Add(LinePatternMenu);
+                var LineWidthMenu = new ToolStripMenuItem("Thickness");
+                foreach (string lw in new string[] { "much thinner", "thinner", "thicker", "much thicker" })
+                {
+                    LineWidthMenu.DropDownItems.Add(new ToolStripMenuItem(lw, null, new EventHandler((s, e) => ChangeLineWidth(s, ClickedPlottable))));
+                }
+                LineMenu.DropDownItems.Add(LineWidthMenu);
+                var LineColorMenu = new ToolStripMenuItem("Color", null, new EventHandler((s, e) => ChangeLineColor(s, ClickedPlottable)));
+                LineMenu.DropDownItems.Add(LineColorMenu);
+                customMenu.Items.Add(LineMenu);
+            }
+
+            if (ClickedPlottable is IHasMarker)
+            {
+                var MarkerMenu = new ToolStripMenuItem("Marker");
+                var MarkerShapeMenu = new ToolStripMenuItem("Shape");
+                foreach (MarkerShape ms in (MarkerShape[])Enum.GetValues(typeof(MarkerShape)))
+                {
+                    MarkerShapeMenu.DropDownItems.Add(new ToolStripMenuItem(ms.ToString(), null, new EventHandler((s, e) => ChangeMarkerShape(s, ClickedPlottable))));
+                }
+                MarkerMenu.DropDownItems.Add(MarkerShapeMenu);
+                var MarkerSizeMenu = new ToolStripMenuItem("Size");
+                foreach (string ms in new string[] { "much smaller", "smaller", "bigger", "much bigger" })
+                {
+                    MarkerSizeMenu.DropDownItems.Add(new ToolStripMenuItem(ms.ToString(), null, new EventHandler((s, e) => ChangeMarkerSize(s, ClickedPlottable))));
+                }
+                MarkerMenu.DropDownItems.Add(MarkerSizeMenu);
+                customMenu.Items.Add(MarkerMenu);
+                var MarkerLineWidthMenu = new ToolStripMenuItem("Thickness");
+                foreach (string lw in new string[] { "much thinner", "thinner", "thicker", "much thicker" })
+                {
+                    MarkerLineWidthMenu.DropDownItems.Add(new ToolStripMenuItem(lw, null, new EventHandler((s, e) => ChangeMarkerLineWidth(s, ClickedPlottable))));
+                }
+                MarkerMenu.DropDownItems.Add(MarkerLineWidthMenu);
+                var MarkerColorMenu = new ToolStripMenuItem("Marker Color", null, new EventHandler((s, e) => ChangeMarkerColor(s, ClickedPlottable)));
+                MarkerMenu.DropDownItems.Add(MarkerColorMenu);
+                var MarkerLineColorMenu = new ToolStripMenuItem("Marker Line Color", null, new EventHandler((s, e) => ChangeMarkerLineColor(s, ClickedPlottable)));
+                MarkerMenu.DropDownItems.Add(MarkerLineColorMenu);
+                customMenu.Items.Add(MarkerMenu);
+            }
+
+            customMenu.Show(Cursor.Position);
+        }
+
+        private void DeletePlottable(IPlottable ClickedPlottable)
+        {
+            formsPlot1.Plot.Remove(ClickedPlottable);
+            formsPlot1.Refresh();
+        }
+
+        private void ChangeLinePattern(object sender, IPlottable ClickedPlottable)
+        {
+            string lpstring = ((ToolStripMenuItem)sender).Text;
+            if (ClickedPlottable is IHasLine line)
+            {
+                // TODO: streamline this
+                foreach (LinePattern lp in LinePattern.GetAllPatterns())
+                {
+                    if (lp.Name == lpstring)
+                    {
+                        line.LinePattern = lp;
+                    }
+                }
+            }
+        }
+
+        private void ChangeLineColor(object sender, IPlottable ClickedPlottable)
+        {
+            if (sender is null)
+            {
+                return;
+            }
+            if (ClickedPlottable is IHasLine line)
+            {
+                var colorDialog = new ColorDialog();
+                if (colorDialog.ShowDialog() == DialogResult.OK)
+                {
+                    line.LineColor = ScottPlot.Color.FromColor(colorDialog.Color);
+                }
+            }
+        }
+
+        private void ChangeLineWidth(object sender, IPlottable ClickedPlottable)
+        {
+            if (sender is null)
+            {
+                return;
+            }
+            var lwcoeff = LineWidthCoefficient(((ToolStripMenuItem)sender).Text);
+            if (ClickedPlottable is IHasLine line)
+            {
+                line.LineWidth *= lwcoeff;
+            }
+        }
+
+        private void ChangeMarkerLineWidth(object sender, IPlottable ClickedPlottable)
+        {
+            if (sender is null)
+            {
+                return;
+            }
+            var lwcoeff = LineWidthCoefficient(((ToolStripMenuItem)sender).Text);
+            if (ClickedPlottable is IHasMarker marker)
+            {
+                marker.MarkerLineWidth *= lwcoeff;
+            }
+        }
+
+        private void ChangeMarkerShape(object sender, IPlottable ClickedPlottable)
+        {
+            if (sender is null)
+            {
+                return;
+            }
+            string msstring = ((ToolStripMenuItem)sender).Text;
+            if (ClickedPlottable is IHasMarker marker)
+            {
+                if (msstring != "None")
+                {
+                    if (marker.MarkerSize == 0)
+                    {
+                        marker.MarkerSize = 1;
+                    }
+                    foreach (MarkerShape ms in (MarkerShape[])Enum.GetValues(typeof(MarkerShape)))
+                    {
+                        if (ms.ToString() == msstring)
+                        {
+                            marker.MarkerShape = ms;
+                        }
+                    }
+                }
+            }
+        }
+
+        private void ChangeMarkerSize(object sender, IPlottable ClickedPlottable)
+        {
+            if (sender is null)
+            {
+                return;
+            }
+            if (ClickedPlottable is IHasMarker marker)
+            {
+                float coeff = MarkerSizeCoefficient(((ToolStripMenuItem)sender).Text);
+                marker.MarkerSize *= coeff;
+            }
+        }
+
+        private void ChangeMarkerColor(object sender, IPlottable ClickedPlottable)
+        {
+            if (sender is null)
+            {
+                return;
+            }
+            if (ClickedPlottable is IHasMarker marker)
+            {
+                var colorDialog = new ColorDialog();
+                if (colorDialog.ShowDialog() == DialogResult.OK)
+                {
+                    marker.MarkerColor = ScottPlot.Color.FromColor(colorDialog.Color);
+                }
+            }
+        }
+
+        private void ChangeMarkerLineColor(object sender, IPlottable ClickedPlottable)
+        {
+            if (sender is null)
+            {
+                return;
+            }
+            if (ClickedPlottable is IHasMarker marker)
+            {
+                var colorDialog = new ColorDialog();
+                if (colorDialog.ShowDialog() == DialogResult.OK)
+                {
+                    marker.MarkerLineColor = ScottPlot.Color.FromColor(colorDialog.Color);
+                }
+            }
+        }
+
+
+private float LineWidthCoefficient(string lwstring)
+{
+    return lwstring switch
+    {
+        "much thinner" => 1 / 2f,
+        "thinner" => 2 / 3f,
+        "thicker" => 3 / 2f,
+        "much thicker" => 2,
+        _ => throw new NotImplementedException(),
+    };
+}
+
+private float MarkerSizeCoefficient(string lwstring)
+{
+    return lwstring switch
+    {
+        "much smaller" => 1 / 2f,
+        "smaller" => 1 / 1.5f,
+        "bigger" => 1.5f,
+        "much bigger" => 2,
+        _ => throw new NotImplementedException(),
+    };
     }
+
+}
 }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -52,8 +52,8 @@ namespace WinForms_Demo.Demos
                 Dock = DockStyle.Fill
             };
 
-            skControl.PaintSurface += (s, e) => { PaintDetachedLegend((SKControl)s, (SKPaintSurfaceEventArgs)e); };
-            skControl.MouseClick += (s, e) => { LegendControl_MouseClick((SKControl)s, e); };
+            skControl.PaintSurface += (s, e) => { PaintDetachedLegend((SKControl)s!, (SKPaintSurfaceEventArgs)e); };
+            skControl.MouseClick += (s, e) => { LegendControl_MouseClick((SKControl)s!, e); };
             form.Controls.Add(skControl);
             bool initialLegendState = formsPlot1.Plot.Legend.IsVisible;
             formsPlot1.Plot.Legend.IsVisible = false;
@@ -182,8 +182,11 @@ namespace WinForms_Demo.Demos
             formsPlot1.Plot.Remove(ClickedPlottable);
         }
 
-        private void ChangeLinePattern(object sender, IPlottable ClickedPlottable)
+        private void ChangeLinePattern(object? sender, IPlottable ClickedPlottable)
         {
+            if (sender is null)
+                return;
+
             string lpstring = ((ToolStripMenuItem)sender).Text;
             if (ClickedPlottable is IHasLine line)
             {
@@ -198,7 +201,7 @@ namespace WinForms_Demo.Demos
             }
         }
 
-        private void ChangeLineColor(object sender, IPlottable ClickedPlottable)
+        private void ChangeLineColor(object? sender, IPlottable ClickedPlottable)
         {
             if (sender is null)
             {
@@ -214,7 +217,7 @@ namespace WinForms_Demo.Demos
             }
         }
 
-        private void ChangeLineWidth(object sender, IPlottable ClickedPlottable)
+        private void ChangeLineWidth(object? sender, IPlottable ClickedPlottable)
         {
             if (sender is null)
             {
@@ -227,7 +230,7 @@ namespace WinForms_Demo.Demos
             }
         }
 
-        private void ChangeMarkerLineWidth(object sender, IPlottable ClickedPlottable)
+        private void ChangeMarkerLineWidth(object? sender, IPlottable ClickedPlottable)
         {
             if (sender is null)
             {
@@ -240,7 +243,7 @@ namespace WinForms_Demo.Demos
             }
         }
 
-        private void ChangeMarkerShape(object sender, IPlottable ClickedPlottable)
+        private void ChangeMarkerShape(object? sender, IPlottable ClickedPlottable)
         {
             if (sender is null)
             {
@@ -266,7 +269,7 @@ namespace WinForms_Demo.Demos
             }
         }
 
-        private void ChangeMarkerSize(object sender, IPlottable ClickedPlottable)
+        private void ChangeMarkerSize(object? sender, IPlottable ClickedPlottable)
         {
             if (sender is null)
             {
@@ -279,7 +282,7 @@ namespace WinForms_Demo.Demos
             }
         }
 
-        private void ChangeMarkerColor(object sender, IPlottable ClickedPlottable)
+        private void ChangeMarkerColor(object? sender, IPlottable ClickedPlottable)
         {
             if (sender is null)
             {
@@ -295,7 +298,7 @@ namespace WinForms_Demo.Demos
             }
         }
 
-        private void ChangeMarkerLineColor(object sender, IPlottable ClickedPlottable)
+        private void ChangeMarkerLineColor(object? sender, IPlottable ClickedPlottable)
         {
             if (sender is null)
             {

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -1,4 +1,4 @@
-﻿using ScottPlot;
+using ScottPlot;
 using SkiaSharp;
 using SkiaSharp.Views.Desktop;
 
@@ -52,20 +52,6 @@ namespace WinForms_Demo.Demos
             PixelRect rect = new(Pixel.Zero, size);
             SKCanvas canvas = e.Surface.Canvas;
             formsPlot1.Plot.Legend.Render(canvas, rect, Alignment.UpperLeft, false);
-            LegendLayout layout = formsPlot1.Plot.Legend.GetLayout(size, false);
-
-            using SKPaint paint = new();
-            for (int i = 0; i < layout.LegendItems.Length; i++)
-            {
-                LegendItem item = layout.LegendItems[i];
-                PixelRect symbolRect = layout.SymbolRects[i];
-
-                if (!item.IsVisible)
-                {
-                    Drawing.DrawRectangle(canvas, symbolRect, Colors.Red.WithAlpha(.2));
-                    // TODO : How to trigger visible updates of the canvas ?
-                }
-            }
         }
 
         private void LegendControl_MouseClick(SKControl sender, EventArgs ee)

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -29,18 +29,31 @@ namespace WinForms_Demo.Demos
 
         private void LaunchDetachedLegend(IPlotControl plotControl)
         {
+            // hide the legend in the original plot
+            plotControl.Plot.Legend.IsVisible = false;
+            plotControl.Refresh();
+
+            // create a form that displays a SkiaSharp canvas the legend can be drawn on
             Form form = new()
             {
                 Text = "Detached Legend",
                 StartPosition = FormStartPosition.CenterScreen,
             };
 
+            form.FormClosed += (s, e) =>
+            {
+                // un-hide the legend in the original plot when the legend viewer is closed
+                plotControl.Plot.Legend.IsVisible = true;
+                plotControl.Refresh();
+            };
+
             SKControl skControl = new()
             {
                 Dock = DockStyle.Fill
             };
+
             skControl.PaintSurface += (s, e) => { PaintDetachedLegend((SKControl)s, (SKPaintSurfaceEventArgs)e); };
-            skControl.MouseClick += (s, e) => {LegendControl_MouseClick((SKControl)s, e); };
+            skControl.MouseClick += (s, e) => { LegendControl_MouseClick((SKControl)s, e); };
             form.Controls.Add(skControl);
             bool initialLegendState = formsPlot1.Plot.Legend.IsVisible;
             formsPlot1.Plot.Legend.IsVisible = false;
@@ -61,7 +74,7 @@ namespace WinForms_Demo.Demos
             var e = (MouseEventArgs)ee;
 
             var item = GetLegendItemUnderMouse(sender, e.Location);
-            var ClickedPlottable = item != null ? item.Plottable: null;
+            var ClickedPlottable = item != null ? item.Plottable : null;
 
             if (e.Button == MouseButtons.Left)
             {
@@ -94,13 +107,13 @@ namespace WinForms_Demo.Demos
             // mouse hit logic must go here because Legend doesn't know about image stretching or display scaling
             var itemslayout = Enumerable.Zip(items, layout.LabelRects, layout.SymbolRects);
             foreach (var il in itemslayout)
-                {
+            {
                 var item = il.First;
                 var lrect = il.Second;
                 var srect = il.Third;
                 if (lrect.Contains(e.X, e.Y) || srect.Contains(e.X, e.Y))
                 {
-                        return item;
+                    return item;
                 }
             }
             return null;
@@ -110,7 +123,7 @@ namespace WinForms_Demo.Demos
         {
             ContextMenuStrip customMenu = new();
 
-            customMenu.Items.Add(new ToolStripMenuItem("Delete", null, new EventHandler((s,e) => DeletePlottable(ClickedPlottable))));
+            customMenu.Items.Add(new ToolStripMenuItem("Delete", null, new EventHandler((s, e) => DeletePlottable(ClickedPlottable))));
 
             if (ClickedPlottable is IHasLine)
             {
@@ -299,29 +312,29 @@ namespace WinForms_Demo.Demos
         }
 
 
-private float LineWidthCoefficient(string lwstring)
-{
-    return lwstring switch
-    {
-        "much thinner" => 1 / 2f,
-        "thinner" => 2 / 3f,
-        "thicker" => 3 / 2f,
-        "much thicker" => 2,
-        _ => throw new NotImplementedException(),
-    };
-}
+        private float LineWidthCoefficient(string lwstring)
+        {
+            return lwstring switch
+            {
+                "much thinner" => 1 / 2f,
+                "thinner" => 2 / 3f,
+                "thicker" => 3 / 2f,
+                "much thicker" => 2,
+                _ => throw new NotImplementedException(),
+            };
+        }
 
-private float MarkerSizeCoefficient(string lwstring)
-{
-    return lwstring switch
-    {
-        "much smaller" => 1 / 2f,
-        "smaller" => 1 / 1.5f,
-        "bigger" => 1.5f,
-        "much bigger" => 2,
-        _ => throw new NotImplementedException(),
-    };
+        private float MarkerSizeCoefficient(string lwstring)
+        {
+            return lwstring switch
+            {
+                "much smaller" => 1 / 2f,
+                "smaller" => 1 / 1.5f,
+                "bigger" => 1.5f,
+                "much bigger" => 2,
+                _ => throw new NotImplementedException(),
+            };
+        }
+
     }
-
-}
 }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.resx
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Program.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Program.cs
@@ -11,7 +11,7 @@ static class Program
         Application.EnableVisualStyles();
 
         // CTRL+D opens this window (useful for testing in development)
-        Type testingFormType = typeof(Demos.MicrophoneDemo);
+        Type testingFormType = typeof(Demos.DetachedLegend);
 
         Application.Run(new MainMenuForm(testingFormType));
     }

--- a/src/ScottPlot5/ScottPlot5/Panels/LegendPanel.cs
+++ b/src/ScottPlot5/ScottPlot5/Panels/LegendPanel.cs
@@ -22,7 +22,7 @@ public class LegendPanel(Legend legend) : PanelBase
         PixelRect rect = GetPanelRect(rp.DataRect, size, offset);
         bool originalVisibility = Legend.IsVisible;
         Legend.IsVisible = true;
-        Legend.Render(rp, rect, Alignment);
+        Legend.Render(rp.Canvas, rect, Alignment);
         Legend.IsVisible = originalVisibility;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
@@ -298,6 +298,13 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
             item.OutlineStyle.Render(canvas, symbolFillOutlineRect, paint);
             item.MarkerStyle.Render(canvas, symbolRect.Center, paint);
             item.ArrowStyle.Render(canvas, symbolLine, paint);
+
+            // Partially hide legend item to reflect that plottable is invisible
+            if (!item.Plottable.IsVisible)
+            {
+                PixelRect itemRect = new PixelRect(symbolRect.TopLeft, labelRect.BottomRight);
+                Drawing.FillRectangle(canvas, itemRect, Colors.White.WithAlpha(.5));
+            }
         }
 
         canvasState.Restore();

--- a/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
@@ -226,11 +226,12 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
         RenderLayout(rp.Canvas, layout);
     }
 
-    /// <summary>
-    /// Render the legend inside the given rectangle
-    /// </summary>
-    /// <param name="rp"></param>
     public void Render(RenderPack rp, PixelRect rect, Alignment alignment)
+    {
+        Render(rp.Canvas, rect, alignment);
+    }
+
+    public void Render(SKCanvas canvs, PixelRect rect, Alignment alignment)
     {
         LegendItem[] items = GetItems();
         if (items.Length == 0)
@@ -247,7 +248,7 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
             SymbolRects = tightLayout.SymbolRects.Select(x => x.WithOffset(legendOffset)).ToArray(),
         };
 
-        RenderLayout(rp.Canvas, layout);
+        RenderLayout(canvs, layout);
     }
 
     private void RenderLayout(SKCanvas canvas, LegendLayout layout)

--- a/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
@@ -116,7 +116,7 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
 
     public bool DisplayPlottableLegendItems { get; set; } = true;
 
-    public LegendItem[] GetItems(bool VisibleOnly=true)
+    public LegendItem[] GetItems(bool VisibleOnly = true)
     {
         List<LegendItem> items = [];
 
@@ -155,7 +155,7 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
         return items.ToArray();
     }
 
-    public LegendLayout GetLayout( PixelSize size, bool VisibleOnly = true)
+    public LegendLayout GetLayout(PixelSize size, bool VisibleOnly = true)
     {
         return Layout.GetLayout(this, GetItems(VisibleOnly), size);
     }
@@ -231,12 +231,12 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
         RenderLayout(rp.Canvas, layout);
     }
 
-    public void Render(RenderPack rp, PixelRect rect, Alignment alignment, bool VisibleOnly=true)
+    public void Render(RenderPack rp, PixelRect rect, Alignment alignment, bool VisibleOnly = true)
     {
         Render(rp.Canvas, rect, alignment, VisibleOnly);
     }
 
-    public void Render(SKCanvas canvs, PixelRect rect, Alignment alignment, bool VisibleOnly=true)
+    public void Render(SKCanvas canvs, PixelRect rect, Alignment alignment, bool VisibleOnly = true)
     {
         LegendItem[] items = GetItems(VisibleOnly);
         if (items.Length == 0)
@@ -300,8 +300,11 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
             item.ArrowStyle.Render(canvas, symbolLine, paint);
 
             // Partially hide legend item to reflect that plottable is invisible
-            if (!item.Plottable.IsVisible)
+            if (item.Plottable is not null)
             {
+                if (!item.Plottable.IsVisible)
+                    continue;
+
                 PixelRect itemRect = new PixelRect(symbolRect.TopLeft, labelRect.BottomRight);
                 Drawing.FillRectangle(canvas, itemRect, Colors.White.WithAlpha(.5));
             }

--- a/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
@@ -116,14 +116,14 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
 
     public bool DisplayPlottableLegendItems { get; set; } = true;
 
-    public LegendItem[] GetItems()
+    public LegendItem[] GetItems(bool VisibleOnly=true)
     {
         List<LegendItem> items = [];
 
         if (DisplayPlottableLegendItems)
         {
             var plottableLegendItems = Plot.PlottableList
-                        .Where(item => item.IsVisible)
+                        .Where(item => (VisibleOnly ? item.IsVisible : true))
                         .SelectMany(x => x.LegendItems)
                         .Where(x => !string.IsNullOrEmpty(x.LabelText));
 
@@ -153,6 +153,11 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
         }
 
         return items.ToArray();
+    }
+
+    public LegendLayout GetLayout( PixelSize size, bool VisibleOnly = true)
+    {
+        return Layout.GetLayout(this, GetItems(VisibleOnly), size);
     }
 
     /// <summary>
@@ -226,14 +231,14 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
         RenderLayout(rp.Canvas, layout);
     }
 
-    public void Render(RenderPack rp, PixelRect rect, Alignment alignment)
+    public void Render(RenderPack rp, PixelRect rect, Alignment alignment, bool VisibleOnly=true)
     {
-        Render(rp.Canvas, rect, alignment);
+        Render(rp.Canvas, rect, alignment, VisibleOnly);
     }
 
-    public void Render(SKCanvas canvs, PixelRect rect, Alignment alignment)
+    public void Render(SKCanvas canvs, PixelRect rect, Alignment alignment, bool VisibleOnly=true)
     {
-        LegendItem[] items = GetItems();
+        LegendItem[] items = GetItems(VisibleOnly);
         if (items.Length == 0)
             return;
 


### PR DESCRIPTION
Adds a demo example for the detacheable legend control + plot modification options.

What remains to be done

- [x] properly setup de demo : need help to structure the example with an additional control for the legend viewer (need help @swharden)
- [x] include the detached legend options and features in the appropriate control
- [x] figure how to track toggling of visibile / invisible plots (see suggestions in #3842
- [ ] figure how to handle plots without text in legend
- [x] figure how to change painting of legend item based on toggled state of the plottable
- [x] figure how to handle legend resize
- [x] properly restore initial legend state upon detached legend closing
- [ ] trigger detached legend update after a modification