### PR TITLE
Legend: default marker style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ _Not yet on NuGet..._
 * Maui: Improve behavior for interactive plots when their user input processor is disabled (#4990, #4989) @Adam--
 * Fonts: Added new styling options for weight, slant, density, etc. (#5013, #4873) @aespitia @Christoph-Wagner
 * Labels: Added styling options for underline with customizable thickness and offset (#4893) @manaruto
+* Legend: Added the ability to customize default marker shape for legend items (#5005, #5006) @aespitia
 
 ## ScottPlot 5.0.55
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-03-22_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/Legend.cs
@@ -138,10 +138,10 @@ public class Legend : ICategory
 
             LegendItem item2 = new()
             {
-                MarkerColor = Colors.Green,    
+                MarkerColor = Colors.Green,
                 MarkerShape = MarkerShape.FilledSquare,
                 LabelText = "Beta"
-            };          
+            };
 
             myPlot.Legend.ManualItems.Add(item1);
             myPlot.Legend.ManualItems.Add(item2);

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/Legend.cs
@@ -21,6 +21,8 @@ public class Legend : ICategory
             var sig2 = myPlot.Add.Signal(Generate.Cos(51));
             sig2.LegendText = "Cos";
 
+            myPlot.Legend.MarkerShapeDefault = MarkerShape.FilledCircle;
+
             myPlot.ShowLegend();
         }
     }

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/Legend.cs
@@ -21,8 +21,6 @@ public class Legend : ICategory
             var sig2 = myPlot.Add.Signal(Generate.Cos(51));
             sig2.LegendText = "Cos";
 
-            myPlot.Legend.MarkerShapeDefault = MarkerShape.FilledCircle;
-
             myPlot.ShowLegend();
         }
     }
@@ -65,6 +63,7 @@ public class Legend : ICategory
                 LineColor = Colors.Magenta,
                 MarkerFillColor = Colors.Magenta,
                 MarkerLineColor = Colors.Magenta,
+                MarkerShape = MarkerShape.Cross,
                 LineWidth = 2,
                 LabelText = "Alpha"
             };
@@ -110,6 +109,46 @@ public class Legend : ICategory
 
             myPlot.Legend.FontSize = 32;
             myPlot.Legend.FontName = Fonts.Serif;
+        }
+    }
+
+    public class LegendOverrideSymbol : RecipeBase
+    {
+        public override string Name => "Legend Default Marker";
+        public override string Description => @"You can override the default rectangular marker used when rendering the legend";
+
+        [Test]
+        public override void Execute()
+        {
+            var sig1 = myPlot.Add.Signal(Generate.Sin(51));
+            sig1.LegendText = "Sin";
+
+            var sig2 = myPlot.Add.Signal(Generate.Cos(51));
+            sig2.LegendText = "Cos";
+
+            myPlot.Legend.MarkerShapeDefault = MarkerShape.FilledCircle;
+
+
+            LegendItem item1 = new()
+            {
+                MarkerFillColor = Colors.Green,
+                MarkerShape = MarkerShape.Cross,
+                LabelText = "Alpha"
+            };
+
+            LegendItem item2 = new()
+            {
+                LineColor = Colors.Yellow,
+                MarkerFillColor = Colors.Yellow,
+                MarkerLineColor = Colors.Yellow,
+                LineWidth = 4,
+                LabelText = "Beta"
+            };          
+
+            myPlot.Legend.ManualItems.Add(item1);
+            myPlot.Legend.ManualItems.Add(item2);
+
+            myPlot.ShowLegend();
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/Legend.cs
@@ -49,7 +49,7 @@ public class Legend : ICategory
     public class ManualLegend : RecipeBase
     {
         public override string Name => "Manual Legend Items";
-        public override string Description => "Legends may be constructed manually.";
+        public override string Description => "Legends may be constructed manually and markers customized.";
 
         [Test]
         public override void Execute()
@@ -107,7 +107,7 @@ public class Legend : ICategory
             myPlot.Legend.ShadowColor = Colors.Blue.WithOpacity(.2);
             myPlot.Legend.ShadowOffset = new(10, 10);
 
-            myPlot.Legend.FontSize = 32;
+            myPlot.Legend.FontSize = 22;
             myPlot.Legend.FontName = Fonts.Serif;
         }
     }
@@ -115,7 +115,7 @@ public class Legend : ICategory
     public class LegendOverrideSymbol : RecipeBase
     {
         public override string Name => "Legend Default Marker";
-        public override string Description => @"You can override the default rectangular marker used when rendering the legend";
+        public override string Description => @"You can override the default rectangular marker used when rendering the legend.  It also maintains the desired marker for manually added items.";
 
         [Test]
         public override void Execute()
@@ -131,17 +131,15 @@ public class Legend : ICategory
 
             LegendItem item1 = new()
             {
-                MarkerFillColor = Colors.Green,
+                MarkerColor = Colors.Red,
                 MarkerShape = MarkerShape.Cross,
                 LabelText = "Alpha"
             };
 
             LegendItem item2 = new()
             {
-                LineColor = Colors.Yellow,
-                MarkerFillColor = Colors.Yellow,
-                MarkerLineColor = Colors.Yellow,
-                LineWidth = 4,
+                MarkerColor = Colors.Green,    
+                MarkerShape = MarkerShape.FilledSquare,
                 LabelText = "Beta"
             };          
 

--- a/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
@@ -293,7 +293,13 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
             PixelRect symbolFillRect = symbolRect.Contract(0, symbolRect.Height * .2f);
             PixelRect symbolFillOutlineRect = symbolFillRect.Expand(1 - item.OutlineWidth);
             PixelLine symbolLine = new(symbolRect.RightCenter, symbolRect.LeftCenter);
-            item.MarkerShape =  MarkerShapeDefault != MarkerShape.None ?  MarkerShapeDefault : MarkerShape.None;
+
+            Debug.WriteLine($"MarkerShape: {item.MarkerShape}, MarkerStyle: {item.MarkerStyle.Shape}, Size: MarkerStyle: {item.MarkerStyle.Size}");
+
+            if(item.MarkerShape == MarkerShape.None && item.MarkerStyle.Shape==MarkerShape.None)
+            {
+                item.MarkerShape = MarkerShapeDefault != MarkerShape.None ? MarkerShapeDefault : MarkerShape.None;
+            }
 
             item.LabelStyle.Render(canvas, labelRect.LeftCenter, paint, true);
 
@@ -303,18 +309,23 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
                 Drawing.DrawRectangle(canvas, labelRect, Colors.Magenta.WithAlpha(.2));
             }
 
-            if(MarkerShapeDefault != MarkerShape.None)
-            {
-                item.MarkerStyle.Shape = MarkerShapeDefault;
-                item.MarkerStyle.Size = item.LabelFontSize;
-            }
-            else
-            {
+            //if(MarkerShapeDefault != MarkerShape.None)
+            //{
+                //item.MarkerStyle.Shape = MarkerShapeDefault;
+                //item.MarkerStyle.Size = item.LabelFontSize;
+            //}
+            //else
+            //{
                 item.MarkerStyle.Shape = item.MarkerShape;
-                item.LineStyle.Render(canvas, symbolLine, paint);
-                item.FillStyle.Render(canvas, symbolFillRect, paint);
-                item.OutlineStyle.Render(canvas, symbolFillOutlineRect, paint);
+                item.MarkerStyle.Size = item.LabelFontSize;
+            if (item.MarkerShape == MarkerShape.None && item.MarkerStyle.Shape == MarkerShape.None)
+            {
+                    item.LineStyle.Render(canvas, symbolLine, paint);                    
             }
+
+            item.FillStyle.Render(canvas, symbolFillRect, paint);
+            item.OutlineStyle.Render(canvas, symbolFillOutlineRect, paint);
+            //}
             
             item.MarkerStyle.Render(canvas, symbolRect.Center, paint);
             item.ArrowStyle.Render(canvas, symbolLine, paint);

--- a/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
@@ -294,7 +294,7 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
             PixelRect symbolFillOutlineRect = symbolFillRect.Expand(1 - item.OutlineWidth);
             PixelLine symbolLine = new(symbolRect.RightCenter, symbolRect.LeftCenter);
 
-            if(item.MarkerShape == MarkerShape.None && item.MarkerStyle.Shape==MarkerShape.None)
+            if (item.MarkerShape == MarkerShape.None && item.MarkerStyle.Shape == MarkerShape.None)
             {
                 item.MarkerShape = MarkerShapeDefault != MarkerShape.None ? MarkerShapeDefault : MarkerShape.None;
                 item.MarkerColor = item.MarkerColor == Colors.Transparent ? Colors.Black : item.MarkerColor;
@@ -308,9 +308,9 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
                 Drawing.DrawRectangle(canvas, labelRect, Colors.Magenta.WithAlpha(.2));
             }
 
-            if(MarkerShapeDefault != MarkerShape.None)
+            if (MarkerShapeDefault != MarkerShape.None)
             {
-                item.MarkerStyle.Shape = item.MarkerShape != MarkerShape.None? item.MarkerShape : MarkerShapeDefault;
+                item.MarkerStyle.Shape = item.MarkerShape != MarkerShape.None ? item.MarkerShape : MarkerShapeDefault;
 
                 //NOTE: tried this but size seems to be defaulting something to something small, so you can barely see the shape, defaulting to font size for now
                 //item.MarkerStyle.Size = item.MarkerStyle.Size != 0 ? item.MarkerStyle.Size : item.LabelFontSize;
@@ -328,13 +328,13 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
 
                 if (item.MarkerShape == MarkerShape.None && item.MarkerStyle.Shape == MarkerShape.None)
                 {
-                        item.LineStyle.Render(canvas, symbolLine, paint);                    
+                    item.LineStyle.Render(canvas, symbolLine, paint);
                 }
 
                 item.FillStyle.Render(canvas, symbolFillRect, paint);
                 item.OutlineStyle.Render(canvas, symbolFillOutlineRect, paint);
             }
-            
+
             item.MarkerStyle.Render(canvas, symbolRect.Center, paint);
             item.ArrowStyle.Render(canvas, symbolLine, paint);
 

--- a/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
@@ -114,6 +114,8 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
     public IEnumerable<LegendItem> LegendItems => LegendItem.None;
     public AxisLimits GetAxisLimits() => AxisLimits.NoLimits;
 
+    public MarkerShape MarkerShapeDefault { get; set; } = MarkerShape.None;
+
     public bool DisplayPlottableLegendItems { get; set; } = true;
 
     /// <summary>
@@ -291,6 +293,7 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
             PixelRect symbolFillRect = symbolRect.Contract(0, symbolRect.Height * .2f);
             PixelRect symbolFillOutlineRect = symbolFillRect.Expand(1 - item.OutlineWidth);
             PixelLine symbolLine = new(symbolRect.RightCenter, symbolRect.LeftCenter);
+            item.MarkerShape =  MarkerShapeDefault != MarkerShape.None ?  MarkerShapeDefault : MarkerShape.None;
 
             item.LabelStyle.Render(canvas, labelRect.LeftCenter, paint, true);
 
@@ -300,9 +303,19 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
                 Drawing.DrawRectangle(canvas, labelRect, Colors.Magenta.WithAlpha(.2));
             }
 
-            item.LineStyle.Render(canvas, symbolLine, paint);
-            item.FillStyle.Render(canvas, symbolFillRect, paint);
-            item.OutlineStyle.Render(canvas, symbolFillOutlineRect, paint);
+            if(MarkerShapeDefault != MarkerShape.None)
+            {
+                item.MarkerStyle.Shape = MarkerShapeDefault;
+                item.MarkerStyle.Size = item.LabelFontSize;
+            }
+            else
+            {
+                item.MarkerStyle.Shape = item.MarkerShape;
+                item.LineStyle.Render(canvas, symbolLine, paint);
+                item.FillStyle.Render(canvas, symbolFillRect, paint);
+                item.OutlineStyle.Render(canvas, symbolFillOutlineRect, paint);
+            }
+            
             item.MarkerStyle.Render(canvas, symbolRect.Center, paint);
             item.ArrowStyle.Render(canvas, symbolLine, paint);
 

--- a/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
@@ -294,11 +294,10 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
             PixelRect symbolFillOutlineRect = symbolFillRect.Expand(1 - item.OutlineWidth);
             PixelLine symbolLine = new(symbolRect.RightCenter, symbolRect.LeftCenter);
 
-            Debug.WriteLine($"MarkerShape: {item.MarkerShape}, MarkerStyle: {item.MarkerStyle.Shape}, Size: MarkerStyle: {item.MarkerStyle.Size}");
-
             if(item.MarkerShape == MarkerShape.None && item.MarkerStyle.Shape==MarkerShape.None)
             {
                 item.MarkerShape = MarkerShapeDefault != MarkerShape.None ? MarkerShapeDefault : MarkerShape.None;
+                item.MarkerColor = item.MarkerColor == Colors.Transparent ? Colors.Black : item.MarkerColor;
             }
 
             item.LabelStyle.Render(canvas, labelRect.LeftCenter, paint, true);
@@ -309,23 +308,32 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
                 Drawing.DrawRectangle(canvas, labelRect, Colors.Magenta.WithAlpha(.2));
             }
 
-            //if(MarkerShapeDefault != MarkerShape.None)
-            //{
-                //item.MarkerStyle.Shape = MarkerShapeDefault;
-                //item.MarkerStyle.Size = item.LabelFontSize;
-            //}
-            //else
-            //{
-                item.MarkerStyle.Shape = item.MarkerShape;
-                item.MarkerStyle.Size = item.LabelFontSize;
-            if (item.MarkerShape == MarkerShape.None && item.MarkerStyle.Shape == MarkerShape.None)
+            if(MarkerShapeDefault != MarkerShape.None)
             {
-                    item.LineStyle.Render(canvas, symbolLine, paint);                    
-            }
+                item.MarkerStyle.Shape = item.MarkerShape != MarkerShape.None? item.MarkerShape : MarkerShapeDefault;
 
-            item.FillStyle.Render(canvas, symbolFillRect, paint);
-            item.OutlineStyle.Render(canvas, symbolFillOutlineRect, paint);
-            //}
+                //NOTE: tried this but size seems to be defaulting something to something small, so you can barely see the shape, defaulting to font size for now
+                //item.MarkerStyle.Size = item.MarkerStyle.Size != 0 ? item.MarkerStyle.Size : item.LabelFontSize;
+                item.MarkerStyle.Size = item.LabelFontSize;
+            }
+            else
+            {
+                item.MarkerStyle.Shape = item.MarkerShape;
+
+                // If the marker size is not set, use the label font size as a fallback
+                //NOTE: Same as above, tried it, but somehow the default is really small, setting to font size for now.
+                //item.MarkerStyle.Size = item.MarkerStyle.Shape != MarkerShape.None && item.MarkerStyle.Size != 0? item.MarkerStyle.Size : item.LabelFontSize;
+
+                item.MarkerStyle.Size = item.LabelFontSize;
+
+                if (item.MarkerShape == MarkerShape.None && item.MarkerStyle.Shape == MarkerShape.None)
+                {
+                        item.LineStyle.Render(canvas, symbolLine, paint);                    
+                }
+
+                item.FillStyle.Render(canvas, symbolFillRect, paint);
+                item.OutlineStyle.Render(canvas, symbolFillOutlineRect, paint);
+            }
             
             item.MarkerStyle.Render(canvas, symbolRect.Center, paint);
             item.ArrowStyle.Render(canvas, symbolLine, paint);


### PR DESCRIPTION
This is to hopefully implement a default marker type, in case you want to keep all of legend defaults, but change the marker style.  Looking for feedback from @swharden or anyone else familiar with the Legend/LegendItems, but hopefully fixes issue #5005

I included a new cookbook item for Legend > Default Marker style

```cs
ScottPlot.Plot myPlot = new();
var sig1 = myPlot.Add.Signal(Generate.Sin(51));
sig1.LegendText = "Sin";

var sig2 = myPlot.Add.Signal(Generate.Cos(51));
sig2.LegendText = "Cos";

myPlot.Legend.MarkerShapeDefault = MarkerShape.FilledCircle;


LegendItem item1 = new()
{
    MarkerColor = Colors.Red,
    MarkerShape = MarkerShape.Cross,
    LabelText = "Alpha"
};

LegendItem item2 = new()
{
    MarkerColor = Colors.Green,
    MarkerShape = MarkerShape.FilledSquare,
    LabelText = "Beta"
};

myPlot.Legend.ManualItems.Add(item1);
myPlot.Legend.ManualItems.Add(item2);

myPlot.ShowLegend();
```

<img width="653" height="422" alt="image" src="https://github.com/user-attachments/assets/b4330493-683b-439f-8756-8a15d289ff94" />
