### PR TITLE
IPlotControl: support multiplot interactivity

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlot.cs
@@ -44,6 +44,7 @@ public class FormsPlot : FormsPlotBase
         SKControl.DoubleClick += SKElement_DoubleClick;
         SKControl.MouseWheel += SKElement_MouseWheel;
         SKControl.KeyDown += SKElement_KeyDown;
+        SKControl.PreviewKeyDown += SKControl_PreviewKeyDown;
         SKControl.KeyUp += SKElement_KeyUp;
         SKControl.LostFocus += SKElement_LostFocus;
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotBase.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotBase.cs
@@ -150,6 +150,12 @@ public abstract class FormsPlotBase : UserControl, IPlotControl
         base.OnKeyDown(e);
     }
 
+    internal void SKControl_PreviewKeyDown(object? sender, PreviewKeyDownEventArgs e)
+    {
+        UserInputProcessor.ProcessKeyDown(e);
+        base.OnPreviewKeyDown(e);
+    }
+
     internal void SKElement_KeyUp(object? sender, KeyEventArgs e)
     {
         UserInputProcessor.ProcessKeyUp(e);

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotExtensions.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/FormsPlotExtensions.cs
@@ -67,6 +67,13 @@ public static class FormsPlotExtensions
         processor.Process(action);
     }
 
+    public static void ProcessKeyDown(this Interactivity.UserInputProcessor processor, PreviewKeyDownEventArgs e)
+    {
+        Interactivity.Key key = e.GetKey();
+        Interactivity.IUserAction action = new Interactivity.UserActions.KeyDown(key);
+        processor.Process(action);
+    }
+
     public static void ProcessKeyUp(this Interactivity.UserInputProcessor processor, KeyEventArgs e)
     {
         Interactivity.Key key = e.GetKey();
@@ -80,6 +87,11 @@ public static class FormsPlotExtensions
     }
 
     internal static Interactivity.Key GetKey(this KeyEventArgs e)
+    {
+        return GetKey(e.KeyCode);
+    }
+
+    internal static Interactivity.Key GetKey(this PreviewKeyDownEventArgs e)
     {
         return GetKey(e.KeyCode);
     }

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/CustomMouseActions.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/CustomMouseActions.cs
@@ -64,7 +64,7 @@ public partial class CustomMouseActions : Form, IDemoWindow
 
             // Q key autoscale too
             var autoscaleKey = new ScottPlot.Interactivity.Key("Q");
-            Action<ScottPlot.Plot, ScottPlot.Pixel> autoscaleAction = (plot, pixel) => plot.Axes.AutoScale();
+            Action<ScottPlot.IPlotControl, ScottPlot.Pixel> autoscaleAction = (plotControl, pixel) => plotControl.Plot.Axes.AutoScale();
             var autoscaleKeyResponse = new ScottPlot.Interactivity.UserActionResponses.KeyPressResponse(autoscaleKey, autoscaleAction);
             formsPlot1.UserInputProcessor.UserActionResponses.Add(autoscaleKeyResponse);
 

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.Designer.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.Designer.cs
@@ -29,93 +29,31 @@ partial class Form1
     private void InitializeComponent()
     {
         formsPlot1 = new ScottPlot.WinForms.FormsPlot();
-        tableLayoutPanel1 = new TableLayoutPanel();
-        groupBox1 = new GroupBox();
-        groupBox2 = new GroupBox();
-        formsPlot2 = new ScottPlot.WinForms.FormsPlot();
-        tableLayoutPanel1.SuspendLayout();
-        groupBox1.SuspendLayout();
-        groupBox2.SuspendLayout();
         SuspendLayout();
         // 
         // formsPlot1
         // 
         formsPlot1.DisplayScale = 1F;
         formsPlot1.Dock = DockStyle.Fill;
-        formsPlot1.Location = new Point(3, 19);
-        formsPlot1.Margin = new Padding(4, 3, 4, 3);
+        formsPlot1.Location = new Point(0, 0);
         formsPlot1.Name = "formsPlot1";
-        formsPlot1.Size = new Size(536, 387);
-        formsPlot1.TabIndex = 1;
-        // 
-        // tableLayoutPanel1
-        // 
-        tableLayoutPanel1.ColumnCount = 2;
-        tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-        tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
-        tableLayoutPanel1.Controls.Add(groupBox1, 0, 0);
-        tableLayoutPanel1.Controls.Add(groupBox2, 1, 0);
-        tableLayoutPanel1.Dock = DockStyle.Fill;
-        tableLayoutPanel1.Location = new Point(0, 0);
-        tableLayoutPanel1.Name = "tableLayoutPanel1";
-        tableLayoutPanel1.RowCount = 1;
-        tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
-        tableLayoutPanel1.Size = new Size(1096, 415);
-        tableLayoutPanel1.TabIndex = 2;
-        // 
-        // groupBox1
-        // 
-        groupBox1.Controls.Add(formsPlot1);
-        groupBox1.Dock = DockStyle.Fill;
-        groupBox1.Location = new Point(3, 3);
-        groupBox1.Name = "groupBox1";
-        groupBox1.Size = new Size(542, 409);
-        groupBox1.TabIndex = 0;
-        groupBox1.TabStop = false;
-        groupBox1.Text = "Default";
-        // 
-        // groupBox2
-        // 
-        groupBox2.Controls.Add(formsPlot2);
-        groupBox2.Dock = DockStyle.Fill;
-        groupBox2.Location = new Point(551, 3);
-        groupBox2.Name = "groupBox2";
-        groupBox2.Size = new Size(542, 409);
-        groupBox2.TabIndex = 1;
-        groupBox2.TabStop = false;
-        groupBox2.Text = "Multiplot";
-        // 
-        // formsPlot2
-        // 
-        formsPlot2.DisplayScale = 1F;
-        formsPlot2.Dock = DockStyle.Fill;
-        formsPlot2.Location = new Point(3, 19);
-        formsPlot2.Margin = new Padding(4, 3, 4, 3);
-        formsPlot2.Name = "formsPlot2";
-        formsPlot2.Size = new Size(536, 387);
-        formsPlot2.TabIndex = 2;
+        formsPlot1.Size = new Size(669, 415);
+        formsPlot1.TabIndex = 0;
         // 
         // Form1
         // 
         AutoScaleDimensions = new SizeF(7F, 15F);
         AutoScaleMode = AutoScaleMode.Font;
-        ClientSize = new Size(1096, 415);
-        Controls.Add(tableLayoutPanel1);
+        ClientSize = new Size(669, 415);
+        Controls.Add(formsPlot1);
         Margin = new Padding(4, 3, 4, 3);
         Name = "Form1";
         StartPosition = FormStartPosition.CenterScreen;
         Text = "ScottPlot 5 - Windows Forms Sandbox";
-        tableLayoutPanel1.ResumeLayout(false);
-        groupBox1.ResumeLayout(false);
-        groupBox2.ResumeLayout(false);
         ResumeLayout(false);
     }
 
     #endregion
 
     private ScottPlot.WinForms.FormsPlot formsPlot1;
-    private TableLayoutPanel tableLayoutPanel1;
-    private GroupBox groupBox1;
-    private GroupBox groupBox2;
-    private ScottPlot.WinForms.FormsPlot formsPlot2;
 }

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
@@ -8,13 +8,11 @@ public partial class Form1 : Form
     {
         InitializeComponent();
 
-        // default
+        // work with the plot like normal
         formsPlot1.Plot.Add.Signal(Generate.Sin());
-        formsPlot1.Plot.Add.Signal(Generate.Cos());
 
-        // multiplot
-        formsPlot2.Plot.Add.Signal(Generate.Sin());
-        var plot2 = formsPlot2.Multiplot.AddPlot();
+        // add a sub-plot and interact with it
+        var plot2 = formsPlot1.Multiplot.AddPlot();
         plot2.Add.Signal(Generate.Cos());
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Interactivity/IUserActionResponse.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/IUserActionResponse.cs
@@ -8,7 +8,7 @@ public interface IUserActionResponse
     /// <summary>
     /// Perform the given action on the specified plot and return a result indicating what to do next.
     /// </summary>
-    ResponseInfo Execute(Plot plot, IUserAction userActions, KeyboardState keys);
+    ResponseInfo Execute(IPlotControl plotControl, IUserAction userActions, KeyboardState keys);
 
     /// <summary>
     /// Reset state to what it was when the action response was first created.
@@ -16,5 +16,5 @@ public interface IUserActionResponse
     /// control loses and re-gains focus or is disabled and re-enabled) and
     /// is designed to reset responses like mouse-drag events that accumulate state.
     /// </summary>
-    void ResetState(Plot plot);
+    void ResetState(IPlotControl plotControl);
 }

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/DoubleClickBenchmark.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/DoubleClickBenchmark.cs
@@ -2,8 +2,12 @@
 
 public class DoubleClickBenchmark(MouseButton button) : DoubleClickResponse(button, ToggleBenchmarkVisibility)
 {
-    public static void ToggleBenchmarkVisibility(Plot plot, Pixel pixel)
+    public static void ToggleBenchmarkVisibility(IPlotControl plotControl, Pixel pixel)
     {
+        Plot? plot = plotControl.GetPlotAtPixel(pixel);
+        if (plot is null)
+            return;
+
         plot.Benchmark.IsVisible = !plot.Benchmark.IsVisible;
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/DoubleClickResponse.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/DoubleClickResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace ScottPlot.Interactivity.UserActionResponses;
 
-public class DoubleClickResponse(MouseButton button, Action<Plot, Pixel> action) : IUserActionResponse
+public class DoubleClickResponse(MouseButton button, Action<IPlotControl, Pixel> action) : IUserActionResponse
 {
     /// <summary>
     /// Which mouse button to watch for double-clicks.
@@ -11,7 +11,7 @@ public class DoubleClickResponse(MouseButton button, Action<Plot, Pixel> action)
     /// This action is invoked when a double-click occurs.
     /// Replace this action with your own logic to customize double-click behavior.
     /// </summary>
-    public Action<Plot, Pixel> ResponseAction { get; } = action;
+    public Action<IPlotControl, Pixel> ResponseAction { get; } = action;
 
     /// <summary>
     /// Consecutive clicks are only considered a double-click if the time between the first
@@ -23,14 +23,14 @@ public class DoubleClickResponse(MouseButton button, Action<Plot, Pixel> action)
 
     private DateTime PreviousMouseDownTime = DateTime.MinValue;
 
-    public void ResetState(Plot plot)
+    public void ResetState(IPlotControl plotControl)
     {
         // Don't reset mouse click times because resets may occur after MouseUp events
         // and double-clicks are unlikely to last long enouigh to persist through legitimate resets.
         // https://github.com/ScottPlot/ScottPlot/issues/4524
     }
 
-    public ResponseInfo Execute(Plot plot, IUserAction userAction, KeyboardState keys)
+    public ResponseInfo Execute(IPlotControl plotControl, IUserAction userAction, KeyboardState keys)
     {
         if (userAction is IMouseButtonAction mouseAction && mouseAction.Button == MouseButton)
         {
@@ -45,7 +45,7 @@ public class DoubleClickResponse(MouseButton button, Action<Plot, Pixel> action)
                 TimeSpan timeSinceFirstMouseDown = mouseAction.DateTime - PreviousMouseDownTime;
                 if (timeSinceFirstMouseDown < MaximumTimeBetweenClicks)
                 {
-                    ResponseAction.Invoke(plot, mouseAction.Pixel);
+                    ResponseAction.Invoke(plotControl, mouseAction.Pixel);
                     LatestMouseDownTime = DateTime.MinValue; // reset time so a third click won't toggle it back
                     return ResponseInfo.Refresh;
                 }

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/KeyPressResponse.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/KeyPressResponse.cs
@@ -2,25 +2,23 @@
 
 namespace ScottPlot.Interactivity.UserActionResponses;
 
-public class KeyPressResponse(Key key, Action<Plot, Pixel> action) : IUserActionResponse
+public class KeyPressResponse(Key key, Action<IPlotControl, Pixel> action) : IUserActionResponse
 {
     Key Key { get; } = key;
 
-    Action<Plot, Pixel> ResponseAction { get; } = action;
+    Action<IPlotControl, Pixel> ResponseAction { get; } = action;
 
-    public void ResetState(Plot plot) { }
+    public void ResetState(IPlotControl plotControl) { }
 
-    public ResponseInfo Execute(Plot plot, IUserAction userAction, KeyboardState keys)
+    public ResponseInfo Execute(IPlotControl plotControl, IUserAction userAction, KeyboardState keys)
     {
         if (userAction is KeyDown keyDownAction)
         {
             if (keyDownAction.Key == Key)
             {
-                ResponseAction.Invoke(plot, Pixel.NaN);
-
+                ResponseAction.Invoke(plotControl, Pixel.NaN);
                 return ResponseInfo.Refresh;
             }
-
         }
 
         return ResponseInfo.NoActionRequired;

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/KeyPressResponse.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/KeyPressResponse.cs
@@ -10,13 +10,21 @@ public class KeyPressResponse(Key key, Action<IPlotControl, Pixel> action) : IUs
 
     public void ResetState(IPlotControl plotControl) { }
 
+    Pixel MousePixel = Pixel.Zero;
+
     public ResponseInfo Execute(IPlotControl plotControl, IUserAction userAction, KeyboardState keys)
     {
+        if (userAction is MouseMove mouseMove)
+        {
+            MousePixel = mouseMove.Pixel;
+            return ResponseInfo.NoActionRequired;
+        }
+
         if (userAction is KeyDown keyDownAction)
         {
             if (keyDownAction.Key == Key)
             {
-                ResponseAction.Invoke(plotControl, Pixel.NaN);
+                ResponseAction.Invoke(plotControl, MousePixel);
                 return ResponseInfo.Refresh;
             }
         }

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/KeyboardAutoscale.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/KeyboardAutoscale.cs
@@ -2,8 +2,12 @@
 
 internal class KeyboardAutoscale(Key key) : KeyPressResponse(key, AutoScale)
 {
-    public static void AutoScale(Plot plot, Pixel pixel)
+    public static void AutoScale(IPlotControl plotControl, Pixel pixel)
     {
+        Plot? plot = plotControl.GetPlotAtPixel(pixel);
+        if (plot is null)
+            return;
+
         plot.Axes.AutoScale();
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/KeyboardPanAndZoom.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/KeyboardPanAndZoom.cs
@@ -1,4 +1,6 @@
-﻿namespace ScottPlot.Interactivity.UserActionResponses;
+﻿using ScottPlot.Interactivity.UserActions;
+
+namespace ScottPlot.Interactivity.UserActionResponses;
 
 public class KeyboardPanAndZoom : IUserActionResponse
 {
@@ -31,32 +33,41 @@ public class KeyboardPanAndZoom : IUserActionResponse
 
     public void ResetState(IPlotControl plotControl) { }
 
+    Pixel MousePixel = Pixel.Zero;
+
     public ResponseInfo Execute(IPlotControl plotControl, IUserAction userInput, KeyboardState keys)
     {
-        if (userInput is UserActions.KeyDown keyDown)
+        if (userInput is MouseMove mouseMove)
         {
-            foreach (Plot plot in plotControl.Multiplot.Plots)
-            {
-                if (keys.IsPressed(ZoomModifierKey))
-                {
-                    if (keyDown.Key == PanLeftKey) return ApplyZoom(plot, DeltaZoomIn, 1);
-                    else if (keyDown.Key == PanRightKey) return ApplyZoom(plot, DeltaZoomOut, 1);
-                    else if (keyDown.Key == PanDownKey) return ApplyZoom(plot, 1, DeltaZoomIn);
-                    else if (keyDown.Key == PanUpKey) return ApplyZoom(plot, 1, DeltaZoomOut);
-                    else return ResponseInfo.NoActionRequired;
-                }
-                else
-                {
-                    float delta = StepDistance;
-                    if (keys.IsPressed(LargeStepKey)) delta = LargeStepDistance;
-                    if (keys.IsPressed(FineStepKey)) delta = FineStepDistance;
+            MousePixel = mouseMove.Pixel;
+            return ResponseInfo.NoActionRequired;
+        }
 
-                    if (keyDown.Key == PanLeftKey) return ApplyPan(plot, -delta, 0);
-                    else if (keyDown.Key == PanRightKey) return ApplyPan(plot, delta, 0);
-                    else if (keyDown.Key == PanDownKey) return ApplyPan(plot, 0, -delta);
-                    else if (keyDown.Key == PanUpKey) return ApplyPan(plot, 0, delta);
-                    else return ResponseInfo.NoActionRequired;
-                }
+        if (userInput is KeyDown keyDown)
+        {
+            Plot? plot = plotControl.GetPlotAtPixel(MousePixel);
+            if (plot is null)
+            {
+                return ResponseInfo.NoActionRequired;
+            }
+
+            if (keys.IsPressed(ZoomModifierKey))
+            {
+                if (keyDown.Key == PanLeftKey) return ApplyZoom(plot, DeltaZoomIn, 1);
+                else if (keyDown.Key == PanRightKey) return ApplyZoom(plot, DeltaZoomOut, 1);
+                else if (keyDown.Key == PanDownKey) return ApplyZoom(plot, 1, DeltaZoomIn);
+                else if (keyDown.Key == PanUpKey) return ApplyZoom(plot, 1, DeltaZoomOut);
+            }
+            else
+            {
+                float delta = StepDistance;
+                if (keys.IsPressed(LargeStepKey)) delta = LargeStepDistance;
+                if (keys.IsPressed(FineStepKey)) delta = FineStepDistance;
+
+                if (keyDown.Key == PanLeftKey) return ApplyPan(plot, -delta, 0);
+                else if (keyDown.Key == PanRightKey) return ApplyPan(plot, delta, 0);
+                else if (keyDown.Key == PanDownKey) return ApplyPan(plot, 0, -delta);
+                else if (keyDown.Key == PanUpKey) return ApplyPan(plot, 0, delta);
             }
         }
 

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/KeyboardPanAndZoom.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/KeyboardPanAndZoom.cs
@@ -29,31 +29,34 @@ public class KeyboardPanAndZoom : IUserActionResponse
     public double DeltaZoomIn { get; set; } = 0.85f;
     public double DeltaZoomOut { get; set; } = 1.15f;
 
-    public void ResetState(Plot plot) { }
+    public void ResetState(IPlotControl plotControl) { }
 
-    public ResponseInfo Execute(Plot plot, IUserAction userInput, KeyboardState keys)
+    public ResponseInfo Execute(IPlotControl plotControl, IUserAction userInput, KeyboardState keys)
     {
         if (userInput is UserActions.KeyDown keyDown)
         {
-            if (keys.IsPressed(ZoomModifierKey))
+            foreach (Plot plot in plotControl.Multiplot.Plots)
             {
-                if (keyDown.Key == PanLeftKey) return ApplyZoom(plot, DeltaZoomIn, 1);
-                else if (keyDown.Key == PanRightKey) return ApplyZoom(plot, DeltaZoomOut, 1);
-                else if (keyDown.Key == PanDownKey) return ApplyZoom(plot, 1, DeltaZoomIn);
-                else if (keyDown.Key == PanUpKey) return ApplyZoom(plot, 1, DeltaZoomOut);
-                else return ResponseInfo.NoActionRequired;
-            }
-            else
-            {
-                float delta = StepDistance;
-                if (keys.IsPressed(LargeStepKey)) delta = LargeStepDistance;
-                if (keys.IsPressed(FineStepKey)) delta = FineStepDistance;
+                if (keys.IsPressed(ZoomModifierKey))
+                {
+                    if (keyDown.Key == PanLeftKey) return ApplyZoom(plot, DeltaZoomIn, 1);
+                    else if (keyDown.Key == PanRightKey) return ApplyZoom(plot, DeltaZoomOut, 1);
+                    else if (keyDown.Key == PanDownKey) return ApplyZoom(plot, 1, DeltaZoomIn);
+                    else if (keyDown.Key == PanUpKey) return ApplyZoom(plot, 1, DeltaZoomOut);
+                    else return ResponseInfo.NoActionRequired;
+                }
+                else
+                {
+                    float delta = StepDistance;
+                    if (keys.IsPressed(LargeStepKey)) delta = LargeStepDistance;
+                    if (keys.IsPressed(FineStepKey)) delta = FineStepDistance;
 
-                if (keyDown.Key == PanLeftKey) return ApplyPan(plot, -delta, 0);
-                else if (keyDown.Key == PanRightKey) return ApplyPan(plot, delta, 0);
-                else if (keyDown.Key == PanDownKey) return ApplyPan(plot, 0, -delta);
-                else if (keyDown.Key == PanUpKey) return ApplyPan(plot, 0, delta);
-                else return ResponseInfo.NoActionRequired;
+                    if (keyDown.Key == PanLeftKey) return ApplyPan(plot, -delta, 0);
+                    else if (keyDown.Key == PanRightKey) return ApplyPan(plot, delta, 0);
+                    else if (keyDown.Key == PanDownKey) return ApplyPan(plot, 0, -delta);
+                    else if (keyDown.Key == PanUpKey) return ApplyPan(plot, 0, delta);
+                    else return ResponseInfo.NoActionRequired;
+                }
             }
         }
 

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseDragZoom.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseDragZoom.cs
@@ -46,19 +46,24 @@ public class MouseDragZoom(MouseButton button) : IUserActionResponse
     /// </summary>
     public bool ChangeOpposingAxesTogether { get; set; } = false;
 
-    public void ResetState(Plot plot)
+    public void ResetState(IPlotControl plotControl)
     {
         RememberedLimits = null;
         MouseDownPixel = Pixel.NaN;
     }
 
-    public ResponseInfo Execute(Plot plot, IUserAction userInput, KeyboardState keys)
+    public ResponseInfo Execute(IPlotControl plotControl, IUserAction userInput, KeyboardState keys)
     {
         if (userInput is IMouseButtonAction mouseDownAction && mouseDownAction.Button == MouseButton && mouseDownAction.IsPressed)
         {
             MouseDownPixel = mouseDownAction.Pixel;
-            RememberedLimits = new(plot);
-            return new ResponseInfo() { IsPrimary = false };
+            Plot? plot = plotControl.GetPlotAtPixel(mouseDownAction.Pixel);
+
+            if (plot is not null)
+            {
+                RememberedLimits = new(plot);
+                return new ResponseInfo() { IsPrimary = false };
+            }
         }
 
         if (MouseDownPixel == Pixel.NaN)
@@ -66,17 +71,23 @@ public class MouseDragZoom(MouseButton button) : IUserActionResponse
 
         if (userInput is IMouseButtonAction mouseUpAction && mouseUpAction.Button == MouseButton && !mouseUpAction.IsPressed)
         {
-            RememberedLimits?.Recall();
-            ApplyToPlot(plot, MouseDownPixel, mouseUpAction.Pixel, keys);
-            MouseDownPixel = Pixel.NaN;
-            return ResponseInfo.Refresh;
+            if (RememberedLimits is not null)
+            {
+                RememberedLimits.Recall();
+                ApplyToPlot(RememberedLimits.Plot, MouseDownPixel, mouseUpAction.Pixel, keys);
+                MouseDownPixel = Pixel.NaN;
+                return ResponseInfo.Refresh;
+            }
         }
 
         if (userInput is IMouseAction mouseMoveAction)
         {
-            RememberedLimits?.Recall();
-            ApplyToPlot(plot, MouseDownPixel, mouseMoveAction.Pixel, keys);
-            return new ResponseInfo() { RefreshNeeded = true, IsPrimary = true };
+            if (RememberedLimits is not null)
+            {
+                RememberedLimits.Recall();
+                ApplyToPlot(RememberedLimits.Plot, MouseDownPixel, mouseMoveAction.Pixel, keys);
+                return new ResponseInfo() { RefreshNeeded = true, IsPrimary = true };
+            }
         }
 
         return new ResponseInfo() { IsPrimary = true };

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseWheelZoom.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/MouseWheelZoom.cs
@@ -16,7 +16,7 @@ public class MouseWheelZoom(Key horizontalLockKey, Key verticalLockKey) : IUserA
 
     Key LockVerticalKey { get; } = verticalLockKey;
 
-    public void ResetState(Plot plot) { }
+    public void ResetState(IPlotControl plotControl) { }
 
     /// <summary>
     /// Fraction of the axis range to change when zooming in and out.
@@ -26,10 +26,14 @@ public class MouseWheelZoom(Key horizontalLockKey, Key verticalLockKey) : IUserA
     private double ZoomInFraction => 1 + ZoomFraction;
     private double ZoomOutFraction => 1 / ZoomInFraction;
 
-    public ResponseInfo Execute(Plot plot, IUserAction userInput, KeyboardState keys)
+    public ResponseInfo Execute(IPlotControl plotControl, IUserAction userInput, KeyboardState keys)
     {
         if (userInput is UserActions.MouseWheelUp mouseDownInput)
         {
+            Plot? plot = plotControl.GetPlotAtPixel(mouseDownInput.Pixel);
+            if (plot is null) 
+                return ResponseInfo.NoActionRequired;
+
             double xFrac = keys.IsPressed(LockHorizontalKey) ? 1 : ZoomInFraction;
             double yFrac = keys.IsPressed(LockVerticalKey) ? 1 : ZoomInFraction;
             MouseAxisManipulation.MouseWheelZoom(plot, xFrac, yFrac, mouseDownInput.Pixel, LockParallelAxes);
@@ -38,6 +42,10 @@ public class MouseWheelZoom(Key horizontalLockKey, Key verticalLockKey) : IUserA
 
         if (userInput is UserActions.MouseWheelDown mouseUpInput)
         {
+            Plot? plot = plotControl.GetPlotAtPixel(mouseUpInput.Pixel);
+            if (plot is null) 
+                return ResponseInfo.NoActionRequired;
+
             double xFrac = keys.IsPressed(LockHorizontalKey) ? 1 : ZoomOutFraction;
             double yFrac = keys.IsPressed(LockVerticalKey) ? 1 : ZoomOutFraction;
             MouseAxisManipulation.MouseWheelZoom(plot, xFrac, yFrac, mouseUpInput.Pixel, LockParallelAxes);

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/SingleClickAutoscale.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/SingleClickAutoscale.cs
@@ -2,8 +2,12 @@
 
 public class SingleClickAutoscale(MouseButton button) : SingleClickResponse(button, AutoScale)
 {
-    public static void AutoScale(Plot plot, Pixel pixel)
+    public static void AutoScale(IPlotControl plotControl, Pixel pixel)
     {
+        Plot? plot = plotControl.GetPlotAtPixel(pixel);
+        if (plot is null)
+            return;
+
         MouseAxisManipulation.AutoScale(plot, pixel, false);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/SingleClickContextMenu.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/SingleClickContextMenu.cs
@@ -2,8 +2,12 @@
 
 public class SingleClickContextMenu(MouseButton button) : SingleClickResponse(button, LaunchContextMenu)
 {
-    public static void LaunchContextMenu(Plot plot, Pixel pixel)
+    public static void LaunchContextMenu(IPlotControl plotControl, Pixel pixel)
     {
+        Plot? plot = plotControl.GetPlotAtPixel(pixel);
+        if (plot is null)
+            return;
+
         plot.ParentControlShowContextMenu(pixel);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/SingleClickResponse.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/SingleClickResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace ScottPlot.Interactivity.UserActionResponses;
 
-public class SingleClickResponse(MouseButton button, Action<Plot, Pixel> action) : IUserActionResponse
+public class SingleClickResponse(MouseButton button, Action<IPlotControl, Pixel> action) : IUserActionResponse
 {
     /// <summary>
     /// Which mouse button to watch for single-click events
@@ -10,22 +10,28 @@ public class SingleClickResponse(MouseButton button, Action<Plot, Pixel> action)
     /// <summary>
     /// This action is invoked when a single-click occurs.
     /// </summary>
-    public Action<Plot, Pixel> ResponseAction { get; } = action;
+    public Action<IPlotControl, Pixel> ResponseAction { get; } = action;
 
     /// <summary>
     /// Location of the previous mouse down event
     /// </summary>
     private Pixel MouseDownPixel = Pixel.NaN;
 
-    public void ResetState(Plot plot)
+    public void ResetState(IPlotControl plotControl)
     {
         MouseDownPixel = Pixel.NaN;
     }
 
-    public ResponseInfo Execute(Plot plot, IUserAction userAction, KeyboardState keys)
+    public ResponseInfo Execute(IPlotControl plotControl, IUserAction userAction, KeyboardState keys)
     {
         if (userAction is IMouseButtonAction buttonAction && buttonAction.Button == MouseButton)
         {
+            Plot? plot = plotControl.GetPlotAtPixel(buttonAction.Pixel);
+            if (plot is null)
+            {
+                return ResponseInfo.NoActionRequired;
+            }
+
             if (buttonAction.IsPressed)
             {
                 MouseDownPixel = buttonAction.Pixel;
@@ -46,7 +52,7 @@ public class SingleClickResponse(MouseButton button, Action<Plot, Pixel> action)
                     return ResponseInfo.NoActionRequired;
                 }
 
-                ResponseAction.Invoke(plot, buttonAction.Pixel);
+                ResponseAction.Invoke(plotControl, buttonAction.Pixel);
                 MouseDownPixel = Pixel.NaN;
 
                 return new ResponseInfo() { RefreshNeeded = true };

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserInputProcessor.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserInputProcessor.cs
@@ -1,9 +1,4 @@
-﻿using ScottPlot.Interactivity.UserActionResponses;
-using System.Reflection.Emit;
-
-namespace ScottPlot.Interactivity;
-
-#pragma warning disable CS0618 // disable obsolete Interaction warning
+﻿namespace ScottPlot.Interactivity;
 
 /// <summary>
 /// This class collects user inputs and performs responses to manipulate a Plot.
@@ -20,7 +15,7 @@ public class UserInputProcessor
     /// <summary>
     /// Tracks which keys are currently pressed
     /// </summary>
-    public readonly KeyboardState KeyState;
+    public readonly KeyboardState KeyState = new();
 
     /// <summary>
     /// Controls whether new events are processed.
@@ -60,7 +55,6 @@ public class UserInputProcessor
     public UserInputProcessor(IPlotControl plotControl)
     {
         PlotControl = plotControl;
-        KeyState = new();
         Reset();
         IsEnabled = true;
     }

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserInputProcessor.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserInputProcessor.cs
@@ -194,7 +194,7 @@ public class UserInputProcessor
     {
         foreach (var response in plotControl.UserInputProcessor.UserActionResponses)
         {
-            response.ResetState(plotControl.Plot);
+            response.ResetState(plotControl);
         }
 
         plotControl.UserInputProcessor.KeyState.Reset();
@@ -232,7 +232,7 @@ public class UserInputProcessor
                     continue;
                 }
 
-                ResponseInfo info = response.Execute(PlotControl.Plot, userAction, KeyState);
+                ResponseInfo info = response.Execute(PlotControl, userAction, KeyState);
                 if (info.RefreshNeeded)
                     refreshNeeded = true;
 

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IPlotControl.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IPlotControl.cs
@@ -10,7 +10,7 @@ public interface IPlotControl
     /// <summary>
     /// The multiplot managed by this interactive control
     /// </summary>
-    Multiplot? Multiplot { get; } // TODO: make this non-nullable
+    Multiplot Multiplot { get; }
 
     /// <summary>
     /// Render the plot and update the image
@@ -60,4 +60,12 @@ public interface IPlotControl
     /// Loads the given Plot into the control
     /// </summary>
     void Reset(Plot plot);
+}
+
+public static class IPlotControlExtensions
+{
+    public static Plot? GetPlotAtPixel(this IPlotControl plotControl, Pixel pixel)
+    {
+        return plotControl.Multiplot.GetPlotAtPixel(pixel);
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/MultiAxisLimits.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/MultiAxisLimits.cs
@@ -6,6 +6,8 @@
 /// </summary>
 public class MultiAxisLimits(Plot plot)
 {
+    public readonly Plot Plot = plot;
+
     private readonly Dictionary<IAxis, CoordinateRange> AxisRanges = plot.Axes.GetAxes()
         .ToDictionary(x => x, x => x.Range.ToCoordinateRange);
 

--- a/src/ScottPlot5/ScottPlot5/Testing/MockPlotControl.cs
+++ b/src/ScottPlot5/ScottPlot5/Testing/MockPlotControl.cs
@@ -44,7 +44,7 @@ public class MockPlotControl : IPlotControl
     public void Refresh()
     {
         RefreshCount += 1;
-        Plot.RenderInMemory(Width, Height);
+        Multiplot.Render(Width, Height);
     }
 
     public void Reset()


### PR DESCRIPTION
This PR updates all `UserInputProcessor` code to pass an `IPlotControl` instead of a `Plot` and adds logic to determine which `Plot` is under the mouse and forward events to that item. This PR is part of #4600

**A single control may now be used to display multiple interactive plots!** This should allow for easier implementation of plots with shared axes and shared layouts because we no longer have to sync settings across multiple plot controls.

```cs
// work with the plot like normal
formsPlot1.Plot.Add.Signal(Generate.Sin());

// add a sub-plot and interact with it
var plot2 = formsPlot1.Multiplot.AddPlot();
plot2.Add.Signal(Generate.Cos());
```

![multiplot2](https://github.com/user-attachments/assets/d637f4be-e036-4422-bf9b-a66dac857149)