### PR TITLE
IAxis: RemoveTickGenerator()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _Not yet on NuGet..._
 * Controls: Improved middle-click-drag zoom rectangle support for plots using inverted axis limits (#4573) @xichaoqiang
 * Ticks: Improved tick placement consistency for financial plots with DateTime axes (#4591) @VladislavPustovarov
 * Line: Added `LineOnTop` and `MarkersOnTop` flags to control which components appear in front (#4610) @nullsoftware @quantfreedom
+* Axes: Added a helper method allowing `Plot.Axes.Left.RemoveTickGenerator()` to quickly disable left axis tick generation (#2875, #4613, #4608, #4613)
 
 ## ScottPlot 5.0.47
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2024-11-24_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/MultiAxis.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/MultiAxis.cs
@@ -81,6 +81,9 @@ public class MultiAxis : ICategory
             myPlot.Axes.Right.Label.Text = "Hello, Right Axis";
             myPlot.Axes.Right.Label.FontSize = 18;
 
+            // it is recommended to remove tick generators from unused axes
+            myPlot.Axes.Left.RemoveTickGenerator();
+
             // pass in the custom axis when calling SetLimits()
             myPlot.Axes.SetLimitsY(bottom: -2, top: 2, yAxis: myPlot.Axes.Right);
         }

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IAxis.cs
@@ -75,4 +75,5 @@ public static class IAxisExtensions
 {
     public static CoordinateRange GetRange(this IAxis axis) => new(axis.Min, axis.Max);
     public static bool IsInverted(this IAxis axis) => axis.Min > axis.Max;
+    public static void RemoveTickGenerator(this IAxis axis) => axis.TickGenerator = new TickGenerators.EmptyTickGenerator();
 }


### PR DESCRIPTION
This PR adds a helper method to simplify removing ticks from unused axes

```cs
myPlot.Axes.Left.RemoveTickGenerator();
```

Related: #2875, #4613, #4608, #4613
