### PR TITLE
IPlotControl: add Multiplot

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
@@ -17,6 +17,7 @@ namespace ScottPlot.Avalonia;
 public class AvaPlot : Controls.Control, IPlotControl
 {
     public Plot Plot { get; internal set; }
+    public Multiplot Multiplot { get; internal set; }
 
     [Obsolete("Deprecated. Use UserInputProcessor instead. See ScottPlot.NET demo and FAQ for usage details.")]
     public IPlotInteraction Interaction { get; set; }
@@ -30,6 +31,7 @@ public class AvaPlot : Controls.Control, IPlotControl
     public AvaPlot()
     {
         Plot = new() { PlotControl = this };
+        Multiplot = new(Plot);
         ClipToBounds = true;
         DisplayScale = DetectDisplayScale();
         Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
@@ -87,6 +89,7 @@ public class AvaPlot : Controls.Control, IPlotControl
         Plot oldPlot = Plot;
         Plot = plot;
         oldPlot?.Dispose();
+        Multiplot.Reset(plot);
     }
 
     public void Refresh()

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/BlazorPlotBase.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/BlazorPlotBase.cs
@@ -14,6 +14,7 @@ public abstract class BlazorPlotBase : ComponentBase, IPlotControl
     public bool EnableRenderLoop { get; set; } = false;
 
     public Plot Plot { get; private set; }
+    public Multiplot Multiplot { get; internal set; }
 
     [Obsolete("Deprecated. Use UserInputProcessor instead. See ScottPlot.NET demo and FAQ for usage details.")]
     public IPlotInteraction Interaction { get; set; }
@@ -24,6 +25,7 @@ public abstract class BlazorPlotBase : ComponentBase, IPlotControl
     public BlazorPlotBase()
     {
         Plot = new() { PlotControl = this };
+        Multiplot = new(Plot);
         DisplayScale = DetectDisplayScale();
 
 #pragma warning disable CS0618 
@@ -52,6 +54,7 @@ public abstract class BlazorPlotBase : ComponentBase, IPlotControl
         Plot = plot;
         oldPlot?.Dispose();
         Plot.PlotControl = this;
+        Multiplot.Reset(Plot);
     }
 
     public virtual void Refresh() { }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Eto/EtoPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Eto/EtoPlot.cs
@@ -11,6 +11,7 @@ namespace ScottPlot.Eto;
 public class EtoPlot : Drawable, IPlotControl
 {
     public Plot Plot { get; internal set; }
+    public Multiplot Multiplot { get; internal set; }
     public GRContext? GRContext => null;
 
     [Obsolete("Deprecated. Use UserInputProcessor instead. See ScottPlot.NET demo and FAQ for usage details.")]
@@ -22,6 +23,7 @@ public class EtoPlot : Drawable, IPlotControl
     public EtoPlot()
     {
         Plot = new() { PlotControl = this };
+        Multiplot = new(Plot);
         DisplayScale = DetectDisplayScale();
         Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
         UserInputProcessor = new(this);
@@ -48,6 +50,7 @@ public class EtoPlot : Drawable, IPlotControl
         Plot oldPlot = Plot;
         Plot = plot;
         oldPlot?.Dispose();
+        Multiplot.Reset(Plot);
     }
 
     public void Refresh()

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlot.cs
@@ -8,6 +8,7 @@ namespace ScottPlot.Maui;
 public class MauiPlot : SKCanvasView, IPlotControl
 {
     public Plot Plot { get; internal set; } = new();
+    public Multiplot Multiplot { get; internal set; }
     public SkiaSharp.GRContext? GRContext => null;
 
     [Obsolete("Deprecated. Use UserInputProcessor instead. See ScottPlot.NET demo and FAQ for usage details.")]
@@ -20,6 +21,7 @@ public class MauiPlot : SKCanvasView, IPlotControl
     public MauiPlot()
     {
         Plot = new Plot() { PlotControl = this };
+        Multiplot = new(Plot);
         DisplayScale = DetectDisplayScale();
         Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
         UserInputProcessor = new(this);
@@ -77,6 +79,8 @@ public class MauiPlot : SKCanvasView, IPlotControl
     public void Reset(Plot plot)
     {
         Plot = plot;
+        Plot.PlotControl = this;
+        Multiplot.Reset(plot);
     }
 
     public void Refresh()

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotBase.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotBase.cs
@@ -15,6 +15,7 @@ public abstract class WpfPlotBase : System.Windows.Controls.Control, IPlotContro
     public abstract void Refresh();
 
     public Plot Plot { get; internal set; }
+    public Multiplot Multiplot { get; internal set; }
 
     [Obsolete("Deprecated. Use UserInputProcessor instead. See ScottPlot.NET demo and FAQ for usage details.")]
     public IPlotInteraction Interaction { get; set; }
@@ -33,6 +34,7 @@ public abstract class WpfPlotBase : System.Windows.Controls.Control, IPlotContro
     public WpfPlotBase()
     {
         Plot = new Plot() { PlotControl = this };
+        Multiplot = new(Plot);
         DisplayScale = DetectDisplayScale();
         Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
         UserInputProcessor = new(this);
@@ -51,6 +53,7 @@ public abstract class WpfPlotBase : System.Windows.Controls.Control, IPlotContro
         Plot = newPlot;
         oldPlot?.Dispose();
         Plot.PlotControl = this;
+        Multiplot.Reset(newPlot);
     }
 
     public void ShowContextMenu(Pixel position)

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlot.cs
@@ -73,7 +73,7 @@ public class FormsPlot : FormsPlotBase
 
     private void SKElement_PaintSurface(object? sender, SKPaintSurfaceEventArgs e)
     {
-        Plot.Render(e.Surface);
+        Multiplot.Render(e.Surface);
     }
 
     public override void Refresh()

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotBase.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotBase.cs
@@ -56,8 +56,7 @@ public abstract class FormsPlotBase : UserControl, IPlotControl
         try
         {
             Plot = new() { PlotControl = this };
-            Multiplot = new();
-            Multiplot.AddPlot(Plot);
+            Multiplot = new(Plot);
             DisplayScale = DetectDisplayScale();
             Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
             UserInputProcessor = new(this);
@@ -117,8 +116,7 @@ public abstract class FormsPlotBase : UserControl, IPlotControl
         if (disposeOldPlot)
             oldPlot?.Dispose();
         Plot.PlotControl = this;
-        Multiplot.Plots.Clear();
-        Multiplot.Plots.Add(plot);
+        Multiplot.Reset(plot);
     }
 
     public void ShowContextMenu(Pixel position)

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotBase.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotBase.cs
@@ -4,9 +4,6 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
-using System.Reflection;
-using System.Reflection.Emit;
-using System.Text;
 using System.Windows.Forms;
 
 namespace ScottPlot.WinForms;
@@ -22,6 +19,10 @@ public abstract class FormsPlotBase : UserControl, IPlotControl
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     [Browsable(false)]
     public Plot Plot { get; internal set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    [Browsable(false)]
+    public Multiplot Multiplot { get; internal set; }
 
     [Obsolete("Deprecated. Use UserInputProcessor instead. See ScottPlot.NET demo and FAQ for usage details.")]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -47,6 +48,7 @@ public abstract class FormsPlotBase : UserControl, IPlotControl
     public FormsPlotBase()
     {
         Plot = null!;
+        Multiplot = null!;
         Interaction = null!;
         UserInputProcessor = null!;
         bool isDesignMode = Process.GetCurrentProcess().ProcessName == "devenv";
@@ -54,11 +56,17 @@ public abstract class FormsPlotBase : UserControl, IPlotControl
         try
         {
             Plot = new() { PlotControl = this };
+            Multiplot = new();
+            Multiplot.AddPlot(Plot);
             DisplayScale = DetectDisplayScale();
             Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
             UserInputProcessor = new(this);
             Menu = new FormsPlotMenu(this);
-            Plot.Title(isDesignMode ? $"ScottPlot {Version.VersionString}" : string.Empty);
+
+            if (isDesignMode)
+            {
+                Plot.Title($"ScottPlot {Version.VersionString}");
+            }
         }
         catch (Exception exception)
         {
@@ -109,6 +117,8 @@ public abstract class FormsPlotBase : UserControl, IPlotControl
         if (disposeOldPlot)
             oldPlot?.Dispose();
         Plot.PlotControl = this;
+        Multiplot.Plots.Clear();
+        Multiplot.Plots.Add(plot);
     }
 
     public void ShowContextMenu(Pixel position)

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/WinUIPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/WinUIPlot.cs
@@ -12,6 +12,7 @@ namespace ScottPlot.WinUI;
 public partial class WinUIPlot : UserControl, IPlotControl
 {
     public Plot Plot { get; internal set; }
+    public Multiplot Multiplot { get; internal set; }
     public SkiaSharp.GRContext? GRContext => null;
 
     [Obsolete("Deprecated. Use UserInputProcessor instead. See ScottPlot.NET demo and FAQ for usage details.")]
@@ -26,6 +27,7 @@ public partial class WinUIPlot : UserControl, IPlotControl
     public WinUIPlot()
     {
         Plot = new() { PlotControl = this };
+        Multiplot = new(Plot);
         Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
         UserInputProcessor = new(this);
         Menu = new WinUIPlotMenu(this);
@@ -75,6 +77,7 @@ public partial class WinUIPlot : UserControl, IPlotControl
     {
         Plot = plot;
         Plot.PlotControl = this;
+        Multiplot.Reset(plot);
     }
 
     public void Refresh()

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.Designer.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.Designer.cs
@@ -28,34 +28,94 @@ partial class Form1
     /// </summary>
     private void InitializeComponent()
     {
-            this.formsPlot1 = new ScottPlot.WinForms.FormsPlot();
-            this.SuspendLayout();
-            // 
-            // formsPlot1
-            // 
-            this.formsPlot1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.formsPlot1.DisplayScale = 1F;
-            this.formsPlot1.Location = new System.Drawing.Point(12, 12);
-            this.formsPlot1.Name = "formsPlot1";
-            this.formsPlot1.Size = new System.Drawing.Size(483, 287);
-            this.formsPlot1.TabIndex = 1;
-            // 
-            // Form1
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(507, 311);
-            this.Controls.Add(this.formsPlot1);
-            this.Name = "Form1";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "ScottPlot 5 - Windows Forms Sandbox";
-            this.ResumeLayout(false);
-
+        formsPlot1 = new ScottPlot.WinForms.FormsPlot();
+        tableLayoutPanel1 = new TableLayoutPanel();
+        groupBox1 = new GroupBox();
+        groupBox2 = new GroupBox();
+        formsPlot2 = new ScottPlot.WinForms.FormsPlot();
+        tableLayoutPanel1.SuspendLayout();
+        groupBox1.SuspendLayout();
+        groupBox2.SuspendLayout();
+        SuspendLayout();
+        // 
+        // formsPlot1
+        // 
+        formsPlot1.DisplayScale = 1F;
+        formsPlot1.Dock = DockStyle.Fill;
+        formsPlot1.Location = new Point(3, 19);
+        formsPlot1.Margin = new Padding(4, 3, 4, 3);
+        formsPlot1.Name = "formsPlot1";
+        formsPlot1.Size = new Size(536, 387);
+        formsPlot1.TabIndex = 1;
+        // 
+        // tableLayoutPanel1
+        // 
+        tableLayoutPanel1.ColumnCount = 2;
+        tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+        tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+        tableLayoutPanel1.Controls.Add(groupBox1, 0, 0);
+        tableLayoutPanel1.Controls.Add(groupBox2, 1, 0);
+        tableLayoutPanel1.Dock = DockStyle.Fill;
+        tableLayoutPanel1.Location = new Point(0, 0);
+        tableLayoutPanel1.Name = "tableLayoutPanel1";
+        tableLayoutPanel1.RowCount = 1;
+        tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+        tableLayoutPanel1.Size = new Size(1096, 415);
+        tableLayoutPanel1.TabIndex = 2;
+        // 
+        // groupBox1
+        // 
+        groupBox1.Controls.Add(formsPlot1);
+        groupBox1.Dock = DockStyle.Fill;
+        groupBox1.Location = new Point(3, 3);
+        groupBox1.Name = "groupBox1";
+        groupBox1.Size = new Size(542, 409);
+        groupBox1.TabIndex = 0;
+        groupBox1.TabStop = false;
+        groupBox1.Text = "Default";
+        // 
+        // groupBox2
+        // 
+        groupBox2.Controls.Add(formsPlot2);
+        groupBox2.Dock = DockStyle.Fill;
+        groupBox2.Location = new Point(551, 3);
+        groupBox2.Name = "groupBox2";
+        groupBox2.Size = new Size(542, 409);
+        groupBox2.TabIndex = 1;
+        groupBox2.TabStop = false;
+        groupBox2.Text = "Multiplot";
+        // 
+        // formsPlot2
+        // 
+        formsPlot2.DisplayScale = 1F;
+        formsPlot2.Dock = DockStyle.Fill;
+        formsPlot2.Location = new Point(3, 19);
+        formsPlot2.Margin = new Padding(4, 3, 4, 3);
+        formsPlot2.Name = "formsPlot2";
+        formsPlot2.Size = new Size(536, 387);
+        formsPlot2.TabIndex = 2;
+        // 
+        // Form1
+        // 
+        AutoScaleDimensions = new SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
+        ClientSize = new Size(1096, 415);
+        Controls.Add(tableLayoutPanel1);
+        Margin = new Padding(4, 3, 4, 3);
+        Name = "Form1";
+        StartPosition = FormStartPosition.CenterScreen;
+        Text = "ScottPlot 5 - Windows Forms Sandbox";
+        tableLayoutPanel1.ResumeLayout(false);
+        groupBox1.ResumeLayout(false);
+        groupBox2.ResumeLayout(false);
+        ResumeLayout(false);
     }
 
     #endregion
 
     private ScottPlot.WinForms.FormsPlot formsPlot1;
+    private TableLayoutPanel tableLayoutPanel1;
+    private GroupBox groupBox1;
+    private GroupBox groupBox2;
+    private ScottPlot.WinForms.FormsPlot formsPlot2;
 }

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
@@ -8,11 +8,13 @@ public partial class Form1 : Form
     {
         InitializeComponent();
 
-        // the Plot is actually the single Plot inside a Multiplot
+        // default
         formsPlot1.Plot.Add.Signal(Generate.Sin());
+        formsPlot1.Plot.Add.Signal(Generate.Cos());
 
-        // subplots can be created and added to the plot
-        var plot2 = formsPlot1.Multiplot.AddPlot();
+        // multiplot
+        formsPlot2.Plot.Add.Signal(Generate.Sin());
+        var plot2 = formsPlot2.Multiplot.AddPlot();
         plot2.Add.Signal(Generate.Cos());
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
@@ -8,8 +8,11 @@ public partial class Form1 : Form
     {
         InitializeComponent();
 
-        double[,] data = ScottPlot.SampleData.MonaLisa();
-        var hm = formsPlot1.Plot.Add.Heatmap(data);
-        hm.Extent = new(-3500, 3500, -3500, 3500);
+        // the Plot is actually the single Plot inside a Multiplot
+        formsPlot1.Plot.Add.Signal(Generate.Sin());
+
+        // subplots can be created and added to the plot
+        var plot2 = formsPlot1.Multiplot.AddPlot();
+        plot2.Add.Signal(Generate.Cos());
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.resx
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IPlotControl.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IPlotControl.cs
@@ -3,9 +3,14 @@
 public interface IPlotControl
 {
     /// <summary>
-    /// The <see cref="Plot"/> displayed by this interactive control
+    /// The primary <see cref="Plot"/> displayed by this interactive control
     /// </summary>
     Plot Plot { get; }
+
+    /// <summary>
+    /// The multiplot managed by this interactive control
+    /// </summary>
+    Multiplot? Multiplot { get; } // TODO: make this non-nullable
 
     /// <summary>
     /// Render the plot and update the image

--- a/src/ScottPlot5/ScottPlot5/Multiplot.cs
+++ b/src/ScottPlot5/ScottPlot5/Multiplot.cs
@@ -10,11 +10,6 @@ public class Multiplot
 
     }
 
-    public Multiplot(IEnumerable<Plot> plots)
-    {
-
-    }
-
     public void AddPlot(Plot plot) => Plots.Add(plot);
 
     public Plot AddPlot()
@@ -26,18 +21,27 @@ public class Multiplot
 
     public void AddPlots(IEnumerable<Plot> plots) => Plots.AddRange(plots);
 
+    public void Render(SKSurface surface)
+    {
+        Render(surface.Canvas, surface.Canvas.LocalClipBounds.ToPixelRect());
+    }
+
+    public void Render(SKCanvas canvas, PixelRect figureRect)
+    {
+        foreach ((FractionRect fracRect, Plot plot) in Layout.GetLayout(Plots))
+        {
+            PixelRect subPlotRect = fracRect.GetPixelRect((int)figureRect.Width, (int)figureRect.Height);
+            plot.RenderManager.ClearCanvasBeforeEachRender = false;
+            plot.Render(canvas, subPlotRect);
+        }
+    }
+
     public Image Render(int width, int height)
     {
         SKImageInfo imageInfo = new(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
         SKSurface surface = SKSurface.Create(imageInfo);
-
-        foreach ((FractionRect rect, Plot plot) in Layout.GetLayout(Plots))
-        {
-            PixelRect pxRect = rect.GetPixelRect(width, height);
-            plot.RenderManager.ClearCanvasBeforeEachRender = false;
-            plot.Render(surface.Canvas, pxRect);
-        }
-
+        PixelRect rect = new(0, width, height, 0);
+        Render(surface.Canvas, rect);
         return new(surface);
     }
 

--- a/src/ScottPlot5/ScottPlot5/Multiplot.cs
+++ b/src/ScottPlot5/ScottPlot5/Multiplot.cs
@@ -10,6 +10,25 @@ public class Multiplot
 
     }
 
+    public Multiplot(Plot initialPlot)
+    {
+        Plots.Add(initialPlot);
+    }
+
+    public Multiplot(IEnumerable<Plot> initialPlots)
+    {
+        foreach (Plot plot in initialPlots)
+        {
+            Plots.Add(plot);
+        }
+    }
+
+    public void Reset(Plot plot)
+    {
+        Plots.Clear();
+        Plots.Add(plot);
+    }
+
     public void AddPlot(Plot plot) => Plots.Add(plot);
 
     public Plot AddPlot(bool matchStyle = true)

--- a/src/ScottPlot5/ScottPlot5/Multiplot.cs
+++ b/src/ScottPlot5/ScottPlot5/Multiplot.cs
@@ -12,10 +12,19 @@ public class Multiplot
 
     public void AddPlot(Plot plot) => Plots.Add(plot);
 
-    public Plot AddPlot()
+    public Plot AddPlot(bool matchStyle = true)
     {
         Plot plot = new();
+
+        if (matchStyle && Plots.Count > 0)
+        {
+            Plot previous = Plots.Last();
+            plot.DataBackground.Color = previous.DataBackground.Color;
+            plot.FigureBackground.Color = previous.FigureBackground.Color;
+        }
+
         Plots.Add(plot);
+
         return plot;
     }
 

--- a/src/ScottPlot5/ScottPlot5/Testing/MockPlotControl.cs
+++ b/src/ScottPlot5/ScottPlot5/Testing/MockPlotControl.cs
@@ -15,6 +15,8 @@ public class MockPlotControl : IPlotControl
     public Pixel Center => new(Width / 2, Height / 2);
 
     public Plot Plot { get; private set; }
+
+    public Multiplot Multiplot { get; private set; }
     public GRContext? GRContext => null;
 
     public IPlotInteraction Interaction { get; set; }
@@ -29,6 +31,7 @@ public class MockPlotControl : IPlotControl
     public MockPlotControl()
     {
         Plot = new() { PlotControl = this };
+        Multiplot = new(Plot);
 
 #pragma warning disable CS0618 
         Interaction = new Control.Interaction(this); // TODO: remove in an upcoming release
@@ -61,6 +64,7 @@ public class MockPlotControl : IPlotControl
         Plot = plot;
         Plot.PlotControl = this;
         oldPlot.Dispose();
+        Multiplot.Reset(plot);
     }
 
     public int ContextMenuLaunchCount { get; private set; } = 0;


### PR DESCRIPTION
This PR adds `Multiplot` to `IPlotControl` and improves its support for rendering onto existing surfaces.

This work is part of a multi-step process to add interactive multi-plot support to user controls (#4600)