### PR TITLE
PolarPlot: Supported filled areas

### DIFF
--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -915,11 +915,11 @@ public class PlottableAdder(Plot plot)
         return plottable;
     }
 
-    public PolarAxis PolarAxis(double radius = 1.0)
+    public PolarAxis PolarAxis(double radius = 1.0, double? spokeLength = null)
     {
         PolarAxis polarAxis = new() { };
         polarAxis.SetCircles(radius, 5);
-        polarAxis.SetSpokes(12, radius * 1.1);
+        polarAxis.SetSpokes(12, spokeLength ?? radius * 1.1);
 
         Plot.PlottableList.Add(polarAxis);
         Plot.HideAxesAndGrid();


### PR DESCRIPTION
I think the need for #4885 is the background fill function of `PolarAxis`, which is to fill the circle (data range) of `PolarAxis` with a specified color.  (If I misunderstood, please tell me 😅)

- The circle (data range) is the maximum of the radius of all `Circles` and the length of `Spokes`.

For this reason I added a new process `RenderBackgroundColor` to `Render` to fill the circle (data range) with the specified color, and implemented `IHasFill` to support the fill color setting.

### Related changes
1. `PolarAxis` implements `IHasFill`
1. Added `RenderBackgroundColor` method and used it in `Render`
1. Added optional spoke length parameter to `PolarAxis` in `PlottableAdder`

### Demo Image
![image](https://github.com/user-attachments/assets/5cc1e0f4-ab04-4e03-9865-66d1c7b4e3ae)

### Demo Code
```cs
formsPlot1.Plot.DataBackground.Color = Colors.LightGray;
// Specifies the default length of the spokes.
var polarAxis = formsPlot1.Plot.Add.PolarAxis(radius: 100, spokeLength: 100);
polarAxis.FillColor = Colors.Pink;
```

resolve #4885