### PR TITLE
Legend Restore MarkerStyle.Size behavior and fix marker clipping inside rectangle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ _Not yet on NuGet..._
 * Polar Axis: Added a `Clockwise` property to support clockwise and counter-clockwise translation between Polar and Cartesian coordinates (#5028, #4884, #5046) @CoderPM2011, @mattwelch2000
 * WinUI: Improved support for plots with transparent backgrounds (#5026, #5029) @diluculo
 * Font: Added `Fonts.Reset()` to restore default styling options (#5013) @aespitia
+* Legend: Respect marker size when a default marker shape is used (#5006, #5031) @manaruto @aespitia 
+* Legend: Improve appearance of large markers in legends (#4999, #5031) @manaruto @winsrp
 
 ## ScottPlot 5.0.55
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-03-22_

--- a/src/ScottPlot5/ScottPlot5/LegendLayouts/Wrapping.cs
+++ b/src/ScottPlot5/ScottPlot5/LegendLayouts/Wrapping.cs
@@ -10,8 +10,10 @@ public class Wrapping : ILegendLayout
         PixelSize[] labelSizes = items.Select(x => x.LabelStyle.Measure(x.LabelText, paint).Size).ToArray();
         float maxLabelWidth = labelSizes.Select(x => x.Width).Max();
         float maxLabelHeight = labelSizes.Select(x => x.Height).Max();
-        float maxItemWidth = legend.SymbolWidth + legend.SymbolPadding + maxLabelWidth;
-        float maxItemHeight = maxLabelHeight;
+        float maxMarker = items.Select(x => x.MarkerStyle.Size).DefaultIfEmpty(0).Max();
+        float symbolSquare = Math.Max(legend.SymbolWidth, maxMarker);
+        float maxItemWidth = symbolSquare + legend.SymbolPadding + maxLabelWidth;
+        float maxItemHeight = Math.Max(maxLabelHeight, symbolSquare);
 
         PixelRect[] labelRects = new PixelRect[items.Length];
         PixelRect[] symbolRects = new PixelRect[items.Length];
@@ -43,9 +45,10 @@ public class Wrapping : ILegendLayout
             PixelRect itemRect = new(nextPixel, new PixelSize(itemWidth, maxItemHeight));
             itemRect = itemRect.Intersect(maxRectAfterPadding);
 
-            symbolRects[i] = new(itemRect.Left, itemRect.Left + legend.SymbolWidth, itemRect.Bottom, itemRect.Top);
+            float thisSymbol = Math.Max(legend.SymbolWidth, items[i].MarkerStyle.Size);
+            symbolRects[i] = new(itemRect.Left, itemRect.Left + thisSymbol, itemRect.Bottom, itemRect.Top);
             labelRects[i] = new(
-                left: itemRect.Left + legend.SymbolWidth + legend.SymbolPadding,
+                left: itemRect.Left + thisSymbol + legend.SymbolPadding,
                 right: itemRect.Right,
                 bottom: itemRect.Bottom,
                 top: itemRect.Top);

--- a/src/ScottPlot5/ScottPlot5/LegendLayouts/Wrapping.cs
+++ b/src/ScottPlot5/ScottPlot5/LegendLayouts/Wrapping.cs
@@ -45,10 +45,10 @@ public class Wrapping : ILegendLayout
             PixelRect itemRect = new(nextPixel, new PixelSize(itemWidth, maxItemHeight));
             itemRect = itemRect.Intersect(maxRectAfterPadding);
 
-            float thisSymbol = Math.Max(legend.SymbolWidth, items[i].MarkerStyle.Size);
-            symbolRects[i] = new(itemRect.Left, itemRect.Left + thisSymbol, itemRect.Bottom, itemRect.Top);
+            float thisSymbolWidth = Math.Max(legend.SymbolWidth, items[i].MarkerStyle.Size);
+            symbolRects[i] = new(itemRect.Left, itemRect.Left + thisSymbolWidth, itemRect.Bottom, itemRect.Top);
             labelRects[i] = new(
-                left: itemRect.Left + thisSymbol + legend.SymbolPadding,
+                left: itemRect.Left + thisSymbolWidth + legend.SymbolPadding,
                 right: itemRect.Right,
                 bottom: itemRect.Bottom,
                 top: itemRect.Top);

--- a/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Legend.cs
@@ -303,9 +303,10 @@ public class Legend(Plot plot) : IPlottable, IHasOutline, IHasBackground, IHasSh
             // - if user gave one, keep it
             // - else, if a default is configured, use that
             bool noExplicitShape = item.MarkerShape == MarkerShape.None && item.MarkerStyle.Shape == MarkerShape.None;
-            if (noExplicitShape && MarkerShapeDefault != MarkerShape.None)
+
+            if (noExplicitShape && MarkerShapeOverride.HasValue)
             {
-                item.MarkerStyle.Shape = MarkerShapeDefault;
+                item.MarkerStyle.Shape = MarkerShapeOverride.Value;
                 if (item.MarkerColor == Colors.Transparent)
                     item.MarkerColor = Colors.Black;
 


### PR DESCRIPTION
This PR addresses a regression introduced after [PR #5006](https://github.com/ScottPlot/ScottPlot/pull/5006), where the MarkerStyle.Size property stopped taking effect when a MarkerShapeDefault was set.

Fixes [#4999](https://github.com/ScottPlot/ScottPlot/issues/4999) (marker shape clipping by legend rectangle).

In the original PR, the logic was:

```cs
if (MarkerShapeDefault != MarkerShape.None)
{
    item.MarkerStyle.Shape = item.MarkerShape != MarkerShape.None ? item.MarkerShape : MarkerShapeDefault;

    // NOTE: tried this but size seems to be defaulting something to something small, 
    // so you can barely see the shape, defaulting to font size for now
    //item.MarkerStyle.Size = item.MarkerStyle.Size != 0 ? item.MarkerStyle.Size : item.LabelFontSize;
    item.MarkerStyle.Size = item.LabelFontSize;
}
else
{
    item.MarkerStyle.Shape = item.MarkerShape;

    // If the marker size is not set, use the label font size as a fallback
    // NOTE: Same as above, tried it, but somehow the default is really small, 
    // setting to font size for now.
    //item.MarkerStyle.Size = item.MarkerStyle.Shape != MarkerShape.None && item.MarkerStyle.Size != 0 
    //    ? item.MarkerStyle.Size : item.LabelFontSize;

    item.MarkerStyle.Size = item.LabelFontSize;

    if (item.MarkerShape == MarkerShape.None && item.MarkerStyle.Shape == MarkerShape.None)
    {
        item.LineStyle.Render(canvas, symbolLine, paint);
    }

    item.FillStyle.Render(canvas, symbolFillRect, paint);
    item.OutlineStyle.Render(canvas, symbolFillOutlineRect, paint);
}
```

Because item.MarkerStyle.Size was being overwritten unconditionally with LabelFontSize, any explicit size set by the user was ignored.


### Changes in this PR

**Legend.cs**

- Removed unconditional overwrite of LegendItem.MarkerStyle.Size with LabelFontSize.
- Apply MarkerShapeDefault only when no explicit marker shape is provided.
- Use label font size as a fallback size iff MarkerStyle.Size <= 0.

**Wrapping.cs**

- Updated Wrapping.GetLayout() to calculate symbol square as the max of Legend.SymbolWidth and the largest MarkerStyle.Size.
- Adjusted row height and per-item symbol rectangles to prevent clipping when markers are larger than the configured symbol width.


Code Example:

```cs
// 1) Add your plottables
var xs = Generate.Consecutive(51);
var ys1 = Generate.Sin(51);
var ys2 = Generate.Cos(51);

var sp1 = formsPlot1.Plot.Add.Scatter(xs, ys1);
sp1.LegendText = "Sine";
sp1.MarkerSize = 15;
sp1.LineWidth = 0;
sp1.Color = Colors.Magenta;

var sp2 = formsPlot1.Plot.Add.Scatter(xs, ys2);
sp2.LegendText = "Cosine";
sp2.MarkerSize = 45;                       // big marker
sp2.MarkerShape = MarkerShape.OpenSquare;
sp2.LineWidth = 0;
sp2.Color = Colors.Green;

var legend = formsPlot1.Plot.ShowLegend(
Alignment.LowerRight,
 ScottPlot.Orientation.Horizontal);

// make the square each symbol sits in ≥ the largest marker
 float big = formsPlot1.Plot.PlottableList
.OfType<IHasMarker>()
.Max(p => p.MarkerStyle.Size);

legend.SymbolWidth = big + 6;

formsPlot1.Refresh();
```
<img width="1222" height="832" alt="Screenshot 2025-08-09 134430" src="https://github.com/user-attachments/assets/55ebd762-a5bc-46b9-8673-ca9bf9a23b97" />

