### PR TITLE
WPF: Pass render requests through the new Multiplot system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-## ScottPlot 5.0.49
+## ScottPlot 5.0.50
 _Not yet on NuGet..._
+
+## ScottPlot 5.0.49
+_Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-01-06_
+* WPF: Updated the WPF control to pass render requests though the new Multiplot system (#4666, #4667) @zygfrydw
 
 ## ScottPlot 5.0.48
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-01-05_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/ScottPlot.Avalonia.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/ScottPlot.Avalonia.csproj
@@ -10,7 +10,7 @@
 
         <!-- NuGet info -->
         <PackageId>ScottPlot.Avalonia</PackageId>
-        <Version>5.0.48</Version>
+        <Version>5.0.49</Version>
         <Authors>Scott Harden</Authors>
         <Company>Harden Technologies, LLC</Company>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/ScottPlot.Blazor.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/ScottPlot.Blazor.csproj
@@ -10,7 +10,7 @@
 
         <!-- NuGet info -->
         <PackageId>ScottPlot.Blazor</PackageId>
-        <Version>5.0.48</Version>
+        <Version>5.0.49</Version>
         <Authors>Scott Harden</Authors>
         <Company>Harden Technologies, LLC</Company>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Eto/ScottPlot.Eto.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Eto/ScottPlot.Eto.csproj
@@ -8,7 +8,7 @@
 
         <!-- NuGet info -->
         <PackageId>ScottPlot.Eto</PackageId>
-        <Version>5.0.48</Version>
+        <Version>5.0.49</Version>
         <Authors>Scott Harden</Authors>
         <Company>Harden Technologies, LLC</Company>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/ScottPlot.Maui.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/ScottPlot.Maui.csproj
@@ -22,7 +22,7 @@
 
         <!-- NuGet info -->
         <PackageId>ScottPlot.Maui</PackageId>
-        <Version>5.0.48</Version>
+        <Version>5.0.49</Version>
         <Authors>Scott Harden</Authors>
         <Company>Harden Technologies, LLC</Company>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/ScottPlot.OpenGL.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/ScottPlot.OpenGL.csproj
@@ -11,7 +11,7 @@
 
         <!-- NuGet info -->
         <PackageId>ScottPlot.OpenGL</PackageId>
-        <Version>5.0.48</Version>
+        <Version>5.0.49</Version>
         <Authors>Scott Harden</Authors>
         <Company>Harden Technologies, LLC</Company>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/ScottPlot.WPF.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/ScottPlot.WPF.csproj
@@ -10,7 +10,7 @@
 
         <!-- NuGet info -->
         <PackageId>ScottPlot.WPF</PackageId>
-        <Version>5.0.48</Version>
+        <Version>5.0.49</Version>
         <Authors>Scott Harden</Authors>
         <Company>Harden Technologies, LLC</Company>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/WpfPlot.cs
@@ -34,7 +34,7 @@ namespace ScottPlot.WPF
                 float width = (float)e.Surface.Canvas.LocalClipBounds.Width;
                 float height = (float)e.Surface.Canvas.LocalClipBounds.Height;
                 PixelRect rect = new(0, width, height, 0);
-                Plot.Render(e.Surface.Canvas, rect);
+                Multiplot.Render(e.Surface.Canvas, rect);
             };
 
             SKElement.MouseDown += SKElement_MouseDown;

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/ScottPlot.WinForms.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/ScottPlot.WinForms.csproj
@@ -13,7 +13,7 @@
 
         <!-- NuGet info -->
         <PackageId>ScottPlot.WinForms</PackageId>
-        <Version>5.0.48</Version>
+        <Version>5.0.49</Version>
         <Authors>Scott Harden</Authors>
         <Company>Harden Technologies, LLC</Company>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/ScottPlot.WinUI.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/ScottPlot.WinUI.csproj
@@ -11,7 +11,7 @@
 
         <!-- NuGet info -->
         <PackageId>ScottPlot.WinUI</PackageId>
-        <Version>5.0.48</Version>
+        <Version>5.0.49</Version>
         <Authors>Scott Harden</Authors>
         <Company>Harden Technologies, LLC</Company>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ScottPlot5/ScottPlot5/ScottPlot.csproj
+++ b/src/ScottPlot5/ScottPlot5/ScottPlot.csproj
@@ -10,7 +10,7 @@
 
         <!-- NuGet info -->
         <PackageId>ScottPlot</PackageId>
-        <Version>5.0.48</Version>
+        <Version>5.0.49</Version>
         <Authors>Scott Harden</Authors>
         <Company>Harden Technologies, LLC</Company>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
This PR fixes plot rendering plots for WPF by calling Render method on `Multiplot` instead of `Plot`. The issue is described here #4666

Fixes #4666.