### PR TITLE
Fix the wrong location when HorizontalLine has a RightAxis and LabelOppositeAxis

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Plottables/HorizontalLine.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/HorizontalLine.cs
@@ -62,7 +62,7 @@ public class HorizontalLine : AxisLine
             return;
 
         float x = LabelOppositeAxis
-            ? rp.DataRect.Right + LabelStyle.PixelPadding.Right
+            ? rp.DataRect.Right + LabelStyle.PixelPadding.Right + rp.Layout.PanelOffsets[Axes.YAxis]
             : rp.DataRect.Left - LabelStyle.PixelPadding.Left - rp.Layout.PanelOffsets[Axes.YAxis];
 
         Alignment defaultAlignment = LabelOppositeAxis


### PR DESCRIPTION
This pr is to fix the incorrect position when HorizontalLine is using RightAxis

The following are the specific manifestations

before:

<img width="475" height="746" alt="image" src="https://github.com/user-attachments/assets/a5662f52-ba47-4746-b216-39d2ce1a2c2a" />

after:
<img width="356" height="746" alt="image" src="https://github.com/user-attachments/assets/3731939f-f995-4d13-b1d0-10e29f1046ec" />

