### PR TITLE
Cookbook: right axis only

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/MultiAxis.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/MultiAxis.cs
@@ -43,7 +43,7 @@ public class MultiAxis : ICategory
         public override void Execute()
         {
             // plottables use the standard X and Y axes by default
-            var sig1 = myPlot.Add.Signal(ScottPlot.Generate.Sin(51, mult: 0.01));
+            var sig1 = myPlot.Add.Signal(Generate.Sin(51, mult: 0.01));
             sig1.Axes.XAxis = myPlot.Axes.Bottom; // standard X axis
             sig1.Axes.YAxis = myPlot.Axes.Left; // standard Y axis
             myPlot.Axes.Left.Label.Text = "Primary Y Axis";
@@ -52,10 +52,37 @@ public class MultiAxis : ICategory
             var yAxis2 = myPlot.Axes.AddLeftAxis();
 
             // add a new plottable and tell it to use the custom Y axis
-            var sig2 = myPlot.Add.Signal(ScottPlot.Generate.Cos(51, mult: 100));
+            var sig2 = myPlot.Add.Signal(Generate.Cos(51, mult: 100));
             sig2.Axes.XAxis = myPlot.Axes.Bottom; // standard X axis
             sig2.Axes.YAxis = yAxis2; // custom Y axis
             yAxis2.LabelText = "Secondary Y Axis";
+        }
+    }
+
+    public class RightAxisOnly : RecipeBase
+    {
+        public override string Name => "Right Axis Only";
+        public override string Description => "The default Y axis is the one on the left of the plot, " +
+            "but the right Y axis may be used instead.";
+
+        [Test]
+        public override void Execute()
+        {
+            // add a plottable to the plot
+            var sig = myPlot.Add.Signal(Generate.Sin());
+
+            // configure the plottable to use the right Y axis
+            sig.Axes.YAxis = myPlot.Axes.Right;
+
+            // configure the grid to display ticks from the right Y axis
+            myPlot.Grid.YAxis = myPlot.Axes.Right;
+
+            // style the right axis as desired
+            myPlot.Axes.Right.Label.Text = "Hello, Right Axis";
+            myPlot.Axes.Right.Label.FontSize = 18;
+
+            // pass in the custom axis when calling SetLimits()
+            myPlot.Axes.SetLimitsY(bottom: -2, top: 2, yAxis: myPlot.Axes.Right);
         }
     }
 }


### PR DESCRIPTION
resolves #4565

```cs
// add a plottable to the plot
var sig = myPlot.Add.Signal(Generate.Sin());

// configure the plottable to use the right Y axis
sig.Axes.YAxis = myPlot.Axes.Right;

// configure the grid to display ticks from the right Y axis
myPlot.Grid.YAxis = myPlot.Axes.Right;

// style the right axis as desired
myPlot.Axes.Right.Label.Text = "Hello, Right Axis";
myPlot.Axes.Right.Label.FontSize = 18;

// pass in the custom axis when calling SetLimits()
myPlot.Axes.SetLimitsY(bottom: -2, top: 2, yAxis: myPlot.Axes.Right);
```

![image](https://github.com/user-attachments/assets/b443f2a6-c2e3-4c14-9412-0cecf61310a9)
