### PR TITLE
Fix AutoScaleAll crash/empty rendering when data range span is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ _Not yet published..._
 * Scatter: Reduce memory allocations when rendering scatter plots (#5129) @Ben-D-Anderson
 * Interactivity: Add trend lines that extend infinitely in both directions (#5181) @btarb24
 * Controls: Improve modifier key handling when plots regain focus (#5209) @btarb24
+* Autoscaling: Fix zero-span axis ranges when data has identical X and Y values (#5234) @AscendLiu
 
 ## ScottPlot 5.1.58
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2026-03-29_

--- a/src/ScottPlot5/ScottPlot5/AutoScalers/FractionalAutoScaler.cs
+++ b/src/ScottPlot5/ScottPlot5/AutoScalers/FractionalAutoScaler.cs
@@ -70,6 +70,12 @@ public class FractionalAutoScaler : IAutoScaler
             double right = xAxis.Range.Max + (xAxis.Range.Span * RightFraction);
             if (NumericConversion.IsReal(left) && NumericConversion.IsReal(right))
             {
+				if (left == right)
+                {
+                    left -= 1.0;
+                    right += 1.0;
+                }
+				
                 if (InvertedX)
                 {
                     xAxis.Range.Set(right, left);
@@ -87,6 +93,12 @@ public class FractionalAutoScaler : IAutoScaler
             double top = yAxis.Range.Max + (yAxis.Range.Span * TopFraction);
             if (NumericConversion.IsReal(bottom) && NumericConversion.IsReal(top))
             {
+				if (bottom == top)
+                {
+                    bottom -= 1.0;
+                    top += 1.0;
+                }
+				
                 if (InvertedY)
                 {
                     yAxis.Range.Set(top, bottom);


### PR DESCRIPTION
### Problem

When all Y values are identical or all X values are identical in a dataset, the `AutoScaleAll` method in `FractionalAutoScaler` fails to calculate a valid axis range.

Specifically:
- `yAxis.Range.Span = Max - Min = 0` (or similarly for X axis)
- The padding calculation results in `bottom == top`, both equal to the constant data value
- The axis ends up with zero range, causing the chart to render nothing or become unviewable

This affects scenarios such as:
- Plotting horizontal or vertical lines
- Datasets where all points share the same X coordinate
- Datasets where all Y values are identical (e.g., constant sensor readings)

### Solution

Added fallback logic in `FractionalAutoScaler.AutoScaleAll`:

- **X-axis:** When `left == right` (zero span), manually set range to `left - 1` and `right + 1`
- **Y-axis:** When `bottom == top` (zero span), manually set range to `bottom - 1` and `top + 1`

This ensures the axis always has a non-zero range, allowing the chart to render correctly even with constant data.

### Testing

- [x] Tested with dataset where all Y values are equal
- [x] Tested with dataset where all X values are equal
- [x] Verified normal data (non-zero span) is unaffected by this change

### Screenshots (if applicable)

| Before | After |
|--------|-------|
| (empty chart rendering) | (chart shows data properly) |

### Related Issues

Fixes #[Issue Number] — *create one first if it doesn't exist*

### Checklist

- [x] My code follows the code style of this project
- [x] I have tested my changes locally
- [x] I have considered edge cases (zero-span data)
- [x] This PR focuses on a single bug fix (no unrelated changes)

---

Let me know if you want me to adjust the tone or add more technical details specific to the `FractionalAutoScaler` class.