### PR TITLE
Multiplot: add support for shared axis limits

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/MultiplotRecipes.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/MultiplotRecipes.cs
@@ -86,9 +86,9 @@ public class MultiplotRecipes : ICategory
             }
 
             // manually set the position for each plot
-            multiplot.PositionedPlots[0].Position = new ScottPlot.SubplotPositions.GridCell(0, 0, 2, 1);
-            multiplot.PositionedPlots[1].Position = new ScottPlot.SubplotPositions.GridCell(1, 0, 2, 2);
-            multiplot.PositionedPlots[2].Position = new ScottPlot.SubplotPositions.GridCell(1, 1, 2, 2);
+            multiplot.SetPosition(0, new ScottPlot.SubplotPositions.GridCell(0, 0, 2, 1));
+            multiplot.SetPosition(1, new ScottPlot.SubplotPositions.GridCell(1, 0, 2, 2));
+            multiplot.SetPosition(2, new ScottPlot.SubplotPositions.GridCell(1, 1, 2, 2));
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
@@ -8,20 +8,16 @@ public partial class Form1 : Form
     {
         InitializeComponent();
 
-        // work with the plot like normal
-        formsPlot1.Plot.Add.Signal(Generate.Sin());
+        Plot[] subplots = formsPlot1.Multiplot.AddPlots(4);
 
-        // add a sub-plot and interact with it
-        var plot2 = formsPlot1.Multiplot.AddPlot();
-        plot2.Add.Signal(Generate.Cos());
+        for (int i = 0; i < subplots.Length; i++)
+        {
+            double scale = Math.Pow(10, i);
+            double[] data = Generate.RandomWalk(100, scale*2);
+            subplots[i].Add.Signal(data);
+            subplots[i].Title($"Subplot {i + 1}");
+        }
 
-        // add another sub-plot
-        var plot3 = formsPlot1.Multiplot.AddPlot();
-        plot3.Add.Signal(Generate.AddNoise(Generate.Sin()));
-
-        // use a custom layout
-        formsPlot1.Multiplot.PositionedPlots[0].Position = new ScottPlot.SubplotPositions.GridCell(0, 0, 2, 1);
-        formsPlot1.Multiplot.PositionedPlots[1].Position = new ScottPlot.SubplotPositions.GridCell(1, 0, 2, 2);
-        formsPlot1.Multiplot.PositionedPlots[2].Position = new ScottPlot.SubplotPositions.GridCell(1, 1, 2, 2);
+        formsPlot1.Multiplot.Layout = new ScottPlot.MultiplotLayouts.Grid(2, 2);
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
@@ -19,5 +19,11 @@ public partial class Form1 : Form
         }
 
         formsPlot1.Multiplot.Layout = new ScottPlot.MultiplotLayouts.Grid(2, 2);
+
+        // share the X axis for all subplots
+        formsPlot1.Multiplot.ShareX(subplots);
+
+        // share the Y axis for select subplots
+        formsPlot1.Multiplot.ShareY([subplots[0], subplots[1]]);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Multiplot.cs
+++ b/src/ScottPlot5/ScottPlot5/Multiplot.cs
@@ -1,40 +1,71 @@
 ﻿namespace ScottPlot;
 
-public class PositionedSubplot(Plot plot, ISubplotPosition position)
-{
-    public Plot Plot { get; set; } = plot;
-    public PixelRect LastRenderRect { get; set; } = PixelRect.NaN;
-    public ISubplotPosition Position { get; set; } = position;
-}
-
 public class Multiplot
 {
-    public int Count => PositionedPlots.Count;
-    public IEnumerable<Plot> Plots => PositionedPlots.Select(x => x.Plot);
-    public List<PositionedSubplot> PositionedPlots { get; } = [];
+    /// <summary>
+    /// Number of subplots in this multiplot
+    /// </summary>
+    public int Count => Subplots.Count;
+
+    /// <summary>
+    /// Copy styling options (e.g., background color) to new plots as they are added
+    /// </summary>
     bool StyleNewPlotsAutomatically { get; set; } = true;
 
     /// <summary>
-    /// This engine is used to resize all plots automatically every time new ones are added
+    /// This list contains plots, logic for positioning them, and records of where they were last rendered
     /// </summary>
-    public IMultiplotLayout? Layout { get; set; } = new ScottPlot.MultiplotLayouts.Rows();
+    private readonly List<PositionedSubplot> Subplots = [];
+    private class PositionedSubplot(Plot plot, ISubplotPosition position)
+    {
+        public Plot Plot { get; set; } = plot;
+        public PixelRect LastRenderRect { get; set; } = PixelRect.NaN;
+        public ISubplotPosition Position { get; set; } = position;
+    }
 
+    private IMultiplotLayout? _Layout = new MultiplotLayouts.Rows();
+
+    /// <summary>
+    /// This logic is used to create the initial layout for subplots in the multiplot
+    /// </summary>
+    public IMultiplotLayout? Layout
+    {
+        get => _Layout;
+        set
+        {
+            _Layout = value;
+            _Layout?.ResetAllPositions(this);
+        }
+    }
+
+    /// <summary>
+    /// Create a multiplot with no initial subplots
+    /// </summary>
     public Multiplot()
     {
 
     }
 
+    /// <summary>
+    /// Create a multiplot with a single subplot
+    /// </summary>
     public Multiplot(Plot plot)
     {
         AddPlot(plot);
     }
 
+    /// <summary>
+    /// Reset this multiplot so it only contains the given plot
+    /// </summary>
     public void Reset(Plot plot)
     {
-        PositionedPlots.Clear();
+        Subplots.Clear();
         AddPlot(plot);
     }
 
+    /// <summary>
+    /// Create a new plot, add it as a subplot, and return it
+    /// </summary>
     public Plot AddPlot()
     {
         Plot plot = new();
@@ -42,28 +73,102 @@ public class Multiplot
         return plot;
     }
 
+    /// <summary>
+    /// Add the given plot as a subplot into this multiplot
+    /// </summary>
     public void AddPlot(Plot plot)
     {
-        if (StyleNewPlotsAutomatically && PositionedPlots.Count > 0)
+        if (StyleNewPlotsAutomatically && Subplots.Count > 0)
         {
-            Plot lastPlot = PositionedPlots.Last().Plot;
+            Plot lastPlot = Subplots.Last().Plot;
             plot.FigureBackground.Color = lastPlot.FigureBackground.Color;
             plot.DataBackground.Color = lastPlot.DataBackground.Color;
         }
 
         PositionedSubplot positionedPlot = new(plot, new SubplotPositions.Full());
-        PositionedPlots.Add(positionedPlot);
+        Subplots.Add(positionedPlot);
         Layout?.ResetAllPositions(this);
     }
 
+    /// <summary>
+    /// Add (or remove) plots until the given number of subplots is achieved
+    /// </summary>
+    public Plot[] AddPlots(int total)
+    {
+        while (Count > total)
+        {
+            Subplots.RemoveAt(Subplots.Count - 1);
+        }
+
+        while (Count < total)
+        {
+            AddPlot();
+        }
+
+        return GetPlots();
+    }
+
+    /// <summary>
+    /// Return all plots in this multiplot
+    /// </summary>
+    public Plot[] GetPlots()
+    {
+        return Subplots.Select(x => x.Plot).ToArray();
+    }
+
+    /// <summary>
+    /// Set the position of the given subplot
+    /// </summary>
+    public void SetPosition(Plot plot, ISubplotPosition position)
+    {
+        for (int i = 0; i < Subplots.Count; i++)
+        {
+            if (Subplots[i].Plot == plot)
+            {
+                Subplots[i].Position = position;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Set the position of the given subplot index
+    /// </summary>
+    public void SetPosition(int plotIndex, ISubplotPosition position)
+    {
+        Subplots[plotIndex].Position = position;
+    }
+
+    /// <summary>
+    /// Get the pixel rectangle where the given subplot was last rendered.
+    /// Returns PixelRect.NaN if a render has not yet occurred.
+    /// </summary>
+    public PixelRect GetLastRenderRectangle(Plot plot)
+    {
+        foreach (var pos in Subplots)
+        {
+            if (pos.Plot == plot)
+            {
+                return pos.LastRenderRect;
+            }
+        }
+
+        throw new KeyNotFoundException();
+    }
+
+    /// <summary>
+    /// Render the multiplot into the clip boundary of the given surface.
+    /// </summary>
     public void Render(SKSurface surface)
     {
         Render(surface.Canvas, surface.Canvas.LocalClipBounds.ToPixelRect());
     }
 
+    /// <summary>
+    /// Render the multiplot on a canvas inside the given rectangle.
+    /// </summary>
     public void Render(SKCanvas canvas, PixelRect figureRect)
     {
-        foreach (var positionedPlot in PositionedPlots)
+        foreach (var positionedPlot in Subplots)
         {
             PixelRect subPlotRect = positionedPlot.Position.GetRect(figureRect);
             positionedPlot.LastRenderRect = subPlotRect;
@@ -72,6 +177,9 @@ public class Multiplot
         }
     }
 
+    /// <summary>
+    /// Create a new image, render the multiplot onto it, and return it
+    /// </summary>
     public Image Render(int width, int height)
     {
         SKImageInfo imageInfo = new(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
@@ -81,14 +189,21 @@ public class Multiplot
         return new(surface);
     }
 
+    /// <summary>
+    /// Save the multiplot as a PNG image file
+    /// </summary>
     public SavedImageInfo SavePng(string filename, int width = 800, int height = 600)
     {
         return Render(width, height).SavePng(filename);
     }
 
+    /// <summary>
+    /// Return the plot beneath the given pixel according to the last render.
+    /// Returns null if no render occurred or the pixel is not over a plot.
+    /// </summary>
     public Plot? GetPlotAtPixel(Pixel pixel)
     {
-        foreach (var positionedPlot in PositionedPlots)
+        foreach (var positionedPlot in Subplots)
         {
             if (positionedPlot.LastRenderRect.Contains(pixel))
                 return positionedPlot.Plot;

--- a/src/ScottPlot5/ScottPlot5/MultiplotLayouts/Columns.cs
+++ b/src/ScottPlot5/ScottPlot5/MultiplotLayouts/Columns.cs
@@ -5,10 +5,11 @@ public class Columns : IMultiplotLayout
     public void ResetAllPositions(Multiplot multiplot)
     {
         double fractionPerColumn = 1.0 / multiplot.Count;
-        for (int i = 0; i < multiplot.PositionedPlots.Count; i++)
+        for (int i = 0; i < multiplot.Count; i++)
         {
             FractionRect fr = new(fractionPerColumn * i, 0, fractionPerColumn, 1);
-            multiplot.PositionedPlots[i].Position = new SubplotPositions.Fractional(fr);
+            ISubplotPosition position = new SubplotPositions.Fractional(fr);
+            multiplot.SetPosition(i, position);
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/MultiplotLayouts/Grid.cs
+++ b/src/ScottPlot5/ScottPlot5/MultiplotLayouts/Grid.cs
@@ -7,12 +7,13 @@ public class Grid(int rows, int columns) : IMultiplotLayout
         double fractionPerRow = 1.0 / rows;
         double fractionPerColumn = 1.0 / columns;
 
-        for (int i = 0; i < multiplot.PositionedPlots.Count; i++)
+        for (int i = 0; i < multiplot.Count; i++)
         {
-            int rowIndex = columns / i;
+            int rowIndex = i / columns;
             int columnIndex = i % columns;
-            FractionRect fr = new(fractionPerColumn * i, fractionPerRow * i, fractionPerColumn, fractionPerRow);
-            multiplot.PositionedPlots[i].Position = new SubplotPositions.Fractional(fr);
+            FractionRect fr = new(fractionPerColumn * columnIndex, fractionPerRow * rowIndex, fractionPerColumn, fractionPerRow);
+            ISubplotPosition position = new SubplotPositions.Fractional(fr);
+            multiplot.SetPosition(i, position);
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/MultiplotLayouts/Rows.cs
+++ b/src/ScottPlot5/ScottPlot5/MultiplotLayouts/Rows.cs
@@ -5,10 +5,11 @@ public class Rows : IMultiplotLayout
     public void ResetAllPositions(Multiplot multiplot)
     {
         double fractionPerRow = 1.0 / multiplot.Count;
-        for (int i = 0; i < multiplot.PositionedPlots.Count; i++)
+        for (int i = 0; i < multiplot.Count; i++)
         {
             FractionRect fr = new(0, fractionPerRow * i, 1, fractionPerRow);
-            multiplot.PositionedPlots[i].Position = new SubplotPositions.Fractional(fr);
+            ISubplotPosition position = new SubplotPositions.Fractional(fr);
+            multiplot.SetPosition(i, position);
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Primitives/AxisLimits.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/AxisLimits.cs
@@ -20,6 +20,8 @@ public readonly struct AxisLimits : IEquatable<AxisLimits>
 
     public CoordinateRange XRange => new(Left, Right);
     public CoordinateRange YRange => new(Bottom, Top);
+    public CoordinateRange HorizontalRange => XRange;
+    public CoordinateRange VerticalRange => YRange;
 
     // TODO: make sure callers aren't using this when they dont have to
     public CoordinateRect Rect => new(Left, Right, Bottom, Top);


### PR DESCRIPTION
This PR adds support for subplots with shared axis limits in mouse-interactive multiplots

This is part of a larger collection of work tracked by #4600

```cs
public Form1()
{
    InitializeComponent();

    Plot[] subplots = formsPlot1.Multiplot.AddPlots(4);

    for (int i = 0; i < subplots.Length; i++)
    {
        double scale = Math.Pow(10, i);
        double[] data = Generate.RandomWalk(100, scale*2);
        subplots[i].Add.Signal(data);
        subplots[i].Title($"Subplot {i + 1}");
    }

    formsPlot1.Multiplot.Layout = new ScottPlot.MultiplotLayouts.Grid(2, 2);

    // share the X axis for all subplots
    formsPlot1.Multiplot.ShareX(subplots);

    // share the Y axis for select subplots
    formsPlot1.Multiplot.ShareY([subplots[0], subplots[1]]);
}
```

![shared](https://github.com/user-attachments/assets/d54b1fe0-3634-436d-8280-8eec59cc593d)
