### PR TITLE
Add Clamp overloads for all common value types to avoid boxing and improve performance

### DIFF
--- a/src/ScottPlot5/ScottPlot5/NumericConversion.cs
+++ b/src/ScottPlot5/ScottPlot5/NumericConversion.cs
@@ -218,6 +218,51 @@ public static class NumericConversion
         return Expression.Lambda<Func<T, T, bool>>(body, paramA, paramB).Compile();
     }
 
+    [MethodImpl(ImplOptions)]
+    public static sbyte Clamp(sbyte value, sbyte min, sbyte max)
+        => value < min ? min : (value > max ? max : value);
+    
+    [MethodImpl(ImplOptions)]
+    public static byte Clamp(byte value, byte min, byte max)
+        => value < min ? min : (value > max ? max : value);
+    
+    [MethodImpl(ImplOptions)]
+    public static short Clamp(short value, short min, short max)
+        => value < min ? min : (value > max ? max : value);
+    
+    [MethodImpl(ImplOptions)]
+    public static ushort Clamp(ushort value, ushort min, ushort max)
+        => value < min ? min : (value > max ? max : value);
+    
+    [MethodImpl(ImplOptions)]
+    public static int Clamp(int value, int min, int max)
+        => value < min ? min : (value > max ? max : value);
+    
+    [MethodImpl(ImplOptions)]
+    public static uint Clamp(uint value, uint min, uint max)
+        => value < min ? min : (value > max ? max : value);
+    
+    [MethodImpl(ImplOptions)]
+    public static long Clamp(long value, long min, long max)
+        => value < min ? min : (value > max ? max : value);
+    
+    [MethodImpl(ImplOptions)]
+    public static ulong Clamp(ulong value, ulong min, ulong max)
+        => value < min ? min : (value > max ? max : value);
+    
+    [MethodImpl(ImplOptions)]
+    public static float Clamp(float value, float min, float max)
+        => value < min ? min : (value > max ? max : value);
+    
+    [MethodImpl(ImplOptions)]
+    public static double Clamp(double value, double min, double max)
+        => value < min ? min : (value > max ? max : value);
+    
+    [MethodImpl(ImplOptions)]
+    public static decimal Clamp(decimal value, decimal min, decimal max)
+        => value < min ? min : (value > max ? max : value);
+
+
     public static T Clamp<T>(T input, T min, T max) where T : IComparable
     {
         if (input.CompareTo(min) < 0) return min;


### PR DESCRIPTION
Add Clamp overloads for all common value types to avoid boxing and improve performance

- Added explicit Clamp overloads for sbyte, byte, short, ushort, int, uint, long, ulong, float, double, and decimal.
- Ensures value type calls use the most efficient implementation and do not fall back to the generic version.
- Retained the generic Clamp<T> for compatibility with other types.
