### PR TITLE
Added empty constructor to Scatter.cs

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
@@ -53,6 +53,14 @@ public class Scatter(IScatterSource data) : IPlottable, IHasLine, IHasMarker, IH
     public double ScaleY { get; set; } = 1;
 
     /// <summary>
+    /// Creates an empty Scatter plot
+    /// </summary>
+    public Scatter()
+    {
+
+    }
+
+    /// <summary>
     /// The style of lines to use when connecting points.
     /// </summary>
     public ConnectStyle ConnectStyle = ConnectStyle.Straight;


### PR DESCRIPTION
Added empty constructor to Scatter.cs

    /// <summary>
    /// Creates an empty Scatter plot
    /// </summary>
    public Scatter()
    {

    }

Related issue: https://github.com/ScottPlot/ScottPlot/issues/4709