### PR TITLE
Fix/ellipse arc and sector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 _Not yet on NuGet..._
 * WPF: Added autoscale option to the default right-click context menu (#4701) @hsfetterman
 * Interactivity: Make all user action responses public (#4743) @manaruto @bwedding
+* Shapes: Improved display of newly added Eclipse and Arc shapes (#4744, #4739) @CoderPM2011
 
 ## ScottPlot 5.0.54
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-01-26_

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -352,6 +352,17 @@ public static class Drawing
         canvas.DrawOval(rect.ToSKRect(), paint);
     }
 
+    public static void DrawArc(SKCanvas canvas, SKPaint paint, LineStyle lineStyle, PixelRect rect, float startAngle, float sweepAngle)
+    {
+        if (!lineStyle.CanBeRendered) return;
+
+        lineStyle.ApplyToPaint(paint);
+        if (lineStyle.Hairline)
+            paint.StrokeWidth = 1f / canvas.TotalMatrix.ScaleX;
+
+        canvas.DrawArc(rect.ToSKRect(), startAngle, sweepAngle, false, paint);
+    }
+
     private static (Angle startAngle, Angle sweepAngle) CorrectEllipseAngle(Angle startAngle, Angle sweepAngle, PixelRect rect)
     {
         Angle Correct(Angle angle)
@@ -388,15 +399,13 @@ public static class Drawing
         return (correctedStart, correctedSweep);
     }
 
-    public static void DrawArc(SKCanvas canvas, SKPaint paint, LineStyle lineStyle, PixelRect rect, float startAngle, float sweepAngle)
+    public static void DrawEllipticalArc(SKCanvas canvas, SKPaint paint, LineStyle lineStyle, PixelRect rect, float startAngle, float sweepAngle)
     {
         if (!lineStyle.CanBeRendered) return;
 
-        lineStyle.ApplyToPaint(paint);
-        if (lineStyle.Hairline)
-            paint.StrokeWidth = 1f / canvas.TotalMatrix.ScaleX;
-
-        canvas.DrawArc(rect.ToSKRect(), startAngle, sweepAngle, false, paint);
+        (Angle correctedStart, Angle correctedSweep) = CorrectEllipseAngle(
+            Angle.FromDegrees(startAngle), Angle.FromDegrees(sweepAngle), rect);
+        DrawArc(canvas, paint, lineStyle, rect, (float)correctedStart.Degrees, (float)correctedSweep.Degrees);
     }
 
     private static SKPath GetEllipticalAnnularSector(PixelRect outerRect, PixelRect innerRect, float startAngle, float sweepAngle)

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -393,10 +393,10 @@ public static class Drawing
         canvas.DrawArc(rect.ToSKRect(), startAngle, sweepAngle, false, paint);
     }
 
-    private static SKPath GetEllipticalAnnularSector(PixelRect rect, PixelRect innerRect, float startAngle, float sweepAngle)
+    private static SKPath GetEllipticalAnnularSector(PixelRect outerRect, PixelRect innerRect, float startAngle, float sweepAngle)
     {
         (Angle correctedStart, Angle correctedSweep) =
-            CorrectEllipseAngle(Angle.FromDegrees(startAngle), Angle.FromDegrees(sweepAngle), rect);
+            CorrectEllipseAngle(Angle.FromDegrees(startAngle), Angle.FromDegrees(sweepAngle), outerRect);
         float start = (float)correctedStart.Degrees;
         float sweep = (float)correctedSweep.Degrees;
 
@@ -407,20 +407,22 @@ public static class Drawing
             return new((float)x, (float)y);
         }
 
-        SKPoint p1 = GetPointOnEllipse(
-                innerRect.Center.X, innerRect.Center.Y,
-                innerRect.Right, innerRect.Bottom,
-                correctedStart + correctedSweep);
+        SKPoint innerArcEndPoint = GetPointOnEllipse(
+            innerRect.Center.X, innerRect.Center.Y,
+            innerRect.Right, innerRect.Bottom,
+            correctedStart + correctedSweep);
 
-        SKPoint p2 = GetPointOnEllipse(
-            rect.Center.X, rect.Center.Y, rect.Right, rect.Bottom, Angle.FromDegrees(0));
+        SKPoint outerArcStartPoint = GetPointOnEllipse(
+            outerRect.Center.X, outerRect.Center.Y,
+            outerRect.Right, outerRect.Bottom,
+            correctedStart);
 
         SKPath path = new();
-        path.AddArc(rect.ToSKRect(), start, sweep);
-        path.LineTo(p1);
-        path.AddArc(innerRect.ToSKRect(), start + sweep, -sweep);
-        path.LineTo(p2);
-        path.MoveTo(p2);
+        path.MoveTo(outerArcStartPoint);
+        path.ArcTo(outerRect.ToSKRect(), start, sweep, false);
+        path.LineTo(innerArcEndPoint);
+        path.ArcTo(innerRect.ToSKRect(), start + sweep, -sweep, false);
+        path.LineTo(outerArcStartPoint);
         path.Close();
         return path;
     }

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -365,7 +365,13 @@ public static class Drawing
                 Angle.FromRadians(Math.Atan2(y * rect.Right, x * rect.Bottom));
 
             // Map back to the original range
-            double scalar = Math.Ceiling(Math.Abs(angle.Degrees) / 360);
+            int absAngleDegrees = (int)Math.Abs(angle.Degrees);
+            int scalar = absAngleDegrees switch
+            {
+                < 180 => 0,
+                < 360 => 1,
+                _ => absAngleDegrees / 360,
+            };
             return angle.Degrees switch
             {
                 < -180 => correctAngle - scalar * Angle.FromDegrees(360),

--- a/src/ScottPlot5/ScottPlot5/Plottables/Ellipse.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Ellipse.cs
@@ -142,7 +142,7 @@ public class Ellipse : IPlottable, IHasLine, IHasFill, IHasLegendText
             }
             else
             {
-                Drawing.DrawArc(rp.Canvas, paint, LineStyle, rect,
+                Drawing.DrawEllipticalArc(rp.Canvas, paint, LineStyle, rect,
                     (float)-startAngle, (float)-SweepAngle.Degrees);
             }
         }


### PR DESCRIPTION
## Drawing: Fixed `GetEllipticalAnnularSector()`
fixed https://github.com/ScottPlot/ScottPlot/pull/4739#issuecomment-2614548897 and #4752
![image](https://github.com/user-attachments/assets/29d11cbb-d820-49b2-90e6-c39a375208de)

## Drawing: Fixed `CorrectEllipseAngle()`
fix angle errors caused by incorrect scale.
### Before
![image](https://github.com/user-attachments/assets/a78cfeee-6360-485d-8383-8bce5b6fff3d)
### After
![image](https://github.com/user-attachments/assets/6067e530-9ecf-4db4-9f2b-a69eef6e9cb9)

## Drawing: Added `DrawEllipticalArc()`
https://github.com/ScottPlot/ScottPlot/pull/4739#issuecomment-2614560381
#4742
Since the angle specified under the ellipse will be deformed, the angle needs to be corrected.
However, its correction affects the normal use of other plots, so separate the elliptical arcs from the arc drawing method.

### Test code
``` cs
formsPlot1.Plot.Axes.SquareUnits();
start = Angle.FromDegrees(-45);
sweep = Angle.FromDegrees(90);

var ellipticalArc = formsPlot1.Plot.Add.EllipticalArc(
    0, 0, 100, 20, start, sweep, Angle.FromDegrees(0));
ellipticalArc.LineWidth = 3;
var ellipticalSector = formsPlot1.Plot.Add.EllipticalSector(
    0, 0, 100, 20, start, sweep, Angle.FromDegrees(0));
ellipticalSector.LineWidth = 0;
ellipticalSector.FillColor = Colors.Red.WithAlpha(0.5);

formsPlot1.Plot.Add.Text($"start[{start}], sweep[{sweep}]", 0, -40);
```

### Before
![image](https://github.com/user-attachments/assets/ae9a44a4-af26-4570-9589-b695b0d2ae1c)
### After
![image](https://github.com/user-attachments/assets/8c675373-3255-4271-9346-430acec23781)

---
related #4739 #4742 #4752

Resolves #4752