### PR TITLE
SignalSourceBase: Fixed GetLimitsX and GetLimitsY (#4868)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ _Not yet on NuGet..._
 * Legend: Respect marker size when a default marker shape is used (#5006, #5031) @manaruto @aespitia 
 * Legend: Improve appearance of large markers in legends (#4999, #5031) @manaruto @winsrp
 * Cookbook: Improve developer experience when generating images using the Visual Studio Test Runner (#4882, #5032) @CoderPM2011
+* Signal: Improve horizontal range accuracy reported by signal plot data sources (#4868, #5033) @CoderPM2011, @dirk-de-bugger, @StendProg
 
 ## ScottPlot 5.0.55
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-03-22_

--- a/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceBase.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceBase.cs
@@ -44,14 +44,12 @@ public abstract class SignalSourceBase
 
     public CoordinateRange GetLimitsX()
     {
-        CoordinateRect rect = GetLimits().Rect;
-        return new CoordinateRange(rect.Left, rect.Left);
+        return GetLimits().Rect.XRange;
     }
 
     public CoordinateRange GetLimitsY()
     {
-        CoordinateRect rect = GetLimits().Rect;
-        return new CoordinateRange(rect.Bottom, rect.Bottom);
+        return GetLimits().Rect.YRange;
     }
 
     public abstract SignalRangeY GetLimitsY(int firstIndex, int lastIndex);


### PR DESCRIPTION
reslove #4868

Fixed the following code: 
https://github.com/ScottPlot/ScottPlot/blob/3de647566c6e626c2fd5b0f0eea6309a3f78edcb/src/ScottPlot5/ScottPlot5/DataSources/SignalSourceBase.cs#L45-L55