### PR TITLE
Axes: SetupMultiplierNotation()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 _Not yet on NuGet..._
 * Controls: Fix issue preventing the context menu from appearing after it was used to open a new window (#4529) @david3951445
 * Interactivity: Created `HitablePlottableDecorator` and `DragablePlottableDecorator` classes that wrap any `IPlottable` to add pixel-based mouse collision detection and drag capability to any plot type (#4531, #4496) @StendProg
+* Ticks: Created a plottable for displaying multiplier notation and added the `Plot.Axes.SetupMultiplierNotation()` helper method for rapidly enabling it with typical options (#4530) @Paraplegia
 
 ## ScottPlot 5.0.46
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-17_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/AxisRecipes.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/AxisRecipes.cs
@@ -395,4 +395,27 @@ public class AxisAndTicks : ICategory
             myPlot.Axes.Left.Label.Image = img2;
         }
     }
+
+    public class MultiplierNotation : RecipeBase
+    {
+        public override string Name => "Multiplier Notation";
+        public override string Description => "Numeric tick labels may be displayed using multiplier notation " +
+            "(where tick labels are displayed using scientific notation with the eponent displayed in the corner of the plot). " +
+            "A helper method is available to set-up multiplier notation with a single statement, but users can " +
+            "interact with the object this method returns (not shown here) or inspect the code inside of that method " +
+            "to learn how to achieve enhanced customization abilities.";
+
+        [Test]
+        public override void Execute()
+        {
+            // plot sample data with extremely large values
+            double[] xs = Generate.RandomSample(50, -1e10, 1e10);
+            double[] ys = Generate.RandomSample(50, -1e20, 1e20);
+            myPlot.Add.Scatter(xs, ys);
+
+            // enable multiplier notation on both primary axes
+            myPlot.Axes.SetupMultiplierNotation(myPlot.Axes.Left);
+            myPlot.Axes.SetupMultiplierNotation(myPlot.Axes.Bottom);
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/TickModifierLabel.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/TickModifierLabel.cs
@@ -1,0 +1,82 @@
+﻿namespace ScottPlot.Plottables;
+
+/// <summary>
+/// This plottable contains logic to modify tick labels to display them
+/// using scientific notation with a multiplier displaed as text 
+/// placed just outside the corner of the data area.
+/// </summary>
+public class TickModifierLabel : IPlottable
+{
+    public bool IsVisible { get; set; } = true;
+    public IAxes Axes { get; set; } = new Axes();
+    public IEnumerable<LegendItem> LegendItems => LegendItem.None;
+    public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
+    public LabelStyle LabelStyle { get; } = new();
+
+    /// <summary>
+    /// The axis this tick modifier will modify tick labels for
+    /// </summary>
+    public IAxis Axis { get; }
+
+    /// <summary>
+    /// This logic determines where the text will be placed relative to the data area
+    /// </summary>
+    public Func<PixelRect, Pixel> GetTextPixel { get; set; }
+
+    /// <summary>
+    /// This logic determines how to display the exponent as a string
+    /// </summary>
+    public Func<int, string> LabelFormatter { get; set; } = (x) => $"1e{x}";
+
+    private int Exponent = 0;
+
+    public TickModifierLabel(IAxis axis)
+    {
+        Axis = axis;
+
+        if (axis is AxisPanels.LeftAxis)
+        {
+            LabelStyle.Alignment = Alignment.LowerLeft;
+            GetTextPixel = (PixelRect dataRect) => dataRect.TopLeft;
+        }
+        else if (axis is AxisPanels.BottomAxis)
+        {
+            LabelStyle.Alignment = Alignment.UpperRight;
+            GetTextPixel = (PixelRect dataRect) => dataRect.BottomRight.WithOffset(0, 20);
+        }
+        else
+        {
+            throw new NotImplementedException($"{axis.GetType()} is not yet supported");
+        }
+    }
+
+    public virtual void UpdateTickLabels()
+    {
+        var tickPositions = Axis.TickGenerator.Ticks.Select(x => x.Position);
+        double tickSpan = tickPositions.Max() - tickPositions.Min();
+
+        Exponent = (int)(Math.Log10(tickSpan));
+
+        double multiplier = Math.Pow(10, Exponent);
+        for (int i = 0; i < Axis.TickGenerator.Ticks.Length; i++)
+        {
+            if (!Axis.TickGenerator.Ticks[i].IsMajor)
+                continue;
+
+            double position = Axis.TickGenerator.Ticks[i].Position;
+            double divided = position / multiplier;
+            string label = $"{divided:0.00}";
+            Axis.TickGenerator.Ticks[i] = Tick.Major(position, label);
+        }
+    }
+
+    public virtual void Render(RenderPack rp)
+    {
+        Pixel px = GetTextPixel.Invoke(rp.DataRect);
+        string label = LabelFormatter.Invoke(Exponent);
+
+        rp.CanvasState.DisableClipping();
+        using SKPaint paint = new();
+        LabelStyle.Render(rp.Canvas, px, paint, label);
+    }
+}


### PR DESCRIPTION
Resolves #4530

```cs
myPlot.Axes.SetupMultiplierNotation(myPlot.Axes.Left);
myPlot.Axes.SetupMultiplierNotation(myPlot.Axes.Bottom);
```

![image](https://github.com/user-attachments/assets/b8bde91f-f387-410c-8107-e0b795667d05)
