### PR TITLE
Multiplot: helper method to enable fixed layout for all subplots

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
@@ -25,5 +25,9 @@ public partial class Form1 : Form
 
         // share the Y axis for select subplots
         formsPlot1.Multiplot.ShareY([subplots[0], subplots[1]]);
+
+        // used manual padding to ensure subplot alignment
+        PixelPadding padding = new(50, 10, 25, 45);
+        formsPlot1.Multiplot.ApplyFixedPadding(padding);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Multiplot.cs
+++ b/src/ScottPlot5/ScottPlot5/Multiplot.cs
@@ -24,6 +24,11 @@ public class Multiplot
         public ISubplotPosition Position { get; set; } = position;
     }
 
+
+    // TODO: improve support for plots with non-standard axis limits
+    private readonly List<PositionedSubplot> PlotsWithSharedX = [];
+    private readonly List<PositionedSubplot> PlotsWithSharedY = [];
+
     private IMultiplotLayout? _Layout = new MultiplotLayouts.Rows();
 
     /// <summary>
@@ -239,14 +244,8 @@ public class Multiplot
         return null;
     }
 
-    // TODO: improve support for plots with non-standard axis limits
-    private List<PositionedSubplot> PlotsWithSharedX = [];
-    private List<PositionedSubplot> PlotsWithSharedY = [];
-
     private void UpdateSharedPlotAxisLimits()
     {
-        // TODO: this shouldn't be the FIRST with changed limits, 
-        // it should be the one that was last changed manually...
         Plot? parentPlotX = GetFirstPlotWithChangedLimitsX();
         if (parentPlotX is not null)
         {
@@ -290,15 +289,35 @@ public class Multiplot
         return null;
     }
 
+    /// <summary>
+    /// Link horizontal axis limits of the given collection of plots
+    /// so when one changes they all change in unison
+    /// </summary>
     public void ShareX(IEnumerable<Plot> plots)
     {
         PlotsWithSharedX.Clear();
         PlotsWithSharedX.AddRange(plots.Select(GetPositionedSubplot));
     }
 
+    /// <summary>
+    /// Link vertical axis limits of the given collection of plots
+    /// so when one changes they all change in unison
+    /// </summary>
     public void ShareY(IEnumerable<Plot> plots)
     {
         PlotsWithSharedY.Clear();
         PlotsWithSharedY.AddRange(plots.Select(GetPositionedSubplot));
+    }
+
+    /// <summary>
+    /// Apply the same fixed amount of padding to all subplots.
+    /// This ensures data area alignment in multi-plot figures.
+    /// </summary>
+    public void ApplyFixedPadding(PixelPadding padding)
+    {
+        foreach (var plot in GetPlots())
+        {
+            plot.Layout.Fixed(padding);
+        }
     }
 }


### PR DESCRIPTION
This PR adds `MultiPlot.ApplyFixedPadding()` to quickly apply a fixed size data area to all subplots ensuring alignment in multi-plot figures.

This work is part of #4600

default | fixed padding
---|---
![image](https://github.com/user-attachments/assets/bb5df74c-d1ea-4b63-92ab-6c0217de6c2d)|![image](https://github.com/user-attachments/assets/4fe4454f-08fa-4e6d-9819-12509e7e07f6)
