### PR TITLE
statistics: Improve performance for histogram data creation

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Benchmarks/Benchmarks/Histogram.cs
+++ b/src/ScottPlot5/ScottPlot5 Benchmarks/Benchmarks/Histogram.cs
@@ -1,0 +1,34 @@
+using BenchmarkDotNet.Attributes;
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScottPlotBench.Benchmarks
+{
+    public class Histogram
+    {
+        [Params(1_000, 10_000, 100_000, 1_000_000)]
+        public int Points { get; set; }
+
+        [Params(100, 200, 500)]
+        public int BinCount { get; set; }
+
+        public double[] Values { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            ScottPlot.RandomDataGenerator gen = new(0);
+            Values = gen.RandomSample(Points);
+        }
+
+        [Benchmark]
+        public void CreateHistogram()
+        {
+            _ = ScottPlot.Statistics.Histogram.WithBinCount(BinCount, Values);
+        }
+    }
+}

--- a/src/ScottPlot5/ScottPlot5/Statistics/Histogram.cs
+++ b/src/ScottPlot5/ScottPlot5/Statistics/Histogram.cs
@@ -124,20 +124,16 @@ public class Histogram
             return;
         }
 
-        // TODO: improve performance using binary search
-        for (int i = 0; i < Counts.Length; i++)
-        {
-            if (value >= Edges[i] && value < Edges[i + 1])
-            {
-                Counts[i] += 1;
-                break;
-            }
-        }
+        double min = Edges[0];
+        double binWidth = (Edges[^1] - min) / Counts.Length;
+        int index = (int)((value - min) / binWidth);
 
         if (value == Edges[^1])
         {
-            Counts[^1] += 1;
+            index = Counts.Length - 1;
         }
+
+        Counts[index] += 1;
     }
 
     public void AddRange(IEnumerable<double> values)


### PR DESCRIPTION
Using fast index calculation instead of loop search. Below are the benchmark results:

**Before(Loop search)**

| Method          | Points  | BinCount | Mean          | Error | Gen0   | Allocated |
|---------------- |-------- |--------- |--------------:|------:|-------:|----------:|
| CreateHistogram | 1000    | 100      |      47.21 us |    NA | 0.2413 |   2.97 KB |
| CreateHistogram | 1000    | 200      |      81.74 us |    NA | 0.4085 |    5.7 KB |
| CreateHistogram | 1000    | 500      |     184.59 us |    NA | 0.9058 |  13.91 KB |
| CreateHistogram | 10000   | 100      |     530.67 us |    NA |      - |   2.97 KB |
| CreateHistogram | 10000   | 200      |     898.61 us |    NA |      - |   5.72 KB |
| CreateHistogram | 10000   | 500      |   1,802.91 us |    NA |      - |  13.91 KB |
| CreateHistogram | 100000  | 100      |   5,034.48 us |    NA |      - |   3.07 KB |
| CreateHistogram | 100000  | 200      |   9,070.75 us |    NA |      - |    5.8 KB |
| CreateHistogram | 100000  | 500      |  19,393.34 us |    NA |      - |  13.95 KB |
| CreateHistogram | 1000000 | 100      |  49,550.32 us |    NA |      - |   3.07 KB |
| CreateHistogram | 1000000 | 200      |  83,300.30 us |    NA |      - |    5.9 KB |
| CreateHistogram | 1000000 | 500      | 184,663.40 us |    NA |      - |   14.3 KB |

**After(Fast index calculation)**

| Method          | Points  | BinCount | Mean          | Error | Gen0   | Gen1   | Allocated |
|---------------- |-------- |--------- |--------------:|------:|-------:|-------:|----------:|
| CreateHistogram | 1000    | 100      |      9.809 us |    NA | 0.3373 |      - |   2.97 KB |
| CreateHistogram | 1000    | 200      |     10.355 us |    NA | 0.6978 |      - |    5.7 KB |
| CreateHistogram | 1000    | 500      |     11.492 us |    NA | 1.7015 | 0.0567 |  13.91 KB |
| CreateHistogram | 10000   | 100      |     90.853 us |    NA |      - |      - |   2.97 KB |
| CreateHistogram | 10000   | 200      |     93.023 us |    NA | 0.4562 |      - |    5.7 KB |
| CreateHistogram | 10000   | 500      |     95.951 us |    NA | 1.4205 |      - |  13.91 KB |
| CreateHistogram | 100000  | 100      |    907.713 us |    NA |      - |      - |   2.97 KB |
| CreateHistogram | 100000  | 200      |    908.355 us |    NA |      - |      - |   5.76 KB |
| CreateHistogram | 100000  | 500      |    910.150 us |    NA |      - |      - |  13.96 KB |
| CreateHistogram | 1000000 | 100      | 15,292.429 us |    NA |      - |      - |   3.02 KB |
| CreateHistogram | 1000000 | 200      | 16,547.000 us |    NA |      - |      - |   5.76 KB |
| CreateHistogram | 1000000 | 500      | 16,435.514 us |    NA |      - |      - |  13.96 KB |

In theory, calculating indexe(`O(1)`) is much faster than binary search(`O(logn)`).