### PR TITLE
Add Range and StackedRange charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ _Not yet on NuGet..._
 * Ticks: Created a plottable for displaying multiplier notation and added the `Plot.Axes.SetupMultiplierNotation()` helper method for rapidly enabling it with typical options (#4530) @Paraplegia
 * Axes: Improve layout support for axes with multi-line axis labels (#4535) @CBrauer
 * Heatmap: Added `Rectangle` property to simplify rendering a heatmap within the edges of a user-defined rectangle in coordinate space (#4552, #4550) @ecrocombe
+* Palette: Exposed `ScottPlot.Palettes.Custom` as an alternative to `ScottPlot.Palette.FromColors()` for creating palettes with user-defined collections of colors
+* Bar: Created `Add.Ranges()` and `Add.StackedRanges()` to simplify creation of stacked range charts (#4548) @quantfreedom @wellcaffeinated
 
 ## ScottPlot 5.0.46
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-17_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
@@ -476,7 +476,7 @@ public class Bar : ICategory
         [Test]
         public override void Execute()
         {
-            List<(string, CoordinateRange)> ranges =
+            List<(string name, CoordinateRange range)> ranges =
             [
                 ("Africa", new(-35, 37)),
                 ("Antarctica", new(-90, -60)),
@@ -486,7 +486,7 @@ public class Bar : ICategory
                 ("South America", new(-56, 13)),
                 ("Australia", new(-47, -28)),
             ];
-            myPlot.Add.RangePlot(ranges);
+            myPlot.Add.Ranges(ranges);
 
             // style the axes
             myPlot.Title("Latitude Range of the Continents");
@@ -513,16 +513,66 @@ public class Bar : ICategory
         [Test]
         public override void Execute()
         {
-            List<(string, CoordinateRange)> ranges =
+            List<(string name, CoordinateRange range)> ranges =
             [
                 ("Ontario", new(-9, 51)),
                 ("England", new(0, 63)),
                 ("Kentucky", new(-4, 72)),
             ];
 
-            myPlot.Add.RangePlot(ranges, horizontal: true);
+            myPlot.Add.Ranges(ranges, horizontal: true);
 
             myPlot.XLabel("Temperature (ºF)");
+        }
+    }
+
+    public class StackedRangeChart : RecipeBase
+    {
+        public override string Name => "Stacked Range Chart";
+        public override string Description => "Stacked range charts depict multiple ranges for a discrete set of items";
+
+        [Test]
+        public override void Execute()
+        {
+            // prepare a custom color palette
+            string[] colorCodes = ["#3369cc", "#95bce3", "#f4a861", "#fd8d00"];
+            ScottPlot.Palettes.Custom palette = new(colorCodes);
+
+            // create a stacked bar chart with a collection of named ranges
+            string[] rangeNames = ["Yearly Low", "Mean Daily Low", "Mean Daily High", "Yearly High"];
+            List<(string name, double[] edges)> ranges =
+            [
+                ("Ontario", [-9, 3, 7, 13, 27]),
+                ("England", [4, 7, 12, 16, 24]),
+                ("Kentucky", [-4, 7, 13, 20, 30]),
+            ];
+            myPlot.Add.StackedRanges(ranges, palette);
+
+            // use tick labels with a degree symbol
+            ScottPlot.TickGenerators.NumericAutomatic tickGen = new();
+            myPlot.Axes.Left.TickGenerator = tickGen;
+            tickGen.LabelFormatter = (x) => $"{x}º";
+
+            // display the legend outside the data area
+            myPlot.ShowLegend(Edge.Right);
+
+            // add items to the legend manually
+            for (int i = 0; i < rangeNames.Length; i++)
+            {
+                LegendItem item = new()
+                {
+                    LabelText = rangeNames[i],
+                    FillColor = palette.GetColor(i),
+                };
+                myPlot.Legend.ManualItems.Add(item);
+            }
+            myPlot.Legend.ManualItems.Reverse();
+
+            // improve styling and alignment
+            myPlot.Legend.OutlineStyle.IsVisible = false;
+            myPlot.Legend.ShadowColor = Colors.Transparent;
+            myPlot.Legend.Padding = new(0);
+            myPlot.Axes.Right.MaximumSize = 0;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
@@ -578,7 +578,7 @@ public class Bar : ICategory
 
     public class StackedRangeHorizontal : RecipeBase
     {
-        public override string Name => "Stacked Range Chart";
+        public override string Name => "Stacked Horizontal Range Chart";
         public override string Description => "Horizontally oriented stacked range charts may be created";
 
         [Test]

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
@@ -575,4 +575,23 @@ public class Bar : ICategory
             myPlot.Axes.Right.MaximumSize = 0;
         }
     }
+
+    public class StackedRangeHorizontal : RecipeBase
+    {
+        public override string Name => "Stacked Range Chart";
+        public override string Description => "Horizontally oriented stacked range charts may be created";
+
+        [Test]
+        public override void Execute()
+        {
+            List<(string name, double[] edges)> ranges =
+            [
+                ("Ontario", [-9, 3, 7, 13, 27]),
+                ("England", [4, 7, 12, 16, 24]),
+                ("Kentucky", [-4, 7, 13, 20, 30]),
+            ];
+
+            myPlot.Add.StackedRanges(ranges, horizontal: true);
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Bar.cs
@@ -467,4 +467,62 @@ public class Bar : ICategory
             myPlot.Axes.Left.SetTicks(tickPositions, tickLabels);
         }
     }
+
+    public class RangeChart : RecipeBase
+    {
+        public override string Name => "Range Chart";
+        public override string Description => "A range chart displays a discrete set of named value ranges";
+
+        [Test]
+        public override void Execute()
+        {
+            List<(string, CoordinateRange)> ranges =
+            [
+                ("Africa", new(-35, 37)),
+                ("Antarctica", new(-90, -60)),
+                ("Asia", new(-11, 81)),
+                ("Europe", new(-36, 71)),
+                ("North America", new(-7, 83)),
+                ("South America", new(-56, 13)),
+                ("Australia", new(-47, -28)),
+            ];
+            myPlot.Add.RangePlot(ranges);
+
+            // style the axes
+            myPlot.Title("Latitude Range of the Continents");
+            myPlot.Axes.Bottom.TickLabelStyle.Rotation = -45;
+            myPlot.Axes.Bottom.TickLabelStyle.Alignment = Alignment.MiddleRight;
+            myPlot.Axes.Bottom.MinimumSize = 100;
+
+            // use tick labels with a degree symbol
+            ScottPlot.TickGenerators.NumericAutomatic tickGen = new();
+            myPlot.Axes.Left.TickGenerator = tickGen;
+            tickGen.LabelFormatter = (x) => $"{x}º";
+
+            // add a horizontal line at zero and push it beneath the range plot
+            var hl = myPlot.Add.HorizontalLine(0, 1, Colors.Black, LinePattern.DenselyDashed);
+            myPlot.MoveToBack(hl);
+        }
+    }
+
+    public class RangeChartHozontal : RecipeBase
+    {
+        public override string Name => "Horizontal Range Chart";
+        public override string Description => "Range charts may be created using horizontally oriented bars";
+
+        [Test]
+        public override void Execute()
+        {
+            List<(string, CoordinateRange)> ranges =
+            [
+                ("Ontario", new(-9, 51)),
+                ("England", new(0, 63)),
+                ("Kentucky", new(-4, 72)),
+            ];
+
+            myPlot.Add.RangePlot(ranges, horizontal: true);
+
+            myPlot.XLabel("Temperature (ºF)");
+        }
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Palettes/Custom.cs
+++ b/src/ScottPlot5/ScottPlot5/Palettes/Custom.cs
@@ -1,6 +1,6 @@
 ﻿namespace ScottPlot.Palettes;
 
-internal class Custom : IPalette
+public class Custom : IPalette
 {
     public Color[] Colors { get; }
 
@@ -8,19 +8,14 @@ internal class Custom : IPalette
 
     public string Description { get; }
 
-    public Custom(Color[] colors, string name, string description)
+    public Custom(Color[] colors, string? name, string? description = null)
     {
         Colors = colors;
-        Name = name;
-        Description = description;
+        Name = name ?? "unnamed";
+        Description = description ?? "no description";
     }
 
-    public Custom(string[] hex, string name, string description)
-    {
-        Colors = Color.FromHex(hex);
-        Name = name;
-        Description = description;
-    }
+    public Custom(string[] hex, string? name = null, string? description = null) : this(Color.FromHex(hex), name, description) { }
 
     public Color GetColor(int index)
     {

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -872,6 +872,43 @@ public class PlottableAdder(Plot plot)
         return radialGaugePlot;
     }
 
+    /// <summary>
+    /// Create a bar plot to represent a collection of named ranges
+    /// </summary>
+    public BarPlot RangePlot(List<(string name, CoordinateRange range)> ranges, Color? color = null, bool horizontal = false)
+    {
+        Color barColor = color ?? GetNextColor();
+
+        // create a bar plot from the collection of ranges
+        Bar[] bars = new Bar[ranges.Count];
+        for (int i = 0; i < ranges.Count; i++)
+        {
+            bars[i] = new()
+            {
+                ValueBase = ranges[i].range.Min,
+                Value = ranges[i].range.Max,
+                Position = i,
+                FillColor = barColor,
+            };
+        }
+        BarPlot bp = Bars(bars);
+        bp.Horizontal = horizontal;
+
+        // use manaul tick labels displaying category names
+        double[] positions = bars.Select(x => x.Position).ToArray();
+        string[] labels = ranges.Select(x => x.name).ToArray();
+        if (horizontal)
+        {
+            Plot.Axes.Left.SetTicks(positions, labels);
+        }
+        else
+        {
+            Plot.Axes.Bottom.SetTicks(positions, labels);
+        }
+
+        return bp;
+    }
+
     public Rectangle Rectangle(CoordinateRect rect)
     {
         return Rectangle(rect.Left, rect.Right, rect.Top, rect.Bottom);

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -1159,7 +1159,7 @@ public class PlottableAdder(Plot plot)
     /// <summary>
     /// Place a stacked bar chart at a single position
     /// </summary>
-    public BarPlot[] StackedRanges(List<(string name, double[] edgeValues)> ranges, IPalette? palette = null)
+    public BarPlot[] StackedRanges(List<(string name, double[] edgeValues)> ranges, IPalette? palette = null, bool horizontal = false)
     {
         BarPlot[] bps = new BarPlot[ranges.Count];
         for (int i = 0; i < ranges.Count; i++)
@@ -1178,11 +1178,19 @@ public class PlottableAdder(Plot plot)
             }
 
             bps[i] = Bars(bars);
+            bps[i].Horizontal = horizontal;
         }
 
         string[] labels = ranges.Select(x => x.name).ToArray();
         double[] positions = Generate.Consecutive(labels.Length);
-        Plot.Axes.Bottom.SetTicks(positions, labels);
+        if (horizontal)
+        {
+            Plot.Axes.Left.SetTicks(positions, labels);
+        }
+        else
+        {
+            Plot.Axes.Bottom.SetTicks(positions, labels);
+        }
 
         return bps;
     }

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -875,7 +875,7 @@ public class PlottableAdder(Plot plot)
     /// <summary>
     /// Create a bar plot to represent a collection of named ranges
     /// </summary>
-    public BarPlot RangePlot(List<(string name, CoordinateRange range)> ranges, Color? color = null, bool horizontal = false)
+    public BarPlot Ranges(List<(string name, CoordinateRange range)> ranges, Color? color = null, bool horizontal = false)
     {
         Color barColor = color ?? GetNextColor();
 
@@ -1154,6 +1154,37 @@ public class PlottableAdder(Plot plot)
     {
         var source = new SignalXYSourceGenericArray<TX, TY>(xs, ys);
         return SignalXY(source, color);
+    }
+
+    /// <summary>
+    /// Place a stacked bar chart at a single position
+    /// </summary>
+    public BarPlot[] StackedRanges(List<(string name, double[] edgeValues)> ranges, IPalette? palette = null)
+    {
+        BarPlot[] bps = new BarPlot[ranges.Count];
+        for (int i = 0; i < ranges.Count; i++)
+        {
+            double[] edgeValues = ranges[i].edgeValues;
+            Bar[] bars = new Bar[edgeValues.Length - 1];
+            for (int j = 0; j < bars.Length; j++)
+            {
+                bars[j] = new()
+                {
+                    ValueBase = edgeValues[j],
+                    Value = edgeValues[j + 1],
+                    Position = i,
+                    FillColor = (palette ?? Palette).GetColor(j),
+                };
+            }
+
+            bps[i] = Bars(bars);
+        }
+
+        string[] labels = ranges.Select(x => x.name).ToArray();
+        double[] positions = Generate.Consecutive(labels.Length);
+        Plot.Axes.Bottom.SetTicks(positions, labels);
+
+        return bps;
     }
 
     public Text Text(string text, Coordinates location)


### PR DESCRIPTION
This PR adds `Plot.Add.Ranges()` and `Plot.Add.StackedRanges()` helper methods to simplify the creation of charts which use bar plots to display ranges of values.

See cookbook for code examples.

Resolves #4548

![image](https://github.com/user-attachments/assets/ef9d945e-27ea-4a0c-8a93-c50ef0608cd6)

![image](https://github.com/user-attachments/assets/d7d9dc39-ced1-4dcf-b480-a7483aa4eae8)
