### PR TITLE
EtoPlot: fix missing Eto.Drawing.PixelFormat reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 _Not yet published..._
 * Avalonia: Add support for Avalonia 12 (#5233) @bclehmann
 * Avalonia: Implement cross-platform copy-to-clipboard (#5167) @bclehmann
+* Eto: Fix PixelFormat namespace ambiguity in EtoPlot builds (#5238) @CoderPM2011
 * Interactivity: Prevent the ability to drag invisible lines (#5215) @btarb24
 
 ## ScottPlot 5.1.58

--- a/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Eto/EtoPlot.cs
+++ b/src/ScottPlot5/ScottPlot5 Controls/ScottPlot.Eto/EtoPlot.cs
@@ -72,7 +72,7 @@ public class EtoPlot : Drawable, IPlotControl
         SKPixmap pixels = img.ToRasterImage().PeekPixels();
         byte[] bytes = pixels.GetPixelSpan().ToArray();
 
-        var bmp = new Bitmap((int)Bounds.Width, (int)Bounds.Height, PixelFormat.Format32bppRgba);
+        var bmp = new Bitmap((int)Bounds.Width, (int)Bounds.Height, global::Eto.Drawing.PixelFormat.Format32bppRgba);
 
         using (var data = bmp.Lock())
         {


### PR DESCRIPTION
This PR fixes recent CI build failures caused by namespace ambiguity in the `EtoPlot` project.

Recent CI runs have failed (see link below).
Investigation revealed that these errors were caused by namespace overlap, preventing PixelFormat from being uniquely resolved.
Specifying the fully qualified name `global::Eto.Drawing.PixelFormat` resolves this conflict.

CI Failure References:
- [https://github.com/ScottPlot/ScottPlot/actions/runs/25382142961/job/74433090611](https://github.com/ScottPlot/ScottPlot/compare/main...CoderPM2011:fix/EtoPlot-missingPixelFormat?expand=1)
- [https://github.com/ScottPlot/ScottPlot/actions/runs/25383548178/job/74438190517](https://github.com/ScottPlot/ScottPlot/compare/main...CoderPM2011:fix/EtoPlot-missingPixelFormat?expand=1)
