### PR TITLE
Fix zooming always enabled even when UserInputProcessor.IsEnabled is false on MAUI

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlotExtensions.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Maui/MauiPlotExtensions.cs
@@ -32,7 +32,7 @@ internal static class MauiPlotExtensions
 
     internal static void ProcessPinchUpdated(this UserInputProcessor processor, MauiPlot plot, PinchGestureUpdatedEventArgs e, float width, float height)
     {
-        if (e.Status == GestureStatus.Running)
+        if (e.Status == GestureStatus.Running && processor.IsEnabled)
         {
             Pixel pixel = e.ScaleOrigin.ToPixelScaled(width, height);
 


### PR DESCRIPTION
On the MAUI implementation, when the device is not a desktop, EnabledTouchEvents are set to false and gesture recognizers are used for touch events instead. The pinch gesture calls ProcessPinchUpdated in MauiPlotExtensions. This method was updated to check if the UserInputProcessor is enabled before making any changes.

Typically, UserActions are used for these interactions and those handle IsEnabled; however, this one does not use those. I assumed that there was a good reason to not use a UserAction when it was originally implemented and chose not to change it.

Resolves #4989