### PR TITLE
Fix: Fonts, Legend Markers, and Radar Rotation Direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ _Not yet on NuGet..._
 * Angle: Added `Inverted` property and support for `Angle` comparison using equality operators
 * Polar Axis: Added a `Clockwise` property to support clockwise and counter-clockwise translation between Polar and Cartesian coordinates (#5028, #4884, #5046) @CoderPM2011, @mattwelch2000
 * WinUI: Improved support for plots with transparent backgrounds (#5026, #5029) @diluculo
+* Font: Added `Fonts.Reset()` to restore default styling options (#5013) @aespitia
 
 ## ScottPlot 5.0.55
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2025-03-22_

--- a/src/ScottPlot5/ScottPlot5 Cookbook/RecipeBase.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/RecipeBase.cs
@@ -40,6 +40,7 @@ public abstract class RecipeBase : IRecipe
     public void ResetRandomNumberGenerator()
     {
         Generate.RandomData.Seed(0);
+        Fonts.Reset();
     }
 
     [TearDown]

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/Legend.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/General/Legend.cs
@@ -114,20 +114,20 @@ public class Legend : ICategory
 
     public class LegendOverrideSymbol : RecipeBase
     {
-        public override string Name => "Legend Default Marker";
-        public override string Description => @"You can override the default rectangular marker used when rendering the legend.  It also maintains the desired marker for manually added items.";
+        public override string Name => "Legend Marker Shape Override";
+        public override string Description => "Use the legend shape override " +
+            "to force all legend items to display using the given marker shape.";
 
         [Test]
         public override void Execute()
         {
+            myPlot.Legend.MarkerShapeOverride = MarkerShape.FilledCircle;
+
             var sig1 = myPlot.Add.Signal(Generate.Sin(51));
             sig1.LegendText = "Sin";
 
             var sig2 = myPlot.Add.Signal(Generate.Cos(51));
             sig2.LegendText = "Cos";
-
-            myPlot.Legend.MarkerShapeDefault = MarkerShape.FilledCircle;
-
 
             LegendItem item1 = new()
             {

--- a/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Radar.cs
+++ b/src/ScottPlot5/ScottPlot5 Cookbook/Recipes/PlotTypes/Radar.cs
@@ -99,6 +99,8 @@ public class Radar : ICategory
             };
 
             var radar = myPlot.Add.Radar(values);
+            radar.Series[0].LegendText = "A";
+            radar.Series[1].LegendText = "B";
 
             string[] spokeLabels = { "Wins", "Poles", "Podiums", "Points", "DNFs" };
             radar.PolarAxis.SetSpokes(spokeLabels, length: 110);

--- a/src/ScottPlot5/ScottPlot5/Fonts.cs
+++ b/src/ScottPlot5/ScottPlot5/Fonts.cs
@@ -31,14 +31,15 @@ public static class Fonts
         FontResolvers.Add(resolver);
     }
 
-    /// <summary>
-    /// This font is used for almost all text rendering.
-    /// </summary>
-    public static string Default { get; set; } = SystemFontResolver.InstalledSansFont();
     public static FontWeight? DefaultWeight { get; set; }
     public static FontSlant? DefaultSlant { get; set; }
     public static FontSpacing? DefaultWidth { get; set; }
     public static SKTypeface? DefaultFontStyle { get; set; }
+
+    /// <summary>
+    /// This font is used for almost all text rendering.
+    /// </summary>
+    public static string Default { get; set; } = SystemFontResolver.InstalledSansFont();
 
     /// <summary>
     /// Name of a sans-serif font present on the system
@@ -289,4 +290,17 @@ public static class Fonts
     }
 
     #endregion
+
+    public static void Reset()
+    {
+        DefaultWeight = null;
+        DefaultSlant = null;
+        DefaultWidth = null;
+        DefaultFontStyle = null;
+
+        Default = SystemFontResolver.InstalledSansFont();
+        Sans = SystemFontResolver.InstalledSansFont();
+        Serif = SystemFontResolver.InstalledSerifFont();
+        Monospace = SystemFontResolver.InstalledMonospaceFont();
+    }
 }

--- a/src/ScottPlot5/ScottPlot5/Plottables/Radar.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Radar.cs
@@ -5,7 +5,11 @@ public class Radar() : IPlottable, IManagesAxisLimits
     /// <summary>
     /// The polar axis drawn beneath each radar series polygon
     /// </summary>
-    public PolarAxis PolarAxis { get; set; } = new() { Rotation = Angle.FromDegrees(90) };
+    public PolarAxis PolarAxis { get; set; } = new()
+    {
+        Rotation = Angle.FromDegrees(-90),
+        Clockwise = true,
+    };
 
     /// <summary>
     /// A collection of RadarSeries, each of which hold a set of values and the styling information that controls how the shape is rendered
@@ -59,7 +63,7 @@ public class Radar() : IPlottable, IManagesAxisLimits
 
         for (int i = 0; i < Series.Count; i++)
         {
-            Coordinates[] cs1 = PolarAxis.GetCoordinates(Series[i].Values, clockwise: true);
+            Coordinates[] cs1 = PolarAxis.GetCoordinates(Series[i].Values);
             Pixel[] pixels = cs1.Select(Axes.GetPixel).ToArray();
             Drawing.FillPath(rp.Canvas, paint, pixels, Series[i].FillStyle);
             Drawing.DrawPath(rp.Canvas, paint, pixels, Series[i].LineStyle, close: true);

--- a/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Signal.cs
@@ -54,7 +54,13 @@ public class Signal(ISignalSource data) : IPlottable, IHasLine, IHasMarker, IHas
 
     public AxisLimits GetAxisLimits() => Data.GetLimits();
 
-    public IEnumerable<LegendItem> LegendItems => LegendItem.Single(this, LegendText, MarkerStyle, LineStyle);
+    public IEnumerable<LegendItem> LegendItems
+    {
+        get
+        {
+            return LegendItem.Single(this, LegendText, MarkerStyle, LineStyle);
+        }
+    }
 
     private CoordinateRange GetVisibleXRange(PixelRect dataRect)
     {


### PR DESCRIPTION
Quick PR to get things ready to publish packages soon:
* Add option to reset fonts https://github.com/ScottPlot/ScottPlot/pull/5013#issuecomment-3194643993
* Minimize untended behavior changes for legend markers https://github.com/ScottPlot/ScottPlot/pull/5006
* Radar: use new polar plot rotation and clockwise features #4884 