### PR TITLE
DataStreamerSource.Clear() should set Data[i] = value not 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _Not yet published..._
 * Lollipop: Add nearest-point support (#5237, #5160) @CoderPM2011
 * Ticks: Add support for custom tick line patterns (#5239) @oktrue
 * Avalonia: Add customizable mouse wheel event handling (#5241, #5240) @oktrue
+* DataStreamer: Fix `Clear(value)` to reset data to the requested value (#5245, #5244) @gutblender
 
 ## ScottPlot 5.1.58
 _Published on [NuGet](https://www.nuget.org/profiles/ScottPlot) on 2026-03-29_

--- a/src/ScottPlot5/ScottPlot5/DataSources/DataStreamerSource.cs
+++ b/src/ScottPlot5/ScottPlot5/DataSources/DataStreamerSource.cs
@@ -98,7 +98,7 @@ public class DataStreamerSource
     public void Clear(double value = 0)
     {
         for (int i = 0; i < Data.Length; i++)
-            Data[i] = 0;
+            Data[i] = value;
 
         DataMin = value;
         DataMax = value;


### PR DESCRIPTION
`DataStreamerSource.Clear()` is intended, according to comments, to set Y-values to the supplied `double value`, however it always sets the underlying value to all 0 and not the provided argument - however that argument does default to 0. In all fairness this is unlikely to cause any issue, because max & min are set to value, also those array elements should be "invalid data". It only has been a small issue for me because I use a `Crosshair` to scrub data in view, which may or may not be valid measurements yet. But in my use case, the idea of an invalid / missed / error value is important and I'm glad `NaN` works so well with ScottPlot. 

Thank you for your attention and for this great control. This is my first PR, so please don't hesitate to advise how I can do this right.

This is related to Issue #5244 
