### PR TITLE
Fix crash when AvaPlot is focused a second time

### DIFF
--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Avalonia/AvaPlot.cs
@@ -145,6 +145,7 @@ public class AvaPlot : Controls.Control, IPlotControl
 
     protected override void OnLostFocus(RoutedEventArgs e)
     {
+        base.OnLostFocus(e);
         UserInputProcessor.ProcessLostFocus();
     }
 


### PR DESCRIPTION
This PR fixes issue #5105.

