### PR TITLE
PolarAxis: Fix incorrect rotation direction when axes are inverted

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Plottables/PolarAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/PolarAxis.cs
@@ -232,7 +232,10 @@ public class PolarAxis : IPlottable, IManagesAxisLimits, IHasFill
         using SKAutoCanvasRestore _ = new(rp.Canvas);
         Pixel origin = Axes.GetPixel(Coordinates.Origin);
         rp.Canvas.Translate(origin.X, origin.Y);
-        rp.Canvas.RotateDegrees(-(float)Rotation.Degrees);
+
+        // Gets the actual rotation angle in Cartesian coordinates, adjusted for axis inversion.
+        Angle effectiveRotation = Axes.XAxis.IsInverted() ^ Axes.YAxis.IsInverted() ? -Rotation : Rotation;
+        rp.Canvas.RotateDegrees(-(float)effectiveRotation.Degrees);
 
         foreach (var spoke in Spokes)
         {
@@ -241,7 +244,7 @@ public class PolarAxis : IPlottable, IManagesAxisLimits, IHasFill
             Drawing.DrawLine(rp.Canvas, paint, new Pixel(0, 0), tipPixel, spoke.LineStyle);
 
             spoke.LabelStyle.Text = spoke.LabelText ?? string.Empty;
-            spoke.LabelStyle.Rotation = (float)Rotation.Degrees;
+            spoke.LabelStyle.Rotation = (float)effectiveRotation.Degrees;
             spoke.LabelStyle.Alignment = Alignment.MiddleCenter;
 
             PolarCoordinates labelPoint = new(spoke.LabelLength, tipPoint.Angle);


### PR DESCRIPTION
This update fixes the rotation direction based on the inversion state of the X and Y axes.

Maybe it can solve the issue #4884

### demo result
A 30-degree rotation was deliberately added in the demo to test the behavior.

The rotation direction depends on the inversion states of the X and Y axes.
If one axis is inverted and the other is not, the rotation is clockwise.
If both axes share the same inversion state, the rotation is counterclockwise.

<img width="546" height="572" alt="image" src="https://github.com/user-attachments/assets/debea2a6-1aaf-42a4-8b79-cb25e36715f9" />

### demo code
```cs
var multiplot = formsPlot1.Multiplot;

multiplot.AddPlots(4);
for (int i = 0; i < 4; i++)
{
    // add a polar axis to the plot
    var plot = multiplot.Subplots.GetPlot(i);
    var polarAxis = plot.Add.PolarAxis(radius: 100);
    polarAxis.Rotation = Angle.FromDegrees(30);

    var colormap = new ScottPlot.Colormaps.Turbo();
    foreach (double fraction in ScottPlot.Generate.Range(0, 1, 0.02))
    {
        // use the polar axis to get X/Y coordinates given a position in polar space
        double radius = 100 * fraction;
        double degrees = 360 * fraction;
        Coordinates pt = polarAxis.GetCoordinates(radius, degrees);

        // place markers or other plot types using X/Y coordinates like normal
        var marker = plot.Add.Marker(pt);
        marker.Color = colormap.GetColor(fraction);
    }
}

// plot0 No invert axis
multiplot.Subplots.GetPlot(0).Title("+30° No invert axis");

// plot1 Invert X axis
multiplot.Subplots.GetPlot(1).Title("+30° Invert X axis");
multiplot.Subplots.GetPlot(1).Axes.InvertX();

// plot2 Invert Y axis
multiplot.Subplots.GetPlot(2).Title("+30° Invert Y axis");
multiplot.Subplots.GetPlot(2).Axes.InvertY();

// plot3 Invert X & Y axis
multiplot.Subplots.GetPlot(3).Title("+30° Invert X & Y axis");
multiplot.Subplots.GetPlot(3).Axes.InvertX();
multiplot.Subplots.GetPlot(3).Axes.InvertY();

// configure the multiplot to use a grid layout
multiplot.Layout = new ScottPlot.MultiplotLayouts.Grid(rows: 2, columns: 2);
```