### PR TITLE
LinePlot: add `LineOnTop` and `MarkersOnTop` flags to control render order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _Not yet on NuGet..._
 * Legend: Made `GetItems()` virtual to support custom ordering logic and made `Plot.Legend` settable (#4571) @onur-akaydin
 * Controls: Improved middle-click-drag zoom rectangle support for plots using inverted axis limits (#4573) @xichaoqiang
 * Ticks: Improved tick placement consistency for financial plots with DateTime axes (#4591) @VladislavPustovarov
+* Line: Added `LineOnTop` and `MarkersOnTop` flags to control which components appear in front (#4610) @nullsoftware @quantfreedom
 
 ## ScottPlot 5.0.47
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-24_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Line.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Line.cs
@@ -90,7 +90,7 @@ public class LinePlot : ICategory
             line1.MarkerColor = Colors.Red;
             line1.MarkerSize = 20;
             line1.MarkerShape = MarkerShape.FilledCircle;
-            line1.LineOnTop = true;
+            line1.LineOnTop = true; // render order is controlled here
 
             var line2 = myPlot.Add.Line(0, 1, 1, 2);
             line2.LineColor = Colors.Orange;
@@ -98,7 +98,7 @@ public class LinePlot : ICategory
             line2.MarkerColor = Colors.Red;
             line2.MarkerSize = 20;
             line2.MarkerShape = MarkerShape.FilledCircle;
-            line2.MarkersOnTop = true;
+            line2.MarkersOnTop = true; // render order is controlled here
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Line.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Line.cs
@@ -74,5 +74,32 @@ public class LinePlot : ICategory
             myPlot.ShowLegend(Alignment.UpperRight);
         }
     }
+
+    public class LinePlotMarkerOrder : RecipeBase
+    {
+        public override string Name => "Line and Marker Order";
+        public override string Description => "Markers may be displayed at the ends of lines, " +
+            "and a flag controls whether the markers are drawn above or below the line.";
+
+        [Test]
+        public override void Execute()
+        {
+            var line1 = myPlot.Add.Line(0, 0, 1, 1);
+            line1.LineColor = Colors.Orange;
+            line1.LineWidth = 5;
+            line1.MarkerColor = Colors.Red;
+            line1.MarkerSize = 20;
+            line1.MarkerShape = MarkerShape.FilledCircle;
+            line1.LineOnTop = true;
+
+            var line2 = myPlot.Add.Line(0, 1, 1, 2);
+            line2.LineColor = Colors.Orange;
+            line2.LineWidth = 5;
+            line2.MarkerColor = Colors.Red;
+            line2.MarkerSize = 20;
+            line2.MarkerShape = MarkerShape.FilledCircle;
+            line2.MarkersOnTop = true;
+        }
+    }
 }
 

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Line.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Line.cs
@@ -92,7 +92,7 @@ public class LinePlot : ICategory
             line1.MarkerShape = MarkerShape.FilledCircle;
             line1.LineOnTop = true; // render order is controlled here
 
-            var line2 = myPlot.Add.Line(0, 1, 1, 2);
+            var line2 = myPlot.Add.Line(1, 0, 2, 1);
             line2.LineColor = Colors.Orange;
             line2.LineWidth = 5;
             line2.MarkerColor = Colors.Red;

--- a/src/ScottPlot5/ScottPlot5/Plottables/LinePlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/LinePlot.cs
@@ -62,13 +62,13 @@ public class LinePlot : IPlottable, IHasLine, IHasMarker, IHasLegendText
 
         if (LineOnTop)
         {
-            DrawLine(rp, paint);
             DrawMarkers(rp, paint);
+            DrawLine(rp, paint);
         }
         else
         {
-            DrawMarkers(rp, paint);
             DrawLine(rp, paint);
+            DrawMarkers(rp, paint);
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/LinePlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/LinePlot.cs
@@ -37,6 +37,9 @@ public class LinePlot : IPlottable, IHasLine, IHasMarker, IHasLegendText
     public LinePattern LinePattern { get => LineStyle.Pattern; set => LineStyle.Pattern = value; }
     public Color LineColor { get => LineStyle.Color; set => LineStyle.Color = value; }
 
+    public bool LineOnTop { get; set; } = true;
+    public bool MarkersOnTop { get => !LineOnTop; set => LineOnTop = !value; }
+
     public Color Color
     {
         get => LineStyle.Color;
@@ -55,12 +58,30 @@ public class LinePlot : IPlottable, IHasLine, IHasMarker, IHasLegendText
 
     public virtual void Render(RenderPack rp)
     {
-        CoordinateLine line = new(Start, End);
-        PixelLine pxLine = Axes.GetPixelLine(line);
-
         using SKPaint paint = new();
+
+        if (LineOnTop)
+        {
+            DrawLine(rp, paint);
+            DrawMarkers(rp, paint);
+        }
+        else
+        {
+            DrawMarkers(rp, paint);
+            DrawLine(rp, paint);
+        }
+    }
+
+    private void DrawMarkers(RenderPack rp, SKPaint paint)
+    {
         Drawing.DrawMarker(rp.Canvas, paint, Axes.GetPixel(Start), MarkerStyle);
         Drawing.DrawMarker(rp.Canvas, paint, Axes.GetPixel(End), MarkerStyle);
+    }
+
+    private void DrawLine(RenderPack rp, SKPaint paint)
+    {
+        CoordinateLine line = new(Start, End);
+        PixelLine pxLine = Axes.GetPixelLine(line);
         Drawing.DrawLine(rp.Canvas, paint, pxLine, LineStyle);
     }
 }


### PR DESCRIPTION
This PR adds `LineOnTop` and `MarkersOnTop` flags to control which components appear in front of `LinePlot` plottables

Resolves #4610

```cs
var line1 = myPlot.Add.Line(0, 0, 1, 1);
line1.LineColor = Colors.Orange;
line1.LineWidth = 5;
line1.MarkerColor = Colors.Red;
line1.MarkerSize = 20;
line1.MarkerShape = MarkerShape.FilledCircle;
line1.LineOnTop = true; // render order is controlled here

var line2 = myPlot.Add.Line(0, 1, 1, 2);
line2.LineColor = Colors.Orange;
line2.LineWidth = 5;
line2.MarkerColor = Colors.Red;
line2.MarkerSize = 20;
line2.MarkerShape = MarkerShape.FilledCircle;
line2.MarkersOnTop = true; // render order is controlled here
```

![image](https://github.com/user-attachments/assets/8bbca73f-504d-4412-bef0-636b891daa51)