### PR TITLE
Cookbook: Polar Spoke Label Padding

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/PolarAxis.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/PolarAxis.cs
@@ -231,4 +231,25 @@ public class PolarAxis : ICategory
             poly2.LineColor = Colors.Black;
         }
     }
+
+    public class PolarSpokeLabelPadding : RecipeBase
+    {
+        public override string Name => "Polar Spoke Label Padding";
+        public override string Description => "Modifies the padding of labels on polar spokes.";
+
+        [Test]
+        public override void Execute()
+        {
+            var polarAxis = myPlot.Add.PolarAxis();
+            polarAxis.SetSpokes(4, 1);
+
+            for (int i = 0; i < polarAxis.Spokes.Count; i++)
+            {
+                polarAxis.Spokes[i].LineWidth = 4;
+                polarAxis.Spokes[i].LabelStyle.FontSize = 16;
+                polarAxis.Spokes[i].LabelPaddingFraction = 0.2 * i;
+                polarAxis.Spokes[i].LabelText = $"{polarAxis.Spokes[i].LabelLength}";
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Polar Spoke Label Padding
Modifies the padding of labels on polar spokes.
![image](https://github.com/user-attachments/assets/d8dfa3ac-477f-4c36-86ad-84f264a0e874)

```cs
var polarAxis = myPlot.Add.PolarAxis();
polarAxis.SetSpokes(4, 1);

for (int i = 0; i < polarAxis.Spokes.Count; i++)
{
    polarAxis.Spokes[i].LineWidth = 4;
    polarAxis.Spokes[i].LabelStyle.FontSize = 16;
    polarAxis.Spokes[i].LabelPaddingFraction = 0.2 * i;
    polarAxis.Spokes[i].LabelText = $"{polarAxis.Spokes[i].LabelLength}";
}
```

related #4716