### PR TITLE
Plot: deprecate PlotControl

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotViewer.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlotViewer.cs
@@ -4,7 +4,6 @@ public static class WpfPlotViewer
 {
     public static void Launch(Plot plot, string title = "", int width = 600, int height = 400)
     {
-        IPlotControl? originalControl = plot.PlotControl;
         WpfPlot wpfPlot = new();
         wpfPlot.Reset(plot);
         System.Windows.Window win = new()
@@ -15,7 +14,6 @@ public static class WpfPlotViewer
             Title = title,
             Content = wpfPlot,
         };
-        win.Closed += (s, e) => plot.PlotControl = originalControl;
         win.ShowDialog();
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotViewer.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotViewer.cs
@@ -24,9 +24,7 @@ public static class FormsPlotViewer
 
     public static void Launch(Plot plot, string title = "", int width = 600, int height = 400, bool blocking = true)
     {
-        IPlotControl? originalControl = plot.PlotControl;
         Form form = CreateForm(plot, title, width, height);
-        form.FormClosed += (s, e) => plot.PlotControl = originalControl;
 
         if (blocking)
             form.ShowDialog();

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -1008,7 +1008,7 @@ public class AxisManager
     /// </summary>
     public void SquareUnits()
     {
-        IAxisRule rule = Plot.PlotControl is null
+        IAxisRule rule = !Plot.HasParentControl
             ? new AxisRules.SquareZoomOut(Bottom, Left) // best for console apps
             : new AxisRules.SquarePreserveX(Bottom, Left); // best for interactive apps
 
@@ -1172,13 +1172,13 @@ public class AxisManager
 
         foreach (Plot plot in plotsNeedingUpdates)
         {
-            if (plot.PlotControl is null)
+            if (!plot.HasParentControl)
             {
                 plot.RenderInMemory();
             }
             else
             {
-                plot.PlotControl.Refresh();
+                plot.ParentControlRefresh();
             }
         }
     }

--- a/src/ScottPlot5/ScottPlot5/Interactivity/MouseAxisManipulation.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/MouseAxisManipulation.cs
@@ -48,7 +48,6 @@ public static class MouseAxisManipulation
     {
         mouseDown = mouseDown.Divide(plot.ScaleFactorF);
         mouseNow = mouseNow.Divide(plot.ScaleFactorF);
-        IPlotControl control = plot.PlotControl ?? throw new NullReferenceException();
 
         float pixelDeltaX = -(mouseNow.X - mouseDown.X);
         float pixelDeltaY = mouseNow.Y - mouseDown.Y;
@@ -89,7 +88,6 @@ public static class MouseAxisManipulation
     {
         mouseDown = mouseDown.Divide(plot.ScaleFactorF);
         mouseNow = mouseNow.Divide(plot.ScaleFactorF);
-        IPlotControl control = plot.PlotControl ?? throw new NullReferenceException();
 
         float pixelDeltaX = mouseNow.X - mouseDown.X;
         float pixelDeltaY = -(mouseNow.Y - mouseDown.Y);

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/SingleClickContextMenu.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/SingleClickContextMenu.cs
@@ -4,7 +4,7 @@ public class SingleClickContextMenu(MouseButton button) : SingleClickResponse(bu
 {
     public static void LaunchContextMenu(Plot plot, Pixel pixel)
     {
-        plot.PlotControl?.ShowContextMenu(pixel);
+        plot.ParentControlShowContextMenu(pixel);
     }
 }
 

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -49,9 +49,19 @@ public class Plot : IDisposable
     public object Sync { get; } = new();
 
     /// <summary>
-    /// The user control this plot belongs to
+    /// Wire this plot to be aware of the interactive control it is part of
     /// </summary>
-    public IPlotControl? PlotControl { get; set; } = null;
+    public IPlotControl? PlotControl
+    {
+        set
+        {
+            ParentControl = value;
+        }
+    }
+
+    private IPlotControl? ParentControl = null;
+
+    public bool HasParentControl => ParentControl is not null;
 
     public Plot()
     {
@@ -675,6 +685,22 @@ public class Plot : IDisposable
         {
             panel.ShowDebugInformation = enable;
         }
+    }
+
+    #endregion
+
+    #region Interactivity
+
+    // These methods were introduced to help reduce reliance on deprecated IPlotControl.Interaction and Plot.PlotControl classes
+
+    internal void ParentControlRefresh()
+    {
+        ParentControl?.Refresh();
+    }
+
+    internal void ParentControlShowContextMenu(Pixel position)
+    {
+        ParentControl?.ShowContextMenu(position);
     }
 
     #endregion


### PR DESCRIPTION
This PR removes `Plot.PlotControl` to ensure no logic reaches into a `Plot` to grab its control for the purposes of interacting with it directly. This is in preparation for implementing interactive mulit-plot controls where the `Multiplot` should hold the control, not each `Plot` (although it is preferable that an implementation strategy be devised which passes the `IPlotControl` through calling functions only if/as needed).

This work is part of a multi-step process to add interactive multi-plot support to user controls (https://github.com/ScottPlot/ScottPlot/issues/4600)