### PR TITLE
Controls: improve multiplot support for context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ _Not yet on NuGet..._
 ## ScottPlot 5.0.50
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-01-06_
 * WPF: Updated the WPF control to pass render requests though the new Multiplot system (#4666, #4667) @zygfrydw @VladislavPustovarov
+* Palette: Added `GetColors()` extension method for creating an array of colors from an existing palette
 
 ## ScottPlot 5.0.48
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-01-05_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ _Not yet on NuGet..._
 ## ScottPlot 5.0.50
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-01-06_
 * WPF: Updated the WPF control to pass render requests though the new Multiplot system (#4666, #4667) @zygfrydw @VladislavPustovarov
+* Multiplot: Improved right-click context menu support for multi-plot user controls (#4671) @nilsakesson
 * Palette: Added `GetColors()` extension method for creating an array of colors from an existing palette
 
 ## ScottPlot 5.0.48

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/BlazorPlotMenu.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/BlazorPlotMenu.cs
@@ -15,7 +15,7 @@ public class BlazorPlotMenu : IPlotMenu
     {
     }
 
-    public void Add(string Label, Action<IPlotControl> action)
+    public void Add(string Label, Action<Plot> action)
     {
     }
 

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/CustomMenu.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/CustomMenu.cs
@@ -1,6 +1,4 @@
-﻿using FluentAssertions;
-using ScottPlot;
-using ScottPlot.WinForms;
+﻿using ScottPlot;
 
 namespace WinForms_Demo.Demos;
 
@@ -32,39 +30,39 @@ public partial class CustomMenu : Form, IDemoWindow
         formsPlot1.Menu?.Clear();
 
         // add menu items with custom actions
-        formsPlot1.Menu?.Add("Add Scatter", (formsplot1) =>
+        formsPlot1.Menu?.Add("Add Scatter", (plot) =>
         {
-            formsplot1.Plot.Add.Scatter(Generate.RandomCoordinates(5));
-            formsplot1.Plot.Axes.AutoScale();
-            formsplot1.Refresh();
+            plot.Add.Scatter(Generate.RandomCoordinates(5));
+            plot.Axes.AutoScale();
+            plot.PlotControl?.Refresh();
         });
 
-        formsPlot1.Menu?.Add("Add Line", (formsplot1) =>
+        formsPlot1.Menu?.Add("Add Line", (plot) =>
         {
-            var line = formsplot1.Plot.Add.Line(Generate.RandomLine());
+            var line = plot.Add.Line(Generate.RandomLine());
             line.LineWidth = 2;
             line.MarkerSize = 20;
-            formsplot1.Plot.Axes.AutoScale();
-            formsplot1.Refresh();
+            plot.Axes.AutoScale();
+            plot.PlotControl?.Refresh();
         });
 
-        formsPlot1.Menu?.Add("Add Text", (formsplot1) =>
+        formsPlot1.Menu?.Add("Add Text", (plot) =>
         {
-            var txt = formsplot1.Plot.Add.Text("Test", Generate.RandomLocation());
+            var txt = plot.Add.Text("Test", Generate.RandomLocation());
             txt.LabelFontSize = 10 + Generate.RandomInteger(20);
             txt.LabelFontColor = Generate.RandomColor(128);
             txt.LabelBold = true;
-            formsplot1.Plot.Axes.AutoScale();
-            formsplot1.Refresh();
+            plot.Axes.AutoScale();
+            plot.PlotControl?.Refresh();
         });
 
         formsPlot1.Menu?.AddSeparator();
 
-        formsPlot1.Menu?.Add("Clear", (formsplot1) =>
+        formsPlot1.Menu?.Add("Clear", (plot) =>
         {
-            formsplot1.Plot.Clear();
-            formsplot1.Plot.Axes.AutoScale();
-            formsplot1.Refresh();
+            plot.Clear();
+            plot.Axes.AutoScale();
+            plot.PlotControl?.Refresh();
         });
 
         formsPlot1.Plot.Title("Custom Right-Click Menu");

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -4,7 +4,7 @@ using SkiaSharp.Views.Desktop;
 
 namespace WinForms_Demo.Demos
 {
-    public partial class DetachedLegend : Form//, IDemoWindow
+    public partial class DetachedLegend : Form, IDemoWindow
     {
         public string Title => "Detachable Legend";
 

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/DetachedLegend.cs
@@ -28,15 +28,15 @@ namespace WinForms_Demo.Demos
             formsPlot1.Menu?.Add("Detach Legend", LaunchDetachedLegend);
         }
 
-        private void LaunchDetachedLegend(IPlotControl plotControl)
+        private void LaunchDetachedLegend(Plot plot)
         {
             // hide the legend in the original plot
-            plotControl.Plot.Legend.IsVisible = false;
-            plotControl.Plot.Legend.ShowItemsFromHiddenPlottables = true;
-            plotControl.Plot.Legend.OutlineWidth = 0;
-            plotControl.Plot.Legend.BackgroundColor = ScottPlot.Color.FromSDColor(SystemColors.Control);
-            plotControl.Plot.Legend.ShadowColor = Colors.Transparent;
-            plotControl.Refresh();
+            plot.Legend.IsVisible = false;
+            plot.Legend.ShowItemsFromHiddenPlottables = true;
+            plot.Legend.OutlineWidth = 0;
+            plot.Legend.BackgroundColor = ScottPlot.Color.FromSDColor(SystemColors.Control);
+            plot.Legend.ShadowColor = Colors.Transparent;
+            plot.PlotControl?.Refresh();
 
             // create a form that displays a SkiaSharp canvas the legend can be drawn on
             Form form = new()
@@ -49,12 +49,12 @@ namespace WinForms_Demo.Demos
             form.FormClosed += (s, e) =>
             {
                 // un-hide the legend in the original plot when the legend viewer is closed
-                plotControl.Plot.Legend.IsVisible = true;
-                plotControl.Plot.Legend.ShowItemsFromHiddenPlottables = false;
-                plotControl.Plot.Legend.OutlineWidth = 1;
-                plotControl.Plot.Legend.BackgroundColor = ScottPlot.Colors.White;
-                plotControl.Plot.Legend.ShadowColor = Colors.Black.WithOpacity(.2);
-                plotControl.Refresh();
+                plot.Legend.IsVisible = true;
+                plot.Legend.ShowItemsFromHiddenPlottables = false;
+                plot.Legend.OutlineWidth = 1;
+                plot.Legend.BackgroundColor = ScottPlot.Colors.White;
+                plot.Legend.ShadowColor = Colors.Black.WithOpacity(.2);
+                plot.PlotControl?.Refresh();
             };
 
             SKControl skControl = new()

--- a/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
+++ b/src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.WinForms/Form1.cs
@@ -9,12 +9,15 @@ public partial class Form1 : Form
         InitializeComponent();
 
         Plot[] subplots = formsPlot1.Multiplot.AddPlots(4);
+        ScottPlot.Color[] colors = new ScottPlot.Palettes.Category10().GetColors(4);
 
         for (int i = 0; i < subplots.Length; i++)
         {
             double scale = Math.Pow(10, i);
             double[] data = Generate.RandomWalk(100, scale*2);
-            subplots[i].Add.Signal(data);
+            var sig = subplots[i].Add.Signal(data);
+            sig.LineWidth = 2;
+            sig.Color = colors[i];
             subplots[i].Title($"Subplot {i + 1}");
         }
 

--- a/src/ScottPlot5/ScottPlot5/AxisManager.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisManager.cs
@@ -1008,7 +1008,7 @@ public class AxisManager
     /// </summary>
     public void SquareUnits()
     {
-        IAxisRule rule = !Plot.HasParentControl
+        IAxisRule rule = Plot.PlotControl is null
             ? new AxisRules.SquareZoomOut(Bottom, Left) // best for console apps
             : new AxisRules.SquarePreserveX(Bottom, Left); // best for interactive apps
 
@@ -1172,13 +1172,13 @@ public class AxisManager
 
         foreach (Plot plot in plotsNeedingUpdates)
         {
-            if (!plot.HasParentControl)
+            if (plot.PlotControl is null)
             {
                 plot.RenderInMemory();
             }
             else
             {
-                plot.ParentControlRefresh();
+                plot.PlotControl.Refresh();
             }
         }
     }

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/SingleClickContextMenu.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/SingleClickContextMenu.cs
@@ -8,7 +8,7 @@ public class SingleClickContextMenu(MouseButton button) : SingleClickResponse(bu
         if (plot is null)
             return;
 
-        plot.ParentControlShowContextMenu(pixel);
+        plot.PlotControl?.ShowContextMenu(pixel);
     }
 }
 

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IPalette.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IPalette.cs
@@ -22,3 +22,11 @@ public interface IPalette
     /// </summary>
     public Color GetColor(int index);
 }
+
+public static class IPaletteExtensions
+{
+    public static Color[] GetColors(this IPalette palette, int count)
+    {
+        return Enumerable.Range(0, count).Select(palette.GetColor).ToArray();
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Interfaces/IPlotMenu.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IPlotMenu.cs
@@ -6,7 +6,7 @@ public interface IPlotMenu
 
     public void Clear();
 
-    public void Add(string Label, Action<IPlotControl> action);
+    public void Add(string Label, Action<Plot> action);
 
     public void AddSeparator();
 

--- a/src/ScottPlot5/ScottPlot5/Multiplot.cs
+++ b/src/ScottPlot5/ScottPlot5/Multiplot.cs
@@ -93,7 +93,7 @@ public class Multiplot
     {
         if (Subplots.Count > 0)
         {
-            plot.PlotControl = Subplots.First().Plot.ParentControl;
+            plot.PlotControl = Subplots.First().Plot.PlotControl;
         }
 
         if (StyleNewPlotsAutomatically && Subplots.Count > 0)

--- a/src/ScottPlot5/ScottPlot5/Multiplot.cs
+++ b/src/ScottPlot5/ScottPlot5/Multiplot.cs
@@ -91,6 +91,11 @@ public class Multiplot
     /// </summary>
     public void AddPlot(Plot plot)
     {
+        if (Subplots.Count > 0)
+        {
+            plot.PlotControl = Subplots.First().Plot.ParentControl;
+        }
+
         if (StyleNewPlotsAutomatically && Subplots.Count > 0)
         {
             Plot lastPlot = Subplots.Last().Plot;

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -57,7 +57,7 @@ public class Plot : IDisposable
         }
     }
 
-    private IPlotControl? ParentControl = null;
+    internal IPlotControl? ParentControl { get; private set; } = null;
 
     public bool HasParentControl => ParentControl is not null;
 

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -47,19 +47,9 @@ public class Plot : IDisposable
     public object Sync { get; } = new();
 
     /// <summary>
-    /// Wire this plot to be aware of the interactive control it is part of
+    /// In GUI environments this property holds a reference to the interactive plot control
     /// </summary>
-    public IPlotControl? PlotControl
-    {
-        set
-        {
-            ParentControl = value;
-        }
-    }
-
-    internal IPlotControl? ParentControl { get; private set; } = null;
-
-    public bool HasParentControl => ParentControl is not null;
+    public IPlotControl? PlotControl { get; set; } = null;
 
     public Plot()
     {
@@ -683,22 +673,6 @@ public class Plot : IDisposable
         {
             panel.ShowDebugInformation = enable;
         }
-    }
-
-    #endregion
-
-    #region Interactivity
-
-    // These methods were introduced to help reduce reliance on deprecated IPlotControl.Interaction and Plot.PlotControl classes
-
-    internal void ParentControlRefresh()
-    {
-        ParentControl?.Refresh();
-    }
-
-    internal void ParentControlShowContextMenu(Pixel position)
-    {
-        ParentControl?.ShowContextMenu(position);
     }
 
     #endregion

--- a/src/ScottPlot5/ScottPlot5/Primitives/ContextMenuItem.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/ContextMenuItem.cs
@@ -7,5 +7,5 @@ public struct ContextMenuItem
 {
     public bool IsSeparator { get; set; }
     public string Label { get; set; }
-    public Action<IPlotControl> OnInvoke { get; set; }
+    public Action<Plot> OnInvoke { get; set; }
 }


### PR DESCRIPTION
This PR modifies `ContextMenuItem.OnInvoke` to act on a specific `Plot` instead of the `IPlotControl` to improve support for multi-plot environments.

All user control menu systems required refactoring to support this change.

Resolves #4671