### PR TITLE
bar: place value below bars when value is negative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _Not yet on NuGet..._
 * Colorbar: Improve support for transparent colormaps (#4685) @Roman-Rak
 * Marker: Setting `LineColor` now sets both line color and outline color to improve support for filled markers with outlines (#4715)
 * Axes: Exposed `GetPanels()` and added `GetXAxes()` and `GetYAxes()` to facilitate advanced customization (#4717) @hsfetterman
+* Bar Plots: Place value labels below the bars for bars with negative values (#4760) @asmallproblem @jux-stef
 
 ## ScottPlot 5.0.54
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-01-26_

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/Plottable/BarTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/Plottable/BarTests.cs
@@ -21,4 +21,35 @@ internal class BarTests
 
         plt.SaveTestImage();
     }
+
+    [Test]
+    public void Test_Bar_TextBelow()
+    {
+        // https://github.com/ScottPlot/ScottPlot/issues/4760
+
+        List<Bar> bars = [];
+        for (int i = 0; i < 10; i++)
+        {
+            double value = Generate.RandomInteger(-100, 100);
+            bars.Add(new()
+            {
+                Position = i,
+                Value = value,
+                Label = value.ToString(),
+                FillColor = Colors.C0,
+                LineWidth = 0,
+            });
+        }
+
+        Plot plot = new();
+        var barPlot = plot.Add.Bars(bars);
+        barPlot.ValueLabelStyle.FontSize = 18;
+        barPlot.ValueLabelStyle.Bold = true;
+
+        plot.Axes.Margins(0.1, 0.25); // increase vertical margins to make room for labels
+
+        plot.Add.HorizontalLine(0, 1, Colors.Black, LinePattern.DenselyDashed);
+        plot.HideGrid();
+        plot.SaveTestImage();
+    }
 }

--- a/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/Plottable/SignalTests.cs
+++ b/src/ScottPlot5/ScottPlot5 Tests/Unit Tests/RenderTests/Plottable/SignalTests.cs
@@ -217,7 +217,8 @@ internal class SignalTests
     [Test]
     public void SignalXY_Throws_IfNotAscending()
     {
-        double[] xs = Generate.RandomWalk(5_000);
+        ScottPlot.RandomDataGenerator gen = new(0);
+        double[] xs = gen.RandomWalk(5_000);
         double[] ys = new double[xs.Length];
 
         ScottPlot.Plot plt = new();
@@ -229,7 +230,8 @@ internal class SignalTests
     [Test]
     public void SignalXY_Throws_IfNotAscending_GenericList()
     {
-        List<double> xs = Generate.RandomWalk(5_000).ToList();
+        ScottPlot.RandomDataGenerator gen = new(0);
+        List<double> xs = gen.RandomWalk(5_000).ToList();
         List<double> ys = new double[xs.Count].ToList();
 
         ScottPlot.Plot plt = new();

--- a/src/ScottPlot5/ScottPlot5/Plottables/BarPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/BarPlot.cs
@@ -20,6 +20,16 @@ public class BarPlot : IPlottable, IHasLegendText
     };
 
     /// <summary>
+    /// Text displayed above each bar, typically containing string representation of the value.
+    /// This label is displayed below the bar for negative bars.
+    /// </summary>
+    public string ValueLabel
+    {
+        get => ValueLabelStyle.Text;
+        set => ValueLabelStyle.Text = value;
+    }
+
+    /// <summary>
     /// Apply a fill color to all bars
     /// </summary>
     public Color Color

--- a/src/ScottPlot5/ScottPlot5/Primitives/Bar.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Bar.cs
@@ -5,10 +5,32 @@ namespace ScottPlot;
 /// </summary>
 public class Bar : IHasFill, IHasLine
 {
+    /// <summary>
+    /// Position (not the value) of the bar.
+    /// Increment position of successive bars so they do not overlap.
+    /// For simple bar plots, position of successive bars is 1, 2, 3, etc. on the horizontal axis.
+    /// </summary>
     public double Position { get; set; }
+
+    /// <summary>
+    /// The value this bar represents.
+    /// This is the top of the bar for bars representing positive values.
+    /// </summary>
     public double Value { get; set; }
-    public double ValueBase { get; set; }
-    public double Size { get; set; } = 0.8; // coordinate units
+
+    /// <summary>
+    /// The position where the bar begins.
+    /// This is the bottom of the bar for bars representing positive values.
+    /// Typically this is zero, so bars extend from zero toward their value.
+    /// </summary>
+    public double ValueBase { get; set; } = 0;
+
+    /// <summary>
+    /// Thickness of the bar in the same units as <see cref="Position"/>.
+    /// Typically the size of each bar is equal to or less than 
+    /// the difference in <see cref="Position"/> between adjacent bars.
+    /// </summary>
+    public double Size { get; set; } = 0.8;
 
     /// <summary>
     /// Size of the error bar extending from <see cref="Value"/>
@@ -41,9 +63,33 @@ public class Bar : IHasFill, IHasLine
     public bool ErrorPositive { get; set; } = true;
     public bool ErrorNegative { get; set; } = true;
 
+    /// <summary>
+    /// Text to display on, above, or below the bar. 
+    /// Typically this is the string representation of the value of the bar.
+    /// </summary>
     public string Label { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Text to display on, above, or below the bar.
+    /// Typically this is the string representation of the value of the bar.
+    /// </summary>
+    public string ValueLabel { get => Label; set => Label = value; }
+
+    /// <summary>
+    /// Enabling this causes the value label to be rendered in the center of the bar
+    /// </summary>
     public bool CenterLabel { get; set; } = false;
+
+    /// <summary>
+    /// Place the value label this many pixels away from the edge of the bar
+    /// </summary>
     public float LabelOffset { get; set; } = 5;
+
+    /// <summary>
+    /// Labels for bars less than this value will be displayed beneath the bar.
+    /// Set this value to negative infinity to force labels to be always on top of the bar.
+    /// </summary>
+    public double LabelInvertWhenValueBelow = 0;
 
     public Orientation Orientation { get; set; } = Orientation.Vertical;
 
@@ -132,12 +178,14 @@ public class Bar : IHasFill, IHasLine
             return;
         }
 
+        bool labelAbove = Value >= LabelInvertWhenValueBelow;
+
         if (Orientation == Orientation.Vertical)
         {
             float xPx = rect.HorizontalCenter;
-            float yPx = rect.Top;
-            labelStyle.Alignment = Alignment.LowerCenter;
-            Pixel labelPixel = new(xPx, yPx - LabelOffset);
+            float yPx = labelAbove ? rect.Top : rect.Bottom;
+            labelStyle.Alignment = labelAbove ? Alignment.LowerCenter : Alignment.UpperCenter;
+            Pixel labelPixel = labelAbove ? new(xPx, yPx - LabelOffset) : new(xPx, yPx + LabelOffset);
             labelStyle.Render(rp.Canvas, labelPixel, paint);
         }
         else


### PR DESCRIPTION
* resolves #4760

![image](https://github.com/user-attachments/assets/73a66a9b-c08c-45d9-bb67-3540c61c5dbb)


```cs
List<Bar> bars = [];
for (int i = 0; i < 10; i++)
{
    double value = Generate.RandomInteger(-100, 100);
    bars.Add(new()
    {
        Position = i,
        Value = value,
        Label = value.ToString(),
        FillColor = Colors.C0,
        LineWidth = 0,
    });
}

Plot plot = new();
var barPlot = plot.Add.Bars(bars);
barPlot.ValueLabelStyle.FontSize = 18;
barPlot.ValueLabelStyle.Bold = true;

plot.Axes.Margins(0.1, 0.25); // increase vertical margins to make room for labels

plot.Add.HorizontalLine(0, 1, Colors.Black, LinePattern.DenselyDashed);
plot.HideGrid();
```