### PR TITLE
Allow SignalXY data source to return IList<Pixel>

### DIFF
--- a/src/ScottPlot5/ScottPlot5/Interfaces/ISignalXYSource.cs
+++ b/src/ScottPlot5/ScottPlot5/Interfaces/ISignalXYSource.cs
@@ -1,6 +1,6 @@
 namespace ScottPlot;
 
-public interface ISignalXYSource
+public interface ISignalXYSourceGeneric
 {
     /// <summary>
     /// Number of values in the data source
@@ -51,7 +51,7 @@ public interface ISignalXYSource
     /// Return pixels to render to display this signal.
     /// May return one extra point on each side of the plot outside the data area.
     /// </summary>
-    Pixel[] GetPixelsToDraw(RenderPack rp, IAxes axes, ConnectStyle connectStyle);
+    IList<Pixel> GetPixelsToDrawGeneric(RenderPack rp, IAxes axes, ConnectStyle connectStyle);
 
     /// <summary>
     /// Return the point nearest a specific location given the X/Y pixel scaling information from a previous render.
@@ -64,4 +64,14 @@ public interface ISignalXYSource
     /// Will return <see cref="DataPoint.None"/> if the nearest point is greater than <paramref name="maxDistance"/> pixels away.
     /// </summary>
     DataPoint GetNearestX(Coordinates location, RenderDetails renderInfo, float maxDistance = 15);
+}
+
+public interface ISignalXYSource : ISignalXYSourceGeneric
+{
+    IList<Pixel> ISignalXYSourceGeneric.GetPixelsToDrawGeneric(RenderPack rp, IAxes axes, ConnectStyle connectStyle)
+    {
+        return GetPixelsToDraw(rp, axes, connectStyle);
+    }
+    
+    Pixel[] GetPixelsToDraw(RenderPack rp, IAxes axes, ConnectStyle connectStyle);
 }

--- a/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
+++ b/src/ScottPlot5/ScottPlot5/PlottableAdder.cs
@@ -1296,7 +1296,7 @@ public class PlottableAdder(Plot plot)
         return Signal(source, color);
     }
 
-    public SignalXY SignalXY(ISignalXYSource source, Color? color = null)
+    public SignalXY SignalXY(ISignalXYSourceGeneric source, Color? color = null)
     {
         SignalXY sig = new(source)
         {

--- a/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/Scatter.cs
@@ -211,7 +211,7 @@ public class Scatter(IScatterSource data) : IPlottable, IHasLine, IHasMarker, IH
     /// </summary>
     /// <param name="points">Array of corner positions</param>
     /// <param name="right">Indicates that a line will extend to the right before rising or falling.</param>
-    public static Pixel[] GetStepDisplayPixels(Pixel[] pixels, bool right)
+    public static Pixel[] GetStepDisplayPixels(IList<Pixel> pixels, bool right)
     {
         Pixel[] pixelsStep = new Pixel[pixels.Count() * 2 - 1];
 
@@ -224,7 +224,7 @@ public class Scatter(IScatterSource data) : IPlottable, IHasLine, IHasMarker, IH
             pixelsStep[i * 2 + 1] = new Pixel(pixels[i + offsetX].X, pixels[i + offsetY].Y);
         }
 
-        pixelsStep[pixelsStep.Length - 1] = pixels[pixels.Length - 1];
+        pixelsStep[pixelsStep.Length - 1] = pixels[pixels.Count - 1];
 
         return pixelsStep;
     }

--- a/src/ScottPlot5/ScottPlot5/Plottables/SignalXY.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/SignalXY.cs
@@ -1,8 +1,8 @@
 namespace ScottPlot.Plottables;
 
-public class SignalXY(ISignalXYSource dataSource) : IPlottable, IHasLine, IHasMarker, IHasLegendText, IGetNearest
+public class SignalXY(ISignalXYSourceGeneric dataSource) : IPlottable, IHasLine, IHasMarker, IHasLegendText, IGetNearest
 {
-    public ISignalXYSource Data { get; set; } = dataSource;
+    public ISignalXYSourceGeneric Data { get; set; } = dataSource;
 
     public bool IsVisible { get; set; } = true;
     public int XAxisIndex { get; set; } = 0;
@@ -70,9 +70,9 @@ public class SignalXY(ISignalXYSource dataSource) : IPlottable, IHasLine, IHasMa
         if (!IsVisible || Data.Count == 0)
             return;
 
-        Pixel[] markerPixels = Data.GetPixelsToDraw(rp, Axes, ConnectStyle);
+        var markerPixels = Data.GetPixelsToDrawGeneric(rp, Axes, ConnectStyle);
 
-        Pixel[] linePixels = ConnectStyle switch
+        var linePixels = ConnectStyle switch
         {
             ConnectStyle.Straight => markerPixels,
             ConnectStyle.StepHorizontal => Scatter.GetStepDisplayPixels(markerPixels, true),


### PR DESCRIPTION
## Rationale

Jimmacle in the discord raised some concerns about the heap allocations in `SignalXYSourceGenericList` and found that reusing a buffer rather than reallocating Pixel arrays in every call was much more performant.

I am interested in implementing that (I got most of the way there on this branch just to prove I did it right: https://github.com/ScottPlot/ScottPlot/compare/main...bclehmann:ScottPlot:feature/reuse-buffer-signalxy-source-generic-list), but for now I think moving the interface to specify an `IList<Pixel>` and letting people handle the dirty work themselves is a fine compromise.

## Details

If simply changing the return type of `ISignalXYSource.GetPixelsToDraw` is acceptable than there's a somewhat simpler PR. But I didn't really want to break user data sources, especially as this change is only really useful (so far at least) to the kinds of people who write those.

So instead I renamed the interface to `ISignalXYSourceGeneric`, and the problematic function to `GetPixelsToDrawGeneric`, and created a new interface with the old name `ISignalXYSource`, which requires implementing `GetPixelsToDraw` returning a `Pixel[]`, and created a default implementation of `ISignalXYSourceGeneric.GetPixelsToDrawGeneric` which wraps it. I believe this makes this a fully source-compatible change, barring any sketchy reflection code that I don't think we have much interest in supporting.

Provided this is a workable approach I think this should be a big improvement with no downside.

## Remaining Concerns

I don't know if `IList` is the right type, it's just what I told the user in the discord I would do. I think `IReadOnlyList` is almost certainly a better choice, and I could be swayed towards `IEnumerable` (which has the benefit of being simpler to implement, though I don't know about its performance characteristics).