### PR TITLE
Plot: Add border styles and rendering features

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Interfaces/IMultiplot.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/IMultiplot.cs
@@ -65,7 +65,7 @@ public static class IMultiplotExtensions
     /// </summary>
     public static void Render(this IMultiplot multiplot, SKSurface surface)
     {
-        multiplot.Render(surface.Canvas, surface.Canvas.LocalClipBounds.ToPixelRect());
+        multiplot.Render(surface.Canvas, surface.Canvas.DeviceClipBounds.ToPixelRect());
     }
 
     /// <summary>

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -253,7 +253,7 @@ public class Plot : IDisposable
     /// </summary>
     public void Render(SKSurface surface)
     {
-        RenderManager.Render(surface.Canvas, surface.Canvas.LocalClipBounds.ToPixelRect());
+        Render(surface.Canvas, surface.Canvas.LocalClipBounds.ToPixelRect());
     }
 
     public Image GetImage(int width, int height)

--- a/src/ScottPlot5/ScottPlot5/Plot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plot.cs
@@ -23,6 +23,11 @@ public class Plot : IDisposable
     /// </summary>
     public BackgroundStyle DataBackground = new() { Color = Colors.Transparent };
 
+    /// <summary>
+    /// Style for the plot border
+    /// </summary>
+    public LineStyle BorderStyle { get; } = new() { };
+
     public IZoomRectangle ZoomRectangle { get; set; }
     public double ScaleFactor { get => ScaleFactorF; set => ScaleFactorF = (float)value; }
     internal float ScaleFactorF { get; private set; } = 1.0f;
@@ -244,7 +249,22 @@ public class Plot : IDisposable
     {
         lock (Sync)
         {
-            RenderManager.Render(canvas, rect);
+            float borderWidth = 0;
+            if (BorderStyle.CanBeRendered)
+            {
+                borderWidth = BorderStyle.Hairline ? 1 : BorderStyle.Width;
+            }
+
+            // The rendering of the plot should be completed before
+            // the rendering of the border to avoid affecting the rendering of the border.
+            RenderManager.Render(canvas, rect.Contract(borderWidth));
+
+            if (borderWidth > 0)
+            {
+                float halfWidth = borderWidth / 2;
+                using SKPaint paint = new();
+                Drawing.DrawRectangle(canvas, rect.Contract(halfWidth), paint, BorderStyle);
+            }
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5/Primitives/PixelRect.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/PixelRect.cs
@@ -422,4 +422,9 @@ public static class PixelRectExtensions
     {
         return new PixelRect(rect.Left, rect.Right, rect.Bottom, rect.Top);
     }
+
+    public static PixelRect ToPixelRect(this SKRectI rect)
+    {
+        return new PixelRect(rect.Left, rect.Right, rect.Bottom, rect.Top);
+    }
 }


### PR DESCRIPTION
This PR mainly adds border style attributes and border rendering functions to `Plot`.
Here are some related adjustments:
1. Use the `Render()` method of the Sync object to uniformly call `RenderManager.Render()`, avoiding distributed rendering processing.
2. Added a conversion method from `SKRectI` to `PixelRect`.
3. Since `LocalClipBounds` in `WinForm` returns a range that exceeds the rendering range, the boundaries of the `Render(IMultiplot, SKSurface)` method have been changed from `LocalClipBounds` to `DeviceClipBounds` to ensure that the rendered content matches the device's clip range.

resolve #4854

### demo result
1. In WinForm
    <img width="559" height="398" alt="image" src="https://github.com/user-attachments/assets/52e5c429-41dd-40e5-80c9-0d500bbef3d8" />

2. Save to image file
    <img width="400" height="300" alt="plot1" src="https://github.com/user-attachments/assets/727ef556-71aa-45b6-8366-c4022ed91cad" />
    <img width="400" height="300" alt="plot2" src="https://github.com/user-attachments/assets/c26eaef1-6834-41b2-a96f-0fa74e67969c" />

### demo code
```cs
var multiplot = formsPlot1.Multiplot;
formsPlot1.Multiplot = multiplot;

multiplot.AddPlots(2);
Plot plot1 = multiplot.Subplots.GetPlot(0);
Plot plot2 = multiplot.Subplots.GetPlot(1);

plot1.BorderStyle.Pattern = LinePattern.Dashed;
plot1.BorderStyle.Color = Colors.Red.WithOpacity(0.5);
plot1.BorderStyle.Width = 20;

plot2.BorderStyle.Color = Colors.Black;
plot2.BorderStyle.Width = 1;

plot1.Add.Signal(Generate.Sin());
plot2.Add.Signal(Generate.Cos());

plot1.SavePng("plot1.png", 400, 300);
plot2.SavePng("plot2.png", 400, 300);
```