### PR TITLE
Lollipop: implement IGetNearest (#5160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ _Not yet published..._
 * Controls: Improve modifier key handling when plots regain focus (#5209) @btarb24
 * Autoscaling: Fix zero-span axis ranges when data has identical X and Y values (#5234) @AscendLiu
 * Polar Coordinates: Fix conversion from Cartesian coordinates (#5236, #5231) @CoderPM2011
+* Lollipop: Add nearest-point support (#5237, #5160) @CoderPM2011
 
 ## ScottPlot 5.1.58
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2026-03-29_

--- a/src/ScottPlot5/ScottPlot5/Plottables/LollipopPlot.cs
+++ b/src/ScottPlot5/ScottPlot5/Plottables/LollipopPlot.cs
@@ -1,6 +1,6 @@
 namespace ScottPlot.Plottables;
 
-public class LollipopPlot : IPlottable, IHasLine, IHasMarker
+public class LollipopPlot : IPlottable, IHasLine, IHasMarker, IGetNearest
 {
     public bool IsVisible { get; set; } = true;
 
@@ -51,6 +51,18 @@ public class LollipopPlot : IPlottable, IHasLine, IHasMarker
     public AxisLimits GetAxisLimits()
     {
         return new AxisLimits(Coordinates);
+    }
+
+    public DataPoint GetNearest(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
+    {
+        DataSources.CoordinateDataSource dataSource = new(Coordinates.ToList());
+        return DataSourceUtilities.GetNearest(dataSource, mouseLocation, renderInfo, maxDistance, Axes.XAxis, Axes.YAxis);
+    }
+
+    public DataPoint GetNearestX(Coordinates mouseLocation, RenderDetails renderInfo, float maxDistance = 15)
+    {
+        DataSources.CoordinateDataSource dataSource = new(Coordinates.ToList());
+        return DataSourceUtilities.GetNearestX(dataSource, mouseLocation, renderInfo, maxDistance, Axes.XAxis);
     }
 
     public virtual void Render(RenderPack rp)


### PR DESCRIPTION
I initially attempted to have `LollipopPlot` inherit from `Scatter` to take advantage of its existing functionality.

However, I found that inheritance introduced too many extra details.

Consequently, I decided to implement `IGetNearest` following the architectural suggestions discussed in #5160.

resolve #5160