### PR TITLE
CoordinateRange: improve NaN support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _Not yet on NuGet..._
 * SignalXY: Improve support for generic X and Y collections (#4753, #4746) @JoeStoneAT @bclehmann
 * Axis Rules: Updated minimum and maximum span rules to improve support for inverted axes (#4755, #4735) @manaruto
 * Avalonia: Improved support for transparency at the window level (#4759, #3444, #4732) @bclehmann
+* CoordinateRange: Improve NaN support for `Extrema()` method (#4770, #4665) @bwedding @uperp
 
 ## ScottPlot 5.0.54
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-01-26_

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/PrimitiveTests/CoordinateRangeTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/UnitTests/PrimitiveTests/CoordinateRangeTests.cs
@@ -96,6 +96,36 @@ internal class CoordinateRangeTests
     }
 
     [Test]
+    public void Test_CoordinateRange_Extrema_Empty()
+    {
+        CoordinateRange.Extrema(Array.Empty<double>()).Should().Be(CoordinateRange.NoLimits);
+    }
+
+    [Test]
+    public void Test_CoordinateRange_Extrema_Single_Value()
+    {
+        CoordinateRange.Extrema(new[] { 3.14159 }).Should().Be(new CoordinateRange(3.14159, 3.14159));
+    }
+
+    [Test]
+    public void Test_CoordinateRange_Extrema_AllNaN()
+    {
+        CoordinateRange.Extrema(new[] { double.NaN, double.NaN }).Should().Be(CoordinateRange.NoLimits);
+    }
+
+    [Test]
+    public void Test_CoordinateRange_Extrema_SomeNaN()
+    {
+        CoordinateRange.Extrema(new[] { 1.0, double.NaN, 2.0 }).Should().Be(new CoordinateRange(1.0, 2.0));
+    }
+
+    [Test]
+    public void Test_CoordinateRange_Extrema_Normal()
+    {
+        CoordinateRange.Extrema(new[] { -1.0, 0.0, 1.0 }).Should().Be(new CoordinateRange(-1.0, 1.0));
+    }
+
+    [Test]
     public void Test_CoordinateRange_Length()
     {
         new CoordinateRange(2, 10).Length.Should().Be(8);

--- a/src/ScottPlot5/ScottPlot5/Primitives/CoordinateRange.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/CoordinateRange.cs
@@ -83,13 +83,10 @@ public readonly struct CoordinateRange(double value1, double value2)
     /// </summary>
     public static CoordinateRange Extrema(IEnumerable<double> values)
     {
-        if (!values.Any())
-            return CoordinateRange.NoLimits;
-
-        var nonNanValues = values.Where(i => !double.IsNaN(i));
-        double min = nonNanValues.Min();
-        double max = nonNanValues.Max();
-        return new(min, max);
+        var nonNanValues = values.Where(i => !double.IsNaN(i)).ToList();
+        return nonNanValues.Any()
+            ? new CoordinateRange(nonNanValues.Min(), nonNanValues.Max())
+            : NoLimits;
     }
 
     /// <summary>


### PR DESCRIPTION
Fix for issue here:
https://github.com/ScottPlot/ScottPlot/issues/4665

Simple fix. I also added 5 unit test cases to test for it.


```cs
    public static CoordinateRange Extrema(IEnumerable<double> values)
    {
        var nonNanValues = values.Where(i => !double.IsNaN(i)).ToList();
        return nonNanValues.Any()
            ? new CoordinateRange(nonNanValues.Min(), nonNanValues.Max())
            : NoLimits;
    }
```