### PR TITLE
Pie: Reorganized code and fixed SVG rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _Not yet on NuGet..._
 * Fonts: Added new styling options for weight, slant, density, etc. (#5013, #4873) @aespitia @Christoph-Wagner
 * Labels: Added styling options for underline with customizable thickness and offset (#4893) @manaruto
 * Legend: Added the ability to customize default marker shape for legend items (#5005, #5006) @aespitia
+* Pie: Added a `Radius` property (instead of forcing `1.0`) and improved rendering and SVG export (#5020) @CoderPM2011 @aespitia
 
 ## ScottPlot 5.0.55
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-03-22_

--- a/src/ScottPlot5/ScottPlot5/Drawing.cs
+++ b/src/ScottPlot5/ScottPlot5/Drawing.cs
@@ -512,12 +512,15 @@ public static class Drawing
         canvasState.Save();
         fillStyle.ApplyToPaint(paint, outerRect);
 
-        // Clip inner oval
-        using SKPath path = new();
+        using SKPath path = new()
+        {
+            FillType = SKPathFillType.EvenOdd
+        };
+        path.AddOval(outerRect.ToSKRect());
         path.AddOval(innerRect.ToSKRect());
-        canvas.ClipPath(path, SKClipOperation.Difference, true);
 
-        canvas.DrawOval(outerRect.ToSKRect(), paint);
+        canvas.DrawPath(path, paint);
+
         canvasState.Restore();
     }
 

--- a/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
@@ -2,6 +2,7 @@ namespace ScottPlot.Plottables;
 
 public class Pie : PieBase
 {
+    public double Radius { get; set; } = 1.0;
     public double ExplodeFraction { get; set; } = 0;
     public double DonutFraction { get; set; } = 0;
 
@@ -12,27 +13,61 @@ public class Pie : PieBase
 
     public override AxisLimits GetAxisLimits()
     {
-        double radius = Math.Max(SliceLabelDistance, 1 + ExplodeFraction) + Padding;
+        double radius = Math.Max(SliceLabelDistance, Radius + ExplodeFraction) + Padding;
         return new AxisLimits(-radius, radius, -radius, radius);
+    }
+
+    protected virtual void RenderDonutSlice(
+        RenderPack rp, SKPaint paint, LineStyle lineStyle, FillStyle fillStyle,
+        float radius, float sliceAngle, float startAngle)
+    {
+        PixelRect outerRect = new(-radius, radius, -radius, radius);
+
+        // radius of the inner edge of the pie when donut mode is enabled
+        float innerRadius = radius * (float)DonutFraction;
+        PixelRect innerRect = new(-innerRadius, innerRadius, -innerRadius, innerRadius);
+
+        if (Math.Abs(sliceAngle) < 360)
+        {
+            Drawing.FillAnnularSector(rp.Canvas, paint, fillStyle, outerRect, innerRect, startAngle, sliceAngle);
+            Drawing.DrawAnnularSector(rp.Canvas, paint, lineStyle, outerRect, innerRect, startAngle, sliceAngle);
+        }
+        else
+        {
+            Drawing.FillEllipticalAnnulus(rp.Canvas, paint, fillStyle, outerRect, innerRect);
+            Drawing.DrawEllipticalAnnulus(rp.Canvas, paint, lineStyle, outerRect, innerRect);
+        }
+    }
+
+    protected virtual void RenderSlice(
+        RenderPack rp, SKPaint paint, LineStyle lineStyle, FillStyle fillStyle,
+        float radius, float sliceAngle, float startAngle)
+    {
+        PixelRect outerRect = new(-radius, radius, -radius, radius);
+
+        if (Math.Abs(sliceAngle) < 360)
+        {
+            Drawing.FillSector(rp.Canvas, paint, fillStyle, outerRect, startAngle, sliceAngle);
+            Drawing.DrawSector(rp.Canvas, paint, lineStyle, outerRect, startAngle, sliceAngle);
+        }
+        else
+        {
+            Drawing.FillOval(rp.Canvas, paint, fillStyle, outerRect);
+            Drawing.DrawOval(rp.Canvas, paint, lineStyle, outerRect);
+        }
     }
 
     public override void Render(RenderPack rp)
     {
-        using SKPath path = new();
         using SKPaint paint = new() { IsAntialias = true };
 
         Pixel origin = Axes.GetPixel(Coordinates.Origin);
 
-        float minX = Math.Abs(Axes.GetPixelX(1) - origin.X);
-        float minY = Math.Abs(Axes.GetPixelY(1) - origin.Y);
+        float minX = Math.Abs(Axes.GetPixelX(Radius) - origin.X);
+        float minY = Math.Abs(Axes.GetPixelY(Radius) - origin.Y);
 
         // radius of the outer edge of the pie
         float outerRadius = Math.Min(minX, minY);
-        SKRect outerRect = new(-outerRadius, -outerRadius, outerRadius, outerRadius);
-
-        // radius of the inner edge of the pie when donut mode is enabled
-        float innerRadius = outerRadius * (float)DonutFraction;
-        SKRect innerRect = new(-innerRadius, -innerRadius, innerRadius, innerRadius);
 
         double totalValue = Slices.Sum(s => s.Value);
         Angle totalAngle = Rotation;
@@ -40,67 +75,32 @@ public class Pie : PieBase
         {
             using SKAutoCanvasRestore _ = new(rp.Canvas);
 
-            var percentage = slice.Value / totalValue;
-            var sliceAngle = Angle.FromDegrees(percentage * 360);
+            Angle sliceAngle = Angle.FromFraction(slice.Value / totalValue);
             Angle centerAngle = totalAngle + sliceAngle / 2;
 
-            Coordinates explosionOffset = new PolarCoordinates(ExplodeFraction * outerRadius, centerAngle).ToCartesian();
+            PolarCoordinates slicePolar = new(ExplodeFraction * outerRadius, centerAngle);
+            Coordinates explosionOffset = slicePolar.ToCartesian();
             rp.Canvas.Translate(
                 (float)(origin.X + explosionOffset.X),
                 (float)(origin.Y + explosionOffset.Y));
 
-            if (sliceAngle.Degrees == 360)
+            if (DonutFraction > 0)
             {
-                if (DonutFraction > 0)
-                {
-                    // Clip inner oval
-                    // avoid clipping to inner oval line
-                    float innerRadius2 = innerRadius - 1;
-                    path.AddOval(new SKRect(
-                        -innerRadius2, -innerRadius2, innerRadius2, innerRadius2));
-                    rp.Canvas.ClipPath(path, SKClipOperation.Difference);
-                    path.Reset();
-
-                    // Draw inner oval line
-                    path.AddOval(innerRect);
-                    LineStyle.ApplyToPaint(paint);
-                    rp.Canvas.DrawPath(path, paint);
-                }
-
-                path.AddOval(outerRect);
+                RenderDonutSlice(rp, paint, LineStyle, slice.Fill, outerRadius, (float)sliceAngle.Degrees, (float)totalAngle.Degrees);
             }
             else
             {
-                Coordinates ptInnerHome = new PolarCoordinates(innerRadius, totalAngle).ToCartesian();
-                Coordinates ptOuterHome = new PolarCoordinates(outerRadius, totalAngle).ToCartesian();
-                Coordinates ptInnerRotated = new PolarCoordinates(innerRadius, totalAngle + sliceAngle).ToCartesian();
-
-                path.MoveTo(new SKPoint((float)ptInnerHome.X, (float)ptInnerHome.Y));
-                path.LineTo(new SKPoint((float)ptOuterHome.X, (float)ptOuterHome.Y));
-                path.ArcTo(outerRect,
-                    (float)totalAngle.Degrees,
-                    (float)sliceAngle.Degrees,
-                    false);
-                path.LineTo(new SKPoint((float)ptInnerRotated.X, (float)ptInnerRotated.Y));
-                path.ArcTo(innerRect,
-                    (float)(totalAngle + sliceAngle).Degrees,
-                    (float)-sliceAngle.Degrees,
-                    false);
-                path.Close();
+                RenderSlice(rp, paint, LineStyle, slice.Fill, outerRadius, (float)sliceAngle.Degrees, (float)totalAngle.Degrees);
             }
 
-            PixelRect rect = new(origin, outerRadius);
-            Drawing.FillPath(rp.Canvas, paint, path, slice.Fill, rect);
-
-            Drawing.DrawPath(rp.Canvas, paint, path, LineStyle);
-
-            Coordinates polar = new PolarCoordinates(1.0 * SliceLabelDistance, centerAngle).ToCartesian();
-            polar.Y = -polar.Y;
-            Pixel px = Axes.GetPixel(polar) - origin;
+            Coordinates textPolar = slicePolar
+                .WithRadius(1.0 * SliceLabelDistance)
+                .ToCartesian();
+            textPolar.Y = -textPolar.Y;
+            Pixel px = Axes.GetPixel(textPolar) - origin;
             slice.LabelStyle.Render(rp.Canvas, px, paint);
 
             totalAngle += sliceAngle;
-            path.Reset();
         }
     }
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Pie.cs
@@ -94,7 +94,7 @@ public class Pie : PieBase
             }
 
             Coordinates textPolar = slicePolar
-                .WithRadius(1.0 * SliceLabelDistance)
+                .WithRadius(Radius * SliceLabelDistance)
                 .ToCartesian();
             textPolar.Y = -textPolar.Y;
             Pixel px = Axes.GetPixel(textPolar) - origin;


### PR DESCRIPTION
**This PR is divided into two parts:**

## 1. **Reorganize the `Pie` class**
   1. Replace hard-coded radius with a `Radius` property
   2. Use `Drawing`’s static methods for slice rendering
   3. Refactor `Render` by extracting slice logic into `RenderSlice()` and `RenderDonutSlice()`

## 2. **Fix `Drawing.FillEllipticalAnnulus()` SVG export**
   1. Raster `ClipPath + Difference` works on pixels but most SVG exporters emit a `<clipPath>` definition with spotty support, leading to missing or malformed rings.
   2. Switched to a single vector path with an Even-Odd fill rule so that the annulus always exports correctly.

### Demo image
<img width="240" height="235" alt="image" src="https://github.com/user-attachments/assets/87717c52-4b7f-4e33-84e0-74224c8bd3c7" />

### Demo code
```cs
Plot plot1 = formsPlot1.Plot;
plot1.HideLegend();
plot1.HideAxesAndGrid();

var pie1 = plot1.Add.Pie([new PieSlice()
{
    Value = 100,
    FillColor = Colors.Red,
    Label = "A"
}]);
pie1.DonutFraction = .5;

File.WriteAllText("./pie.html", $"""
    <html>
    {plot1.GetSvgHtml(300, 300)}
    </html>
    """);
```

reslove #4692 #4981 