### PR TITLE
CoordinateRangeMutable: Make Min, Max inverted-aware

### DIFF
--- a/src/ScottPlot5/ScottPlot5/AxisRules/MaximumBoundary.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/MaximumBoundary.cs
@@ -11,62 +11,27 @@ public class MaximumBoundary(IXAxis xAxis, IYAxis yAxis, AxisLimits limits) : IA
         double horizontalSpan = Math.Min(Math.Abs(XAxis.Range.Span), Limits.XRange.Span);
         double verticalSpan = Math.Min(Math.Abs(YAxis.Range.Span), Limits.YRange.Span);
 
-        if (XAxis.IsInverted())
+        if (XAxis.Range.Max > Limits.XRange.Max)
         {
-            if (XAxis.Range.Min > Limits.XRange.Max)
-            {
-                XAxis.Range.Min = Limits.XRange.Max;
-                XAxis.Range.Max = Limits.XRange.Max - horizontalSpan;
-            }
-
-            if (XAxis.Range.Max < Limits.XRange.Min)
-            {
-                XAxis.Range.Max = Limits.XRange.Min;
-                XAxis.Range.Min = Limits.XRange.Min + horizontalSpan;
-            }
+            XAxis.Range.Max = Limits.XRange.Max;
+            XAxis.Range.Min = Limits.XRange.Max - horizontalSpan;
         }
-        else
+        if (XAxis.Range.Min < Limits.XRange.Min)
         {
-            if (XAxis.Range.Max > Limits.XRange.Max)
-            {
-                XAxis.Range.Max = Limits.XRange.Max;
-                XAxis.Range.Min = Limits.XRange.Max - horizontalSpan;
-            }
-
-            if (XAxis.Range.Min < Limits.XRange.Min)
-            {
-                XAxis.Range.Min = Limits.XRange.Min;
-                XAxis.Range.Max = Limits.XRange.Min + horizontalSpan;
-            }
+            XAxis.Range.Min = Limits.XRange.Min;
+            XAxis.Range.Max = Limits.XRange.Min + horizontalSpan;
         }
 
-        if (YAxis.IsInverted())
+        if (YAxis.Range.Max > Limits.YRange.Max)
         {
-            if (YAxis.Range.Min > Limits.YRange.Max)
-            {
-                YAxis.Range.Min = Limits.YRange.Max;
-                YAxis.Range.Max = Limits.YRange.Max - verticalSpan;
-            }
-
-            if (YAxis.Range.Max < Limits.YRange.Min)
-            {
-                YAxis.Range.Max = Limits.YRange.Min;
-                YAxis.Range.Min = Limits.YRange.Min + verticalSpan;
-            }
+            YAxis.Range.Max = Limits.YRange.Max;
+            YAxis.Range.Min = Limits.YRange.Max - verticalSpan;
         }
-        else
-        {
-            if (YAxis.Range.Max > Limits.YRange.Max)
-            {
-                YAxis.Range.Max = Limits.YRange.Max;
-                YAxis.Range.Min = Limits.YRange.Max - verticalSpan;
-            }
 
-            if (YAxis.Range.Min < Limits.YRange.Min)
-            {
-                YAxis.Range.Min = Limits.YRange.Min;
-                YAxis.Range.Max = Limits.YRange.Min + verticalSpan;
-            }
+        if (YAxis.Range.Min < Limits.YRange.Min)
+        {
+            YAxis.Range.Min = Limits.YRange.Min;
+            YAxis.Range.Max = Limits.YRange.Min + verticalSpan;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisRules/MinimumBoundary.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/MinimumBoundary.cs
@@ -10,63 +10,29 @@ public class MinimumBoundary(IXAxis xAxis, IYAxis yAxis, AxisLimits limits) : IA
     {
         double horizontalSpan = Math.Max(Math.Abs(XAxis.Range.Span), Limits.XRange.Span);
         double verticalSpan = Math.Max(Math.Abs(YAxis.Range.Span), Limits.YRange.Span);
-
-        if (XAxis.IsInverted())
+        
+        if (XAxis.Range.Max < Limits.XRange.Max)
         {
-            if (XAxis.Range.Min < Limits.XRange.Max)
-            {
-                XAxis.Range.Min = Limits.XRange.Max;
-                XAxis.Range.Max = Limits.XRange.Max - horizontalSpan;
-            }
-
-            if (XAxis.Range.Max > Limits.XRange.Min)
-            {
-                XAxis.Range.Max = Limits.XRange.Min;
-                XAxis.Range.Min = Limits.XRange.Min + horizontalSpan;
-            }
-        }
-        else
-        {
-            if (XAxis.Range.Max < Limits.XRange.Max)
-            {
-                XAxis.Range.Max = Limits.XRange.Max;
-                XAxis.Range.Min = Limits.XRange.Max - horizontalSpan;
-            }
-
-            if (XAxis.Range.Min > Limits.XRange.Min)
-            {
-                XAxis.Range.Min = Limits.XRange.Min;
-                XAxis.Range.Max = Limits.XRange.Min + horizontalSpan;
-            }
+            XAxis.Range.Max = Limits.XRange.Max;
+            XAxis.Range.Min = Limits.XRange.Max - horizontalSpan;
         }
 
-        if (YAxis.IsInverted())
+        if (XAxis.Range.Min > Limits.XRange.Min)
         {
-            if (YAxis.Range.Min < Limits.YRange.Max)
-            {
-                YAxis.Range.Min = Limits.YRange.Max;
-                YAxis.Range.Max = Limits.YRange.Max - verticalSpan;
-            }
-
-            if (YAxis.Range.Max > Limits.YRange.Min)
-            {
-                YAxis.Range.Max = Limits.YRange.Min;
-                YAxis.Range.Min = Limits.YRange.Min + verticalSpan;
-            }
+            XAxis.Range.Min = Limits.XRange.Min;
+            XAxis.Range.Max = Limits.XRange.Min + horizontalSpan;
         }
-        else
-        {
-            if (YAxis.Range.Max < Limits.YRange.Max)
-            {
-                YAxis.Range.Max = Limits.YRange.Max;
-                YAxis.Range.Min = Limits.YRange.Max - verticalSpan;
-            }
 
-            if (YAxis.Range.Min > Limits.YRange.Min)
-            {
-                YAxis.Range.Min = Limits.YRange.Min;
-                YAxis.Range.Max = Limits.YRange.Min + verticalSpan;
-            }
+        if (YAxis.Range.Max < Limits.YRange.Max)
+        {
+            YAxis.Range.Max = Limits.YRange.Max;
+            YAxis.Range.Min = Limits.YRange.Max - verticalSpan;
+        }
+
+        if (YAxis.Range.Min > Limits.YRange.Min)
+        {
+            YAxis.Range.Min = Limits.YRange.Min;
+            YAxis.Range.Max = Limits.YRange.Min + verticalSpan;
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/AxisRules/SnapToTicksX.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/SnapToTicksX.cs
@@ -91,7 +91,7 @@ public class SnapToTicksX(IXAxis xAxis) : IAxisRule
         }
 
         //This is to handle panning, which can be jumpy if we snap before it has panned more than half the tick interval
-        if (isPanning & Math.Abs(newLimits.Max - oldRight) < tickDelta / 2)
+        if (isPanning && Math.Abs(newRight - oldRight) < tickDelta / 2)
         {
             newRight = oldRight;
             newLeft = oldLeft;

--- a/src/ScottPlot5/ScottPlot5/AxisRules/SnapToTicksY.cs
+++ b/src/ScottPlot5/ScottPlot5/AxisRules/SnapToTicksY.cs
@@ -89,7 +89,7 @@ public class SnapToTicksY(IYAxis yAxis) : IAxisRule
         }
 
         //This is to handle panning, which can be jumpy if we snap before it has panned more than half the tick interval
-        if (isPanning & Math.Abs(newLimits.Max - oldTop) < tickDelta / 2)
+        if (isPanning && Math.Abs(newTop - oldTop) < tickDelta / 2)
         {
             newTop = oldTop;
             newBottom = oldBottom;

--- a/src/ScottPlot5/ScottPlot5/Primitives/CoordinateRangeMutable.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/CoordinateRangeMutable.cs
@@ -14,7 +14,7 @@ public class CoordinateRangeMutable : IEquatable<CoordinateRangeMutable> // TODO
         get => Math.Min(Value1, Value2);
         set // Unfortunately we need a setter to support code from when Min was allowed to be greater than Max
         {
-            if (Value1 < Value2)
+            if (Value1 <= Value2)
             {
                 Value1 = value;
             } else


### PR DESCRIPTION
This was brought up in #4794 

## Process

I renamed `Min` and `Max` to Value1 and Value2 and went through the changes, swapping them back to Min/Max when I judged that that was the intention of the code (and was not a bug).

I collapsed some manual checks on `IsInverted` that were no longer needed, and I also replaced (presumably) accidental uses of bitwise and `&` with logical and `&&`. To my surprise, `bool1 & bool2` returns a boolean in C#, and is thus legal in if conditions. The only point of this with booleans would be to prevent short-circuit evaluation and the potential branch prediction mishaps it can sometimes cause.

Finally, the `Equals` implementation for `CoordinateRangeMutable` was incorrect. I fixed that, though maybe it should be made in a separate PR since I have the feeling this one could take some time to get right.

## Remaining ambiguity

I have a fair number of questions, they're mostly in TODO comments.

I'm unsure of how to handle setters here. Maybe the right answer is to require these to be readonly properties, and I'm definitely warming to that viewpoint. My first pass was to have setters on Min/Max change whichever of Value1/Value2 was actually the min or max. Which is a relatively practical choice for simplifying code that was already consciously deciding to preserve `IsInverted` when writing to these properties. But it is also ambiguous in the case when Value1 = Value2, and so you can get very different ranges depending on what is fundamentally an arbitrary choice.

There's a lot of similar choices, like for the range `[1, -1]` there's two ways to expand that range to include 2. You can turn it into `[-1, 2]`, and you can turn it into `[2, -1]`. Currently my code uninverts them as did the previous implementation, which I feel is most reasonable, but I do also get the feeling that `IsInverted` should maybe be preserved?

Relatedly, should `[1, -1].Contains(0)` return true? Currently it does (the old code did not), but is this correct? Formally this is saying that the following includes the element 0, which is clearly false.

 $$ \\{ x \\: : \\: 1 \leq x \leq -1 \\} $$

And finally, this is inevitably a breaking change. If we argue that it's a bug fix then that's one thing, but if there's user code out there that is already handling inverted ranges then I don't think this is going to be pleasant for them.

All of this makes me wonder if this change is too ambitious and we should instead be trying to find a more modest way to manage this misnomer. Maybe that's just doc comments on `Min` and `Max`.

## Testing

Since this touches so much it'll be hard for me to adequately test this. At the very least I want to ensure that #4783 and #4629 don't regress, but I haven't tested that yet.