### PR TITLE
Axis Rules: Improve support for boundaries on plots with inverted axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## ScottPlot 5.0.53
 _Not yet on NuGet..._
+* Axis Rules: Improved support for inner and boundaries on plots with inverted axis limits (#4686, #4609) @kebox7
 
 ## ScottPlot 5.0.52
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-01-08_

--- a/src/ScottPlot5/ScottPlot5/AxisRules/MaximumBoundary.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/MaximumBoundary.cs
@@ -8,16 +8,21 @@ public class MaximumBoundary(IXAxis xAxis, IYAxis yAxis, AxisLimits limits) : IA
 
     public void Apply(RenderPack rp, bool beforeLayout)
     {
+        double horizontalSpan = Math.Min(Math.Abs(XAxis.Range.Span), Limits.XRange.Span);
+        double verticalSpan = Math.Min(Math.Abs(YAxis.Range.Span), Limits.YRange.Span);
+
         if (XAxis.IsInverted())
         {
             if (XAxis.Range.Min > Limits.XRange.Max)
             {
                 XAxis.Range.Min = Limits.XRange.Max;
+                XAxis.Range.Max = Limits.XRange.Max - horizontalSpan;
             }
 
             if (XAxis.Range.Max < Limits.XRange.Min)
             {
                 XAxis.Range.Max = Limits.XRange.Min;
+                XAxis.Range.Min = Limits.XRange.Min + horizontalSpan;
             }
         }
         else
@@ -25,11 +30,13 @@ public class MaximumBoundary(IXAxis xAxis, IYAxis yAxis, AxisLimits limits) : IA
             if (XAxis.Range.Max > Limits.XRange.Max)
             {
                 XAxis.Range.Max = Limits.XRange.Max;
+                XAxis.Range.Min = Limits.XRange.Max - horizontalSpan;
             }
 
             if (XAxis.Range.Min < Limits.XRange.Min)
             {
                 XAxis.Range.Min = Limits.XRange.Min;
+                XAxis.Range.Max = Limits.XRange.Min + horizontalSpan;
             }
         }
 
@@ -38,11 +45,13 @@ public class MaximumBoundary(IXAxis xAxis, IYAxis yAxis, AxisLimits limits) : IA
             if (YAxis.Range.Min > Limits.YRange.Max)
             {
                 YAxis.Range.Min = Limits.YRange.Max;
+                YAxis.Range.Max = Limits.YRange.Max - verticalSpan;
             }
 
             if (YAxis.Range.Max < Limits.YRange.Min)
             {
                 YAxis.Range.Max = Limits.YRange.Min;
+                YAxis.Range.Min = Limits.YRange.Min + verticalSpan;
             }
         }
         else
@@ -50,11 +59,13 @@ public class MaximumBoundary(IXAxis xAxis, IYAxis yAxis, AxisLimits limits) : IA
             if (YAxis.Range.Max > Limits.YRange.Max)
             {
                 YAxis.Range.Max = Limits.YRange.Max;
+                YAxis.Range.Min = Limits.YRange.Max - verticalSpan;
             }
 
             if (YAxis.Range.Min < Limits.YRange.Min)
             {
                 YAxis.Range.Min = Limits.YRange.Min;
+                YAxis.Range.Max = Limits.YRange.Min + verticalSpan;
             }
         }
     }

--- a/src/ScottPlot5/ScottPlot5/AxisRules/MinimumBoundary.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/MinimumBoundary.cs
@@ -8,16 +8,21 @@ public class MinimumBoundary(IXAxis xAxis, IYAxis yAxis, AxisLimits limits) : IA
 
     public void Apply(RenderPack rp, bool beforeLayout)
     {
+        double horizontalSpan = Math.Max(Math.Abs(XAxis.Range.Span), Limits.XRange.Span);
+        double verticalSpan = Math.Max(Math.Abs(YAxis.Range.Span), Limits.YRange.Span);
+
         if (XAxis.IsInverted())
         {
             if (XAxis.Range.Min < Limits.XRange.Max)
             {
                 XAxis.Range.Min = Limits.XRange.Max;
+                XAxis.Range.Max = Limits.XRange.Max - horizontalSpan;
             }
 
             if (XAxis.Range.Max > Limits.XRange.Min)
             {
                 XAxis.Range.Max = Limits.XRange.Min;
+                XAxis.Range.Min = Limits.XRange.Min + horizontalSpan;
             }
         }
         else
@@ -25,11 +30,13 @@ public class MinimumBoundary(IXAxis xAxis, IYAxis yAxis, AxisLimits limits) : IA
             if (XAxis.Range.Max < Limits.XRange.Max)
             {
                 XAxis.Range.Max = Limits.XRange.Max;
+                XAxis.Range.Min = Limits.XRange.Max - horizontalSpan;
             }
 
             if (XAxis.Range.Min > Limits.XRange.Min)
             {
                 XAxis.Range.Min = Limits.XRange.Min;
+                XAxis.Range.Max = Limits.XRange.Min + horizontalSpan;
             }
         }
 
@@ -38,11 +45,13 @@ public class MinimumBoundary(IXAxis xAxis, IYAxis yAxis, AxisLimits limits) : IA
             if (YAxis.Range.Min < Limits.YRange.Max)
             {
                 YAxis.Range.Min = Limits.YRange.Max;
+                YAxis.Range.Max = Limits.YRange.Max - verticalSpan;
             }
 
             if (YAxis.Range.Max > Limits.YRange.Min)
             {
                 YAxis.Range.Max = Limits.YRange.Min;
+                YAxis.Range.Min = Limits.YRange.Min + verticalSpan;
             }
         }
         else
@@ -50,11 +59,13 @@ public class MinimumBoundary(IXAxis xAxis, IYAxis yAxis, AxisLimits limits) : IA
             if (YAxis.Range.Max < Limits.YRange.Max)
             {
                 YAxis.Range.Max = Limits.YRange.Max;
+                YAxis.Range.Min = Limits.YRange.Max - verticalSpan;
             }
 
             if (YAxis.Range.Min > Limits.YRange.Min)
             {
                 YAxis.Range.Min = Limits.YRange.Min;
+                YAxis.Range.Max = Limits.YRange.Min + verticalSpan;
             }
         }
     }


### PR DESCRIPTION
PR #4609 (Axis Rules: limit rules do not function property on inverted axes) adds support for inner/outer bounds rules for inverted axes. But it has some peculiarities, when panning the chart to the specified boundary values, zoomming occurs. In my opinion, this is not very correct. This PR fixes this behavior.

`MinimumBoundary` вefore:

https://github.com/user-attachments/assets/c84070d2-a169-495b-94c4-4c7fd42f98ed

`MinimumBoundary` after:

https://github.com/user-attachments/assets/4eb02416-690b-4bde-9610-9b344e3af921

`MaximumBoundary` вefore:

https://github.com/user-attachments/assets/8803d07f-0e41-4836-8ae8-a649556084f7

`MaximumBoundary` after:

https://github.com/user-attachments/assets/0c0fed50-e548-413c-85bc-a8aa35a9e4da

