### PR TITLE
Colors: Adding color opacity property

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/ColorRecipes.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/ColorRecipes.cs
@@ -64,10 +64,12 @@ public class ColorRecipes : ICategory
             var circle1 = myPlot.Add.Circle(0, 0, 1);
             var circle2 = myPlot.Add.Circle(1, 0, 1);
             var circle3 = myPlot.Add.Circle(2, 0, 1);
+            var circle4 = myPlot.Add.Circle(3, 0, 1);
 
             circle1.FillColor = new Color(red: 255, green: 0, blue: 0, alpha: 128);
             circle2.FillColor = Colors.Green.WithAlpha(.5);
             circle3.FillColor = Colors.Blue.WithAlpha(.5);
+            circle4.FillColor = Colors.Magenta.WithOpacity(Colors.Magenta.Opacity/2);
 
             // set outline style for all circles on the plot
             foreach (var circle in myPlot.GetPlottables<ScottPlot.Plottables.Ellipse>())

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/ColorRecipes.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/ColorRecipes.cs
@@ -69,7 +69,7 @@ public class ColorRecipes : ICategory
             circle1.FillColor = new Color(red: 255, green: 0, blue: 0, alpha: 128);
             circle2.FillColor = Colors.Green.WithAlpha(.5);
             circle3.FillColor = Colors.Blue.WithAlpha(.5);
-            circle4.FillColor = Colors.Magenta.WithOpacity(Colors.Magenta.Opacity/2);
+            circle4.FillColor = Colors.Magenta.WithOpacity(Colors.Magenta.Opacity / 2);
 
             // set outline style for all circles on the plot
             foreach (var circle in myPlot.GetPlottables<ScottPlot.Plottables.Ellipse>())

--- a/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
@@ -27,7 +27,7 @@ public readonly struct Color
     {
         get
         {
-            return (Alpha/255) ;
+            return (Alpha / 255);
         }
     }
 

--- a/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Color.cs
@@ -23,6 +23,14 @@ public readonly struct Color
         }
     }
 
+    public double Opacity
+    {
+        get
+        {
+            return (Alpha/255) ;
+        }
+    }
+
     public uint PremultipliedARGB
     {
         get


### PR DESCRIPTION
This is to address the request in #5041, if I understood it correctly.

Colors should now have an Opacity property that returns the Alpha/255 as a double

```cs
Colors.Magenta.WithOpacity(Colors.Magenta.Opacity / 2);
```