### PR TITLE
Drawing: Improve DrawPath/FillPath and DrawPath/FillCircle name consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _Not yet on NuGet..._
 * WinUI: Improve support for modifier keys when combining mouse and keyboard inputs (#4967, #4970) @diluculo
 * Markers: Added new `OpenCircleWithDot`, `OpenCircleWithCross`, and `OpenCircleWithEks` markers (#4963, #4972) @CoderPM2011
 * NumericConversion: Added type-specific `Clamp()` overloads prevent boxing and improve performance (#4985) @kevin100702
+* Drawing: Add `FillPath()` and `FillCircle()` and deprecate draw overloads that accept a `FillStyle` (#4987) @CoderPM2011
 
 ## ScottPlot 5.0.55
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-03-22_

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/CustomMarkerDemo.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/CustomMarkerDemo.cs
@@ -46,7 +46,7 @@ public partial class CustomMarkerDemo : Form, IDemoWindow
             float centerY = center.Y;
 
             // face
-            Drawing.DrawCircle(canvas, center, faceRadius, markerStyle.FillStyle, paint);
+            Drawing.FillCircle(canvas, center, faceRadius, markerStyle.FillStyle, paint);
             Drawing.DrawCircle(canvas, center, faceRadius, markerStyle.LineStyle, paint);
 
             // left eye

--- a/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/CustomPlotType.cs
+++ b/src/ScottPlot5/ScottPlot5 Demos/ScottPlot5 WinForms Demo/Demos/CustomPlotType.cs
@@ -46,7 +46,7 @@ class RainbowPlot : IPlottable
             Coordinates centerCoordinates = new(Xs[i], Ys[i]);
             Pixel centerPixel = Axes.GetPixel(centerCoordinates);
             FillStyle.Color = Colormap.GetColor(i / (Xs.Length - 1.0));
-            ScottPlot.Drawing.DrawCircle(rp.Canvas, centerPixel, Radius, FillStyle, paint);
+            ScottPlot.Drawing.FillCircle(rp.Canvas, centerPixel, Radius, FillStyle, paint);
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/ArrowShapes/Arrowhead.cs
+++ b/src/ScottPlot5/ScottPlot5/ArrowShapes/Arrowhead.cs
@@ -18,7 +18,7 @@ public class Arrowhead : IArrowShape
             new(0, 0),
         ];
 
-        Drawing.DrawPath(rp.Canvas, rp.Paint, pixels, arrowStyle.FillStyle);
+        Drawing.FillPath(rp.Canvas, rp.Paint, pixels, arrowStyle.FillStyle);
         Drawing.DrawPath(rp.Canvas, rp.Paint, pixels, arrowStyle.LineStyle);
 
         rp.CanvasState.Restore();

--- a/src/ScottPlot5/ScottPlot5/ArrowShapes/Chevron.cs
+++ b/src/ScottPlot5/ScottPlot5/ArrowShapes/Chevron.cs
@@ -21,7 +21,7 @@ public class Chevron : IArrowShape
             new(0, 0),
         ];
 
-        Drawing.DrawPath(rp.Canvas, rp.Paint, pixels, arrowStyle.FillStyle);
+        Drawing.FillPath(rp.Canvas, rp.Paint, pixels, arrowStyle.FillStyle);
         Drawing.DrawPath(rp.Canvas, rp.Paint, pixels, arrowStyle.LineStyle);
 
         rp.CanvasState.Restore();

--- a/src/ScottPlot5/ScottPlot5/ArrowShapes/Double.cs
+++ b/src/ScottPlot5/ScottPlot5/ArrowShapes/Double.cs
@@ -25,7 +25,7 @@ public class Double : IArrowShape
             new(0, 0),
         ];
 
-        Drawing.DrawPath(rp.Canvas, rp.Paint, pixels, arrowStyle.FillStyle);
+        Drawing.FillPath(rp.Canvas, rp.Paint, pixels, arrowStyle.FillStyle);
         Drawing.DrawPath(rp.Canvas, rp.Paint, pixels, arrowStyle.LineStyle);
 
         rp.CanvasState.Restore();

--- a/src/ScottPlot5/ScottPlot5/ArrowShapes/Pentagon.cs
+++ b/src/ScottPlot5/ScottPlot5/ArrowShapes/Pentagon.cs
@@ -20,7 +20,7 @@ public class Pentagon : IArrowShape
             new(0, 0),
         ];
 
-        Drawing.DrawPath(rp.Canvas, rp.Paint, pixels, arrowStyle.FillStyle);
+        Drawing.FillPath(rp.Canvas, rp.Paint, pixels, arrowStyle.FillStyle);
         Drawing.DrawPath(rp.Canvas, rp.Paint, pixels, arrowStyle.LineStyle);
 
         rp.CanvasState.Restore();

--- a/src/ScottPlot5/ScottPlot5/ArrowShapes/Single.cs
+++ b/src/ScottPlot5/ScottPlot5/ArrowShapes/Single.cs
@@ -22,7 +22,7 @@ public class Single : IArrowShape
             new(0, 0),
         ];
 
-        Drawing.DrawPath(rp.Canvas, rp.Paint, pixels, arrowStyle.FillStyle);
+        Drawing.FillPath(rp.Canvas, rp.Paint, pixels, arrowStyle.FillStyle);
         Drawing.DrawPath(rp.Canvas, rp.Paint, pixels, arrowStyle.LineStyle);
 
         rp.CanvasState.Restore();

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -144,12 +144,24 @@ public static class Drawing
         DrawPath(canvas, paint, path.Pixels, lineStyle, text, labelStyle);
     }
 
+    [Obsolete($"use FillPath()", false)]
     public static void DrawPath(SKCanvas canvas, SKPaint paint, PixelPath path, FillStyle fillStyle)
     {
-        DrawPath(canvas, paint, path.Pixels, fillStyle);
+        FillPath(canvas, paint, path, fillStyle);
     }
 
+    public static void FillPath(SKCanvas canvas, SKPaint paint, PixelPath path, FillStyle fillStyle)
+    {
+        FillPath(canvas, paint, path.Pixels, fillStyle);
+    }
+
+    [Obsolete($"use FillPath()", false)]
     public static void DrawPath(SKCanvas canvas, SKPaint paint, IEnumerable<Pixel> pixels, FillStyle fillStyle)
+    {
+        FillPath(canvas, paint, pixels, fillStyle);
+    }
+
+    public static void FillPath(SKCanvas canvas, SKPaint paint, IEnumerable<Pixel> pixels, FillStyle fillStyle)
     {
         if (fillStyle.IsVisible == false || fillStyle.Color == Colors.Transparent)
             return;
@@ -171,7 +183,7 @@ public static class Drawing
         }
 
         PixelRect rect = new(xMin, xMax, yMax, yMin);
-        DrawPath(canvas, paint, path, fillStyle, rect);
+        FillPath(canvas, paint, path, fillStyle, rect);
     }
 
     public static void DrawPath(SKCanvas canvas, SKPaint paint, SKPath path, LineStyle lineStyle)
@@ -185,7 +197,13 @@ public static class Drawing
         canvas.DrawPath(path, paint);
     }
 
+    [Obsolete($"use FillPath()", false)]
     public static void DrawPath(SKCanvas canvas, SKPaint paint, SKPath path, FillStyle fillStyle, PixelRect rect)
+    {
+        FillPath(canvas, paint, path, fillStyle, rect);
+    }
+
+    public static void FillPath(SKCanvas canvas, SKPaint paint, SKPath path, FillStyle fillStyle, PixelRect rect)
     {
         if (fillStyle.IsVisible == false || fillStyle.Color == Colors.Transparent)
             return;

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -240,6 +240,8 @@ public static class Drawing
 
     public static void FillRectangle(SKCanvas canvas, PixelRect rect, SKPaint paint, FillStyle fillStyle)
     {
+        if (!fillStyle.IsVisible) return;
+        if (fillStyle.Color == Colors.Transparent) return;
         fillStyle.ApplyToPaint(paint, rect);
         canvas.DrawRect(rect.ToSKRect(), paint);
     }
@@ -270,13 +272,10 @@ public static class Drawing
         canvas.DrawRect(rect.ToSKRect(), paint);
     }
 
+    [Obsolete($"use FillRectangle()", false)]
     public static void DrawRectangle(SKCanvas canvas, PixelRect rect, SKPaint paint, FillStyle fillStyle)
     {
-        if (!fillStyle.IsVisible) return;
-        if (fillStyle.Color == Colors.Transparent) return;
-
-        fillStyle.ApplyToPaint(paint, rect);
-        canvas.DrawRect(rect.ToSKRect(), paint);
+        FillRectangle(canvas, rect, paint, fillStyle);
     }
 
     public static void DrawRectangle(SKCanvas canvas, PixelRect rect, SKPaint paint)

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -330,7 +330,13 @@ public static class Drawing
         canvas.DrawCircle(center.ToSKPoint(), radius, paint);
     }
 
+    [Obsolete("use FillCircle()", false)]
     public static void DrawCircle(SKCanvas canvas, Pixel center, float radius, FillStyle fillStyle, SKPaint paint)
+    {
+        FillCircle(canvas, center, radius, fillStyle, paint);
+    }
+
+    public static void FillCircle(SKCanvas canvas, Pixel center, float radius, FillStyle fillStyle, SKPaint paint)
     {
         if (!fillStyle.IsVisible) return;
         if (fillStyle.Color == Colors.Transparent) return;

--- a/src/ScottPlot5/ScottPlot5/Markers/FilledCircle.cs
+++ b/src/ScottPlot5/ScottPlot5/Markers/FilledCircle.cs
@@ -6,7 +6,7 @@ internal class FilledCircle : IMarker
     {
         float radius = size / 2;
 
-        Drawing.DrawCircle(canvas, center, radius, markerStyle.FillStyle, paint);
+        Drawing.FillCircle(canvas, center, radius, markerStyle.FillStyle, paint);
         Drawing.DrawCircle(canvas, center, radius, markerStyle.OutlineStyle, paint);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Markers/FilledDiamond.cs
+++ b/src/ScottPlot5/ScottPlot5/Markers/FilledDiamond.cs
@@ -19,7 +19,7 @@ internal class FilledDiamond : IMarker
         SKPath path = new();
         path.AddPoly(pointsList);
 
-        Drawing.DrawPath(canvas, paint, path, markerStyle.FillStyle, rect);
+        Drawing.FillPath(canvas, paint, path, markerStyle.FillStyle, rect);
         Drawing.DrawPath(canvas, paint, path, markerStyle.OutlineStyle);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Markers/FilledSquare.cs
+++ b/src/ScottPlot5/ScottPlot5/Markers/FilledSquare.cs
@@ -6,7 +6,7 @@ internal class FilledSquare : IMarker
     {
         PixelRect rect = new(center, size / 2);
 
-        Drawing.DrawRectangle(canvas, rect, paint, markerStyle.FillStyle);
+        Drawing.FillRectangle(canvas, rect, paint, markerStyle.FillStyle);
         Drawing.DrawRectangle(canvas, rect, paint, markerStyle.OutlineStyle);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Markers/FilledTriangleDown.cs
+++ b/src/ScottPlot5/ScottPlot5/Markers/FilledTriangleDown.cs
@@ -21,7 +21,7 @@ internal class FilledTriangleDown : IMarker
         path.AddPoly(pointsList);
 
         PixelRect rect = new(center, radius);
-        Drawing.DrawPath(canvas, paint, path, markerStyle.FillStyle, rect);
+        Drawing.FillPath(canvas, paint, path, markerStyle.FillStyle, rect);
         Drawing.DrawPath(canvas, paint, path, markerStyle.OutlineStyle);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Markers/FilledTriangleUp.cs
+++ b/src/ScottPlot5/ScottPlot5/Markers/FilledTriangleUp.cs
@@ -21,7 +21,7 @@ internal class FilledTriangleUp : IMarker
         path.AddPoly(pointsList);
 
         PixelRect rect = new(center, radius);
-        Drawing.DrawPath(canvas, paint, path, markerStyle.FillStyle, rect);
+        Drawing.FillPath(canvas, paint, path, markerStyle.FillStyle, rect);
         Drawing.DrawPath(canvas, paint, path, markerStyle.OutlineStyle);
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
@@ -90,7 +90,7 @@ public class Pie : PieBase
             }
 
             PixelRect rect = new(origin, outerRadius);
-            Drawing.DrawPath(rp.Canvas, paint, path, slice.Fill, rect);
+            Drawing.FillPath(rp.Canvas, paint, path, slice.Fill, rect);
 
             Drawing.DrawPath(rp.Canvas, paint, path, LineStyle);
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/Radar.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Radar.cs
@@ -61,7 +61,7 @@ public class Radar() : IPlottable, IManagesAxisLimits
         {
             Coordinates[] cs1 = PolarAxis.GetCoordinates(Series[i].Values, clockwise: true);
             Pixel[] pixels = cs1.Select(Axes.GetPixel).ToArray();
-            Drawing.DrawPath(rp.Canvas, paint, pixels, Series[i].FillStyle);
+            Drawing.FillPath(rp.Canvas, paint, pixels, Series[i].FillStyle);
             Drawing.DrawPath(rp.Canvas, paint, pixels, Series[i].LineStyle, close: true);
         }
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
@@ -177,7 +177,7 @@ public class Scatter(IScatterSource data) : IPlottable, IHasLine, IHasMarker, IH
                     rp.CanvasState.Save();
                     rp.CanvasState.Clip(rectAbove);
                     fs.Color = ColorPositions.Count > 0 ? Colors.Black : FillYAboveColor;
-                    Drawing.DrawPath(rp.Canvas, paint, fillPath, fs, rectAbove);
+                    Drawing.FillPath(rp.Canvas, paint, fillPath, fs, rectAbove);
                     rp.CanvasState.Restore();
                 }
 
@@ -187,7 +187,7 @@ public class Scatter(IScatterSource data) : IPlottable, IHasLine, IHasMarker, IH
                     rp.CanvasState.Save();
                     rp.CanvasState.Clip(rectBelow);
                     fs.Color = ColorPositions.Count > 0 ? Colors.Black : FillYBelowColor;
-                    Drawing.DrawPath(rp.Canvas, paint, fillPath, fs, rectBelow);
+                    Drawing.FillPath(rp.Canvas, paint, fillPath, fs, rectBelow);
                     rp.CanvasState.Restore();
                 }
             }
@@ -197,7 +197,7 @@ public class Scatter(IScatterSource data) : IPlottable, IHasLine, IHasMarker, IH
                 rp.CanvasState.Save();
                 rp.CanvasState.Clip(fullRect);
                 fs.Color = ColorPositions.Count > 0 ? Colors.Black : FillYColor;
-                Drawing.DrawPath(rp.Canvas, paint, fillPath, fs, fullRect);
+                Drawing.FillPath(rp.Canvas, paint, fillPath, fs, fullRect);
                 rp.CanvasState.Restore();
             }
         }


### PR DESCRIPTION
Rename `DrawXXX()` methods using `FillStyle` to `FillXXX()`.

The old methods still exist but are now marked as obsolete and forward calls to the new methods, with a reminder for users to migrate.

---

I noticed that FillRectangle had duplicate implementations, so I merged and simplified them.