### PR TITLE
Add global.json to enforce .NET 9 SDK

### DIFF
--- a/src/ScottPlot5/global.json
+++ b/src/ScottPlot5/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "9.0.100",
+        "rollForward": "feature"
+    }
+}


### PR DESCRIPTION
Fixes #5161

Added `global.json` to specify minimum .NET SDK version 9.0.100.