### PR TITLE
Fix transparent background frame accumulation with axis rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ _Not yet on NuGet..._
 * Pie: Added a `Radius` property (instead of forcing `1.0`) and improved rendering and SVG export (#5020) @CoderPM2011 @aespitia
 * Data Streamer: Added `FillY` and related properties so streaming plots support filled ares (#4948, #5023) @manaruto @Stephanowicz
 * Plot: Added `FigureBorder` and `DataBorder` for displaying custom borders on plots and subplots (#4854, #5024) @CoderPM2011
+* WinUI: Improved support for plots with transparent backgrounds (#5026, #5029) @diluculo
 
 ## ScottPlot 5.0.55
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-03-22_

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
@@ -109,7 +109,11 @@ public class RenderManager(Plot plot)
         int maxRenderCount = 5;
         for (int i = 0; i < maxRenderCount; i++)
         {
-            canvas.Clear();
+            // Only clear when background is transparent
+            if (Plot.FigureBackground?.Color.A < 255)
+            {
+                canvas.Clear();
+            }
 
             RenderOnce(canvas, rect);
             if (!LastRender.AxisLimitsChanged)

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
@@ -109,6 +109,8 @@ public class RenderManager(Plot plot)
         int maxRenderCount = 5;
         for (int i = 0; i < maxRenderCount; i++)
         {
+            canvas.Clear();
+
             RenderOnce(canvas, rect);
             if (!LastRender.AxisLimitsChanged)
                 return;

--- a/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
+++ b/src/ScottPlot5/ScottPlot5/Rendering/RenderManager.cs
@@ -109,12 +109,6 @@ public class RenderManager(Plot plot)
         int maxRenderCount = 5;
         for (int i = 0; i < maxRenderCount; i++)
         {
-            // Only clear when background is transparent
-            if (Plot.FigureBackground?.Color.A < 255)
-            {
-                canvas.Clear();
-            }
-
             RenderOnce(canvas, rect);
             if (!LastRender.AxisLimitsChanged)
                 return;
@@ -128,7 +122,13 @@ public class RenderManager(Plot plot)
 
         IsRendering = true;
 
-        // TODO: make this an object
+        // If the figure background is semi-transparent, clear early in the render pipeline
+        // to compensate for WinUI issues. https://github.com/ScottPlot/ScottPlot/issues/5026
+        if (ClearCanvasBeforeEachRender && Plot.FigureBackground.Color.A < 255)
+        {
+            canvas.Clear();
+        }
+
         List<(string, TimeSpan)> actionTimes = [];
 
         using RenderPack rp = new(Plot, rect, canvas);


### PR DESCRIPTION
Fixes #5026

**Problem**
Transparent backgrounds in WinUI3 cause frame accumulation when using axis rules (`SquareZoomOut`, `SquarePreserveX`, etc.) due to improper canvas clearing between iterations.

**Solution**
Add `canvas.Clear()` before each render iteration in `RenderManager.Render()` to force proper clearing of WinUI3's transparent rendering pipeline.