### PR TITLE
Add OnLostFocus event handling to AvaPlot

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
@@ -8,6 +8,7 @@ using Avalonia.Threading;
 using SkiaSharp;
 
 using Controls = Avalonia.Controls;
+using Avalonia.Interactivity;
 
 namespace ScottPlot.Avalonia;
 
@@ -140,6 +141,11 @@ public class AvaPlot : Controls.Control, IPlotControl
     protected override void OnKeyUp(KeyEventArgs e)
     {
         UserInputProcessor.ProcessKeyUp(e);
+    }
+
+    protected override void OnLostFocus(RoutedEventArgs e)
+    {
+        UserInputProcessor.ProcessLostFocus();
     }
 
     public float DetectDisplayScale()


### PR DESCRIPTION
Add OnLostFocus event handling to AvaPlot
fix KeyState wrong

After I switch windows using tab + alt, AvaPlot cannot get the key up event correctly, resulting in inconsistent behavior of mouse operations