### PR TITLE
Make KeyboardAutoscale.cs public to allow removal from UserInputProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## ScottPlot 5.0.55
 _Not yet on NuGet..._
 * WPF: Added autoscale option to the default right-click context menu (#4701) @hsfetterman
+* Interactivity: Make all user action responses public (#4743) @manaruto @bwedding
 
 ## ScottPlot 5.0.54
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-01-26_

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/CodeTests/CodeRequirementTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/CodeTests/CodeRequirementTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Security.Cryptography.X509Certificates;
 
 namespace ScottPlotTests.CodeTests;
 
@@ -80,6 +79,24 @@ internal class CodeRequirementTests
             if (!classInfo.IsVisible)
             {
                 throw new InvalidOperationException($"{type.Namespace}.{type.Name} should be public");
+            }
+        }
+    }
+
+    [Test]
+    public void Test_UserActionResponses_ArePublic()
+    {
+        string targetNamespace = "ScottPlot.Interactivity.UserActionResponses";
+        var actionTypes = Assembly.GetAssembly(typeof(ScottPlot.Plot))!
+                              .GetTypes()
+                              .Where(t => t.IsClass && t.Namespace == targetNamespace);
+
+        foreach (Type type in actionTypes)
+        {
+            TypeInfo classInfo = type.GetTypeInfo();
+            if (classInfo.IsNotPublic)
+            {
+                throw new InvalidOperationException($"{type.FullName} should be public");
             }
         }
     }

--- a/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/KeyboardAutoscale.cs
+++ b/src/ScottPlot5/ScottPlot5/Interactivity/UserActionResponses/KeyboardAutoscale.cs
@@ -1,6 +1,6 @@
 ﻿namespace ScottPlot.Interactivity.UserActionResponses;
 
-internal class KeyboardAutoscale(Key key) : KeyPressResponse(key, AutoScale)
+public class KeyboardAutoscale(Key key) : KeyPressResponse(key, AutoScale)
 {
     public static void AutoScale(IPlotControl plotControl, Pixel pixel)
     {


### PR DESCRIPTION
This pull request updates the KeyboardAutoscale class  by changing its access modifier from internal to public. This change ensures consistency with other user action response classes and allows users to remove the KeyboardAutoscale action using the UserInputProcessor.RemoveAll<T> method.

[#4664](https://github.com/ScottPlot/ScottPlot/issues/4664)
