### PR TITLE
Fix ternary coordinate validation in TriangularAxis

### DIFF
--- a/.github/workflows/task-autoformat-check.yaml
+++ b/.github/workflows/task-autoformat-check.yaml
@@ -16,5 +16,4 @@ jobs:
         with:
           dotnet-version: "9.0.103" #https://github.com/dotnet/sdk/issues/46780#issuecomment-2654628175
       - name: Code Format Check
-        run: dotnet format ScottPlot5 --verify-no-changes --verbosity diagnostic
-        working-directory: .src/ScottPlot5/
+        run: dotnet format "src/ScottPlot5/ScottPlot5/ScottPlot.csproj" --verify-no-changes

--- a/.github/workflows/task-autoformat-check.yaml
+++ b/.github/workflows/task-autoformat-check.yaml
@@ -17,4 +17,4 @@ jobs:
           dotnet-version: "9.0.103" #https://github.com/dotnet/sdk/issues/46780#issuecomment-2654628175
       - name: Code Format Check
         run: dotnet format ScottPlot5 --verify-no-changes --verbosity diagnostic
-        working-directory: .src/ScottPlot5/
+        working-directory: ./src/ScottPlot5/

--- a/.github/workflows/task-autoformat-check.yaml
+++ b/.github/workflows/task-autoformat-check.yaml
@@ -17,4 +17,4 @@ jobs:
           dotnet-version: "9.0.103" #https://github.com/dotnet/sdk/issues/46780#issuecomment-2654628175
       - name: Code Format Check
         run: dotnet format ScottPlot5 --verify-no-changes --verbosity diagnostic
-        working-directory: ./src/ScottPlot5/
+        working-directory: .src/ScottPlot5/

--- a/.github/workflows/task-autoformat-check.yaml
+++ b/.github/workflows/task-autoformat-check.yaml
@@ -16,4 +16,5 @@ jobs:
         with:
           dotnet-version: "9.0.103" #https://github.com/dotnet/sdk/issues/46780#issuecomment-2654628175
       - name: Code Format Check
-        run: dotnet format "src/ScottPlot5/ScottPlot5/ScottPlot.csproj" --verify-no-changes
+        run: dotnet format ScottPlot5 --verify-no-changes --verbosity diagnostic
+        working-directory: .src/ScottPlot5/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ _Not yet on NuGet..._
 * CoordinateRange: Improve NaN support for `Extrema()` method (#4770, #4665) @bwedding @uperp
 * Rendering: Improved performance by simplifying axis limit change detection to reduce duplicate renders (#4790, #4783) @bclehmann @dtoppani-twist @chen1tian @ssharks
 * Rectangular Grid: Improve logic used to identify cells from coordinates, fixing issues associated with contour line plots (#4787, #4791) @StendProg @ScottSSapphire
+* Axes: Improve coordinate lookup logic for translating between triangular and Cartesian axes (#4798) @manaruto
 
 ## ScottPlot 5.0.54
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-01-26_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ _Not yet on NuGet..._
 * CoordinateRange: Improve NaN support for `Extrema()` method (#4770, #4665) @bwedding @uperp
 * Rendering: Improved performance by simplifying axis limit change detection to reduce duplicate renders (#4790, #4783) @bclehmann @dtoppani-twist @chen1tian @ssharks
 * Rectangular Grid: Improve logic used to identify cells from coordinates, fixing issues associated with contour line plots (#4787, #4791) @StendProg @ScottSSapphire
-* Axes: Improve coordinate lookup logic for translating between triangular and Cartesian axes (#4798) @manaruto
+* Axes: Improve coordinate lookup logic for translating between triangular and Cartesian axes (#4797, #4798) @manaruto
 
 ## ScottPlot 5.0.54
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-01-26_

--- a/src/ScottPlot5/ScottPlot5/Plottables/SmithChartAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/SmithChartAxis.cs
@@ -11,7 +11,7 @@ public class SmithChartAxis : IPlottable, IManagesAxisLimits
     {
         // Γ = (z - 1) / (z + 1)
         //   = (R + jX - 1) / (R + jX + 1)
-        //   = a + jc
+        //   = a + jc 
 
         double R = normalizedImpedance.X;
         double X = normalizedImpedance.Y;

--- a/src/ScottPlot5/ScottPlot5/Plottables/TriangularAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/TriangularAxis.cs
@@ -39,12 +39,27 @@ public class TriangularAxis(bool clockwise) : IPlottable
     /// </summary>
     public Coordinates GetCoordinates(double bottomFraction, double leftFraction, double rightFraction)
     {
-        if (leftFraction + rightFraction != 1)
+        if (Math.Abs(bottomFraction + leftFraction + rightFraction - 1) > 1e-6)
         {
-            throw new ArgumentException("sum of left and right fractions must equal 1");
+            throw new ArgumentException("The sum of bottom, left, and right fractions must equal 1.");
         }
 
-        return GetCoordinates(bottomFraction, leftFraction);
+        double x, y;
+        
+        if (!Clockwise)
+        {
+            // Counterclockwise transformation
+            x = 0.5 * (2 * bottomFraction + rightFraction);
+            y = (Math.Sqrt(3) / 2) * rightFraction;
+        }
+        else
+        {
+            // Clockwise transformation
+            x = 0.5 * (2 * rightFraction + leftFraction);
+            y = (Math.Sqrt(3) / 2) * leftFraction;
+        }
+        
+        return new Coordinates(x, y);
     }
 
     public virtual void Render(RenderPack rp)

--- a/src/ScottPlot5/ScottPlot5/Plottables/TriangularAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/TriangularAxis.cs
@@ -33,9 +33,7 @@ public class TriangularAxis(bool clockwise) : IPlottable
     }
 
     /// <summary>
-    /// Return coordinates for a point on the triangle for a fractional distance 
-    /// (0 through 1, inclusive) along all three axes. This overload requires
-    /// the sum of <paramref name="leftFraction"/> and <paramref name="rightFraction"/> to equal 1.
+    /// Converts ternary coordinates (bottom, left, right) to Cartesian coordinates (X, Y)
     /// </summary>
     public Coordinates GetCoordinates(double bottomFraction, double leftFraction, double rightFraction)
     {
@@ -45,7 +43,7 @@ public class TriangularAxis(bool clockwise) : IPlottable
         }
 
         double x, y;
-        
+
         if (!Clockwise)
         {
             // Counterclockwise transformation
@@ -58,7 +56,7 @@ public class TriangularAxis(bool clockwise) : IPlottable
             x = 0.5 * (2 * rightFraction + leftFraction);
             y = (Math.Sqrt(3) / 2) * leftFraction;
         }
-        
+
         return new Coordinates(x, y);
     }
 


### PR DESCRIPTION
This PR fixes an issue with the `GetCoordinates` method in `TriangularAxis`. The original method incorrectly enforced `leftFraction + rightFraction = 1`, which violates ternary plot rules.

- Ensures that `bottomFraction + leftFraction + rightFraction = 1` as required for valid ternary plots.
- Supports both clockwise and counterclockwise transformations.


#4797 