### PR TITLE
Update Blazor component to handle dotnet 9 rendermodes

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/BlazorPlot.razor
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/BlazorPlot.razor
@@ -6,32 +6,52 @@
      onmousewheel="return false;"
      onmousedown="return false;"
      style=@Style>
-    <SKCanvasView @ref="SKView"
-                  style="width:inherit; height:inherit;"
-                  OnPaintSurface="OnPaintSurface"
-                  IgnorePixelScaling="true"
-                  EnableRenderLoop="EnableRenderLoop"
-                  @onpointerdown="OnPointerPressed"
-                  @onpointermove="OnPointerMoved"
-                  @onpointerup="OnPointerReleased"
-                  @onwheel="OnPointerWheelChanged"
-                  @onkeydown="OnKeyDown"
-                  @onkeyup="OnKeyUp" />
+    @if (OperatingSystem.IsBrowser())
+    {
+        <SKCanvasView @ref="SKView"
+                      style="width:inherit; height:inherit;"
+                      OnPaintSurface="OnPaintSurface"
+                      IgnorePixelScaling="true"
+                      EnableRenderLoop="EnableRenderLoop"
+                      @onpointerdown="OnPointerPressed"
+                      @onpointermove="OnPointerMoved"
+                      @onpointerup="OnPointerReleased"
+                      @onwheel="OnPointerWheelChanged"
+                      @onkeydown="OnKeyDown"
+                      @onkeyup="OnKeyUp" />
+    }
+    else
+    {
+        <div class="@NoPlotCss">
+            Plot component will only show in Blazor client-side
+            Blazor Server and pre-rendering are not supported
+        </div>
+        <div>&nbsp;Current Mode</div>
+        <ul>
+            <li>Name: @rendererInfoName</li>
+            <li>Is Interactive: @rendererInteractive</li>
+        </ul>
+    }
 </div>
 
 @code {
-
-    private SKCanvasView SKView { get; set; } = new();
+    string NoPlotCss => RendererInfo.Name switch
+    {
+        "Server" => "bg-warning p-3",
+        "Static" => "bg-info p-3",
+        _ => "bg-danger p-3"
+    });
+    public string rendererInfoName => RendererInfo.Name;
+    public string rendererInteractive => RendererInfo.IsInteractive.ToString();
+    private SKCanvasView? SKView { get; set; } = OperatingSystem.IsBrowser() ? new() : null;
+    public override void Refresh()
+    {
+        SKView?.Invalidate();
+    }
 
     public void OnPaintSurface(SKPaintSurfaceEventArgs e)
     {
         Multiplot.Render(e.Surface);
-    }
-
-
-    public override void Refresh()
-    {
-        SKView.Invalidate();
     }
 
 }

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/BlazorPlot.razor
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/BlazorPlot.razor
@@ -40,7 +40,7 @@
         "Server" => "bg-warning p-3",
         "Static" => "bg-info p-3",
         _ => "bg-danger p-3"
-    });
+    };
     public string rendererInfoName => RendererInfo.Name;
     public string rendererInteractive => RendererInfo.IsInteractive.ToString();
     private SKCanvasView? SKView { get; set; } = OperatingSystem.IsBrowser() ? new() : null;

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/ScottPlot.Blazor.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Blazor/ScottPlot.Blazor.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>11</LangVersion>
@@ -49,8 +49,11 @@
 
     <!-- Package dependencies -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
-        <PackageReference Include="SkiaSharp.Views.Blazor" Version="2.88.9" />
+        <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.2" />
+        <PackageReference Include="SkiaSharp.HarfBuzz" Version="3.116.1" />
+        <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.116.1" />
+        <PackageReference Include="SkiaSharp.Views.Blazor" Version="3.116.1" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/ScottPlot.Maui.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/ScottPlot.Maui.csproj
@@ -60,8 +60,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-        <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="2.88.9" />
-        <PackageReference Include="SkiaSharp.Views.Maui.Core" Version="2.88.9" />
+        <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="3.116.1" />
+        <PackageReference Include="SkiaSharp.Views.Maui.Core" Version="3.116.1" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/SKGLElement.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/SKGLElement.cs
@@ -217,8 +217,9 @@ namespace SkiaSharp.Views.WPF
             using (new SKAutoCanvasRestore(canvas, true))
             {
                 // start drawing
+                OnPaintSurface(new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType));
 #pragma warning disable CS0618 // Type or member is obsolete
-                OnPaintSurface(new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType, glInfo));
+                //OnPaintSurface(new SKPaintGLSurfaceEventArgs(surface, renderTarget, surfaceOrigin, colorType, glInfo));
 #pragma warning restore CS0618 // Type or member is obsolete
             }
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/ScottPlot.WPF.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WPF/ScottPlot.WPF.csproj
@@ -58,7 +58,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SkiaSharp.Views.WPF" Version="2.88.9" />
+        <PackageReference Include="SkiaSharp.Views.WPF" Version="3.116.1" />
         <ProjectReference Include="..\..\ScottPlot5\ScottPlot.csproj" />
     </ItemGroup>
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/ScottPlot.WinForms.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinForms/ScottPlot.WinForms.csproj
@@ -52,7 +52,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SkiaSharp.Views.WindowsForms" Version="2.88.9" />
+        <PackageReference Include="SkiaSharp.Views.WindowsForms" Version="3.116.1" />
         <ProjectReference Include="..\..\ScottPlot5\ScottPlot.csproj" />
     </ItemGroup>
 

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/ScottPlot.WinUI.csproj
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.WinUI/ScottPlot.WinUI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <!-- ref ; https://github.com/unoplatform/uno/discussions/10977 -->
     <PropertyGroup>
-        <TargetFrameworks>net6.0-windows10.0.19041;net6.0;net8.0;net8.0-windows10.0.19041.0;net8.0-ios;net8.0-maccatalyst;net8.0-android</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-windows10.0.19041.0;net8.0-ios;net8.0-maccatalyst;net8.0-android</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
         <LangVersion>11</LangVersion>
@@ -64,14 +64,14 @@
     <ItemGroup Condition="$(TargetFramework.Contains('windows'))">
         <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
         <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240802000" />
-        <PackageReference Include="SkiaSharp.Views.WinUI" Version="2.88.9" />
+        <PackageReference Include="SkiaSharp.Views.WinUI" Version="3.116.1" />
         <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.27" />
         <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.27" />
     </ItemGroup>
 
     <ItemGroup Condition="!$(TargetFramework.Contains('windows'))">
-        <PackageReference Include="Uno.WinUI" Version="4.10.39" />
-        <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.9" />
+        <PackageReference Include="Uno.WinUI" Version="5.6.70" />
+        <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="3.116.1" />
     </ItemGroup>
 
 </Project>

--- a/src/ScottPlot5/ScottPlot5 Tests/Graphical Test Runner/Graphical Test Runner.csproj
+++ b/src/ScottPlot5/ScottPlot5 Tests/Graphical Test Runner/Graphical Test Runner.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SkiaSharp" Version="2.88.9" />
+      <PackageReference Include="SkiaSharp" Version="3.116.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
@@ -407,13 +407,34 @@ public class Heatmap(double[,] intensities) : IPlottable, IHasColorAxis
         if (Bitmap is null)
             Update(); // automatically generate the bitmap on first render if it was not generated manually
 
+        //SKSamplingOptions samplingOptions = Smooth
+        //    ? new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None)
+        //    : new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None);
+        //SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNearest);
+
         using SKPaint paint = new()
         {
-            FilterQuality = Smooth ? SKFilterQuality.High : SKFilterQuality.None
+            IsAntialias = Smooth,
+            //FilterQuality = Smooth ? SKFilterQuality.High : SKFilterQuality.None,
+           // FilterOptions = samplingOptions
         };
 
         SKRect rect = Axes.GetPixelRect(GetAlignedExtent()).ToSKRect();
-
+        
         rp.Canvas.DrawBitmap(Bitmap, rect, paint);
     }
+    //public virtual void Render(RenderPack rp)
+    //{
+    //    if (Bitmap is null)
+    //        Update(); // automatically generate the bitmap on first render if it was not generated manually
+
+    //    using SKPaint paint = new()
+    //    {
+    //        FilterQuality = Smooth ? SKFilterQuality.High : SKFilterQuality.None
+    //    };
+
+    //    SKRect rect = Axes.GetPixelRect(GetAlignedExtent()).ToSKRect();
+
+    //    rp.Canvas.DrawBitmap(Bitmap, rect, paint);
+    //}
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Heatmap.cs
@@ -407,20 +407,13 @@ public class Heatmap(double[,] intensities) : IPlottable, IHasColorAxis
         if (Bitmap is null)
             Update(); // automatically generate the bitmap on first render if it was not generated manually
 
-        //SKSamplingOptions samplingOptions = Smooth
-        //    ? new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None)
-        //    : new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None);
-        //SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNearest);
-
         using SKPaint paint = new()
         {
             IsAntialias = Smooth,
-            //FilterQuality = Smooth ? SKFilterQuality.High : SKFilterQuality.None,
-           // FilterOptions = samplingOptions
         };
 
         SKRect rect = Axes.GetPixelRect(GetAlignedExtent()).ToSKRect();
-        
+
         rp.Canvas.DrawBitmap(Bitmap, rect, paint);
     }
     //public virtual void Render(RenderPack rp)

--- a/src/ScottPlot5/ScottPlot5/ScottPlot.csproj
+++ b/src/ScottPlot5/ScottPlot5/ScottPlot.csproj
@@ -48,10 +48,10 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SkiaSharp" Version="2.88.9" />
-        <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.9" />
-        <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0.3" />
-        <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.9" />
+        <PackageReference Include="SkiaSharp" Version="3.116.1" />
+        <PackageReference Include="SkiaSharp.HarfBuzz" Version="3.116.1" />
+        <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.0.1" />
+        <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.116.1" />
     </ItemGroup>
 
     <!-- Packages allowing modern C# language features to be used in .NET Framework project -->


### PR DESCRIPTION
added checks to only create the Skia view when running in the browser

```cs
   private SKCanvasView? SKView { get; set; } = OperatingSystem.IsBrowser() ? new() : null;
   public override void Refresh()
   {
       SKView?.Invalidate();
   }
```
and
```cs
 @if (OperatingSystem.IsBrowser())
 {
     <SKCanvasView @ref="SKView"
                   style="width:inherit; height:inherit;"
                   OnPaintSurface="OnPaintSurface"
                   IgnorePixelScaling="true"
                   EnableRenderLoop="EnableRenderLoop"
                   @onpointerdown="OnPointerPressed"
                   @onpointermove="OnPointerMoved"
                   @onpointerup="OnPointerReleased"
                   @onwheel="OnPointerWheelChanged"
                   @onkeydown="OnKeyDown"
                   @onkeyup="OnKeyUp" />
 }
```