### PR TITLE
AvaPlot: Always render to new layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ _Not yet on NuGet..._
 * Shapes: Improved display of newly added Eclipse and Arc shapes (#4744, #4739) @CoderPM2011
 * SignalXY: Improve support for generic X and Y collections (#4753, #4746) @JoeStoneAT @bclehmann
 * Axis Rules: Updated minimum and maximum span rules to improve support for inverted axes (#4755, #4735) @manaruto
+* Avalonia: Improved support for transparency at the window level (#4759, #3444, #4732) @bclehmann
 
 ## ScottPlot 5.0.54
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-01-26_

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
@@ -61,9 +61,9 @@ public class AvaPlot : Controls.Control, IPlotControl
             using var lease = leaseFeature.Lease();
             PixelRect rect = new(0, (float)Bounds.Width, (float)Bounds.Height, 0);
 
+            using SKAutoCanvasRestore _ = new(lease.SkCanvas, false);
             lease.SkCanvas.SaveLayer();
             Multiplot.Render(lease.SkCanvas, rect);
-            lease.SkCanvas.Restore();
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
@@ -60,7 +60,10 @@ public class AvaPlot : Controls.Control, IPlotControl
 
             using var lease = leaseFeature.Lease();
             PixelRect rect = new(0, (float)Bounds.Width, (float)Bounds.Height, 0);
+
+            lease.SkCanvas.SaveLayer();
             Multiplot.Render(lease.SkCanvas, rect);
+            lease.SkCanvas.Restore();
         }
     }
 


### PR DESCRIPTION
This fixes #4732, and in a more permanent way than just fixing the workaround that we used to have. That workaround is no longer necessary.

What I believe happened is our `Render` method was permitted to overwrite the SKCanvas of controls beneath us, Avalonia was not implicitly creating new canvases for different controls and blending them during compositing according to each control's depth. Instead, we need to do that ourselves.

### Testing

My starting point for all of these examples is the Avalonia Sandbox project in `src/ScottPlot5/ScottPlot5 Sandbox/Sandbox.Avalonia.Desktop`

I replaced `MainView.axaml.cs` with this:
```cs
using Avalonia.Controls;
using ScottPlot.Avalonia;
using ScottPlot;

namespace Sandbox.Avalonia;

public partial class MainView : UserControl
{
    public MainView()
    {
        InitializeComponent();

        AvaPlot.UserInputProcessor.IsEnabled = true;
        AvaPlot.Plot.FigureBackground.Color = Colors.Transparent;

        AvaPlot.Plot.Add.Signal(Generate.Sin());
        AvaPlot.Plot.Add.Signal(Generate.Cos());
        AvaPlot.Refresh();
    }
}
```

And to ensure that the background is visible through the plot I replaced `MainWindow.axaml` with this, making the MainView component cyan:
```xml
<Window xmlns="https://github.com/avaloniaui"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
		xmlns:local="clr-namespace:Sandbox.Avalonia"
        xmlns:ScottPlot="clr-namespace:ScottPlot.Avalonia;assembly=ScottPlot.Avalonia"
        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
        x:Class="Sandbox.Avalonia.MainWindow"
        Title="Avalonia">

	<local:MainView Background="Cyan" />
</Window>
```

As expected, it gave this result:
![image](https://github.com/user-attachments/assets/6e351224-b3ae-4e1a-afca-4986d0056740)

To ensure I didn't break anything if users wanted a truly see-through window, I also tested this `MainWindow.axaml`:
```xml
<Window xmlns="https://github.com/avaloniaui"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
		xmlns:local="clr-namespace:Sandbox.Avalonia"
        xmlns:ScottPlot="clr-namespace:ScottPlot.Avalonia;assembly=ScottPlot.Avalonia"
        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
        x:Class="Sandbox.Avalonia.MainWindow"
		Background="Transparent" <!-- Note that the window is also set to transparent, not just its child -->
        Title="Avalonia">

	<local:MainView Background="Transparent" />
</Window>

```
Which gave the expected result:
![image](https://github.com/user-attachments/assets/bb9184da-e094-4e71-b29e-6902ad6d893e)
