### PR TITLE
Added CleanupGL() method into ScatterGL class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## ScottPlot 5.0.53
 _Not yet on NuGet..._
 * Axis Rules: Improved support for inner and boundaries on plots with inverted axis limits (#4686, #4609) @kebox7
+* OpenGL: Improved behavior for applications which have multiple OpenGL instances (#4693) @onur-akaydin
 
 ## ScottPlot 5.0.52
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-01-08_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/Plottables/ScatterGL.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/Plottables/ScatterGL.cs
@@ -61,11 +61,11 @@ public class ScatterGL : Scatter, IPlottableGL
     {
         if (GLHasBeenInitialized)
         {
-            // Delete vertex arrays and buffers
             GL.DeleteVertexArray(VertexArrayObject);
             GL.DeleteBuffer(VertexBufferObject);
 
-            // Dispose shader programs
+            LinesProgram?.GLFinish();
+            MarkerProgram?.GLFinish();
             LinesProgram?.Dispose();
             MarkerProgram?.Dispose();
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/Plottables/ScatterGL.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.OpenGL/Plottables/ScatterGL.cs
@@ -42,6 +42,7 @@ public class ScatterGL : Scatter, IPlottableGL
 
     protected virtual void InitializeGL()
     {
+        CleanupGL();
         LinesProgram = new LinesProgram();
         MarkerProgram = new MarkerFillCircleProgram();
 
@@ -54,6 +55,22 @@ public class ScatterGL : Scatter, IPlottableGL
         GL.EnableVertexAttribArray(0);
         Vertices = Array.Empty<double>();
         GLHasBeenInitialized = true;
+    }
+
+    protected virtual void CleanupGL()
+    {
+        if (GLHasBeenInitialized)
+        {
+            // Delete vertex arrays and buffers
+            GL.DeleteVertexArray(VertexArrayObject);
+            GL.DeleteBuffer(VertexBufferObject);
+
+            // Dispose shader programs
+            LinesProgram?.Dispose();
+            MarkerProgram?.Dispose();
+
+            GLHasBeenInitialized = false;
+        }
     }
 
     protected Matrix4d CalcTransform()


### PR DESCRIPTION
Although the InitializeGL method is intended to be called only once, I had to call it many times in a project. Especially in cases where Vertices were recalculated. InitializeGL() causes memory leaks when called again. To prevent this, I added the CleanupGL() method to cleanup OpenGL resources and call it from the beginning of InitializeGL().