### PR TITLE
AxisBase.Measure() improve multiline support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ _Not yet on NuGet..._
 * Controls: Fix issue preventing the context menu from appearing after it was used to open a new window (#4529) @david3951445
 * Interactivity: Created `HitablePlottableDecorator` and `DragablePlottableDecorator` classes that wrap any `IPlottable` to add pixel-based mouse collision detection and drag capability to any plot type (#4531, #4496) @StendProg
 * Ticks: Created a plottable for displaying multiplier notation and added the `Plot.Axes.SetupMultiplierNotation()` helper method for rapidly enabling it with typical options (#4530) @Paraplegia
+* Axes: Improve layout support for axes with multi-line axis labels (#4535) @CBrauer
 
 ## ScottPlot 5.0.46
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-17_

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/XAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/XAxisBase.cs
@@ -27,7 +27,7 @@ public abstract class XAxisBase : AxisBase, IXAxis
 
         float axisLabelHeight = string.IsNullOrEmpty(LabelStyle.Text) && LabelStyle.Image is null
             ? EmptyLabelPadding.Vertical
-            : LabelStyle.Measure(LabelText, paint).LineHeight
+            : LabelStyle.Measure(LabelText, paint).Height
                 + PaddingBetweenTickAndAxisLabels.Vertical
                 + PaddingOutsideAxisLabels.Vertical;
 

--- a/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisPanels/YAxisBase.cs
@@ -35,7 +35,7 @@ public abstract class YAxisBase : AxisBase, IYAxis
 
         float axisLabelHeight = string.IsNullOrEmpty(LabelStyle.Text) && LabelStyle.Image is null
             ? EmptyLabelPadding.Horizontal
-            : LabelStyle.Measure(LabelText, paint).LineHeight
+            : LabelStyle.Measure(LabelText, paint).Height
                 + PaddingBetweenTickAndAxisLabels.Horizontal
                 + PaddingOutsideAxisLabels.Horizontal;
 


### PR DESCRIPTION
resolves #4535

```cs
formsPlot1.Plot.XLabel("Line 1\nLine 2\nLine 3");
formsPlot1.Plot.YLabel("Line 1\nLine 2\nLine 3");
```

before | after
---|---
![image](https://github.com/user-attachments/assets/1ea1c7af-1d42-469c-a0c5-de82d89402f3)|![image](https://github.com/user-attachments/assets/cb6fc5ff-552a-4ebf-984e-01c283927db9)
