### PR TITLE
SignalXYSourceGenericList: Reduce allocations and copying to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _Not yet on NuGet..._
 * Rendering: Improved performance by simplifying axis limit change detection to reduce duplicate renders (#4790, #4783) @bclehmann @dtoppani-twist @chen1tian @ssharks
 * Rectangular Grid: Improve logic used to identify cells from coordinates, fixing issues associated with contour line plots (#4787, #4791) @StendProg @ScottSSapphire
 * Axes: Improve coordinate lookup logic for translating between triangular and Cartesian axes (#4797, #4798) @manaruto
+* SignalXY: Improve performance by reducing allocations and copying inside the render loop (#4794, #4753) @bclehmann
 
 ## ScottPlot 5.0.54
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-01-26_

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericList.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalXYSourceGenericList.cs
@@ -1,5 +1,3 @@
-using System.Data.SqlTypes;
-
 namespace ScottPlot.DataSources;
 
 public class SignalXYSourceGenericList<Tx, Ty> : ISignalXYSource, IDataSource, IGetNearest


### PR DESCRIPTION
This requires a binary search implementation for IReadOnlyList. I tested this by calling both Array.BinarySearch on Xs.ToArray() and my implementation on every received input and throwing if they didn't match.

The performance is much improved, the previous implementation dropped below 60fps for relatively modest input lengths (much past 10000 points) At this point `System.Linq.Enumerable.ToArray<T>` takes up ~75% of the CPU time in the profiler. On the new one I left it running by accident and it's still going strong at 1 million+ points, even on a debug build.

Discussed in my review comment on #4753

I tested it with this Avalonia app:

```cs
using Avalonia.Controls;
using ScottPlot.Avalonia;
using ScottPlot;
using System.Collections.Generic;
using Avalonia.Threading;
using System.Linq;
using System;

namespace Sandbox.Avalonia;

public partial class MainView : UserControl
{
    readonly ScottPlot.DataGenerators.RandomWalker Walker1 = new(0);

    readonly DispatcherTimer updateTimer = new();

    public MainView()
    {
        InitializeComponent();

        AvaPlot.UserInputProcessor.IsEnabled = true;

        List<double> xList = new();
        List<double> yList = new();

        var plt = AvaPlot.Plot.Add.SignalXY(xList, yList);

        updateTimer.Interval = TimeSpan.FromMilliseconds(200);
        updateTimer.Start();
        updateTimer.Tick += (s, e) =>
        {
            int count = 50;

            // add new sample data
            xList.AddRange(Generate.Consecutive(count, 1, xList.LastOrDefault(0) + 1));
            yList.AddRange(Walker1.Next(count));
            AvaPlot.Plot.Axes.AutoScale();
            AvaPlot.Refresh();
        };
    }
}

```