### PR TITLE
PolarAxis: Add a `Clockwise` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ _Not yet on NuGet..._
 * Pie: Added a `Radius` property (instead of forcing `1.0`) and improved rendering and SVG export (#5020) @CoderPM2011 @aespitia
 * Data Streamer: Added `FillY` and related properties so streaming plots support filled ares (#4948, #5023) @manaruto @Stephanowicz
 * Plot: Added `FigureBorder` and `DataBorder` for displaying custom borders on plots and subplots (#4854, #5024) @CoderPM2011
+* Angle: Added `Inverted` property and support for `Angle` comparison using equality operators
 
 ## ScottPlot 5.0.55
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-03-22_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ _Not yet on NuGet..._
 * Data Streamer: Added `FillY` and related properties so streaming plots support filled ares (#4948, #5023) @manaruto @Stephanowicz
 * Plot: Added `FigureBorder` and `DataBorder` for displaying custom borders on plots and subplots (#4854, #5024) @CoderPM2011
 * Angle: Added `Inverted` property and support for `Angle` comparison using equality operators
-* Polar Axis: Added a `Clockwise` property to support clockwise and counter-clockwise translation between Polar and Cartesian coordinates (#5028, #4884) @CoderPM2011, @mattwelch2000
+* Polar Axis: Added a `Clockwise` property to support clockwise and counter-clockwise translation between Polar and Cartesian coordinates (#5028, #4884, #5046) @CoderPM2011, @mattwelch2000
 
 ## ScottPlot 5.0.55
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-03-22_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ _Not yet on NuGet..._
 * Data Streamer: Added `FillY` and related properties so streaming plots support filled ares (#4948, #5023) @manaruto @Stephanowicz
 * Plot: Added `FigureBorder` and `DataBorder` for displaying custom borders on plots and subplots (#4854, #5024) @CoderPM2011
 * Angle: Added `Inverted` property and support for `Angle` comparison using equality operators
+* Polar Axis: Added a `Clockwise` property to support clockwise and counter-clockwise translation between Polar and Cartesian coordinates (#5028, #4884) @CoderPM2011, @mattwelch2000
 
 ## ScottPlot 5.0.55
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-03-22_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/PolarAxis.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/PolarAxis.cs
@@ -56,6 +56,29 @@ public class PolarAxis : ICategory
         }
     }
 
+    public class PolarClockwise : RecipeBase
+    {
+        public override string Name => "Clockwise Polar Axis";
+        public override string Description => "Clockwise polar plots are common for representing spatial orientation.";
+
+        [Test]
+        public override void Execute()
+        {
+            var polarAxis = myPlot.Add.PolarAxis();
+            polarAxis.Clockwise = true;
+            polarAxis.Rotation = Angle.FromDegrees(-90);
+
+            IColormap colormap = new ScottPlot.Colormaps.Turbo();
+            foreach (double degrees in ScottPlot.Generate.Range(0, 360, 10))
+            {
+                double fraction = degrees / 360.0;
+                Coordinates pt = polarAxis.GetCoordinates(fraction, degrees);
+                var marker = myPlot.Add.Marker(pt);
+                marker.Color = colormap.GetColor(fraction);
+            }
+        }
+    }
+
     public class PolarAxisArrow : RecipeBase
     {
         public override string Name => "Polar Axis with Arrows";
@@ -72,7 +95,7 @@ public class PolarAxis : ICategory
                 new(30, Angle.FromDegrees(240)),
             ];
 
-            var polarAxis = myPlot.Add.PolarAxis(30);
+            var polarAxis = myPlot.Add.PolarAxis(radius: 30);
             polarAxis.Circles.ForEach(x => x.LinePattern = LinePattern.Dotted);
             polarAxis.Spokes.ForEach(x => x.LinePattern = LinePattern.Dotted);
 

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/PolarAxis.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/PolarAxis.cs
@@ -16,19 +16,18 @@ public class PolarAxis : ICategory
         public override void Execute()
         {
             // add a polar axis to the plot
-            var polarAxis = myPlot.Add.PolarAxis(radius: 100);
+            var polarAxis = myPlot.Add.PolarAxis();
 
             IColormap colormap = new ScottPlot.Colormaps.Turbo();
-            foreach (double fraction in ScottPlot.Generate.Range(0, 1, 0.02))
+            foreach (double degrees in ScottPlot.Generate.Range(0, 360, 10))
             {
                 // use the polar axis to get X/Y coordinates given a position in polar space
-                double radius = 100 * fraction;
-                double degrees = 360 * fraction;
+                double radius = degrees / 360.0;
                 Coordinates pt = polarAxis.GetCoordinates(radius, degrees);
 
                 // place markers or other plot types using X/Y coordinates like normal
                 var marker = myPlot.Add.Marker(pt);
-                marker.Color = colormap.GetColor(fraction);
+                marker.Color = colormap.GetColor(radius);
             }
         }
     }
@@ -41,17 +40,17 @@ public class PolarAxis : ICategory
         [Test]
         public override void Execute()
         {
-            var polarAxis = myPlot.Add.PolarAxis(radius: 100);
-            polarAxis.Rotation = Angle.FromDegrees(-90);
+            var polarAxis = myPlot.Add.PolarAxis();
+            polarAxis.Rotation = Angle.FromDegrees(90); // default direction is counter-clockwise
 
             IColormap colormap = new ScottPlot.Colormaps.Turbo();
-            foreach (double fraction in ScottPlot.Generate.Range(0, 1, 0.02))
+            foreach (double degrees in ScottPlot.Generate.Range(0, 360, 10))
             {
-                double radius = 100 * fraction;
-                double degrees = 360 * fraction;
+                double radius = degrees / 360.0;
                 Coordinates pt = polarAxis.GetCoordinates(radius, degrees);
+
                 var marker = myPlot.Add.Marker(pt);
-                marker.Color = colormap.GetColor(fraction);
+                marker.Color = colormap.GetColor(radius);
             }
         }
     }
@@ -66,7 +65,7 @@ public class PolarAxis : ICategory
         {
             var polarAxis = myPlot.Add.PolarAxis();
             polarAxis.Clockwise = true;
-            polarAxis.Rotation = Angle.FromDegrees(-90);
+            polarAxis.Rotation = Angle.FromDegrees(-90); // direction will be counter-clockwise
 
             IColormap colormap = new ScottPlot.Colormaps.Turbo();
             foreach (double degrees in ScottPlot.Generate.Range(0, 360, 10))

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/PolarAxis.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/PolarAxis.cs
@@ -252,6 +252,7 @@ public class PolarAxis : ICategory
         public override void Execute()
         {
             var polarAxis = myPlot.Add.PolarAxis();
+            polarAxis.Clockwise = true;
             polarAxis.Rotation = Angle.FromDegrees(-90);
 
             // add labeled spokes
@@ -263,7 +264,7 @@ public class PolarAxis : ICategory
             polarAxis.SetCircles(ticks);
 
             // convert radar values to coordinates
-            double[] values1 = { 5, 4, 5, 2, 3 };
+            double[] values1 = { 5, 4, 3, 2, 3 };
             double[] values2 = { 2, 3, 2, 4, 2 };
             Coordinates[] cs1 = polarAxis.GetCoordinates(values1);
             Coordinates[] cs2 = polarAxis.GetCoordinates(values2);

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -915,11 +915,11 @@ public class PlottableAdder(Plot plot)
         return plottable;
     }
 
-    public PolarAxis PolarAxis(double radius = 1.0, double spokeLength = 1.1)
+    public PolarAxis PolarAxis(double radius = 1.0, double spokeLength = 1.1, int circleCount = 5, int spokeCount = 12)
     {
-        PolarAxis polarAxis = new() { };
-        polarAxis.SetCircles(radius, 5);
-        polarAxis.SetSpokes(12, radius * spokeLength);
+        PolarAxis polarAxis = new();
+        polarAxis.SetCircles(radius, circleCount);
+        polarAxis.SetSpokes(spokeCount, radius * spokeLength);
 
         Plot.PlottableList.Add(polarAxis);
         Plot.HideAxesAndGrid();

--- a/src/ScottPlot5/ScottPlot5/Plottables/PolarAxis.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/PolarAxis.cs
@@ -32,7 +32,7 @@ public class PolarAxis : IPlottable, IManagesAxisLimits, IHasFill
     /// Determines whether angles ascend clockwise or counter-clockwise relative to the origin.
     /// The origin can be effectively changed by setting <see cref="Rotation"/>.
     /// </summary>
-    public bool Clockwise { get; set; } = true;
+    public bool Clockwise { get; set; } = false;
 
     /// <summary>
     /// If enabled, radial ticks will be drawn using straight lines connecting intersections circles and spokes

--- a/src/ScottPlot5/ScottPlot5/Primitives/Angle.cs
+++ b/src/ScottPlot5/ScottPlot5/Primitives/Angle.cs
@@ -6,9 +6,11 @@ public struct Angle
 
     public double Radians
     {
-        get => Degrees * Math.PI / 180;
+        readonly get => Degrees * Math.PI / 180;
         set => Degrees = value * 180 / Math.PI;
     }
+
+    public readonly Angle Inverted => FromDegrees(-Degrees);
 
     public readonly Angle Normalized
     {
@@ -87,5 +89,25 @@ public struct Angle
     public static Angle operator %(Angle a, double b)
     {
         return FromDegrees(a.Degrees % b);
+    }
+
+    public static bool operator ==(Angle a, Angle b)
+    {
+        return a.Degrees == b.Degrees;
+    }
+
+    public static bool operator !=(Angle a, Angle b)
+    {
+        return a.Degrees != b.Degrees;
+    }
+
+    public readonly override bool Equals(object? obj)
+    {
+        return obj is Angle other && Degrees == other.Degrees;
+    }
+
+    public readonly override int GetHashCode()
+    {
+        return Degrees.GetHashCode();
     }
 }


### PR DESCRIPTION
Resolves #4884 

Default | `Rotation=-90` and `Clockwise=true`
---|---
<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/3266546b-7ded-4ff3-bfd3-7be0635c1c56" />|<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/a4bf213e-e083-4288-9209-4f7f25a0085b" />
