### PR TITLE
Fix inverted axis min max span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ _Not yet on NuGet..._
 * Interactivity: Make all user action responses public (#4743) @manaruto @bwedding
 * Shapes: Improved display of newly added Eclipse and Arc shapes (#4744, #4739) @CoderPM2011
 * SignalXY: Improve support for generic X and Y collections (#4753, #4746) @JoeStoneAT @bclehmann
+* Axis Rules: Updated minimum and maximum span rules to improve support for inverted axes (#4755, #4735) @manaruto
 
 ## ScottPlot 5.0.54
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-01-26_

--- a/src/ScottPlot5/ScottPlot5/AxisRules/MaximumSpan.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/MaximumSpan.cs
@@ -10,18 +10,42 @@ public class MaximumSpan(IXAxis xAxis, IYAxis yAxis, double xSpan, double ySpan)
 
     public void Apply(RenderPack rp, bool beforeLayout)
     {
-        if (XAxis.Range.Span > XSpan)
+        if (XAxis.IsInverted())
         {
-            double xMin = XAxis.Range.Center - XSpan / 2;
-            double xMax = XAxis.Range.Center + XSpan / 2;
-            XAxis.Range.Set(xMin, xMax);
+            if (Math.Abs(XAxis.Range.Span) > XSpan)
+            {
+                double xMin = XAxis.Range.Center - XSpan / 2;
+                double xMax = XAxis.Range.Center + XSpan / 2;
+                XAxis.Range.Set(xMax, xMin);
+            }
+        }
+        else
+        {
+            if (XAxis.Range.Span > XSpan)
+            {
+                double xMin = XAxis.Range.Center - XSpan / 2;
+                double xMax = XAxis.Range.Center + XSpan / 2;
+                XAxis.Range.Set(xMin, xMax);
+            }
         }
 
-        if (YAxis.Range.Span > YSpan)
+        if (YAxis.IsInverted())
         {
-            double yMin = YAxis.Range.Center - YSpan / 2;
-            double yMax = YAxis.Range.Center + YSpan / 2;
-            YAxis.Range.Set(yMin, yMax);
+            if (Math.Abs(YAxis.Range.Span) > YSpan)
+            {
+                double yMin = YAxis.Range.Center - YSpan / 2;
+                double yMax = YAxis.Range.Center + YSpan / 2;
+                YAxis.Range.Set(yMax, yMin);
+            }
+        }
+        else
+        {
+            if (YAxis.Range.Span > YSpan)
+            {
+                double yMin = YAxis.Range.Center - YSpan / 2;
+                double yMax = YAxis.Range.Center + YSpan / 2;
+                YAxis.Range.Set(yMin, yMax);
+            }
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisRules/MinimumSpan.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/MinimumSpan.cs
@@ -10,18 +10,42 @@ public class MinimumSpan(IXAxis xAxis, IYAxis yAxis, double xSpan, double ySpan)
 
     public void Apply(RenderPack rp, bool beforeLayout)
     {
-        if (XAxis.Range.Span < XSpan)
+        if (XAxis.IsInverted())
         {
-            double xMin = XAxis.Range.Center - XSpan / 2;
-            double xMax = XAxis.Range.Center + XSpan / 2;
-            XAxis.Range.Set(xMin, xMax);
+            if (Math.Abs(XAxis.Range.Span) < XSpan)
+            {
+                double xMin = XAxis.Range.Center - XSpan / 2;
+                double xMax = XAxis.Range.Center + XSpan / 2;
+                XAxis.Range.Set(xMax, xMin);
+            }
+        }
+        else
+        {
+            if (XAxis.Range.Span < XSpan)
+            {
+                double xMin = XAxis.Range.Center - XSpan / 2;
+                double xMax = XAxis.Range.Center + XSpan / 2;
+                XAxis.Range.Set(xMin, xMax);
+            }
         }
 
-        if (YAxis.Range.Span < YSpan)
+        if (YAxis.IsInverted())
         {
-            double yMin = YAxis.Range.Center - YSpan / 2;
-            double yMax = YAxis.Range.Center + YSpan / 2;
-            YAxis.Range.Set(yMin, yMax);
+            if (Math.Abs(YAxis.Range.Span) < YSpan)
+            {
+                double yMin = YAxis.Range.Center - YSpan / 2;
+                double yMax = YAxis.Range.Center + YSpan / 2;
+                YAxis.Range.Set(yMax, yMin);
+            }
+        }
+        else
+        {
+            if (YAxis.Range.Span < YSpan)
+            {
+                double yMin = YAxis.Range.Center - YSpan / 2;
+                double yMax = YAxis.Range.Center + YSpan / 2;
+                YAxis.Range.Set(yMin, yMax);
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes the behavior of MinimumSpan and MaximumSpan rules when an axis is inverted (Min > Max). Previously, these rules did not correctly account for inverted axes, leading to incorrect enforcement of span constraints.

➜ If MinimumSpan or MaximumSpan is used alongside a minimum or maximum boundary, the constraints were not being applied correctly.
    
➜ If MinimumSpan or MaximumSpan is used alone (without min/max boundary constraints), the axis ticks would not be displayed as inverted.

[#4735](https://github.com/ScottPlot/ScottPlot/issues/4735)

