### PR TITLE
Multiplot: add Clear() method to remove all plottables

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Multiplot.cs
+++ b/src/ScottPlot5/ScottPlot5/Multiplot.cs
@@ -26,4 +26,15 @@ public class Multiplot : IMultiplot
             LastRender.Remember(plot, subplotRectangles[i]);
         }
     }
+
+    /// <summary>
+    /// Clears all plottables from each subplot in this multiplot.
+    /// </summary>
+    public void Clear()
+    {
+        foreach (var subplot in Subplots.GetPlots())
+        {
+            subplot.Clear(); 
+        }
+    }
 }


### PR DESCRIPTION
## Summary

This pull request adds a `Clear()` method to the `Multiplot` class.  
It provides a simple way to clear all plottables from every subplot in a `Multiplot` layout.

## Purpose

Currently, there is no built-in method to clear all subplots at once.  
This addition improves usability by allowing users to reset all subplots with a single call.

## Usage Example

```cs
ScottPlot.WinForms.FormsPlot formPlot = new();
formPlot.Plot.Multiplot = new ScottPlot.Multiplot(2, 2);

// Add some data to each subplot
foreach (var subplot in formPlot.Plot.Multiplot.Subplots.GetPlots())
{
    subplot.AddSignal(ScottPlot.Generate.Sin(100));
}

// Clear all subplots
formPlot.Plot.Multiplot.Clear();
```

## Notes

- This change does not affect the layout or configuration of the multiplot itself—only the plottables are removed.
- The new method internally calls `Plot.Clear()` on each subplot.